### PR TITLE
update executor tools

### DIFF
--- a/e2e/scenarios/connect-handoff.test.ts
+++ b/e2e/scenarios/connect-handoff.test.ts
@@ -89,13 +89,15 @@ const sent = await t({
 return { ok: sent.ok, path, result: sent.ok ? sent.data : sent.error };
 `;
 
-/** Run `execute`, auto-approving a paused execution (policy elicitation) once,
- *  and parse the sandbox's JSON return value. */
+/** Run `execute`, auto-approving any paused executions (approval-gated tools
+ *  pause once per gated call) and parse the sandbox's JSON return value. */
 const executeJson = (session: McpSession, code: string) =>
   Effect.gen(function* () {
     let result = yield* session.call("execute", { code });
-    if (result.text.includes("executionId:")) {
+    let guard = 0;
+    while (result.text.includes("executionId:") && guard < 10) {
       result = yield* session.approvePaused(result.text);
+      guard += 1;
     }
     expect(result.ok, `execute completed (got: ${result.text.slice(0, 400)})`).toBe(true);
     return JSON.parse(result.text) as Record<string, unknown>;
@@ -148,10 +150,12 @@ scenario(
       orgSlug: orgSlug!,
     }).pipe(
       // Best-effort cleanup even on failure: drop the created connection(s)
-      // over MCP, then the integration over the API.
+      // over MCP, then the integration over the API. `connections.remove` is
+      // approval-gated, so the cleanup execute pauses per connection;
+      // `executeJson` auto-approves each pause so the removes actually run.
       Effect.ensuring(
         Effect.gen(function* () {
-          yield* session.call("execute", { code: removeConnectionsCode(integration) });
+          yield* executeJson(session, removeConnectionsCode(integration));
           yield* client.openapi.removeSpec({ params: { slug: integration } });
         }).pipe(Effect.ignore),
       ),

--- a/e2e/scenarios/no-auth-connection.test.ts
+++ b/e2e/scenarios/no-auth-connection.test.ts
@@ -192,9 +192,12 @@ scenario(
     }).pipe(
       // Selfhost shares one workspace identity — leaked connections fail other
       // scenarios' zero-state assertions, so drop everything this run made.
+      // `connections.remove` is approval-gated, so the cleanup execute pauses
+      // per connection; `executeJson` auto-approves each pause so the removes
+      // actually run.
       Effect.ensuring(
         Effect.gen(function* () {
-          yield* session.call("execute", { code: removeConnectionsCode(integration) });
+          yield* executeJson(session, removeConnectionsCode(integration));
           yield* client.openapi.removeSpec({ params: { slug: integration } });
         }).pipe(Effect.ignore),
       ),

--- a/e2e/scenarios/oauth-client-handoff.test.ts
+++ b/e2e/scenarios/oauth-client-handoff.test.ts
@@ -1,0 +1,478 @@
+// Secrets never cross the agent boundary: a confidential OAuth app is registered
+// through a BROWSER handoff, not by passing the client secret as a tool argument.
+//
+// This is the regression guard for the secret-leak fix. The agent-facing
+// `oauth.clients.create` used to take a `clientSecret`, which meant a confidential
+// app's secret flowed through the LLM context window. That field is gone; the
+// agent now calls `oauth.clients.createHandoff`, which returns a deep link into
+// the web UI where the HUMAN types the secret, exactly like a pasted connection
+// credential (`connections.createHandoff`).
+//
+// Three scenarios:
+//   1. `createHandoff` returns a correct, secret-free deep link and is NOT
+//      approval-gated (it is the safe path). A smuggled `clientSecret` argument
+//      never appears in the URL.
+//   2. `oauth.clients.create` still pauses for human approval (the write gate
+//      survived the secret removal) and writes nothing when declined.
+//   3. Watch-it: the agent hands off, a human opens the URL and types the secret
+//      into the Register-OAuth-app form (auto-opened and pre-filled from the
+//      handoff), the app registers, and the agent completes a client-credentials
+//      connection against the Microsoft emulator without ever seeing the secret.
+import { randomBytes } from "node:crypto";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import { AccountHttpApi } from "@executor-js/api";
+import { composePluginApi } from "@executor-js/api/server";
+import { connectEmulator, type EmulatorClient, type IssuedCredential } from "@executor-js/emulate";
+import { MICROSOFT_CLIENT_CREDENTIALS_AUTH_TEMPLATE_SLUG } from "@executor-js/plugin-microsoft";
+import { microsoftHttpPlugin } from "@executor-js/plugin-microsoft/api";
+import { ConnectionName, IntegrationSlug, OAuthClientSlug } from "@executor-js/sdk/shared";
+
+import { scenario } from "../src/scenario";
+import { Api, Browser, Mcp, Target } from "../src/services";
+import type { McpSession } from "../src/surfaces/mcp";
+
+const microsoftApi = composePluginApi([microsoftHttpPlugin()] as const);
+
+const unique = (prefix: string) => `${prefix}_${randomBytes(4).toString("hex")}`;
+
+// A sentinel the agent tries to smuggle as a `clientSecret` argument the handoff
+// tool does not declare. The secret must never reach the returned URL (nor any
+// part of the agent-visible response), proving the boundary drops it.
+const SMUGGLED_SECRET = "SMUGGLED_SECRET_DO_NOT_LEAK_4f1a9c";
+
+/** Run `execute`, auto-approving any paused (approval-gated) calls, and parse the
+ *  sandbox's JSON return value. Mirrors the connect-handoff helper. */
+const executeJson = (session: McpSession, code: string) =>
+  Effect.gen(function* () {
+    let result = yield* session.call("execute", { code });
+    let guard = 0;
+    while (result.text.includes("executionId:") && guard < 10) {
+      result = yield* session.approvePaused(result.text);
+      guard += 1;
+    }
+    expect(result.ok, `execute completed (got: ${result.text.slice(0, 400)})`).toBe(true);
+    return JSON.parse(result.text) as Record<string, unknown>;
+  });
+
+// ---------------------------------------------------------------------------
+// 1. The handoff URL: secret-free, correctly addressed, and not approval-gated.
+// ---------------------------------------------------------------------------
+
+const createHandoffCode = (input: {
+  readonly integration: string;
+  readonly slug: string;
+  readonly clientId: string;
+  readonly authorizationUrl: string;
+  readonly tokenUrl: string;
+}) => `
+const handoff = await tools.executor.coreTools.oauth.clients.createHandoff({
+  integration: ${JSON.stringify(input.integration)},
+  owner: "user",
+  slug: ${JSON.stringify(input.slug)},
+  grant: "client_credentials",
+  clientId: ${JSON.stringify(input.clientId)},
+  authorizationUrl: ${JSON.stringify(input.authorizationUrl)},
+  tokenUrl: ${JSON.stringify(input.tokenUrl)},
+});
+return handoff.ok
+  ? { ok: true, url: handoff.data.url, instructions: handoff.data.instructions }
+  : { ok: false, error: handoff.error };
+`;
+
+// The same call, but with a `clientSecret` the tool does not declare. Whatever
+// the boundary does with the excess field (drop or reject), the secret VALUE
+// must not appear anywhere in the agent-visible result.
+const smuggleSecretCode = (input: {
+  readonly integration: string;
+  readonly slug: string;
+  readonly clientId: string;
+  readonly tokenUrl: string;
+}) => `
+const handoff = await tools.executor.coreTools.oauth.clients.createHandoff({
+  integration: ${JSON.stringify(input.integration)},
+  slug: ${JSON.stringify(input.slug)},
+  grant: "client_credentials",
+  clientId: ${JSON.stringify(input.clientId)},
+  tokenUrl: ${JSON.stringify(input.tokenUrl)},
+  clientSecret: ${JSON.stringify(SMUGGLED_SECRET)},
+});
+return JSON.stringify(handoff);
+`;
+
+scenario(
+  "OAuth client · createHandoff returns a secret-free deep link and is not approval-gated",
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const { client: makeApiClient } = yield* Api;
+    const mcp = yield* Mcp;
+    const identity = yield* target.newIdentity();
+    const session = mcp.session(identity);
+
+    // The bound org's slug, read from the same surface the console shell reads —
+    // the handoff URL must canonicalize onto exactly this org.
+    const accountClient = yield* makeApiClient(AccountHttpApi, identity);
+    const me = yield* accountClient.account.me();
+    const orgSlug = me.organization?.slug;
+    expect(orgSlug, "the bound organization advertises a URL slug").toBeTruthy();
+
+    const integration = unique("oauthhf");
+    const clientSlug = unique("app");
+    const clientId = unique("client-id");
+    const authorizationUrl = "https://issuer.example.com/oauth2/v2.0/authorize";
+    const tokenUrl = "https://issuer.example.com/oauth2/v2.0/token";
+
+    // createHandoff is a pure URL builder — it must NOT pause for approval (it is
+    // the safe path that routes the secret to the human, mirroring
+    // `connections.createHandoff`).
+    const raw = yield* session.call("execute", {
+      code: createHandoffCode({
+        integration,
+        slug: clientSlug,
+        clientId,
+        authorizationUrl,
+        tokenUrl,
+      }),
+    });
+    expect(raw.text, "createHandoff is not approval-gated (no pause)").not.toContain(
+      "executionId:",
+    );
+    expect(raw.ok, `createHandoff execute completed (got: ${raw.text.slice(0, 400)})`).toBe(true);
+    const handoff = JSON.parse(raw.text) as { ok: boolean; url?: string; instructions?: string };
+    expect(handoff.ok, `createHandoff succeeded: ${raw.text.slice(0, 400)}`).toBe(true);
+
+    const url = new URL(String(handoff.url));
+    expect(url.origin, `handoff URL (${handoff.url}) targets this deployment`).toBe(
+      new URL(target.baseUrl).origin,
+    );
+    expect(url.pathname, `handoff URL (${handoff.url}) carries the bound org slug`).toBe(
+      `/${orgSlug}/integrations/${integration}`,
+    );
+    // The flags that flip the integration's Add-account flow into the
+    // Register-OAuth-app form, pre-filled with the agent's non-secret fields.
+    expect(url.searchParams.get("addAccount")).toBe("1");
+    expect(url.searchParams.get("oauthClient")).toBe("1");
+    expect(url.searchParams.get("owner")).toBe("user");
+    expect(url.searchParams.get("clientSlug")).toBe(clientSlug);
+    expect(url.searchParams.get("grant")).toBe("client_credentials");
+    expect(url.searchParams.get("clientId")).toBe(clientId);
+    expect(url.searchParams.get("authorizationUrl")).toBe(authorizationUrl);
+    expect(url.searchParams.get("tokenUrl")).toBe(tokenUrl);
+
+    // No secret leaves the host: there is no secret-bearing field on the tool,
+    // so the URL carries none.
+    expect(url.searchParams.get("clientSecret"), "no clientSecret param").toBeNull();
+    expect(url.searchParams.get("secret"), "no secret param").toBeNull();
+
+    // The instructions steer the agent away from ever asking for the secret.
+    expect(String(handoff.instructions)).toMatch(/client secret/i);
+    expect(String(handoff.instructions)).toMatch(/chat/i);
+
+    // Adversarial: an agent that tries to smuggle a secret as an undeclared
+    // argument gets it dropped — the value never appears in the response.
+    const smuggled = yield* session.call("execute", {
+      code: smuggleSecretCode({ integration, slug: clientSlug, clientId, tokenUrl }),
+    });
+    expect(
+      smuggled.text.includes(SMUGGLED_SECRET),
+      "a smuggled client secret never reaches the agent-visible handoff result",
+    ).toBe(false);
+  }),
+);
+
+// ---------------------------------------------------------------------------
+// 2. The write path stays gated: `oauth.clients.create` (now secret-free) still
+//    pauses for human approval, and a decline writes nothing.
+// ---------------------------------------------------------------------------
+
+const createPublicClientCode = (slug: string) => `
+const result = await tools.executor.coreTools.oauth.clients.create({
+  owner: "user",
+  slug: ${JSON.stringify(slug)},
+  authorizationUrl: "https://issuer.example.com/authorize",
+  tokenUrl: "https://issuer.example.com/token",
+  grant: "authorization_code",
+  clientId: ${JSON.stringify(unique("public-client"))},
+});
+return JSON.stringify(result);
+`;
+
+const listClientsCode = `
+const result = await tools.executor.coreTools.oauth.clients.list({});
+return JSON.stringify(result.ok ? result.data.clients.map((c) => c.slug) : { error: result.error });
+`;
+
+scenario(
+  "OAuth client · oauth.clients.create still pauses for human approval and a decline writes nothing",
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const mcp = yield* Mcp;
+    const identity = yield* target.newIdentity();
+    const session = mcp.session(identity);
+    const slug = unique("gated-app");
+
+    yield* session.listTools();
+
+    // Nothing has registered a policy here — the only thing that can pause this
+    // call is the tool's own `requiresApproval` annotation, which must have
+    // survived dropping the client secret from the input.
+    const paused = yield* session.call("execute", { code: createPublicClientCode(slug) });
+    expect(paused.text, "oauth.clients.create pauses for approval (annotation guard)").toContain(
+      "Execution paused",
+    );
+    expect(paused.text, "paused result carries the executionId").toContain("executionId:");
+
+    // Decline: the client must not be written.
+    const match = /\bexecutionId:\s*(\S+)/.exec(paused.text);
+    expect(match, "paused result carries an executionId to resume").not.toBeNull();
+    yield* session.call("resume", { executionId: match![1], action: "decline" });
+
+    const slugs = JSON.parse((yield* session.call("execute", { code: listClientsCode })).text) as
+      | ReadonlyArray<string>
+      | { error: unknown };
+    expect(
+      Array.isArray(slugs) && slugs.includes(slug),
+      "a declined oauth.clients.create never registered the client",
+    ).toBe(false);
+  }),
+);
+
+// ---------------------------------------------------------------------------
+// 3. Watch-it: the whole secret-free path, end to end, against the hosted
+//    Microsoft emulator. The agent hands off; the human types the secret in the
+//    browser; the agent connects.
+// ---------------------------------------------------------------------------
+
+const EMULATOR_BASE = "https://microsoft.emulators.dev";
+
+const handoffForBrowserCode = (input: {
+  readonly integration: string;
+  readonly slug: string;
+  readonly clientId: string;
+  readonly authorizationUrl: string;
+  readonly tokenUrl: string;
+}) => `
+const handoff = await tools.executor.coreTools.oauth.clients.createHandoff({
+  integration: ${JSON.stringify(input.integration)},
+  owner: "org",
+  slug: ${JSON.stringify(input.slug)},
+  grant: "client_credentials",
+  clientId: ${JSON.stringify(input.clientId)},
+  authorizationUrl: ${JSON.stringify(input.authorizationUrl)},
+  tokenUrl: ${JSON.stringify(input.tokenUrl)},
+  label: "Microsoft Graph (emulated)",
+});
+return handoff.ok ? { ok: true, url: handoff.data.url } : { ok: false, error: handoff.error };
+`;
+
+const listClientSlugsCode = `
+const result = await tools.executor.coreTools.oauth.clients.list({});
+return result.ok ? { ok: true, slugs: result.data.clients.map((c) => c.slug) } : { ok: false, error: result.error };
+`;
+
+const startConnectionCode = (input: {
+  readonly slug: string;
+  readonly integration: string;
+  readonly connection: string;
+  readonly template: string;
+}) => `
+const started = await tools.executor.coreTools.oauth.start({
+  client: ${JSON.stringify(input.slug)},
+  clientOwner: "org",
+  owner: "org",
+  name: ${JSON.stringify(input.connection)},
+  integration: ${JSON.stringify(input.integration)},
+  template: ${JSON.stringify(input.template)},
+});
+return started.ok ? { ok: true, status: started.data.status } : { ok: false, error: started.error };
+`;
+
+const requireOAuthClientCredential = (credential: IssuedCredential) =>
+  Effect.gen(function* () {
+    if (
+      credential.client_id &&
+      credential.client_secret &&
+      credential.authorization_url &&
+      credential.token_url
+    ) {
+      return {
+        clientId: credential.client_id,
+        clientSecret: credential.client_secret,
+        authorizationUrl: credential.authorization_url,
+        tokenUrl: credential.token_url,
+      };
+    }
+    return yield* Effect.die("Microsoft emulator returned incomplete OAuth client credentials.");
+  });
+
+scenario(
+  "OAuth client · agent hands off, the human enters the secret in the browser, and the app connects",
+  { timeout: 240_000 },
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const { client: makeApiClient } = yield* Api;
+    const mcp = yield* Mcp;
+    const browser = yield* Browser;
+    const identity = yield* target.newIdentity();
+    const session = mcp.session(identity);
+    const client = yield* makeApiClient(microsoftApi, identity);
+
+    const accountClient = yield* makeApiClient(AccountHttpApi, identity);
+    const me = yield* accountClient.account.me();
+    const orgSlug = me.organization?.slug;
+    expect(orgSlug, "the bound organization advertises a URL slug").toBeTruthy();
+
+    const integration = unique("msgraph");
+    const clientSlug = unique("msgraph_app");
+    const connection = "machine";
+    const template = MICROSOFT_CLIENT_CREDENTIALS_AUTH_TEMPLATE_SLUG;
+
+    // The hosted emulator mints a real-shaped client-credentials app and records
+    // every token exchange — the ledger is shared, so key everything off the
+    // unique minted clientId.
+    const emulator: EmulatorClient = yield* Effect.promise(() =>
+      connectEmulator({ baseUrl: EMULATOR_BASE, service: "microsoft" }),
+    );
+    const minted = yield* Effect.promise(() =>
+      emulator.credentials.mint({ type: "oauth-client-credentials", name: "Executor E2E Graph" }),
+    );
+    const oauth = yield* requireOAuthClientCredential(minted);
+
+    yield* Effect.ensuring(
+      Effect.gen(function* () {
+        // Register the Microsoft Graph integration so the console has an OAuth
+        // method to register a client against.
+        yield* client.microsoft.addGraph({
+          payload: {
+            presetIds: ["users"],
+            customScopes: [],
+            slug: integration,
+            name: "Microsoft Graph Emulator",
+            baseUrl: emulator.baseUrl,
+            specUrl: emulator.openapiUrl,
+          },
+        });
+
+        // 1. The agent asks for a browser handoff URL — it has the client id and
+        //    endpoints (discovered/known), but never the secret.
+        const handoff = yield* executeJson(
+          session,
+          handoffForBrowserCode({
+            integration,
+            slug: clientSlug,
+            clientId: oauth.clientId,
+            authorizationUrl: oauth.authorizationUrl,
+            tokenUrl: oauth.tokenUrl,
+          }),
+        );
+        expect(handoff.ok, `createHandoff succeeded: ${JSON.stringify(handoff)}`).toBe(true);
+        const handoffUrl = String(handoff.url);
+
+        const parsed = new URL(handoffUrl);
+        expect(parsed.origin, `handoff URL (${handoffUrl}) targets this deployment`).toBe(
+          new URL(target.baseUrl).origin,
+        );
+        expect(parsed.pathname).toBe(`/${orgSlug}/integrations/${integration}`);
+        // The agent's URL carries the client id but NOT the secret.
+        expect(handoffUrl).toContain(oauth.clientId);
+        expect(
+          handoffUrl.includes(oauth.clientSecret),
+          "the handoff URL never carries the client secret",
+        ).toBe(false);
+
+        // 2. The human opens the URL: the Register-OAuth-app form is open and
+        //    pre-filled from the handoff. They type ONLY the secret.
+        yield* browser.session(identity, async ({ page, step }) => {
+          await step("Open the agent's handoff URL", async () => {
+            await page.goto(handoffUrl, { waitUntil: "networkidle" });
+          });
+
+          await step("The Register-OAuth-app form auto-opens, pre-filled", async () => {
+            await page
+              .getByRole("heading", { name: "Register OAuth app" })
+              .waitFor({ timeout: 20_000 });
+            // The agent's non-secret fields pre-filled — this is the whole point
+            // of the handoff: the human verifies, they don't re-type.
+            await expect
+              .poll(() => page.locator("#oauth-client-id").inputValue())
+              .toBe(oauth.clientId);
+            await expect
+              .poll(() => page.locator("#grant-client_credentials").isChecked())
+              .toBe(true);
+          });
+
+          await step("The human types the client secret (only the secret)", async () => {
+            const secret = page.locator("#oauth-client-secret");
+            await secret.waitFor({ timeout: 15_000 });
+            await secret.fill(oauth.clientSecret);
+          });
+
+          await step("Register the app", async () => {
+            await page.getByRole("button", { name: "Register app" }).click();
+            // onCreated returns to the Add-connection view — the register form closes.
+            await page
+              .getByRole("heading", { name: "Register OAuth app" })
+              .waitFor({ state: "hidden", timeout: 20_000 });
+          });
+        });
+
+        // 3. The agent discovers the browser-registered client and completes the
+        //    connection — client credentials need no user consent.
+        const listed = yield* executeJson(session, listClientSlugsCode);
+        expect(
+          (listed.slugs as ReadonlyArray<string> | undefined)?.includes(clientSlug),
+          `the agent sees the human-registered client: ${JSON.stringify(listed)}`,
+        ).toBe(true);
+
+        const started = yield* executeJson(
+          session,
+          startConnectionCode({
+            slug: clientSlug,
+            integration,
+            connection,
+            template: String(template),
+          }),
+        );
+        expect(started.ok, `oauth.start succeeded: ${JSON.stringify(started)}`).toBe(true);
+        expect(started.status, "client-credentials OAuth connected without browser consent").toBe(
+          "connected",
+        );
+
+        // 4. The emulator ledger proves Executor exchanged THIS app's credentials.
+        const ledger = yield* Effect.promise(() => emulator.ledger.list());
+        const tokenRequest = ledger.find(
+          (entry) =>
+            entry.path === "/oauth2/v2.0/token" &&
+            JSON.stringify(entry.request.body ?? "").includes(oauth.clientId),
+        );
+        expect(
+          tokenRequest?.response.status,
+          "the emulator recorded a client-credentials token exchange for this app",
+        ).toBe(200);
+        expect(tokenRequest?.request.body).toMatchObject({ grant_type: "client_credentials" });
+      }),
+      // Best-effort teardown: selfhost shares one workspace, so remove everything.
+      Effect.gen(function* () {
+        yield* client.connections
+          .remove({
+            params: {
+              owner: "org",
+              integration: IntegrationSlug.make(integration),
+              name: ConnectionName.make(connection),
+            },
+          })
+          .pipe(Effect.ignore);
+        yield* client.oauth
+          .removeClient({
+            params: { slug: OAuthClientSlug.make(clientSlug) },
+            payload: { owner: "org" },
+          })
+          .pipe(Effect.ignore);
+        yield* client.microsoft.removeGraph({ params: { slug: integration } }).pipe(Effect.ignore);
+      }).pipe(Effect.ignore),
+    );
+  }),
+);

--- a/e2e/scenarios/policy-tool-approval.test.ts
+++ b/e2e/scenarios/policy-tool-approval.test.ts
@@ -1,0 +1,144 @@
+// Cross-target: the policy-mutation core tools gate themselves on human
+// approval via their OWN `requiresApproval` annotation, with no policy in play.
+//
+// This is the regression guard for the approval-bypass finding: a prior rewrite
+// of `coreTools` dropped the `requiresApproval` annotations from the policy
+// tools, so prompt-injected sandbox code could call
+// `tools.executor.coreTools.policies.create({ pattern: "*", action: "approve" })`
+// and silently disable every other approval gate. Here the sandbox calls
+// `policies.create` directly with NO matching policy present, so the only thing
+// that can pause the execution is the tool's annotation. If the annotation is
+// missing the call runs silently and the "Execution paused" assertion fails.
+//
+// Runs over MCP in model-managed elicitation mode (no browser): a gated call
+// returns a paused result carrying an `executionId`; `resume` accepts or
+// declines it. The created policy is a `block` rule on a unique, non-matching
+// pattern, so even a leak cannot gate another scenario's tools; it is removed in
+// an `ensuring` finalizer regardless.
+import { randomUUID } from "node:crypto";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import { composePluginApi } from "@executor-js/api/server";
+
+import { scenario } from "../src/scenario";
+import { Api, Mcp, Target } from "../src/services";
+
+const coreApi = composePluginApi([] as const);
+
+/** Sandbox code that creates a policy through the gated core tool. The pattern
+ *  is unique-per-run and matches no real tool, so the rule is inert. */
+const createPolicyCode = (pattern: string) => `
+const result = await tools.executor.coreTools.policies.create({
+  owner: "user",
+  pattern: ${JSON.stringify(pattern)},
+  action: "block",
+});
+return JSON.stringify(result);
+`;
+
+scenario(
+  "Policy tools · policies.create pauses for approval from its own annotation, then runs once approved",
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const apiSurface = yield* Api;
+    const mcp = yield* Mcp;
+    const identity = yield* target.newIdentity();
+    const client = yield* apiSurface.client(coreApi, identity);
+    const pattern = `policy-guard-approve-${randomUUID().slice(0, 8)}.*`;
+
+    // Best-effort removal of any policy left under `pattern` for this identity.
+    const cleanup = client.policies.list().pipe(
+      Effect.flatMap((list) =>
+        Effect.forEach(
+          list.filter((p) => p.pattern === pattern),
+          (p) =>
+            client.policies
+              .remove({ params: { policyId: p.id }, payload: { owner: "user" } })
+              .pipe(Effect.ignore),
+        ),
+      ),
+      Effect.ignore,
+    );
+
+    yield* Effect.gen(function* () {
+      const session = mcp.session(identity);
+
+      // Warm the OAuth handshake before the gated call.
+      const tools = yield* session.listTools();
+      expect(tools).toContain("execute");
+
+      // No policy exists for `policies.create` here — the only thing that can
+      // pause this call is the tool's `requiresApproval` annotation.
+      const paused = yield* session.call("execute", { code: createPolicyCode(pattern) });
+      expect(
+        paused.text,
+        "policies.create paused for approval with no policy present (annotation guard)",
+      ).toContain("Execution paused");
+      expect(paused.text, "paused result carries the executionId").toContain("executionId:");
+
+      // The policy must not exist until the human approves.
+      const beforeApproval = yield* client.policies.list();
+      expect(
+        beforeApproval.some((p) => p.pattern === pattern),
+        "policy is not written while the approval is still pending",
+      ).toBe(false);
+
+      const resumed = yield* session.approvePaused(paused.text);
+      expect(resumed.ok, "resumed execution completed without error").toBe(true);
+
+      const afterApproval = yield* client.policies.list();
+      expect(
+        afterApproval.some((p) => p.pattern === pattern),
+        "policy is written only after the human approves",
+      ).toBe(true);
+    }).pipe(Effect.ensuring(cleanup));
+  }),
+);
+
+scenario(
+  "Policy tools · declining the approval blocks policies.create",
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const apiSurface = yield* Api;
+    const mcp = yield* Mcp;
+    const identity = yield* target.newIdentity();
+    const client = yield* apiSurface.client(coreApi, identity);
+    const pattern = `policy-guard-decline-${randomUUID().slice(0, 8)}.*`;
+
+    const cleanup = client.policies.list().pipe(
+      Effect.flatMap((list) =>
+        Effect.forEach(
+          list.filter((p) => p.pattern === pattern),
+          (p) =>
+            client.policies
+              .remove({ params: { policyId: p.id }, payload: { owner: "user" } })
+              .pipe(Effect.ignore),
+        ),
+      ),
+      Effect.ignore,
+    );
+
+    yield* Effect.gen(function* () {
+      const session = mcp.session(identity);
+      yield* session.listTools();
+
+      const paused = yield* session.call("execute", { code: createPolicyCode(pattern) });
+      expect(paused.text, "policies.create paused for approval (annotation guard)").toContain(
+        "Execution paused",
+      );
+
+      const match = /\bexecutionId:\s*(\S+)/.exec(paused.text);
+      expect(match, "paused result carries an executionId to resume").not.toBeNull();
+      yield* session.call("resume", { executionId: match![1], action: "decline" });
+
+      const list = yield* client.policies.list();
+      expect(
+        list.some((p) => p.pattern === pattern),
+        "declined policies.create never wrote the policy",
+      ).toBe(false);
+    }).pipe(Effect.ensuring(cleanup));
+  }),
+);

--- a/packages/core/sdk/src/client.ts
+++ b/packages/core/sdk/src/client.ts
@@ -113,6 +113,19 @@ export interface IntegrationAccountHandoff {
   readonly template?: string;
   /** Non-secret connection label to prefill. */
   readonly label?: string;
+  /** Present when the agent handed off a CONFIDENTIAL OAuth-app registration
+   *  (via `oauth.clients.createHandoff`): the accounts UI opens the
+   *  Register-OAuth-app form pre-filled with these NON-secret fields, and the
+   *  human types the client secret directly into the browser. */
+  readonly oauthClient?: {
+    /** Preselected client slug; when set the form's slug is fixed. */
+    readonly slug?: string;
+    readonly grant?: string;
+    readonly clientId?: string;
+    readonly authorizationUrl?: string;
+    readonly tokenUrl?: string;
+    readonly resource?: string;
+  };
 }
 
 /** Outcome of applying an edit-sheet section's staged change. `summary` is

--- a/packages/core/sdk/src/core-tools.ts
+++ b/packages/core/sdk/src/core-tools.ts
@@ -231,6 +231,10 @@ const OAuthClientOutput = Schema.Struct({
 const OAuthClientsListOutput = Schema.Struct({
   clients: Schema.Array(OAuthClientOutput),
 });
+// No `clientSecret`: a confidential client's secret must never cross the agent
+// boundary (it would land in the LLM context window). This tool registers a
+// PUBLIC client only; a secret-bearing app is registered by the human through
+// `oauth.clients.createHandoff`, which deep-links them to the web form.
 const OAuthCreateClientInput = Schema.Struct({
   owner: OwnerSchema,
   slug: Schema.String,
@@ -238,8 +242,26 @@ const OAuthCreateClientInput = Schema.Struct({
   tokenUrl: Schema.String,
   grant: OAuthGrantSchema,
   clientId: Schema.String,
-  clientSecret: Schema.String,
   resource: Schema.optional(Schema.NullOr(Schema.String)),
+});
+// Browser-handoff for a CONFIDENTIAL OAuth app: carries only the NON-secret
+// fields the form pre-fills. The client secret is typed by the human in the web
+// UI, exactly like a pasted connection credential, so it never reaches the
+// agent. Mirrors `ConnectionCreateHandoffInput`.
+const OAuthCreateClientHandoffInput = Schema.Struct({
+  integration: Schema.String,
+  owner: Schema.optional(OwnerSchema),
+  slug: Schema.optional(Schema.String),
+  grant: Schema.optional(OAuthGrantSchema),
+  clientId: Schema.optional(Schema.String),
+  authorizationUrl: Schema.optional(Schema.String),
+  tokenUrl: Schema.optional(Schema.String),
+  resource: Schema.optional(Schema.NullOr(Schema.String)),
+  label: Schema.optional(Schema.String),
+});
+const OAuthCreateClientHandoffOutput = Schema.Struct({
+  url: Schema.String,
+  instructions: Schema.String,
 });
 const OAuthClientOutputRef = Schema.Struct({
   client: Schema.String,
@@ -321,6 +343,8 @@ const PolicyUpdateInputStd = schemaToStandard(PolicyUpdateInput);
 const PolicyRemoveInputStd = schemaToStandard(PolicyRemoveInput);
 const OAuthClientsListOutputStd = schemaToStandard(OAuthClientsListOutput);
 const OAuthCreateClientInputStd = schemaToStandard(OAuthCreateClientInput);
+const OAuthCreateClientHandoffInputStd = schemaToStandard(OAuthCreateClientHandoffInput);
+const OAuthCreateClientHandoffOutputStd = schemaToStandard(OAuthCreateClientHandoffOutput);
 const OAuthClientOutputRefStd = schemaToStandard(OAuthClientOutputRef);
 const OAuthRegisterDynamicInputStd = schemaToStandard(OAuthRegisterDynamicInput);
 const OAuthRemoveClientInputStd = schemaToStandard(OAuthRemoveClientInput);
@@ -445,6 +469,31 @@ const connectionCreateHandoffUrl = (
   return new URL(path, webBaseUrl.endsWith("/") ? webBaseUrl : `${webBaseUrl}/`).toString();
 };
 
+const oauthClientCreateHandoffUrl = (
+  webBaseUrl: string | undefined,
+  orgSlug: string | undefined,
+  input: typeof OAuthCreateClientHandoffInput.Type,
+): string => {
+  // `oauthClient=1` flips the integration's Add-account flow straight into the
+  // Register-OAuth-app form; the rest pre-fill its NON-secret fields. The client
+  // secret is deliberately absent: the human types it in the browser, so it is
+  // never placed in this URL (nor in the agent's context). Same builder shape as
+  // `connectionCreateHandoffUrl`.
+  const search = new URLSearchParams({ addAccount: "1", oauthClient: "1" });
+  if (input.owner !== undefined) search.set("owner", input.owner);
+  if (input.slug !== undefined) search.set("clientSlug", input.slug);
+  if (input.grant !== undefined) search.set("grant", input.grant);
+  if (input.clientId !== undefined) search.set("clientId", input.clientId);
+  if (input.authorizationUrl !== undefined) search.set("authorizationUrl", input.authorizationUrl);
+  if (input.tokenUrl !== undefined) search.set("tokenUrl", input.tokenUrl);
+  if (input.resource != null && input.resource.length > 0) search.set("resource", input.resource);
+  if (input.label !== undefined) search.set("label", input.label);
+  const orgPrefix = orgSlug !== undefined && orgSlug.length > 0 ? `/${orgSlug}` : "";
+  const path = `${orgPrefix}/integrations/${encodeURIComponent(input.integration)}?${search.toString()}`;
+  if (webBaseUrl === undefined || webBaseUrl.length === 0) return path;
+  return new URL(path, webBaseUrl.endsWith("/") ? webBaseUrl : `${webBaseUrl}/`).toString();
+};
+
 export interface CoreToolsPluginOptions {
   readonly webBaseUrl?: string;
   /** The bound org's URL slug, prefixed onto browser-handoff URLs so they open
@@ -526,6 +575,13 @@ export const coreToolsPlugin = definePlugin((options: CoreToolsPluginOptions = {
             'Low-level create or replace for a saved connection from provider item references. For a no-auth integration (public MCP server, public REST API), pass `template: "none"` with no `from`/`inputs` to wire it up directly. For normal API keys/tokens, use `connections.createHandoff` so the user enters the credential in the web UI. OAuth credentials should use `oauth.start`.',
           inputSchema: ConnectionCreateInputStd,
           outputSchema: ConnectionOutputStd,
+          // Creating a connection binds a credential reference and roots a new
+          // tool catalog: every tool that connection produces then becomes
+          // callable. Even the no-auth (`template: "none"`) path pulls tools
+          // from an arbitrary endpoint. Prompt-injected code could silently
+          // wire an attacker-chosen integration or credential, so this is
+          // approval-gated (the v1 `sources.configure` carried the same guard).
+          annotations: { requiresApproval: true },
           execute: (input: typeof ConnectionCreateInput.Type, { ctx }) =>
             Effect.map(
               ctx.connections.create(createConnectionInputFromTool(input)),
@@ -553,6 +609,10 @@ export const coreToolsPlugin = definePlugin((options: CoreToolsPluginOptions = {
             "Remove a saved connection and its produced tools by owner, integration, and connection name.",
           inputSchema: ConnectionRefInputStd,
           outputSchema: RemovedOutputStd,
+          // Deleting a connection drops it and every tool it produced, which
+          // prompt-injected code could use to disrupt an integration or force a
+          // re-add flow. Approval-gated, matching v1 `sources.remove`.
+          annotations: { requiresApproval: true },
           execute: (input: typeof ConnectionRefInput.Type, { ctx }) =>
             Effect.map(ctx.connections.remove(connectionRefFromInput(input)), () => ({
               removed: true,
@@ -564,6 +624,11 @@ export const coreToolsPlugin = definePlugin((options: CoreToolsPluginOptions = {
             "Re-run an integration's tool production for a saved connection, replacing that connection's persisted tools.",
           inputSchema: ConnectionRefInputStd,
           outputSchema: ConnectionsRefreshOutputStd,
+          // Refresh replaces a connection's persisted tool set; for a mutable
+          // upstream (an MCP server whose catalog can change) this can swap in
+          // different tools without confirmation. Approval-gated, matching v1
+          // `sources.refresh`.
+          annotations: { requiresApproval: true },
           execute: (input: typeof ConnectionRefInput.Type, { ctx }) =>
             Effect.map(ctx.connections.refresh(connectionRefFromInput(input)), (tools) => ({
               tools: tools.map(toolToOutput),
@@ -617,9 +682,20 @@ export const coreToolsPlugin = definePlugin((options: CoreToolsPluginOptions = {
         tool({
           name: "oauth.clients.create",
           description:
-            "Register or replace an owner-scoped OAuth client from explicit client credentials. Use grant `client_credentials` for machine OAuth or `authorization_code` for browser consent flows.",
+            "Register or replace an owner-scoped OAuth client WITHOUT a client secret: a PUBLIC client (PKCE / authorization_code) or a discovery-prefill placeholder. To register a CONFIDENTIAL client that has a secret, call `oauth.clients.createHandoff` instead so the human enters the secret in the web UI; never pass a client secret through this tool.",
           inputSchema: OAuthCreateClientInputStd,
           outputSchema: OAuthClientOutputRefStd,
+          // This persists an OAuth client and REPLACES on slug collision. It
+          // takes NO client secret: a secret would have to travel through the
+          // agent's context window, so a confidential app is registered by the
+          // human via `oauth.clients.createHandoff`. An empty secret registers a
+          // PUBLIC client. The remaining risk is the write itself: prompt-injected
+          // code could register a client with an attacker-controlled
+          // authorizationUrl/tokenUrl, then drive `oauth.start` to mint a
+          // connection and route the user's tokens to the attacker. The
+          // highest-value gate here; matches v1 `sources.bindings.set`, which
+          // guarded credential writes.
+          annotations: { requiresApproval: true },
           execute: (input: typeof OAuthCreateClientInput.Type, { ctx }) =>
             Effect.map(
               ctx.oauth.createClient({
@@ -629,11 +705,32 @@ export const coreToolsPlugin = definePlugin((options: CoreToolsPluginOptions = {
                 tokenUrl: input.tokenUrl,
                 grant: input.grant,
                 clientId: input.clientId,
-                clientSecret: input.clientSecret,
+                // No secret crosses the agent boundary; an empty secret registers
+                // a public client. Confidential clients go through
+                // `oauth.clients.createHandoff`.
+                clientSecret: "",
                 resource: input.resource ?? null,
               }),
               (client) => ({ client: String(client) }),
             ),
+        }),
+        tool({
+          name: "oauth.clients.createHandoff",
+          description:
+            "Return a browser URL that opens the Register-OAuth-app form for one integration, pre-filled with the non-secret fields (client id, endpoints, grant). Use this for any CONFIDENTIAL OAuth app: the user types the client secret directly in the web UI instead of sending it through the agent. After they register the app, call `oauth.clients.list` to discover its owner and slug, then `oauth.start`.",
+          inputSchema: OAuthCreateClientHandoffInputStd,
+          outputSchema: OAuthCreateClientHandoffOutputStd,
+          // Pure URL builder: no DB write, no token, no secret. This is the SAFE
+          // path (it routes the secret to the human in the browser), so it is
+          // deliberately NOT approval-gated, mirroring `connections.createHandoff`.
+          execute: (input: typeof OAuthCreateClientHandoffInput.Type) => {
+            const url = oauthClientCreateHandoffUrl(options.webBaseUrl, options.orgSlug, input);
+            return Effect.succeed({
+              url,
+              instructions:
+                "Ask the user to open this URL and register the OAuth app in the Executor web UI, entering the client secret there. Do not ask them to paste the client secret into chat. After they finish, call oauth.clients.list to find the registered client (owner + slug), then oauth.start.",
+            });
+          },
         }),
         tool({
           name: "oauth.clients.registerDynamic",
@@ -641,6 +738,10 @@ export const coreToolsPlugin = definePlugin((options: CoreToolsPluginOptions = {
             "Register an OAuth client through RFC 7591 Dynamic Client Registration and save the minted client for later `oauth.start` calls.",
           inputSchema: OAuthRegisterDynamicInputStd,
           outputSchema: OAuthClientOutputRefStd,
+          // Same risk class as `oauth.clients.create`: registers a client at a
+          // caller-supplied endpoint and persists the minted credentials for
+          // later `oauth.start` abuse. Approval-gated. See `oauth.clients.create`.
+          annotations: { requiresApproval: true },
           execute: (input: typeof OAuthRegisterDynamicInput.Type, { ctx }) =>
             Effect.map(
               ctx.oauth.registerDynamicClient({
@@ -668,6 +769,11 @@ export const coreToolsPlugin = definePlugin((options: CoreToolsPluginOptions = {
             "Remove an owner-scoped OAuth client by owner and slug. Existing connections are not cascaded.",
           inputSchema: OAuthRemoveClientInputStd,
           outputSchema: RemovedOutputStd,
+          // Removing a client breaks token refresh for every connection that
+          // depends on it (a silent DoS) and can force re-auth through an
+          // attacker-supplied replacement. Approval-gated, matching v1
+          // `sources.bindings.remove`.
+          annotations: { requiresApproval: true },
           execute: (input: typeof OAuthRemoveClientInput.Type, { ctx }) =>
             Effect.map(
               ctx.oauth.removeClient(input.owner as Owner, OAuthClientSlug.make(input.slug)),
@@ -696,6 +802,14 @@ export const coreToolsPlugin = definePlugin((options: CoreToolsPluginOptions = {
             "Start OAuth through a registered client to mint a connection for an integration. `client_credentials` clients return `connected`; authorization-code clients return an authorization URL and state.",
           inputSchema: OAuthStartInputStd,
           outputSchema: OAuthStartOutputStd,
+          // This is the materialization step that turns a registered client
+          // into a live connection. For `client_credentials` it completes
+          // synchronously (status `connected`) with no browser step, so a
+          // prompt-injected call against an attacker-registered client mints a
+          // credentialed connection with no human in the loop. The
+          // authorization-code path already returns a URL the user must visit,
+          // but one gate on the whole tool covers the silent path cleanly.
+          annotations: { requiresApproval: true },
           execute: (input: typeof OAuthStartInput.Type, { ctx }) =>
             Effect.map(
               ctx.oauth.start({
@@ -752,6 +866,11 @@ export const coreToolsPlugin = definePlugin((options: CoreToolsPluginOptions = {
             "Create a tool policy. `pattern` matches a tool address tail (`integration.connection.tool`, `integration.*`, `*`); `action` is approve/require_approval/block. `owner` is org (workspace guardrail) or user (personal).",
           inputSchema: PolicyCreateInputStd,
           outputSchema: PolicyOutputStd,
+          // A policy decides which tools run without confirmation, so creating
+          // one can silence every other approval gate (e.g. `approve *`). It
+          // must itself require approval, otherwise prompt-injected code could
+          // disable approvals by writing its own bypass policy.
+          annotations: { requiresApproval: true },
           execute: (input: typeof PolicyCreateInput.Type, { ctx }) =>
             Effect.map(
               ctx.core.policies.create({
@@ -773,6 +892,10 @@ export const coreToolsPlugin = definePlugin((options: CoreToolsPluginOptions = {
           description: "Update a tool policy's pattern and/or action by id + owner.",
           inputSchema: PolicyUpdateInputStd,
           outputSchema: PolicyOutputStd,
+          // Editing a policy can broaden a pattern or flip an action to
+          // `approve`, weakening an approval gate just as creation can, so it
+          // requires approval too. See `policies.create`.
+          annotations: { requiresApproval: true },
           execute: (input: typeof PolicyUpdateInput.Type, { ctx }) =>
             Effect.map(
               ctx.core.policies.update({
@@ -795,6 +918,10 @@ export const coreToolsPlugin = definePlugin((options: CoreToolsPluginOptions = {
           description: "Remove a tool policy by id + owner.",
           inputSchema: PolicyRemoveInputStd,
           outputSchema: RemovedOutputStd,
+          // Removing a policy can drop a `block` or `require_approval`
+          // guardrail, so deletion is also approval-gated. See
+          // `policies.create`.
+          annotations: { requiresApproval: true },
           execute: (input: typeof PolicyRemoveInput.Type, { ctx }) =>
             Effect.map(
               ctx.core.policies.remove({

--- a/packages/core/sdk/src/executor.test.ts
+++ b/packages/core/sdk/src/executor.test.ts
@@ -300,7 +300,7 @@ describe("createExecutor", () => {
     }),
   );
 
-  it.effect("registers and starts client-credentials OAuth through Executor tools", () =>
+  it.effect("starts a client-credentials connection through the oauth.start tool", () =>
     Effect.scoped(
       Effect.gen(function* () {
         const server = yield* serveOAuthTestServer({ scopes: ["read"] });
@@ -312,20 +312,22 @@ describe("createExecutor", () => {
         yield* executor.demo.seed();
 
         const client = OAuthClientSlug.make("demo-machine");
-        const registered = yield* executor.execute(
-          ToolAddress.make("executor.coreTools.oauth.clients.create"),
-          {
-            owner: "org",
-            slug: String(client),
-            authorizationUrl: server.authorizationEndpoint,
-            tokenUrl: server.tokenEndpoint,
-            grant: "client_credentials",
-            clientId: "test-client",
-            clientSecret: "test-secret",
-            resource: server.resourceUrl,
-          },
-        );
-        expect(registered).toEqual({ client: String(client) });
+        // A confidential client_credentials app carries a secret, so it is
+        // registered through the service layer (the browser-handoff path the web
+        // UI uses) rather than the agent-facing `oauth.clients.create` tool,
+        // which no longer accepts a client secret. The connection still starts
+        // through the `oauth.start` tool below.
+        const registered = yield* executor.oauth.createClient({
+          owner: "org",
+          slug: client,
+          authorizationUrl: server.authorizationEndpoint,
+          tokenUrl: server.tokenEndpoint,
+          grant: "client_credentials",
+          clientId: "test-client",
+          clientSecret: "test-secret",
+          resource: server.resourceUrl,
+        });
+        expect(registered).toEqual(client);
 
         const started = yield* executor.execute(
           ToolAddress.make("executor.coreTools.oauth.start"),

--- a/packages/react/src/components/add-account-modal.tsx
+++ b/packages/react/src/components/add-account-modal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useAtomSet, useAtomValue } from "@effect/atom-react";
 import * as Exit from "effect/Exit";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
@@ -48,7 +48,7 @@ import {
 } from "../plugins/use-effective-oauth-client";
 import { cn } from "../lib/utils";
 import { buildUsageMap, connectionsUsingClient } from "../lib/oauth-client-usage";
-import { OAuthClientForm } from "./oauth-client-form";
+import { OAuthClientForm, type OAuthClientFormPrefill } from "./oauth-client-form";
 import { RemoveOAuthAppDialog } from "./remove-oauth-app-dialog";
 import { AddCustomMethodForm, type CreateCustomMethod } from "./add-custom-method-modal";
 import { PlacementLine, type AuthMethod } from "../lib/auth-placements";
@@ -734,6 +734,43 @@ export function AddAccountModal(props: {
     setMethodId(initialMethod?.id ?? allMethods[0]!.id);
   }, [allMethods, initialState?.template, methodId]);
 
+  // Non-secret prefill carried by an `oauth.clients.createHandoff` deep link.
+  // The agent fills in the endpoints/grant/client id it discovered; the client
+  // secret is deliberately absent and is typed by the human in the form below.
+  const oauthClientHandoff = initialState?.oauthClient;
+  const oauthHandoffPrefill = useMemo<OAuthClientFormPrefill | undefined>(() => {
+    if (!oauthClientHandoff) return undefined;
+    const grant =
+      oauthClientHandoff.grant === "authorization_code" ||
+      oauthClientHandoff.grant === "client_credentials"
+        ? oauthClientHandoff.grant
+        : undefined;
+    return {
+      ...(oauthClientHandoff.authorizationUrl
+        ? { authorizationUrl: oauthClientHandoff.authorizationUrl }
+        : {}),
+      ...(oauthClientHandoff.tokenUrl ? { tokenUrl: oauthClientHandoff.tokenUrl } : {}),
+      ...(oauthClientHandoff.resource ? { resource: oauthClientHandoff.resource } : {}),
+      ...(grant ? { grant } : {}),
+      ...(oauthClientHandoff.clientId ? { clientId: oauthClientHandoff.clientId } : {}),
+    };
+  }, [oauthClientHandoff]);
+
+  // Jump straight into the Register-OAuth-app sub-view when the agent handed off
+  // an OAuth-app registration. Fire once per handoff key (tracked by ref) so the
+  // user can cancel back out without it springing open again; retries on later
+  // renders only while the methods list is still empty.
+  const oauthHandoffOpenedKey = useRef<string | null>(null);
+  useEffect(() => {
+    if (!initialState?.oauthClient) return;
+    if (oauthHandoffOpenedKey.current === initialState.key) return;
+    const oauthMethod = allMethods.find((m: AuthMethod) => m.kind === "oauth");
+    if (!oauthMethod) return;
+    oauthHandoffOpenedKey.current = initialState.key;
+    setMethodId(oauthMethod.id);
+    setRegisteringOAuthClient(true);
+  }, [initialState, allMethods]);
+
   const isOAuth = method?.kind === "oauth";
   const isNoAuth = method?.kind === "none";
   // The distinct credential inputs the selected method needs — one per variable
@@ -1206,11 +1243,24 @@ export function AddAccountModal(props: {
                   String(app.slug),
                 )}
                 prefill={{
-                  authorizationUrl: method.oauth?.authorizationUrl,
-                  tokenUrl: method.oauth?.tokenUrl,
+                  authorizationUrl:
+                    oauthHandoffPrefill?.authorizationUrl ?? method.oauth?.authorizationUrl,
+                  tokenUrl: oauthHandoffPrefill?.tokenUrl ?? method.oauth?.tokenUrl,
                   scopes: method.oauth?.scopes,
                   registrationEndpoint: method.oauth?.registrationEndpoint,
+                  ...(oauthHandoffPrefill?.grant ? { grant: oauthHandoffPrefill.grant } : {}),
+                  ...(oauthHandoffPrefill?.clientId
+                    ? { clientId: oauthHandoffPrefill.clientId }
+                    : {}),
+                  ...(oauthHandoffPrefill?.resource != null
+                    ? { resource: oauthHandoffPrefill.resource }
+                    : {}),
                 }}
+                fixedSlug={
+                  oauthClientHandoff?.slug != null && oauthClientHandoff.slug.length > 0
+                    ? OAuthClientSlug.make(oauthClientHandoff.slug)
+                    : undefined
+                }
                 onCreated={(result: { readonly owner: Owner; readonly slug: OAuthClientSlug }) => {
                   setPickedApp(String(result.slug));
                   setRegisteringOAuthClient(false);

--- a/packages/react/src/pages/integration-detail.tsx
+++ b/packages/react/src/pages/integration-detail.tsx
@@ -108,11 +108,32 @@ export function IntegrationDetailPage(props: { namespace: string }) {
     const owner = search.get("owner");
     const template = search.get("template");
     const label = search.get("label");
+    // `oauthClient=1` is the OAuth-app registration handoff
+    // (`oauth.clients.createHandoff`): pull the NON-secret prefill fields. The
+    // client secret is never in the URL; the human types it into the form.
+    const oauthClient = ((): IntegrationAccountHandoff["oauthClient"] => {
+      if (search.get("oauthClient") !== "1") return undefined;
+      const slug = search.get("clientSlug");
+      const grant = search.get("grant");
+      const clientId = search.get("clientId");
+      const authorizationUrl = search.get("authorizationUrl");
+      const tokenUrl = search.get("tokenUrl");
+      const resource = search.get("resource");
+      return {
+        ...(slug != null && slug.length > 0 ? { slug } : {}),
+        ...(grant != null && grant.length > 0 ? { grant } : {}),
+        ...(clientId != null && clientId.length > 0 ? { clientId } : {}),
+        ...(authorizationUrl != null && authorizationUrl.length > 0 ? { authorizationUrl } : {}),
+        ...(tokenUrl != null && tokenUrl.length > 0 ? { tokenUrl } : {}),
+        ...(resource != null && resource.length > 0 ? { resource } : {}),
+      };
+    })();
     return {
       key: locationSearch,
       ...(owner === "org" || owner === "user" ? { owner } : {}),
       ...(template != null && template.length > 0 ? { template } : {}),
       ...(label != null && label.length > 0 ? { label } : {}),
+      ...(oauthClient !== undefined ? { oauthClient } : {}),
     };
   }, [locationSearch]);
 


### PR DESCRIPTION
Confidential OAuth-app secrets now register through a browser handoff (`oauth.clients.createHandoff`) instead of crossing the agent context, and connection/oauth/policy writes are approval-gated. e2e coverage included.