### PR TITLE
Add changesets for the 1.5.18 patch release

### DIFF
--- a/.changeset/core-tools-no-auth-connections.md
+++ b/.changeset/core-tools-no-auth-connections.md
@@ -1,0 +1,9 @@
+---
+"executor": patch
+---
+
+`connections.create` now accepts no-auth connections (the `none` template with
+no credential), which previously failed validation with "Expected exactly one
+provider credential origin". Agents can wire up public, no-auth integrations
+(public MCP servers, public REST APIs) programmatically instead of bouncing
+through the web UI. Templates that take a credential still require exactly one.

--- a/.changeset/openapi-file-emit-descriptions.md
+++ b/.changeset/openapi-file-emit-descriptions.md
@@ -1,0 +1,8 @@
+---
+"executor": patch
+---
+
+OpenAPI tools that return a file now spell out how to emit it directly in the
+tool's description, so an agent sees the `emit(result.data)` contract before its
+first call instead of only discovering it after a failed attempt or by reading
+`describe.tool`. Non-file tools are unchanged.


### PR DESCRIPTION
Cuts a patch release (1.5.18) for two user-facing fixes that merged since 1.5.17 without a changeset. On merge, the release workflow opens a Version Packages PR; merging that publishes.

- **OpenAPI file-returning tools describe how to emit the file.** The `emit(result.data)` contract now rides the stored tool description, so agents see it before the first call. (#1081)
- **`connections.create` accepts no-auth connections.** Creating a `none`-template connection no longer fails validation, so public, no-auth integrations can be wired up programmatically. (#1083)

Both keyed `"executor": patch`; the fixed package group bumps to 1.5.18 with internal dependents cascading, matching how 1.5.17 was cut.