### PR TITLE
Harden Windows browser opener commands

### DIFF
--- a/apps/cli/src/device-login.test.ts
+++ b/apps/cli/src/device-login.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import { browserOpenCommand } from "./device-login";
+
+describe("browserOpenCommand", () => {
+  it("opens Windows browser URLs without cmd.exe", () => {
+    const command = browserOpenCommand(
+      "https://executor.example/login?next=a%20b&token=abc123",
+      "win32",
+    );
+
+    expect(command).toEqual([
+      "rundll32.exe",
+      ["url.dll,FileProtocolHandler", "https://executor.example/login?next=a%20b&token=abc123"],
+    ]);
+  });
+
+  it("passes the browser URL as one argument on every platform", () => {
+    expect(browserOpenCommand("https://executor.example/login?x=1&y=2", "darwin")).toEqual([
+      "open",
+      ["https://executor.example/login?x=1&y=2"],
+    ]);
+    expect(browserOpenCommand("https://executor.example/login?x=1&y=2", "linux")).toEqual([
+      "xdg-open",
+      ["https://executor.example/login?x=1&y=2"],
+    ]);
+  });
+
+  it("refuses non-browser URL schemes", () => {
+    expect(browserOpenCommand("javascript:alert(1)", "win32")).toBeUndefined();
+    expect(browserOpenCommand("file:///C:/Windows/System32/calc.exe", "win32")).toBeUndefined();
+    expect(browserOpenCommand("not a url", "win32")).toBeUndefined();
+  });
+});

--- a/apps/cli/src/device-login.ts
+++ b/apps/cli/src/device-login.ts
@@ -311,11 +311,33 @@ export const refreshDeviceTokens = async (input: {
   };
 };
 
+export type BrowserOpenCommand = readonly [command: string, args: ReadonlyArray<string>];
+
+const normalizeBrowserOpenUrl = (url: string): string | undefined => {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "http:" || parsed.protocol === "https:" ? parsed.href : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+export const browserOpenCommand = (
+  url: string,
+  platform: typeof process.platform = process.platform,
+): BrowserOpenCommand | undefined => {
+  const normalizedUrl = normalizeBrowserOpenUrl(url);
+  if (!normalizedUrl) return undefined;
+  if (platform === "darwin") return ["open", [normalizedUrl]];
+  if (platform === "win32") return ["rundll32.exe", ["url.dll,FileProtocolHandler", normalizedUrl]];
+  return ["xdg-open", [normalizedUrl]];
+};
+
 /** Best-effort open the verification URL in the user's default browser. */
 export const openBrowser = (url: string): void => {
-  const platform = process.platform;
-  const command = platform === "darwin" ? "open" : platform === "win32" ? "cmd" : "xdg-open";
-  const args = platform === "win32" ? ["/c", "start", "", url] : [url];
+  const openCommand = browserOpenCommand(url);
+  if (!openCommand) return;
+  const [command, args] = openCommand;
   try {
     const child = spawn(command, args, { stdio: "ignore", detached: true });
     // Swallow async spawn failures (e.g. the opener binary is missing), the

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -2,7 +2,6 @@
 // before any import (e.g. `@executor-js/local` → libSQL) eagerly loads them.
 import "./native-bindings";
 
-import { execFile } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { existsSync, realpathSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
@@ -2821,16 +2820,7 @@ const installCommand = Command.make(
  */
 const openInBrowser = (url: string): Effect.Effect<void> =>
   Effect.sync(() => {
-    const [cmd, args]: readonly [string, ReadonlyArray<string>] =
-      process.platform === "darwin"
-        ? ["open", [url]]
-        : process.platform === "win32"
-          ? ["cmd", ["/c", "start", "", url]]
-          : ["xdg-open", [url]];
-    // best-effort: ignore failures (e.g. no opener on headless Linux). The URL
-    // was printed above for manual open; execFile's callback absorbs the error,
-    // so there's no unhandled 'error' event to crash the CLI.
-    execFile(cmd, [...args], () => {});
+    openBrowser(url);
   });
 
 const printNoRunningLocalWebApp = (): void => {


### PR DESCRIPTION
## What changed

- Restrict automatic browser opening to HTTP and HTTPS verification URLs.
- Avoid invoking `cmd /c start` on Windows and use the shell-safe browser open path instead.
- Reuse the shared opener from CLI entry points.

## Why

A verification URL is server-controlled input. On Windows, passing it through shell command construction can turn malformed URLs into command execution.

## Validation

- `bun run --cwd apps/cli test src/device-login.test.ts`
- `bun run --cwd apps/cli typecheck`

## Stack

Base: `main`

Next: `fix/hosted-egress-dns-guard`