### PR TITLE
Add DNS checks to hosted egress guard

### DIFF
--- a/packages/core/sdk/src/hosted-http-client.test.ts
+++ b/packages/core/sdk/src/hosted-http-client.test.ts
@@ -2,7 +2,15 @@ import { describe, expect, it } from "@effect/vitest";
 import { Effect, Predicate, Result } from "effect";
 import { HttpClient, HttpClientRequest } from "effect/unstable/http";
 
-import { makeHostedHttpClientLayer, validateHostedOutboundUrl } from "./hosted-http-client";
+import {
+  type HostedHostnameResolver,
+  makeHostedHttpClientLayer,
+  validateHostedOutboundUrl,
+} from "./hosted-http-client";
+
+const publicResolver: HostedHostnameResolver = async () => [
+  { address: "93.184.216.34", family: 4 },
+];
 
 describe("hosted outbound HTTP client", () => {
   it.effect("allows public HTTP and HTTPS URLs", () =>
@@ -51,6 +59,42 @@ describe("hosted outbound HTTP client", () => {
     }),
   );
 
+  it.effect("rejects hostnames that resolve to local or private addresses", () =>
+    Effect.gen(function* () {
+      const error = yield* validateHostedOutboundUrl("https://api.example/openapi.json", {
+        resolveHostname: async () => [{ address: "10.0.0.10", family: 4 }],
+      }).pipe(Effect.flip);
+
+      expect(Predicate.isTagged(error, "HostedOutboundRequestBlocked")).toBe(true);
+    }),
+  );
+
+  it.effect("checks DNS before the first fetch call", () =>
+    Effect.gen(function* () {
+      let calls = 0;
+      const fakeFetch: typeof globalThis.fetch = (async () => {
+        calls++;
+        return new Response("unexpected", { status: 200 });
+      }) as typeof globalThis.fetch;
+
+      const result = yield* Effect.gen(function* () {
+        const client = yield* HttpClient.HttpClient;
+        return yield* client.execute(HttpClientRequest.get("https://api.example/start"));
+      }).pipe(
+        Effect.provide(
+          makeHostedHttpClientLayer({
+            fetch: fakeFetch,
+            resolveHostname: async () => [{ address: "169.254.169.254", family: 4 }],
+          }),
+        ),
+        Effect.result,
+      );
+
+      expect(Result.isFailure(result)).toBe(true);
+      expect(calls).toBe(0);
+    }),
+  );
+
   it.effect("checks redirected URLs before following them", () =>
     Effect.gen(function* () {
       let calls = 0;
@@ -68,7 +112,12 @@ describe("hosted outbound HTTP client", () => {
       const result = yield* Effect.gen(function* () {
         const client = yield* HttpClient.HttpClient;
         return yield* client.execute(HttpClientRequest.get("https://public.example/start"));
-      }).pipe(Effect.provide(makeHostedHttpClientLayer({ fetch: fakeFetch })), Effect.result);
+      }).pipe(
+        Effect.provide(
+          makeHostedHttpClientLayer({ fetch: fakeFetch, resolveHostname: publicResolver }),
+        ),
+        Effect.result,
+      );
 
       expect(Result.isFailure(result)).toBe(true);
       expect(calls).toBe(1);
@@ -110,7 +159,11 @@ describe("hosted outbound HTTP client", () => {
             }),
           ),
         );
-      }).pipe(Effect.provide(makeHostedHttpClientLayer({ fetch: fakeFetch })));
+      }).pipe(
+        Effect.provide(
+          makeHostedHttpClientLayer({ fetch: fakeFetch, resolveHostname: publicResolver }),
+        ),
+      );
 
       expect(response.status).toBe(200);
       expect(seen).toHaveLength(2);
@@ -152,7 +205,11 @@ describe("hosted outbound HTTP client", () => {
             HttpClientRequest.setHeaders({ authorization: "Bearer secret" }),
           ),
         );
-      }).pipe(Effect.provide(makeHostedHttpClientLayer({ fetch: fakeFetch })));
+      }).pipe(
+        Effect.provide(
+          makeHostedHttpClientLayer({ fetch: fakeFetch, resolveHostname: publicResolver }),
+        ),
+      );
 
       expect(response.status).toBe(200);
       expect(seen).toHaveLength(2);
@@ -181,7 +238,12 @@ describe("hosted outbound HTTP client", () => {
       const result = yield* Effect.gen(function* () {
         const client = yield* HttpClient.HttpClient;
         return yield* client.execute(HttpClientRequest.get("https://api.example/start"));
-      }).pipe(Effect.provide(makeHostedHttpClientLayer({ fetch: fakeFetch })), Effect.result);
+      }).pipe(
+        Effect.provide(
+          makeHostedHttpClientLayer({ fetch: fakeFetch, resolveHostname: publicResolver }),
+        ),
+        Effect.result,
+      );
 
       expect(Result.isFailure(result)).toBe(true);
       expect(calls).toBe(1);

--- a/packages/core/sdk/src/hosted-http-client.ts
+++ b/packages/core/sdk/src/hosted-http-client.ts
@@ -9,10 +9,20 @@ export class HostedOutboundRequestBlocked extends Schema.TaggedErrorClass<Hosted
   },
 ) {}
 
+export interface HostedResolvedAddress {
+  readonly address: string;
+  readonly family?: 4 | 6;
+}
+
+export type HostedHostnameResolver = (
+  hostname: string,
+) => Promise<ReadonlyArray<HostedResolvedAddress>>;
+
 export interface HostedHttpClientOptions {
   readonly allowLocalNetwork?: boolean;
   readonly maxRedirects?: number;
   readonly fetch?: typeof globalThis.fetch;
+  readonly resolveHostname?: HostedHostnameResolver;
 }
 
 const parseIpv4 = (hostname: string): readonly [number, number, number, number] | null => {
@@ -58,13 +68,37 @@ const parseIpv4MappedIpv6 = (
   return [high >> 8, high & 0xff, low >> 8, low & 0xff];
 };
 
-const isPrivateIpv4 = ([a, b]: readonly [number, number, number, number]): boolean =>
+const isBlockedIpv4 = ([a, b]: readonly [number, number, number, number]): boolean =>
   a === 0 ||
   a === 10 ||
   a === 127 ||
+  (a === 100 && b >= 64 && b <= 127) ||
   (a === 169 && b === 254) ||
   (a === 172 && b >= 16 && b <= 31) ||
-  (a === 192 && b === 168);
+  (a === 192 && b === 0) ||
+  (a === 192 && b === 168) ||
+  (a === 198 && (b === 18 || b === 19)) ||
+  a >= 224;
+
+const isBlockedIpv6 = (hostname: string): boolean => {
+  const normalized = hostname.toLowerCase();
+  if (
+    normalized === "::" ||
+    normalized === "::1" ||
+    normalized === "0:0:0:0:0:0:0:0" ||
+    normalized === "0:0:0:0:0:0:0:1"
+  ) {
+    return true;
+  }
+  const firstWordText = normalized.split(":").find((part) => part.length > 0);
+  if (!firstWordText || !/^[0-9a-f]{1,4}$/.test(firstWordText)) return false;
+  const firstWord = Number.parseInt(firstWordText, 16);
+  return (
+    (firstWord & 0xffc0) === 0xfe80 ||
+    (firstWord & 0xfe00) === 0xfc00 ||
+    (firstWord & 0xff00) === 0xff00
+  );
+};
 
 const isBlockedMetadataHostname = (hostname: string): boolean => {
   const normalized = hostname.toLowerCase();
@@ -80,15 +114,24 @@ const isLocalOrPrivateHostname = (hostname: string): boolean => {
   const normalized = hostname.toLowerCase().replace(/^\[|\]$/g, "");
   if (normalized === "localhost" || normalized.endsWith(".localhost")) return true;
   const ipv4 = parseIpv4(normalized);
-  if (ipv4) return isPrivateIpv4(ipv4);
+  if (ipv4) return isBlockedIpv4(ipv4);
   const mappedIpv4 = parseIpv4MappedIpv6(normalized);
-  if (mappedIpv4) return isPrivateIpv4(mappedIpv4);
-  return (
-    normalized === "::1" ||
-    normalized.startsWith("fe80:") ||
-    normalized.startsWith("fc") ||
-    normalized.startsWith("fd")
-  );
+  if (mappedIpv4) return isBlockedIpv4(mappedIpv4);
+  return isBlockedIpv6(normalized);
+};
+
+const isAddressLiteral = (hostname: string): boolean => {
+  const normalized = hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  return parseIpv4(normalized) !== null || /^[0-9a-f:.]+$/i.test(normalized);
+};
+
+const resolveHostnameWithNodeDns: HostedHostnameResolver = async (hostname) => {
+  const { lookup } = await import("node:dns/promises");
+  const addresses = await lookup(hostname, { all: true, verbatim: true });
+  return addresses.map(({ address, family }) => ({
+    address,
+    family: family === 6 ? 6 : 4,
+  }));
 };
 
 export const validateHostedOutboundUrl = (
@@ -125,6 +168,34 @@ export const validateHostedOutboundUrl = (
         reason: "Local and private network addresses are not allowed",
       });
     }
+
+    const normalizedHostname = url.hostname.toLowerCase().replace(/^\[|\]$/g, "");
+    if (!options.allowLocalNetwork && options.resolveHostname && !isAddressLiteral(url.hostname)) {
+      const addresses = yield* Effect.tryPromise({
+        try: () => options.resolveHostname!(normalizedHostname),
+        catch: () =>
+          new HostedOutboundRequestBlocked({
+            url: value,
+            reason: "Hostname could not be resolved",
+          }),
+      });
+
+      if (addresses.length === 0) {
+        return yield* new HostedOutboundRequestBlocked({
+          url: value,
+          reason: "Hostname did not resolve to an address",
+        });
+      }
+
+      for (const { address } of addresses) {
+        if (isLocalOrPrivateHostname(address)) {
+          return yield* new HostedOutboundRequestBlocked({
+            url: value,
+            reason: "Resolved address is local or private",
+          });
+        }
+      }
+    }
   });
 
 const CREDENTIAL_HEADERS = ["authorization", "proxy-authorization", "cookie"] as const;
@@ -140,12 +211,16 @@ const guardFetch = (
   options: HostedHttpClientOptions,
 ): typeof globalThis.fetch =>
   (async (input, init) => {
+    const guardOptions = {
+      ...options,
+      resolveHostname: options.resolveHostname ?? resolveHostnameWithNodeDns,
+    };
     const maxRedirects = options.maxRedirects ?? 10;
     let current: Parameters<typeof globalThis.fetch>[0] | URL = input;
     let currentInit = init;
     for (let redirects = 0; redirects <= maxRedirects; redirects++) {
       const url = current instanceof Request ? current.url : String(current);
-      Effect.runSync(validateHostedOutboundUrl(url, options));
+      await Effect.runPromise(validateHostedOutboundUrl(url, guardOptions));
       const response = await underlying(current, {
         ...currentInit,
         redirect: "manual",


### PR DESCRIPTION
## What changed

- Resolve hostnames before hosted outbound requests.
- Block loopback, private, link-local, metadata, reserved, multicast, and other non-public DNS results.
- Keep the resolver injectable so tests can pin DNS-rebinding cases.

## Why

The hosted egress guard blocked obvious literal private hosts, but a public-looking hostname could resolve to private infrastructure at request time.

## Validation

- `bun --bun vitest run src/hosted-http-client.test.ts` from `packages/core/sdk`
- `bun run --cwd packages/core/sdk typecheck`

## Stack

Base: `fix/windows-safe-browser-open`

Previous: #1099

Next: `fix/oauth-hosted-egress-guard`