### PR TITLE
Route OAuth token HTTP through hosted egress guard

### DIFF
--- a/packages/core/api/src/server/scoped-executor.ts
+++ b/packages/core/api/src/server/scoped-executor.ts
@@ -41,7 +41,7 @@ import {
   type Executor,
   type StorageFailure,
 } from "@executor-js/sdk";
-import { makeHostedHttpClientLayer } from "@executor-js/sdk/host-internal";
+import { makeHostedFetch, makeHostedHttpClientLayer } from "@executor-js/sdk/host-internal";
 
 import { DbProvider } from "./executor-fuma-db";
 
@@ -241,9 +241,11 @@ export const makeScopedExecutor = <
     });
 
     const plugins = pluginsFactory();
-    const httpClientLayer = makeHostedHttpClientLayer({
+    const hostedHttpOptions = {
       allowLocalNetwork: config.allowLocalNetwork,
-    });
+    };
+    const httpClientLayer = makeHostedHttpClientLayer(hostedHttpOptions);
+    const hostedFetch = makeHostedFetch(hostedHttpOptions);
 
     // The org id is the tenant (catalog partition); the account id is the acting
     // subject (drives `owner: "user"` rows). `organizationName` is no longer part
@@ -255,6 +257,7 @@ export const makeScopedExecutor = <
       blobs,
       plugins,
       httpClientLayer,
+      fetch: hostedFetch,
       onElicitation: "accept-all",
       redirectUri,
       coreTools: {

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -358,6 +358,11 @@ export interface ExecutorConfig<TPlugins extends readonly AnyPlugin[] = readonly
   readonly onElicitation: OnElicitation;
   readonly httpClientLayer?: Layer.Layer<HttpClient.HttpClient>;
   /**
+   * Fetch API implementation for dependencies that cannot consume `httpClientLayer`.
+   * Prefer `httpClientLayer` for normal SDK and plugin HTTP.
+   */
+  readonly fetch?: typeof globalThis.fetch;
+  /**
    * The OAuth callback URL (`${webBaseUrl}/oauth/callback`) the host serves and
    * sends to providers. There is NO localhost default: omit it (or pass
    * undefined) only for executors that never run interactive OAuth — the
@@ -1455,6 +1460,7 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
                 scopes: grantedScopes,
                 resource: clientRow.resource ? String(clientRow.resource) : undefined,
                 endpointUrlPolicy: config.oauthEndpointUrlPolicy,
+                fetch: config.fetch,
               }).pipe(
                 // A client_credentials failure is never a rotated-refresh-token
                 // problem, so do NOT map invalid_grant → reauth. Surface as a
@@ -1487,6 +1493,7 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
                   // (MCP servers require this on refresh).
                   resource: clientRow.resource ? String(clientRow.resource) : undefined,
                   endpointUrlPolicy: config.oauthEndpointUrlPolicy,
+                  fetch: config.fetch,
                 }).pipe(
                   Effect.mapError((cause) =>
                     cause.error === "invalid_grant"
@@ -3079,6 +3086,7 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
           }),
         ),
       httpClientLayer: config.httpClientLayer,
+      fetch: config.fetch,
       endpointUrlPolicy: config.oauthEndpointUrlPolicy,
       // EXPLICIT — no localhost default. When a caller omits `redirectUri` the
       // OAuth service receives `null` and redirect-requiring flows fail loudly

--- a/packages/core/sdk/src/host-internal.ts
+++ b/packages/core/sdk/src/host-internal.ts
@@ -6,10 +6,12 @@
 // exists so the host layer (`@executor-js/api/server`) can reach SDK-resident
 // host machinery without that machinery polluting the plugin-author surface:
 //
-//   - `makeHostedHttpClientLayer` / `HostedOutboundRequestBlocked`: the hosted
-//     HTTP client builder. `validateHostedOutboundUrl` is consumed by
-//     `createExecutor`'s built-in `fetch` tool (the SSRF guard), which is why
-//     the module stays in the SDK rather than moving wholesale to the host.
+//   - `makeHostedHttpClientLayer` / `makeHostedFetch` /
+//     `HostedOutboundRequestBlocked`: the hosted HTTP client builder plus the
+//     guarded Fetch API adapter for libraries that require fetch. The shared
+//     outbound URL guard is consumed by `createExecutor`'s built-in `fetch` tool
+//     (the SSRF guard), which is why the module stays in the SDK rather than
+//     moving wholesale to the host.
 //   - `createExecutorFumaDb` + its types: the pure, driver-agnostic FumaDB
 //     assembly. It stays in the SDK because the SDK's own sqlite test backend
 //     builds its handle with it; the host layer re-exports it (and pairs it
@@ -22,6 +24,7 @@
 
 export {
   HostedOutboundRequestBlocked,
+  makeHostedFetch,
   makeHostedHttpClientLayer,
   type HostedHttpClientOptions,
 } from "./hosted-http-client";

--- a/packages/core/sdk/src/hosted-http-client.test.ts
+++ b/packages/core/sdk/src/hosted-http-client.test.ts
@@ -4,6 +4,7 @@ import { HttpClient, HttpClientRequest } from "effect/unstable/http";
 
 import {
   type HostedHostnameResolver,
+  makeHostedFetch,
   makeHostedHttpClientLayer,
   validateHostedOutboundUrl,
 } from "./hosted-http-client";
@@ -94,6 +95,22 @@ describe("hosted outbound HTTP client", () => {
       expect(calls).toBe(0);
     }),
   );
+
+  it("applies the DNS guard to fetch callers", async () => {
+    let calls = 0;
+    const hostedFetch = makeHostedFetch({
+      fetch: (async () => {
+        calls++;
+        return new Response("unexpected", { status: 200 });
+      }) as typeof globalThis.fetch,
+      resolveHostname: async () => [{ address: "10.0.0.20", family: 4 }],
+    });
+
+    await expect(hostedFetch("https://api.example/token")).rejects.toMatchObject({
+      _tag: "HostedOutboundRequestBlocked",
+    });
+    expect(calls).toBe(0);
+  });
 
   it.effect("checks redirected URLs before following them", () =>
     Effect.gen(function* () {

--- a/packages/core/sdk/src/hosted-http-client.ts
+++ b/packages/core/sdk/src/hosted-http-client.ts
@@ -246,6 +246,10 @@ const guardFetch = (
     return await underlying(current, { ...currentInit, redirect: "manual" });
   }) as typeof globalThis.fetch;
 
+export const makeHostedFetch = (options: HostedHttpClientOptions = {}): typeof globalThis.fetch =>
+  // oxlint-disable-next-line executor/no-raw-fetch -- boundary: exposes a guarded Fetch API adapter for libraries that require fetch
+  guardFetch(options.fetch ?? globalThis.fetch, options);
+
 export const makeHostedHttpClientLayer = (
   options: HostedHttpClientOptions = {},
 ): Layer.Layer<HttpClient.HttpClient> =>

--- a/packages/core/sdk/src/oauth-helpers.test.ts
+++ b/packages/core/sdk/src/oauth-helpers.test.ts
@@ -608,6 +608,49 @@ describe("exchangeAuthorizationCode", () => {
 });
 
 describe("exchangeClientCredentials", () => {
+  it.effect("routes token grant requests through the injected fetch", () =>
+    withTokenEndpoint(tokenResponse(validRefreshBody), ({ tokenUrl }) =>
+      Effect.gen(function* () {
+        const seen: Array<{ url: string; method: string | undefined }> = [];
+        const customFetch: typeof globalThis.fetch = (async (input, init) => {
+          seen.push({
+            url: input instanceof Request ? input.url : String(input),
+            method: init?.method,
+          });
+          // oxlint-disable-next-line executor/no-raw-fetch -- boundary: test fetch adapter delegates to the local token endpoint
+          return fetch(input, init);
+        }) as typeof globalThis.fetch;
+
+        yield* exchangeAuthorizationCode({
+          tokenUrl,
+          clientId: "cid",
+          redirectUrl: "https://app.example.com/cb",
+          codeVerifier: "verifier",
+          code: "abc",
+          fetch: customFetch,
+        });
+        yield* exchangeClientCredentials({
+          tokenUrl,
+          clientId: "cid",
+          clientSecret: "secret",
+          fetch: customFetch,
+        });
+        yield* refreshAccessToken({
+          tokenUrl,
+          clientId: "cid",
+          refreshToken: "old",
+          fetch: customFetch,
+        });
+
+        expect(seen).toEqual([
+          { url: tokenUrl, method: "POST" },
+          { url: tokenUrl, method: "POST" },
+          { url: tokenUrl, method: "POST" },
+        ]);
+      }),
+    ),
+  );
+
   it.effect("rejects unsupported token URL schemes before exchange", () =>
     Effect.gen(function* () {
       const exit = yield* Effect.exit(

--- a/packages/core/sdk/src/oauth-helpers.ts
+++ b/packages/core/sdk/src/oauth-helpers.ts
@@ -417,10 +417,14 @@ const oauth4webapiRequestOptions = (
   targetUrl: string,
   timeoutMs: number | undefined,
   endpointUrlPolicy: OAuthEndpointUrlPolicy = {},
+  customFetch?: typeof globalThis.fetch,
 ): Record<string, unknown> => {
   const options: Record<string, unknown> = {
     signal: AbortSignal.timeout(timeoutMs ?? OAUTH2_DEFAULT_TIMEOUT_MS),
   };
+  if (customFetch) {
+    (options as { [oauth.customFetch]?: typeof globalThis.fetch })[oauth.customFetch] = customFetch;
+  }
   if (
     isLoopbackHttpUrl(targetUrl) ||
     (URL.canParse(targetUrl) &&
@@ -510,6 +514,7 @@ export type ExchangeAuthorizationCodeInput = {
   readonly resource?: string;
   readonly timeoutMs?: number;
   readonly endpointUrlPolicy?: OAuthEndpointUrlPolicy;
+  readonly fetch?: typeof globalThis.fetch;
 };
 
 export const exchangeAuthorizationCode = (
@@ -545,7 +550,12 @@ export const exchangeAuthorizationCode = (
         clientAuth,
         "authorization_code",
         params,
-        oauth4webapiRequestOptions(input.tokenUrl, input.timeoutMs, input.endpointUrlPolicy),
+        oauth4webapiRequestOptions(
+          input.tokenUrl,
+          input.timeoutMs,
+          input.endpointUrlPolicy,
+          input.fetch,
+        ),
       );
       return await processTokenEndpointResponse(as, client, response);
     },
@@ -568,6 +578,7 @@ export type ExchangeClientCredentialsInput = {
   readonly resource?: string;
   readonly timeoutMs?: number;
   readonly endpointUrlPolicy?: OAuthEndpointUrlPolicy;
+  readonly fetch?: typeof globalThis.fetch;
 };
 
 export const exchangeClientCredentials = (
@@ -593,7 +604,12 @@ export const exchangeClientCredentials = (
         client,
         clientAuth,
         params,
-        oauth4webapiRequestOptions(input.tokenUrl, input.timeoutMs, input.endpointUrlPolicy),
+        oauth4webapiRequestOptions(
+          input.tokenUrl,
+          input.timeoutMs,
+          input.endpointUrlPolicy,
+          input.fetch,
+        ),
       );
       const result = await oauth.processClientCredentialsResponse(as, client, response);
       return tokenResponseFrom(result);
@@ -621,6 +637,7 @@ export type RefreshAccessTokenInput = {
   readonly resource?: string;
   readonly timeoutMs?: number;
   readonly endpointUrlPolicy?: OAuthEndpointUrlPolicy;
+  readonly fetch?: typeof globalThis.fetch;
 };
 
 export const refreshAccessToken = (
@@ -652,7 +669,12 @@ export const refreshAccessToken = (
         clientAuth,
         input.refreshToken,
         {
-          ...oauth4webapiRequestOptions(input.tokenUrl, input.timeoutMs, input.endpointUrlPolicy),
+          ...oauth4webapiRequestOptions(
+            input.tokenUrl,
+            input.timeoutMs,
+            input.endpointUrlPolicy,
+            input.fetch,
+          ),
           additionalParameters,
         },
       );

--- a/packages/core/sdk/src/oauth-service.ts
+++ b/packages/core/sdk/src/oauth-service.ts
@@ -132,6 +132,7 @@ export interface OAuthServiceDeps {
     template: AuthTemplateSlug,
   ) => Effect.Effect<readonly string[], StorageFailure>;
   readonly httpClientLayer?: Layer.Layer<HttpClient.HttpClient>;
+  readonly fetch?: typeof globalThis.fetch;
   readonly endpointUrlPolicy?: OAuthEndpointUrlPolicy;
   /**
    * The OAuth callback URL (`${webBaseUrl}${mountPrefix}/oauth/callback`) the host
@@ -341,6 +342,7 @@ const validateClientEndpoints = (
 
 export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
   const httpClientLayer = deps.httpClientLayer ?? FetchHttpClient.layer;
+  const fetch = deps.fetch;
   // EXPLICIT — no localhost default. `null` means this executor has no OAuth
   // callback; redirect-requiring flows fail loudly via `requireRedirectUri`.
   const redirectUri = deps.redirectUri;
@@ -678,6 +680,7 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
           scopes: requestedScopes,
           resource: client.resource ?? undefined,
           endpointUrlPolicy: deps.endpointUrlPolicy,
+          fetch,
         }).pipe(
           Effect.mapError(
             (cause) =>
@@ -854,6 +857,7 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
         code: input.code,
         resource: client.resource ?? undefined,
         endpointUrlPolicy: deps.endpointUrlPolicy,
+        fetch,
       }).pipe(
         Effect.mapError(
           (cause) =>


### PR DESCRIPTION
## What changed

- Add a shared hosted Fetch API adapter for libraries that require fetch, using the same hosted outbound URL guard as the hosted HttpClient layer.
- Pass that adapter into `createExecutor` as the generic `fetch` boundary while normal SDK and plugin HTTP stays on `httpClientLayer`.
- Route OAuth token exchange, client-credentials, and refresh requests through that guarded fetch boundary.

## Why

OAuth4WebAPI requires a fetch-compatible hook for token endpoint calls. Hosted executors need that forced boundary to use the same private-network guard as the rest of hosted outbound HTTP.

## Validation

- `bun --bun vitest run src/oauth-helpers.test.ts src/oauth-flow.test.ts src/hosted-http-client.test.ts` from `packages/core/sdk`
- `bun --bun run typecheck` from `packages/core/sdk`
- `bun --bun run typecheck` from `packages/core/api`

## Stack

Base: `fix/hosted-egress-dns-guard`

Previous: #1100

Next: `fix/mcp-hosted-egress-guard`