### PR TITLE
Route MCP transports through the hosted HttpClient

### DIFF
--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -1920,6 +1920,7 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
           .resolveTools({
             integration: rowToIntegration(integrationRow),
             config: decodeJsonColumn(integrationRow.config),
+            httpClientLayer: runtime.ctx.httpClientLayer,
             connection: ref,
             template: existingRow ? AuthTemplateSlug.make(existingRow.template) : null,
             storage: runtime.storage,

--- a/packages/core/sdk/src/plugin.ts
+++ b/packages/core/sdk/src/plugin.ts
@@ -211,6 +211,7 @@ export interface ResolveToolsInput<TStore = unknown> {
    *  facades (e.g. a content-addressed spec blob) instead of inlining them
    *  in `config`. */
   readonly storage: TStore;
+  readonly httpClientLayer: Layer.Layer<HttpClient.HttpClient>;
   /** The connection whose tools are being resolved. */
   readonly connection: ConnectionRef;
   /** Which of the integration's declared auth methods the connection binds

--- a/packages/plugins/mcp/src/sdk/connection.ts
+++ b/packages/plugins/mcp/src/sdk/connection.ts
@@ -2,8 +2,10 @@ import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import type { FetchLike } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { CfWorkerJsonSchemaValidator } from "@modelcontextprotocol/sdk/validation/cfworker";
-import { Effect, Predicate } from "effect";
+import { Effect, Layer, Predicate, Stream } from "effect";
+import { HttpClient, HttpClientRequest } from "effect/unstable/http";
 
 // NOTE: `StdioClientTransport` is NOT imported eagerly. The upstream module
 // (`@modelcontextprotocol/sdk/client/stdio.js`) touches `node:child_process`
@@ -42,6 +44,7 @@ export type RemoteConnectorInput = Omit<
   readonly headers?: Record<string, string>;
   readonly queryParams?: Record<string, string>;
   readonly authProvider?: OAuthClientProvider;
+  readonly httpClientLayer?: Layer.Layer<HttpClient.HttpClient>;
 };
 
 export type StdioConnectorInput = McpStdioIntegrationConfig;
@@ -58,6 +61,100 @@ const buildEndpointUrl = (endpoint: string, queryParams: Record<string, string>)
     url.searchParams.set(key, value);
   }
   return url;
+};
+
+type HttpMethod = Parameters<typeof HttpClientRequest.make>[0];
+const HTTP_METHODS = new Set<HttpMethod>([
+  "DELETE",
+  "GET",
+  "HEAD",
+  "OPTIONS",
+  "PATCH",
+  "POST",
+  "PUT",
+]);
+
+const httpMethodFrom = (method: string | undefined): HttpMethod => {
+  const normalized = (method ?? "GET").toUpperCase() as HttpMethod;
+  return HTTP_METHODS.has(normalized) ? normalized : "POST";
+};
+
+const headersFrom = (headers: HeadersInit | undefined): Headers =>
+  headers ? new Headers(headers) : new Headers();
+
+const recordFromHeaders = (headers: Headers): Record<string, string> =>
+  Object.fromEntries(headers.entries());
+
+const applyBody = async (
+  request: HttpClientRequest.HttpClientRequest,
+  headers: Headers,
+  body: BodyInit | null | undefined,
+): Promise<HttpClientRequest.HttpClientRequest> => {
+  if (body == null) return request;
+  const contentType = headers.get("content-type") ?? undefined;
+  if (typeof body === "string") return HttpClientRequest.bodyText(request, body, contentType);
+  if (body instanceof URLSearchParams) {
+    return HttpClientRequest.bodyText(
+      request,
+      body.toString(),
+      contentType ?? "application/x-www-form-urlencoded;charset=UTF-8",
+    );
+  }
+  if (body instanceof Uint8Array)
+    return HttpClientRequest.bodyUint8Array(request, body, contentType);
+  if (body instanceof ArrayBuffer) {
+    return HttpClientRequest.bodyUint8Array(request, new Uint8Array(body), contentType);
+  }
+  const bytes = new Uint8Array(await new Response(body).arrayBuffer());
+  return HttpClientRequest.bodyUint8Array(request, bytes, contentType);
+};
+
+const abortError = (signal: AbortSignal): unknown => {
+  if (signal.reason !== undefined) return signal.reason;
+  // oxlint-disable-next-line executor/no-error-constructor -- boundary: Fetch-compatible adapter must reject with an AbortError-shaped value
+  const error = new Error("The operation was aborted");
+  error.name = "AbortError";
+  return error;
+};
+
+const fetchFromHttpClientLayer = (
+  httpClientLayer: Layer.Layer<HttpClient.HttpClient>,
+): FetchLike => {
+  const execute: FetchLike = async (url, init) => {
+    const headers = headersFrom(init?.headers);
+    const requestWithoutBody = HttpClientRequest.make(httpMethodFrom(init?.method))(url, {
+      headers: recordFromHeaders(headers),
+    });
+    const request = await applyBody(requestWithoutBody, headers, init?.body);
+    const effect = Effect.gen(function* () {
+      const client = yield* HttpClient.HttpClient;
+      const response = yield* client.execute(request);
+      const responseHeaders = new Headers();
+      for (const [key, value] of Object.entries(response.headers)) {
+        if (value !== undefined) responseHeaders.set(key, value);
+      }
+      const body =
+        response.status === 204 || response.status === 205 || response.status === 304
+          ? null
+          : Stream.toReadableStream(response.stream);
+      return new Response(body, {
+        status: response.status,
+        headers: responseHeaders,
+      });
+    }).pipe(Effect.provide(httpClientLayer));
+    const promise = Effect.runPromise(effect);
+    if (!init?.signal) return promise;
+    // oxlint-disable-next-line executor/no-promise-reject -- boundary: Fetch-compatible adapter mirrors abort rejection semantics
+    if (init.signal.aborted) return Promise.reject(abortError(init.signal));
+    const aborted = new Promise<never>((_, reject) => {
+      // oxlint-disable-next-line executor/no-promise-reject -- boundary: Fetch-compatible adapter races the Effect request against AbortSignal
+      init.signal?.addEventListener("abort", () => reject(abortError(init.signal!)), {
+        once: true,
+      });
+    });
+    return Promise.race([promise, aborted]);
+  };
+  return execute;
 };
 
 // Use the cfworker JSON Schema validator instead of the SDK's default
@@ -157,6 +254,7 @@ export const createMcpConnector = (input: ConnectorInput): McpConnector => {
   const headers = input.headers ?? {};
   const remoteTransport = input.remoteTransport ?? "auto";
   const requestInit = Object.keys(headers).length > 0 ? { headers } : undefined;
+  const fetch = input.httpClientLayer ? fetchFromHttpClientLayer(input.httpClientLayer) : undefined;
 
   const endpoint = buildEndpointUrl(input.endpoint, input.queryParams ?? {});
 
@@ -166,6 +264,7 @@ export const createMcpConnector = (input: ConnectorInput): McpConnector => {
       new StreamableHTTPClientTransport(endpoint, {
         requestInit,
         authProvider: input.authProvider,
+        fetch,
       }),
   });
 
@@ -175,6 +274,7 @@ export const createMcpConnector = (input: ConnectorInput): McpConnector => {
       new SSEClientTransport(endpoint, {
         requestInit,
         authProvider: input.authProvider,
+        fetch,
       }),
   });
 

--- a/packages/plugins/mcp/src/sdk/plugin.test.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "@effect/vitest";
-import { Effect, Option, Predicate, Schema } from "effect";
-import { HttpServerResponse } from "effect/unstable/http";
+import { Effect, Layer, Option, Predicate, Schema } from "effect";
+import {
+  HttpClient,
+  HttpClientRequest,
+  HttpClientResponse,
+  HttpServerResponse,
+} from "effect/unstable/http";
 
 import {
   AuthTemplateSlug,
@@ -17,6 +22,7 @@ import {
   serveTestHttpApp,
 } from "@executor-js/sdk/testing";
 
+import { createMcpConnector } from "./connection";
 import { mcpPlugin, userFacingProbeMessage } from "./plugin";
 import { McpInvocationError } from "./errors";
 import { extractManifestFromListToolsResult, deriveMcpNamespace, joinToolPath } from "./manifest";
@@ -296,6 +302,30 @@ describe("mcpPlugin", () => {
       expect(executor.mcp.probeEndpoint).toBeTypeOf("function");
       expect(executor.oauth.start).toBeTypeOf("function");
       expect(executor.oauth.complete).toBeTypeOf("function");
+    }),
+  );
+
+  it.effect("routes remote connector traffic through the provided HttpClient layer", () =>
+    Effect.gen(function* () {
+      const seen: string[] = [];
+      const httpClientLayer = Layer.succeed(HttpClient.HttpClient)(
+        HttpClient.make((request: HttpClientRequest.HttpClientRequest) => {
+          seen.push(request.url);
+          return Effect.succeed(
+            HttpClientResponse.fromWeb(request, new Response("blocked", { status: 403 })),
+          );
+        }),
+      );
+
+      const error = yield* createMcpConnector({
+        transport: "remote",
+        endpoint: "https://internal.example/mcp",
+        remoteTransport: "streamable-http",
+        httpClientLayer,
+      }).pipe(Effect.flip);
+
+      expect(Predicate.isTagged(error, "McpConnectionError")).toBe(true);
+      expect(seen).toEqual(["https://internal.example/mcp"]);
     }),
   );
 

--- a/packages/plugins/mcp/src/sdk/plugin.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.ts
@@ -469,6 +469,7 @@ const buildConnectorInput = (
   values: Record<string, string | null>,
   templateSlug: string | null,
   allowStdio: boolean,
+  httpClientLayer?: Layer.Layer<HttpClient.HttpClient>,
 ): Effect.Effect<ConnectorInput, McpConnectionError> => {
   if (config.transport === "stdio") {
     if (!allowStdio) {
@@ -512,6 +513,7 @@ const buildConnectorInput = (
     queryParams: Object.keys(queryParams).length > 0 ? queryParams : undefined,
     headers: Object.keys(headers).length > 0 ? headers : undefined,
     authProvider,
+    httpClientLayer,
   });
 };
 
@@ -636,6 +638,7 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
             endpoint: trimmed,
             headers: probeHeaders,
             queryParams: probeQueryParams,
+            httpClientLayer,
           });
 
           const result = yield* discoverTools(connector).pipe(
@@ -929,7 +932,7 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
     // Discovery failures (auth not ready, server down) yield an empty tool set
     // rather than failing — the connection still lands and can be refreshed.
     // -----------------------------------------------------------------------
-    resolveTools: ({ config, connection, template, getValues }) =>
+    resolveTools: ({ config, connection, template, getValues, httpClientLayer }) =>
       Effect.gen(function* () {
         const parsed = parseMcpIntegrationConfig(config);
         if (!parsed) return { tools: [] as readonly ToolDef[] };
@@ -945,6 +948,7 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
           values,
           template === null ? null : String(template),
           allowStdio,
+          httpClientLayer,
         ).pipe(
           Effect.map((ci) => createMcpConnector(ci)),
           Effect.result,
@@ -968,7 +972,7 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
         }),
       ) as Effect.Effect<{ readonly tools: readonly ToolDef[] }, StorageFailure>,
 
-    invokeTool: ({ toolRow, credential, args, elicit }) =>
+    invokeTool: ({ ctx, toolRow, credential, args, elicit }) =>
       Effect.gen(function* () {
         const parsed = parseMcpIntegrationConfig(credential.config);
         if (!parsed) {
@@ -1013,6 +1017,7 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
           credential.values,
           String(credential.template),
           allowStdio,
+          options?.httpClientLayer ?? ctx.httpClientLayer,
         ).pipe(Effect.map((ci) => createMcpConnector(ci)));
 
         const raw = yield* invokeMcpTool({
@@ -1087,7 +1092,11 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
         const name = parsed.value.hostname || "mcp";
         const slug = deriveMcpNamespace({ endpoint: trimmed });
 
-        const connector = createMcpConnector({ transport: "remote", endpoint: trimmed });
+        const connector = createMcpConnector({
+          transport: "remote",
+          endpoint: trimmed,
+          httpClientLayer,
+        });
 
         const connected = yield* discoverTools(connector).pipe(
           Effect.map(() => true),

--- a/packages/plugins/openapi/src/sdk/spec-blob.test.ts
+++ b/packages/plugins/openapi/src/sdk/spec-blob.test.ts
@@ -161,6 +161,7 @@ describe("OpenAPI plugin — spec blob storage", () => {
           },
           template: null,
           storage,
+          httpClientLayer: FetchHttpClient.layer,
           getValue: () => Effect.succeed(null),
           getValues: () => Effect.succeed({}),
         });


### PR DESCRIPTION
## What changed

- Add an internal fetch adapter for MCP SSE and streamable HTTP transports that is backed by the executor `HttpClient` layer.
- Thread the executor HTTP layer through MCP probe, detect, resolveTools, and invoke paths.
- Extend the SDK resolve-tools input so plugins can receive the guarded layer consistently.

## Why

Remote MCP setup and invocation created upstream MCP transports directly, bypassing hosted outbound egress policy.

## Validation

- `bun --bun vitest run src/sdk/plugin.test.ts src/sdk/invoke.test.ts src/sdk/probe-shape.test.ts` from `packages/plugins/mcp`
- `bun run --cwd packages/plugins/mcp typecheck`
- `bun run --cwd packages/core/sdk typecheck`

## Stack

Base: `fix/oauth-hosted-egress-guard`

Previous: #1101

Next: `fix/graphql-hosted-egress-guard`