### PR TITLE
Constrain OpenAPI server variable origins

### DIFF
--- a/packages/plugins/openapi/src/sdk/invoke.ts
+++ b/packages/plugins/openapi/src/sdk/invoke.ts
@@ -12,6 +12,7 @@ import {
   type MediaBinding,
   type OperationParameter,
   type ServerInfo,
+  type ServerVariable,
 } from "./types";
 
 // ---------------------------------------------------------------------------
@@ -745,31 +746,82 @@ export const invoke = Effect.fn("OpenApi.invoke")(function* (
   });
 });
 
+const urlOrigin = (value: string): string | null => {
+  return URL.canParse(value) ? new URL(value).origin : null;
+};
+
+const enumValues = (variable: ServerVariable | undefined): readonly string[] | undefined =>
+  variable ? Option.getOrUndefined(variable.enum) : undefined;
+
+const validateServerVariableOverrides = (
+  templateUrl: string,
+  variables: Record<string, ServerVariable>,
+  overrides: Record<string, string>,
+): Effect.Effect<void, OpenApiInvocationError> =>
+  Effect.gen(function* () {
+    const defaultUrl = resolveServerUrl(templateUrl, variables, {});
+    const defaultOrigin = urlOrigin(defaultUrl);
+    const resolvedUrl = resolveServerUrl(templateUrl, variables, overrides);
+    const resolvedOrigin = urlOrigin(resolvedUrl);
+
+    for (const [name, value] of Object.entries(overrides)) {
+      const variable = variables[name];
+      const allowed = enumValues(variable);
+      if (allowed && !allowed.includes(value)) {
+        return yield* new OpenApiInvocationError({
+          message: `Server variable "${name}" must be one of: ${allowed.join(", ")}`,
+          statusCode: Option.none(),
+        });
+      }
+    }
+
+    if (!defaultOrigin || !resolvedOrigin || defaultOrigin === resolvedOrigin) return;
+
+    const unsafe = Object.keys(overrides).filter((name) => {
+      const variable = variables[name];
+      if (!variable || enumValues(variable)) return false;
+      const singleOrigin = urlOrigin(
+        resolveServerUrl(templateUrl, variables, { [name]: overrides[name]! }),
+      );
+      return singleOrigin !== null && singleOrigin !== defaultOrigin;
+    });
+
+    if (unsafe.length > 0) {
+      return yield* new OpenApiInvocationError({
+        message: `Server variable override cannot change request origin: ${unsafe.join(", ")}`,
+        statusCode: Option.none(),
+      });
+    }
+  });
+
 // Connection `baseUrl` wins; otherwise the call's chosen server (`server.url`, or
 // the first) resolved with its `{variables}` (call values, else spec defaults).
 const resolveRequestHost = (
   servers: readonly ServerInfo[],
   serverArg: unknown,
   baseUrl: string,
-): string => {
-  if (baseUrl) return baseUrl;
-  if (servers.length === 0) return "";
+): Effect.Effect<string, OpenApiInvocationError> =>
+  Effect.gen(function* () {
+    if (baseUrl) return baseUrl;
+    if (servers.length === 0) return "";
 
-  const arg = (
-    typeof serverArg === "object" && serverArg !== null && !Array.isArray(serverArg)
-      ? serverArg
-      : {}
-  ) as { url?: unknown; variables?: unknown };
-  const chosen = servers.find((server) => server.url === arg.url) ?? servers[0]!;
+    const arg = (
+      typeof serverArg === "object" && serverArg !== null && !Array.isArray(serverArg)
+        ? serverArg
+        : {}
+    ) as { url?: unknown; variables?: unknown };
+    const chosen = servers.find((server) => server.url === arg.url) ?? servers[0]!;
 
-  const overrides: Record<string, string> = {};
-  if (typeof arg.variables === "object" && arg.variables !== null) {
-    for (const [name, value] of Object.entries(arg.variables as Record<string, unknown>)) {
-      if (value != null && value !== "") overrides[name] = String(value);
+    const overrides: Record<string, string> = {};
+    if (typeof arg.variables === "object" && arg.variables !== null) {
+      for (const [name, value] of Object.entries(arg.variables as Record<string, unknown>)) {
+        if (value != null && value !== "") overrides[name] = String(value);
+      }
     }
-  }
-  return resolveServerUrl(chosen.url, Option.getOrUndefined(chosen.variables), overrides);
-};
+    const variables = Option.getOrUndefined(chosen.variables) ?? {};
+    yield* validateServerVariableOverrides(chosen.url, variables, overrides);
+    return resolveServerUrl(chosen.url, variables, overrides);
+  });
 
 // ---------------------------------------------------------------------------
 // Invoke with a provided HttpClient layer + per-call host resolution
@@ -783,32 +835,38 @@ export const invokeWithLayer = (
   sourceQueryParams: Record<string, string>,
   httpClientLayer: Layer.Layer<HttpClient.HttpClient, never, never>,
 ) => {
-  const effectiveBaseUrl = resolveRequestHost(operation.servers ?? [], args.server, baseUrl);
-  const clientWithBaseUrl = effectiveBaseUrl
-    ? Layer.effect(
-        HttpClient.HttpClient,
-        Effect.map(
-          Effect.service(HttpClient.HttpClient),
-          HttpClient.mapRequest(HttpClientRequest.prependUrl(effectiveBaseUrl)),
-        ),
-      ).pipe(Layer.provide(httpClientLayer))
-    : httpClientLayer;
+  return Effect.gen(function* () {
+    const effectiveBaseUrl = yield* resolveRequestHost(
+      operation.servers ?? [],
+      args.server,
+      baseUrl,
+    );
+    const clientWithBaseUrl = effectiveBaseUrl
+      ? Layer.effect(
+          HttpClient.HttpClient,
+          Effect.map(
+            Effect.service(HttpClient.HttpClient),
+            HttpClient.mapRequest(HttpClientRequest.prependUrl(effectiveBaseUrl)),
+          ),
+        ).pipe(Layer.provide(httpClientLayer))
+      : httpClientLayer;
 
-  return invoke(operation, args, resolvedHeaders, sourceQueryParams).pipe(
-    Effect.provide(clientWithBaseUrl),
-    // `invoke` annotates http.status_code on ITS span (`OpenApi.invoke`,
-    // via Effect.fn) — annotateCurrentSpan inside it never reaches this
-    // wrapper span. Stamp the status here too so queries against
-    // `plugin.openapi.invoke` see the upstream outcome directly.
-    Effect.tap((result) => Effect.annotateCurrentSpan({ "http.status_code": result.status })),
-    Effect.withSpan("plugin.openapi.invoke", {
-      attributes: {
-        "plugin.openapi.method": operation.method.toUpperCase(),
-        "plugin.openapi.path_template": operation.pathTemplate,
-        "plugin.openapi.base_url": effectiveBaseUrl,
-      },
-    }),
-  );
+    return yield* invoke(operation, args, resolvedHeaders, sourceQueryParams).pipe(
+      Effect.provide(clientWithBaseUrl),
+      // `invoke` annotates http.status_code on ITS span (`OpenApi.invoke`,
+      // via Effect.fn), annotateCurrentSpan inside it never reaches this
+      // wrapper span. Stamp the status here too so queries against
+      // `plugin.openapi.invoke` see the upstream outcome directly.
+      Effect.tap((result) => Effect.annotateCurrentSpan({ "http.status_code": result.status })),
+      Effect.withSpan("plugin.openapi.invoke", {
+        attributes: {
+          "plugin.openapi.method": operation.method.toUpperCase(),
+          "plugin.openapi.path_template": operation.pathTemplate,
+          "plugin.openapi.base_url": effectiveBaseUrl,
+        },
+      }),
+    );
+  });
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/plugins/openapi/src/sdk/query-serialization.test.ts
+++ b/packages/plugins/openapi/src/sdk/query-serialization.test.ts
@@ -1,10 +1,10 @@
 import { expect, it } from "@effect/vitest";
-import { Effect, Option } from "effect";
+import { Cause, Effect, Exit, Option } from "effect";
 import { FetchHttpClient } from "effect/unstable/http";
 import { createServer, type Server } from "node:http";
 
 import { invokeWithLayer } from "./invoke";
-import { OperationBinding, OperationParameter, ServerInfo } from "./types";
+import { OperationBinding, OperationParameter, ServerInfo, ServerVariable } from "./types";
 
 const withServer = <A>(
   f: (input: { readonly baseUrl: string; readonly requests: string[] }) => Promise<A>,
@@ -215,6 +215,87 @@ it.effect("falls back to the base URL for bindings persisted without servers", (
 
       await Effect.runPromise(
         invokeWithLayer(operation, {}, baseUrl, {}, {}, FetchHttpClient.layer),
+      );
+
+      expect(new URL(requests[0]!, "http://executor.test").pathname).toBe("/ping");
+    }),
+  ),
+);
+
+it.effect("rejects server variable overrides that move an unbounded request origin", () =>
+  Effect.gen(function* () {
+    const operation = OperationBinding.make({
+      method: "get",
+      servers: [
+        ServerInfo.make({
+          url: "https://{host}/api",
+          description: Option.none(),
+          variables: Option.some({
+            host: ServerVariable.make({
+              default: "api.example.com",
+              enum: Option.none(),
+              description: Option.none(),
+            }),
+          }),
+        }),
+      ],
+      pathTemplate: "/ping",
+      requestBody: Option.none(),
+      responseBody: Option.none(),
+      parameters: [],
+    });
+
+    const exit = yield* invokeWithLayer(
+      operation,
+      { server: { variables: { host: "169.254.169.254" } } },
+      "",
+      {},
+      {},
+      FetchHttpClient.layer,
+    ).pipe(Effect.exit);
+
+    expect(Exit.isFailure(exit)).toBe(true);
+    const text = Exit.match(exit, {
+      onFailure: (cause) => Cause.pretty(cause),
+      onSuccess: () => "",
+    });
+    expect(text).toMatch(/cannot change request origin|host/i);
+  }),
+);
+
+it.effect("allows server variable origin changes when the value is enum-bounded", () =>
+  Effect.promise(() =>
+    withServer(async ({ baseUrl, requests }) => {
+      const operation = OperationBinding.make({
+        method: "get",
+        servers: [
+          ServerInfo.make({
+            url: "{origin}",
+            description: Option.none(),
+            variables: Option.some({
+              origin: ServerVariable.make({
+                default: "https://api.example.com",
+                enum: Option.some(["https://api.example.com", baseUrl]),
+                description: Option.none(),
+              }),
+            }),
+          }),
+        ],
+        pathTemplate: "/ping",
+        requestBody: Option.none(),
+        responseBody: Option.none(),
+        parameters: [],
+      });
+
+      await Effect.runPromise(
+        invokeWithLayer(
+          operation,
+          { server: { variables: { origin: baseUrl } } },
+          "",
+          {},
+          {},
+          FetchHttpClient.layer,
+        ),
       );
 
       expect(new URL(requests[0]!, "http://executor.test").pathname).toBe("/ping");


### PR DESCRIPTION
## What changed

- Validate OpenAPI server variable overrides before invocation.
- Reject unbounded server variables that change the request origin.
- Allow origin changes only when the selected variable value is explicitly enum-bounded by the spec.

## Why

A broad OpenAPI server template such as `https://{host}` let a tool caller redirect authenticated invocations to arbitrary hosts.

## Status

Skipped from the DeepSec batch merge in #1106. Left as a standalone draft for follow-up because this can affect legitimate tenant-host OpenAPI specs.

## Validation

- Previous targeted validation passed before the batch decision.
- Needs a follow-up review of tenant-host compatibility before merge.