### PR TITLE
Fix combobox inside the health-check editor sheet

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -342,6 +342,7 @@
         "@executor-js/api": "workspace:*",
         "@executor-js/emulate": "^0.7.5",
         "@executor-js/mcporter": "^0.11.4",
+        "@executor-js/plugin-google": "workspace:*",
         "@executor-js/plugin-graphql": "workspace:*",
         "@executor-js/plugin-mcp": "workspace:*",
         "@executor-js/plugin-microsoft": "workspace:*",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -23,6 +23,7 @@
     "@executor-js/api": "workspace:*",
     "@executor-js/emulate": "^0.7.5",
     "@executor-js/mcporter": "^0.11.4",
+    "@executor-js/plugin-google": "workspace:*",
     "@executor-js/plugin-graphql": "workspace:*",
     "@executor-js/plugin-mcp": "workspace:*",
     "@executor-js/plugin-microsoft": "workspace:*",

--- a/e2e/scenarios/health-checks-mcp.test.ts
+++ b/e2e/scenarios/health-checks-mcp.test.ts
@@ -1,0 +1,129 @@
+// Health checks for MCP connections, liveness-only: a connection's credential is
+// probed by dialing the server and listing tools (the same path tool discovery
+// uses). A live token reads healthy; a revoked/wrong token reads expired. MCP
+// has no usable identity source, so there is no identity field and no operation
+// picker - only the alive/expired signal. The connect-modal "Validate key" path
+// (connections.validate) runs the same probe on an unsaved credential.
+//
+// The upstream is a real in-process MCP server (the plugin's own test helper)
+// gated on a bearer token, so revoking the token mid-scenario reproduces the
+// "dev token expired" transition on a saved connection.
+import { randomBytes } from "node:crypto";
+
+import { Effect } from "effect";
+import { expect } from "@effect/vitest";
+import type { HttpApiClient } from "effect/unstable/httpapi";
+import { composePluginApi } from "@executor-js/api/server";
+import { mcpHttpPlugin } from "@executor-js/plugin-mcp/api";
+import { makeEchoMcpServer, serveMcpServer } from "@executor-js/plugin-mcp/testing";
+import { variable } from "@executor-js/sdk/http-auth";
+import { AuthTemplateSlug, ConnectionName, IntegrationSlug } from "@executor-js/sdk/shared";
+
+import { scenario } from "../src/scenario";
+import { Api, Target } from "../src/services";
+
+const api = composePluginApi([mcpHttpPlugin()] as const);
+type Client = HttpApiClient.ForApi<typeof api>;
+
+const newSlug = (prefix: string) =>
+  IntegrationSlug.make(`${prefix}-${randomBytes(4).toString("hex")}`);
+
+scenario(
+  "Health checks · MCP liveness reports healthy, then expired when the token is revoked",
+  {},
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const { client: makeClient } = yield* Api;
+      const identity = yield* target.newIdentity();
+      const client: Client = yield* makeClient(api, identity);
+      const goodToken = `mcp_${randomBytes(8).toString("hex")}`;
+      const slug = newSlug("hc-mcp");
+      const name = ConnectionName.make("main");
+
+      // A real MCP server gated on the bearer token. `live` flips off to
+      // reproduce a revoked credential against an already-saved connection.
+      let live = true;
+      const server = yield* serveMcpServer(() => makeEchoMcpServer({ name: "liveness-mcp" }), {
+        auth: {
+          validateAuthorization: (authorization) =>
+            Effect.succeed(live && authorization === `Bearer ${goodToken}`),
+        },
+      });
+
+      yield* Effect.ensuring(
+        Effect.gen(function* () {
+          yield* client.mcp.addServer({
+            payload: {
+              transport: "remote",
+              name: "Liveness MCP",
+              endpoint: server.url,
+              slug: String(slug),
+              // Pin streamable-http so the probe's failure is the server's 401
+              // (no auto SSE fallback to muddy the classification).
+              remoteTransport: "streamable-http",
+              authenticationTemplate: [
+                {
+                  slug: "bearer",
+                  type: "apiKey",
+                  headers: { Authorization: ["Bearer ", variable("token")] },
+                },
+              ],
+            },
+          });
+
+          yield* client.connections.create({
+            payload: {
+              owner: "org",
+              name,
+              integration: slug,
+              template: AuthTemplateSlug.make("bearer"),
+              value: goodToken,
+            },
+          });
+
+          // Saved connection with the live token: alive.
+          const healthy = yield* client.connections.checkHealth({
+            params: { owner: "org", integration: slug, name },
+          });
+          expect(healthy.status, "a live MCP credential is healthy").toBe("healthy");
+
+          // Key-first validate (unsaved credential) runs the same probe.
+          const validated = yield* client.connections.validate({
+            payload: {
+              owner: "org",
+              integration: slug,
+              template: AuthTemplateSlug.make("bearer"),
+              value: goodToken,
+            },
+          });
+          expect(validated.status, "validating a live key is healthy").toBe("healthy");
+          const rejected = yield* client.connections.validate({
+            payload: {
+              owner: "org",
+              integration: slug,
+              template: AuthTemplateSlug.make("bearer"),
+              value: "wrong-token",
+            },
+          });
+          expect(rejected.status, "validating a rejected key is expired").toBe("expired");
+
+          // The upstream revokes the saved token: the same connection now expired.
+          live = false;
+          const expired = yield* client.connections.checkHealth({
+            params: { owner: "org", integration: slug, name },
+          });
+          expect(expired.status, "a revoked MCP credential reads expired").toBe("expired");
+          // No identity is ever derived for MCP (manual label only).
+          expect(expired.identity, "MCP surfaces no derived identity").toBeUndefined();
+        }),
+        Effect.gen(function* () {
+          yield* client.connections
+            .remove({ params: { owner: "org", integration: slug, name } })
+            .pipe(Effect.ignore);
+          yield* client.mcp.removeServer({ params: { slug } }).pipe(Effect.ignore);
+        }),
+      );
+    }),
+  ),
+);

--- a/e2e/scenarios/health-checks-providers.test.ts
+++ b/e2e/scenarios/health-checks-providers.test.ts
@@ -1,0 +1,158 @@
+// Health checks for the Google provider plugin. Provider integrations wire the
+// OpenAPI health-check backing and auto-configure a default identity check
+// (People API `people.get`) at add time, so a connection reports alive/expired +
+// identity out of the box. Here we pin the auto-default + the typed candidate the
+// editor would show; the probe itself is the shared OpenAPI path exercised by
+// health-checks.ts.
+import { randomBytes } from "node:crypto";
+import { createServer } from "node:http";
+
+import { Effect } from "effect";
+import { expect } from "@effect/vitest";
+import type { HttpApiClient } from "effect/unstable/httpapi";
+import { composePluginApi } from "@executor-js/api/server";
+import { googleHttpPlugin } from "@executor-js/plugin-google/api";
+import { IntegrationSlug } from "@executor-js/sdk/shared";
+
+import { scenario } from "../src/scenario";
+import { Api, Target } from "../src/services";
+
+const api = composePluginApi([googleHttpPlugin()] as const);
+type Client = HttpApiClient.ForApi<typeof api>;
+
+const newSlug = (prefix: string) =>
+  IntegrationSlug.make(`${prefix}-${randomBytes(4).toString("hex")}`);
+
+/** A minimal Google Discovery document for the People API, served locally so
+ *  `addBundle` (which fetches the discovery URL) is hermetic. `people.get` is the
+ *  canonical identity call; its response carries `emailAddresses[].value`. */
+const peopleDiscoveryDoc = (): string =>
+  JSON.stringify({
+    kind: "discovery#restDescription",
+    name: "people",
+    version: "v1",
+    title: "People API",
+    rootUrl: "https://people.example.com/",
+    servicePath: "",
+    auth: {
+      oauth2: {
+        scopes: {
+          "https://www.googleapis.com/auth/userinfo.email": { description: "See your email" },
+        },
+      },
+    },
+    resources: {
+      people: {
+        methods: {
+          get: {
+            id: "people.people.get",
+            httpMethod: "GET",
+            path: "v1/{resourceName}",
+            scopes: ["https://www.googleapis.com/auth/userinfo.email"],
+            parameters: {
+              resourceName: { location: "path", required: true, type: "string" },
+              personFields: { location: "query", type: "string" },
+            },
+            response: { $ref: "Person" },
+          },
+        },
+      },
+    },
+    schemas: {
+      Person: {
+        id: "Person",
+        type: "object",
+        properties: {
+          resourceName: { type: "string" },
+          emailAddresses: { type: "array", items: { $ref: "EmailAddress" } },
+          names: { type: "array", items: { $ref: "Name" } },
+        },
+      },
+      EmailAddress: {
+        id: "EmailAddress",
+        type: "object",
+        properties: { value: { type: "string" } },
+      },
+      Name: { id: "Name", type: "object", properties: { displayName: { type: "string" } } },
+    },
+  });
+
+/** Serve the People discovery doc at a `/people/`-containing path (so the plugin
+ *  recognizes the bundle as containing the People API). */
+const servePeopleDiscovery = () =>
+  Effect.acquireRelease(
+    Effect.callback<{ readonly discoveryUrl: string; readonly close: () => void }>((resume) => {
+      const doc = peopleDiscoveryDoc();
+      const server = createServer((request, response) => {
+        if ((request.url ?? "").includes("/apis/people/")) {
+          response.writeHead(200, { "content-type": "application/json" });
+          response.end(doc);
+          return;
+        }
+        response.writeHead(404, { "content-type": "application/json" });
+        response.end(JSON.stringify({ error: "not_found" }));
+      });
+      server.listen(0, "127.0.0.1", () => {
+        const address = server.address();
+        const port = typeof address === "object" && address ? address.port : 0;
+        resume(
+          Effect.succeed({
+            discoveryUrl: `http://127.0.0.1:${port}/discovery/v1/apis/people/v1/rest`,
+            close: () => {
+              server.close();
+              server.closeAllConnections();
+            },
+          }),
+        );
+      });
+    }),
+    (server) => Effect.sync(server.close),
+  );
+
+scenario(
+  "Health checks · adding a Google People bundle auto-configures the identity check",
+  {},
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const { client: makeClient } = yield* Api;
+      const identity = yield* target.newIdentity();
+      const client: Client = yield* makeClient(api, identity);
+      const discovery = yield* servePeopleDiscovery();
+      const slug = newSlug("hc-google");
+
+      yield* Effect.ensuring(
+        Effect.gen(function* () {
+          yield* client.google.addBundle({
+            payload: { urls: [discovery.discoveryUrl], slug: String(slug) },
+          });
+
+          // The People identity call is offered as a candidate, with its typed
+          // response fields (so the editor's identity picker lists the email).
+          const candidates = yield* client.integrations.healthCheckCandidates({ params: { slug } });
+          const peopleGet = candidates.find((candidate) => candidate.method === "get");
+          if (!peopleGet) return yield* Effect.die("People bundle exposed no GET candidate");
+          expect(
+            (peopleGet.responseFields ?? []).map((field) => field.path),
+            "the email identity field is projected from the response schema",
+          ).toContain("emailAddresses.0.value");
+
+          // Adding the bundle auto-wrote the default identity health check: the
+          // People identity call, with the required pinned args and email field.
+          const stored = yield* client.integrations.healthCheckGet({ params: { slug } });
+          expect(stored?.operation, "the default check targets the People identity call").toBe(
+            peopleGet.operation,
+          );
+          expect(stored?.identityField, "the default reads the email field").toBe(
+            "emailAddresses.0.value",
+          );
+          expect(stored?.args, "the People call's required args are pinned").toEqual({
+            resourceName: "people/me",
+            personFields: "names,emailAddresses",
+          });
+        }),
+        client.google.removeBundle({ params: { slug: String(slug) } }).pipe(Effect.ignore),
+      );
+    }),
+  ),
+);

--- a/e2e/scenarios/health-checks-ui.test.ts
+++ b/e2e/scenarios/health-checks-ui.test.ts
@@ -1,0 +1,432 @@
+// Cross-target (browser): the UI side of connection health checks, the feature
+// that answers "has this credential expired?" (the Google 7-day dev-token case).
+// These scenarios pin the operation picker, the part that lets a user choose
+// WHICH call the probe runs:
+//
+//  1. Add Connection: with no health check configured yet, the user picks a
+//     read-only operation inline, clicks "Check the key works", the probe runs,
+//     and the picked operation is saved as the integration's health check.
+//  2. Edit sheet, large spec: typing into the operation combobox filters a
+//     hundreds-long candidate list down to the one match, and committing it
+//     stores the real operation (not the freeform text typed to find it).
+//  3. Add screen, large spec: the same picker is fed by the bounded spec
+//     preview, so typing must reach an operation ranked well past the preview's
+//     top slice.
+//
+// The upstream API is a real node:http server on 127.0.0.1 that gates `GET /me`
+// on a bearer token. The probe runs server-side, so the in-process server is
+// reachable from the dev server on the same host.
+//
+// These scenarios skip on targets without a browser surface (selfhost today).
+import { randomBytes } from "node:crypto";
+import { createServer } from "node:http";
+
+import { Effect } from "effect";
+import { expect } from "@effect/vitest";
+import type { HttpApiClient } from "effect/unstable/httpapi";
+import type { Page } from "playwright";
+import { composePluginApi } from "@executor-js/api/server";
+import { openApiHttpPlugin } from "@executor-js/plugin-openapi/api";
+import { IntegrationSlug } from "@executor-js/sdk/shared";
+
+import { scenario } from "../src/scenario";
+import { Api, Browser, Target } from "../src/services";
+
+const api = composePluginApi([openApiHttpPlugin()] as const);
+type Client = HttpApiClient.ForApi<typeof api>;
+
+const newSlug = (prefix: string) =>
+  IntegrationSlug.make(`${prefix}-${randomBytes(4).toString("hex")}`);
+
+/** OpenAPI 3 spec with an auth-gated GET (`/me`, the obvious health check) plus a
+ *  destructive POST so the candidate ranking has something to sort the GET ahead
+ *  of. */
+const identitySpec = (baseUrl: string): string =>
+  JSON.stringify({
+    openapi: "3.0.3",
+    info: { title: "Identity API", version: "1.0.0" },
+    servers: [{ url: baseUrl }],
+    paths: {
+      "/me": {
+        get: {
+          operationId: "getMe",
+          summary: "The current account",
+          responses: {
+            "200": {
+              description: "The authenticated account",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: { email: { type: "string" }, login: { type: "string" } },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      "/messages": {
+        post: {
+          operationId: "sendMessage",
+          summary: "Send a message",
+          responses: { "201": { description: "created" } },
+        },
+      },
+    },
+  });
+
+/** A real node:http API on 127.0.0.1. `GET /me` returns 200 only when the bearer
+ *  token matches; any other token is a 401. Closed by the scope's finalizer. */
+const serveIdentityApi = (validToken: string) =>
+  Effect.acquireRelease(
+    Effect.callback<{ readonly url: string; readonly close: () => void }>((resume) => {
+      const server = createServer((request, response) => {
+        const authorized = request.headers["authorization"] === `Bearer ${validToken}`;
+        if (request.method === "GET" && (request.url ?? "").startsWith("/me")) {
+          response.writeHead(authorized ? 200 : 401, { "content-type": "application/json" });
+          response.end(
+            JSON.stringify(authorized ? { email: "alice@example.com" } : { error: "x" }),
+          );
+          return;
+        }
+        response.writeHead(404, { "content-type": "application/json" });
+        response.end(JSON.stringify({ error: "not_found" }));
+      });
+      server.listen(0, "127.0.0.1", () => {
+        const address = server.address();
+        const port = typeof address === "object" && address ? address.port : 0;
+        resume(
+          Effect.succeed({
+            url: `http://127.0.0.1:${port}`,
+            close: () => {
+              server.close();
+              server.closeAllConnections();
+            },
+          }),
+        );
+      });
+    }),
+    (server) => Effect.sync(server.close),
+  );
+
+/** Register the identity integration against `baseUrl` with a bearer-token auth
+ *  method (single `token` input → connection `value`). */
+const registerIdentityIntegration = (client: Client, slug: IntegrationSlug, baseUrl: string) =>
+  client.openapi.addSpec({
+    payload: {
+      spec: { kind: "blob", value: identitySpec(baseUrl) },
+      slug,
+      baseUrl,
+      authenticationTemplate: [
+        {
+          slug: "apiKey",
+          type: "apiKey",
+          headers: { authorization: ["Bearer ", { type: "variable", name: "token" }] },
+        },
+      ],
+    },
+  });
+
+/** Select the combobox option whose visible text contains `optionText` by
+ *  keyboard (so it works inside a modal without a portaled-popup click). */
+const selectComboboxOption = async (page: Page, inputId: string, optionText: string) => {
+  const input = page.locator(`#${inputId}`);
+  await input.click();
+  const target = page.getByRole("option").filter({ hasText: optionText }).first();
+  await target.waitFor({ timeout: 10_000 });
+  for (let i = 0; i < 16; i++) {
+    if ((await target.getAttribute("data-highlighted")) !== null) break;
+    await input.press("ArrowDown");
+  }
+  await input.press("Enter");
+};
+
+// A distinctive operation buried in a large spec, found by its unique summary
+// (which no filler operation shares) so the filter test can search for it.
+const PROBE_TOKEN = "ztarget";
+const PROBE_SUMMARY = `Health probe candidate ${PROBE_TOKEN}`;
+
+/** An OpenAPI 3 spec with ~250 GET operations plus one distinctive probe. The
+ *  candidate list is far longer than the popup renders at once, so the operation
+ *  picker only surfaces a given operation when typing actually filters the list.
+ *  The title is parameterizable so the add screen (which mints the slug from the
+ *  title) gets a collision-free integration per run. */
+const largeSpec = (baseUrl: string, title = "Big API"): string => {
+  const okJson = {
+    "200": {
+      description: "ok",
+      content: {
+        "application/json": { schema: { type: "object", properties: { id: { type: "string" } } } },
+      },
+    },
+  };
+  const paths: Record<string, unknown> = {};
+  for (let index = 0; index < 250; index++) {
+    paths[`/things/item${index}`] = {
+      get: { operationId: `getThing${index}`, summary: `Thing number ${index}`, responses: okJson },
+    };
+  }
+  paths["/probe/target"] = {
+    get: { operationId: "probeTarget", summary: PROBE_SUMMARY, responses: okJson },
+  };
+  return JSON.stringify({
+    openapi: "3.0.3",
+    info: { title, version: "1.0.0" },
+    servers: [{ url: baseUrl }],
+    paths,
+  });
+};
+
+// ===========================================================================
+// 1. Add Connection, no check configured: pick an operation inline, check the
+//    key works, and the picked operation is saved as the integration's check.
+// ===========================================================================
+
+scenario(
+  "Health checks (UI) · Add Connection checks the key against an inline-picked operation and saves it",
+  {},
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const browser = yield* Browser;
+      const { client: makeClient } = yield* Api;
+      const identity = yield* target.newIdentity();
+      const client = yield* makeClient(api, identity);
+      const goodToken = `gk_${randomBytes(8).toString("hex")}`;
+      const server = yield* serveIdentityApi(goodToken);
+      const slug = newSlug("hc-ui-connect-check");
+
+      yield* Effect.ensuring(
+        Effect.gen(function* () {
+          // Register the integration but deliberately configure NO health check:
+          // the Add Connection modal must let the user pick one inline.
+          yield* registerIdentityIntegration(client, slug, server.url);
+          expect(
+            yield* client.integrations.healthCheckGet({ params: { slug } }),
+            "no health check is configured up front",
+          ).toBeNull();
+          const candidates = yield* client.integrations.healthCheckCandidates({ params: { slug } });
+          const getMe = candidates.find((candidate) => candidate.method === "get");
+          if (!getMe) return yield* Effect.die("identity spec exposed no GET candidate");
+
+          yield* browser.session(identity, async ({ page, step }) => {
+            const dialog = page.getByRole("dialog");
+
+            await step("Open the Add Connection modal", async () => {
+              await page.goto(`/integrations/${slug}`, { waitUntil: "networkidle" });
+              await page.getByRole("button", { name: "Add connection", exact: true }).click();
+              await page.getByRole("heading", { name: /Add connection/ }).waitFor();
+            });
+
+            await step("Paste the key and pick an operation to test it against", async () => {
+              await dialog.getByPlaceholder("paste the value / token").fill(goodToken);
+              // No check configured ⇒ the inline operation picker is shown.
+              await selectComboboxOption(page, "connect-health-check-operation", "getMe");
+            });
+
+            await step("Check the key works: it probes healthy", async () => {
+              await dialog.getByRole("button", { name: "Check the key works" }).click();
+              await dialog.getByText("Healthy").waitFor({ timeout: 30_000 });
+            });
+          });
+
+          // The healthy inline check was persisted as the integration's check.
+          const stored = yield* client.integrations.healthCheckGet({ params: { slug } });
+          expect(stored?.operation, "the picked operation was saved as the health check").toBe(
+            getMe.operation,
+          );
+        }),
+        client.openapi.removeSpec({ params: { slug } }).pipe(Effect.ignore),
+      );
+    }),
+  ),
+);
+
+// ===========================================================================
+// 2. Edit sheet, large spec: typing filters the operation picker to the match.
+// ===========================================================================
+
+scenario(
+  "Health checks (UI) · large spec: typing filters the operation picker down to the match",
+  {},
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const browser = yield* Browser;
+      const { client: makeClient } = yield* Api;
+      const identity = yield* target.newIdentity();
+      const client = yield* makeClient(api, identity);
+      const slug = newSlug("hc-ui-large");
+
+      yield* Effect.ensuring(
+        Effect.gen(function* () {
+          yield* client.openapi.addSpec({
+            payload: {
+              spec: { kind: "blob", value: largeSpec("https://big.example.com") },
+              slug,
+              baseUrl: "https://big.example.com",
+              authenticationTemplate: [
+                {
+                  slug: "apiKey",
+                  type: "apiKey",
+                  headers: {
+                    authorization: ["Bearer ", { type: "variable", name: "token" }],
+                  },
+                },
+              ],
+            },
+          });
+          // The toolPath the registration assigned the distinctive probe op,
+          // matched by its unique summary, so the read-back asserts exactly the
+          // operation the on-camera filter-then-pick selected.
+          const candidates = yield* client.integrations.healthCheckCandidates({ params: { slug } });
+          const probe = candidates.find((candidate) => candidate.summary === PROBE_SUMMARY);
+          if (!probe) return yield* Effect.die("large spec is missing its probe operation");
+          const probeOperation = probe.operation;
+          // Sanity: the spec really is large, so the picker can't just show them all.
+          expect(candidates.length).toBeGreaterThan(100);
+
+          yield* browser.session(identity, async ({ page, step }) => {
+            const input = page.locator("#health-check-operation");
+            const options = page.getByRole("option");
+
+            await step("Open the health-check editor over the large spec", async () => {
+              await page.goto(`/integrations/${slug}`, { waitUntil: "networkidle" });
+              await page.getByRole("heading", { level: 3, name: "Health check" }).waitFor();
+              await page.getByRole("button", { name: "Set up" }).click();
+              await input.waitFor();
+            });
+
+            await step("A broad query still surfaces many operations", async () => {
+              await input.click();
+              // Real keystrokes (base-ui filters on the input value, not a
+              // programmatic set): a shared summary prefix matches the fillers.
+              await input.selectText();
+              await input.pressSequentially("Thing number", { delay: 10 });
+              await options.filter({ hasText: "Thing number" }).first().waitFor();
+              // The popup caps how many it renders, but a broad match fills it.
+              expect(await options.count()).toBeGreaterThan(20);
+            });
+
+            await step("A distinctive query narrows the list to the one match", async () => {
+              await input.selectText();
+              await input.pressSequentially(PROBE_TOKEN, { delay: 10 });
+              const match = options.filter({ hasText: PROBE_SUMMARY }).first();
+              await match.waitFor({ timeout: 10_000 });
+              // Typing actually filters: the hundreds collapse to the single
+              // matching operation (plus the freeform echo of the typed text).
+              expect(await options.count()).toBeLessThanOrEqual(3);
+            });
+
+            await step("Select the filtered operation and save", async () => {
+              const match = options.filter({ hasText: PROBE_SUMMARY }).first();
+              // base-ui pre-highlights the freeform echo; arrow onto the real op.
+              for (let i = 0; i < 8; i++) {
+                if ((await match.getAttribute("data-highlighted")) !== null) break;
+                await input.press("ArrowDown");
+              }
+              await input.press("Enter");
+              await page.getByRole("button", { name: "Save", exact: true }).click();
+              await input.waitFor({ state: "hidden" });
+            });
+          });
+
+          // The picker committed the real operation behind the matched summary,
+          // not the freeform text that was typed to find it.
+          const stored = yield* client.integrations.healthCheckGet({ params: { slug } });
+          expect(stored?.operation).toBe(probeOperation);
+        }),
+        Effect.gen(function* () {
+          yield* client.openapi.removeSpec({ params: { slug } }).pipe(Effect.ignore);
+        }),
+      );
+    }),
+  ),
+);
+
+// ===========================================================================
+// 3. Add screen, large spec: the operation picker is fed by the bounded spec
+//    preview, so it must carry enough of a big spec that typing reaches an
+//    operation ranked well past the preview's top slice (the Vercel "user"
+//    case: searching found nothing because the op wasn't in the top few).
+// ===========================================================================
+
+scenario(
+  "Health checks (UI) · add screen large spec: typing reaches an operation beyond the preview's top slice",
+  {},
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const browser = yield* Browser;
+      const { client: makeClient } = yield* Api;
+      const identity = yield* target.newIdentity();
+      const client = yield* makeClient(api, identity);
+      // The add screen mints the slug from the title, so make it unique. Search
+      // for an operation whose toolPath sorts far past the old top-10 cap.
+      const title = `Big API ${randomBytes(4).toString("hex")}`;
+      const spec = largeSpec("https://big.example.com", title);
+      const targetSummary = "Thing number 137";
+
+      let createdSlug = "";
+      yield* Effect.ensuring(
+        Effect.gen(function* () {
+          yield* browser.session(identity, async ({ page, step }) => {
+            const input = page.locator("#add-health-check-operation");
+            const options = page.getByRole("option");
+
+            await step("Open the Add form and paste the large spec", async () => {
+              await page.goto("/integrations/add/openapi", { waitUntil: "networkidle" });
+              await page.getByPlaceholder("https://api.example.com/openapi.json").fill(spec);
+              await page
+                .getByRole("heading", { name: "Health check (optional)" })
+                .waitFor({ timeout: 20_000 });
+            });
+
+            await step("Type to reach an operation past the preview's top slice", async () => {
+              await input.click();
+              // Real keystrokes; the operation isn't in the first handful, so it
+              // is reachable only because the preview now carries the whole spec.
+              await input.selectText();
+              await input.pressSequentially(targetSummary, { delay: 10 });
+              // The real option carries the GET label + toolPath; the freeform
+              // echo is just the typed text, so "GET" disambiguates them.
+              const match = options.filter({ hasText: targetSummary }).filter({ hasText: "GET" });
+              await match.first().waitFor({ timeout: 10_000 });
+            });
+
+            await step("Select the found operation and add the integration", async () => {
+              const match = options.filter({ hasText: targetSummary }).filter({ hasText: "GET" });
+              for (let i = 0; i < 8; i++) {
+                if ((await match.first().getAttribute("data-highlighted")) !== null) break;
+                await input.press("ArrowDown");
+              }
+              await input.press("Enter");
+              await page.getByRole("button", { name: "Add integration" }).click();
+              await page.waitForURL(/\/integrations\/[^/?#]+$/, { timeout: 30_000 });
+              const url = page.url().match(/\/integrations\/([^/?#]+)/);
+              createdSlug = url?.[1] ?? "";
+            });
+          });
+
+          expect(createdSlug.length).toBeGreaterThan(0);
+          const slug = IntegrationSlug.make(createdSlug);
+          // The drafted check persisted the operation behind the matched summary,
+          // proving the add-screen search reached past the preview's top slice.
+          const candidates = yield* client.integrations.healthCheckCandidates({ params: { slug } });
+          const expected = candidates.find((candidate) => candidate.summary === targetSummary);
+          if (!expected) return yield* Effect.die("created integration is missing the target op");
+          const stored = yield* client.integrations.healthCheckGet({ params: { slug } });
+          expect(stored?.operation).toBe(expected.operation);
+        }),
+        Effect.gen(function* () {
+          if (createdSlug.length > 0) {
+            yield* client.openapi
+              .removeSpec({ params: { slug: IntegrationSlug.make(createdSlug) } })
+              .pipe(Effect.ignore);
+          }
+        }),
+      );
+    }),
+  ),
+);

--- a/e2e/scenarios/health-checks-ui.test.ts
+++ b/e2e/scenarios/health-checks-ui.test.ts
@@ -27,13 +27,16 @@ import type { HttpApiClient } from "effect/unstable/httpapi";
 import type { Page } from "playwright";
 import { composePluginApi } from "@executor-js/api/server";
 import { openApiHttpPlugin } from "@executor-js/plugin-openapi/api";
-import { IntegrationSlug } from "@executor-js/sdk/shared";
+import { AuthTemplateSlug, ConnectionName, IntegrationSlug } from "@executor-js/sdk/shared";
 
 import { scenario } from "../src/scenario";
 import { Api, Browser, Target } from "../src/services";
 
 const api = composePluginApi([openApiHttpPlugin()] as const);
 type Client = HttpApiClient.ForApi<typeof api>;
+
+const TEMPLATE = AuthTemplateSlug.make("apiKey");
+const IDENTITY = "alice@example.com";
 
 const newSlug = (prefix: string) =>
   IntegrationSlug.make(`${prefix}-${randomBytes(4).toString("hex")}`);
@@ -85,9 +88,7 @@ const serveIdentityApi = (validToken: string) =>
         const authorized = request.headers["authorization"] === `Bearer ${validToken}`;
         if (request.method === "GET" && (request.url ?? "").startsWith("/me")) {
           response.writeHead(authorized ? 200 : 401, { "content-type": "application/json" });
-          response.end(
-            JSON.stringify(authorized ? { email: "alice@example.com" } : { error: "x" }),
-          );
+          response.end(JSON.stringify(authorized ? { email: IDENTITY } : { error: "x" }));
           return;
         }
         response.writeHead(404, { "content-type": "application/json" });
@@ -126,6 +127,57 @@ const registerIdentityIntegration = (client: Client, slug: IntegrationSlug, base
         },
       ],
     },
+  });
+
+/** Like `serveIdentityApi`, but with a `revoke()` that flips the key off so a
+ *  saved connection's previously-good key stops working mid-session (the editor
+ *  scenario's healthy -> expired transition). */
+const serveMutableIdentityApi = (validToken: string) =>
+  Effect.acquireRelease(
+    Effect.callback<{
+      readonly url: string;
+      readonly revoke: () => void;
+      readonly close: () => void;
+    }>((resume) => {
+      let live = true;
+      const server = createServer((request, response) => {
+        const authorized = live && request.headers["authorization"] === `Bearer ${validToken}`;
+        if (request.method === "GET" && (request.url ?? "").startsWith("/me")) {
+          response.writeHead(authorized ? 200 : 401, { "content-type": "application/json" });
+          response.end(JSON.stringify(authorized ? { email: IDENTITY } : { error: "x" }));
+          return;
+        }
+        response.writeHead(404, { "content-type": "application/json" });
+        response.end(JSON.stringify({ error: "not_found" }));
+      });
+      server.listen(0, "127.0.0.1", () => {
+        const address = server.address();
+        const port = typeof address === "object" && address ? address.port : 0;
+        resume(
+          Effect.succeed({
+            url: `http://127.0.0.1:${port}`,
+            revoke: () => {
+              live = false;
+            },
+            close: () => {
+              server.close();
+              server.closeAllConnections();
+            },
+          }),
+        );
+      });
+    }),
+    (server) => Effect.sync(server.close),
+  );
+
+/** The stored operation name for the GET probe (openapi prefixes it by tag),
+ *  discovered the same way the editor does: from the ranked candidate list. */
+const getMeOperation = (client: Client, slug: IntegrationSlug) =>
+  Effect.gen(function* () {
+    const candidates = yield* client.integrations.healthCheckCandidates({ params: { slug } });
+    const getMe = candidates.find((candidate) => candidate.method === "get");
+    if (!getMe) return yield* Effect.die("identity spec exposed no GET candidate");
+    return getMe.operation;
   });
 
 /** Select the combobox option whose visible text contains `optionText` by
@@ -426,6 +478,165 @@ scenario(
               .pipe(Effect.ignore);
           }
         }),
+      );
+    }),
+  ),
+);
+
+// ===========================================================================
+// 4. Edit sheet WITH identity: pick the operation + identity field, live-preview
+//    the response, then drive "Check now" on a saved connection healthy ->
+//    expired once the upstream revokes the key. (identity layer)
+// ===========================================================================
+
+scenario(
+  "Health checks (UI) · edit sheet with identity: preview the response, then healthy then expired",
+  {},
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const browser = yield* Browser;
+      const { client: makeClient } = yield* Api;
+      const identity = yield* target.newIdentity();
+      const client = yield* makeClient(api, identity);
+      const goodToken = `gk_${randomBytes(8).toString("hex")}`;
+      const server = yield* serveMutableIdentityApi(goodToken);
+      const slug = newSlug("hc-ui-id");
+      const name = ConnectionName.make("main");
+
+      yield* Effect.ensuring(
+        Effect.gen(function* () {
+          // Off camera: the integration and a saved connection holding the live
+          // key. The health check is configured ON camera in the editor below.
+          yield* registerIdentityIntegration(client, slug, server.url);
+          const operation = yield* getMeOperation(client, slug);
+          yield* client.connections.create({
+            payload: {
+              owner: "org",
+              name,
+              integration: slug,
+              template: TEMPLATE,
+              value: goodToken,
+            },
+          });
+
+          yield* browser.session(identity, async ({ page, step }) => {
+            const connections = page.locator("section").filter({
+              has: page.getByRole("heading", { level: 3, name: "Connections" }),
+            });
+            const menuTrigger = connections.locator('button[aria-haspopup="menu"]');
+
+            await step("Open the integration's connections", async () => {
+              await page.goto(`/integrations/${slug}`, { waitUntil: "networkidle" });
+              await connections.getByText("main", { exact: true }).waitFor();
+              await page.getByRole("heading", { level: 3, name: "Health check" }).waitFor();
+            });
+
+            await step("Pick the GET identity call and its email identity field", async () => {
+              await page.getByRole("button", { name: "Set up" }).click();
+              await selectComboboxOption(page, "health-check-operation", operation);
+              await selectComboboxOption(page, "health-check-identity", "email");
+            });
+
+            await step("Live preview a pasted key: status, response, and identity", async () => {
+              const sheet = page.getByRole("dialog");
+              await page.locator("#health-check-preview-key").fill(goodToken);
+              await sheet.getByRole("button", { name: "Preview", exact: true }).click();
+              await sheet.getByText("Response", { exact: true }).waitFor({ timeout: 30_000 });
+              await sheet.getByText("Resolves to:").waitFor();
+              await sheet.getByText(IDENTITY).first().waitFor();
+            });
+
+            await step("Save the health check", async () => {
+              await page.getByRole("button", { name: "Save", exact: true }).click();
+              await page.locator("#health-check-operation").waitFor({ state: "hidden" });
+            });
+
+            await step("Check the live connection: healthy, and whose account it is", async () => {
+              await menuTrigger.click();
+              await page.getByRole("menuitem", { name: "Check now" }).click();
+              await connections.getByText(IDENTITY).waitFor({ timeout: 30_000 });
+              await connections.getByLabel("Status: Healthy").waitFor();
+            });
+
+            await step("The upstream revokes the key: the connection reads expired", async () => {
+              server.revoke();
+              await menuTrigger.click();
+              await page.getByRole("menuitem", { name: "Check now" }).click();
+              await connections.getByText("Expired", { exact: true }).waitFor({ timeout: 30_000 });
+              await connections.getByLabel("Status: Expired").waitFor();
+            });
+          });
+
+          const stored = yield* client.integrations.healthCheckGet({ params: { slug } });
+          expect(stored).toEqual({ operation, identityField: "email" });
+        }),
+        Effect.gen(function* () {
+          yield* client.connections
+            .remove({ params: { owner: "org", integration: slug, name } })
+            .pipe(Effect.ignore);
+          yield* client.openapi.removeSpec({ params: { slug } }).pipe(Effect.ignore);
+        }),
+      );
+    }),
+  ),
+);
+
+// ===========================================================================
+// 5. Add Connection, check configured WITH identity: checking the key derives
+//    the connection name from the probed identity. (identity layer)
+// ===========================================================================
+
+scenario(
+  "Health checks (UI) · Add Connection derives the connection name from the probed identity",
+  {},
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const browser = yield* Browser;
+      const { client: makeClient } = yield* Api;
+      const identity = yield* target.newIdentity();
+      const client = yield* makeClient(api, identity);
+      const goodToken = `gk_${randomBytes(8).toString("hex")}`;
+      const server = yield* serveIdentityApi(goodToken);
+      const slug = newSlug("hc-ui-name");
+
+      yield* Effect.ensuring(
+        Effect.gen(function* () {
+          // Configure a check WITH an identity field up front, so the Add
+          // Connection modal probes against it (no inline picker needed).
+          yield* registerIdentityIntegration(client, slug, server.url);
+          const operation = yield* getMeOperation(client, slug);
+          yield* client.integrations.healthCheckSet({
+            params: { slug },
+            payload: { spec: { operation, identityField: "email" } },
+          });
+
+          yield* browser.session(identity, async ({ page, step }) => {
+            const dialog = page.getByRole("dialog");
+
+            await step("Open the Add Connection modal", async () => {
+              await page.goto(`/integrations/${slug}`, { waitUntil: "networkidle" });
+              await page.getByRole("button", { name: "Add connection", exact: true }).click();
+              await page.getByRole("heading", { name: /Add connection/ }).waitFor();
+            });
+
+            await step("A valid key checks healthy and names the connection", async () => {
+              await dialog.getByPlaceholder("paste the value / token").fill(goodToken);
+              await dialog.getByRole("button", { name: "Check the key works" }).click();
+              await dialog.getByText("Healthy").waitFor({ timeout: 30_000 });
+              // The probed identity auto-fills the display name.
+              await page.waitForFunction(
+                (expected) =>
+                  (document.querySelector("#connection-name") as HTMLInputElement | null)?.value ===
+                  expected,
+                IDENTITY,
+                { timeout: 10_000 },
+              );
+            });
+          });
+        }),
+        client.openapi.removeSpec({ params: { slug } }).pipe(Effect.ignore),
       );
     }),
   ),

--- a/e2e/scenarios/health-checks-ui.test.ts
+++ b/e2e/scenarios/health-checks-ui.test.ts
@@ -641,3 +641,144 @@ scenario(
     }),
   ),
 );
+
+// ===========================================================================
+// 6. Edit sheet, click interaction: the combobox popup is portaled outside the
+//    Radix sheet, so clicking an option must not be treated as an outside
+//    interaction that dismisses the sheet (keyboard scenarios above miss this).
+// ===========================================================================
+
+scenario(
+  "Health checks (UI) · clicking a combobox option in the sheet selects it without closing the sheet",
+  {},
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const browser = yield* Browser;
+      const { client: makeClient } = yield* Api;
+      const identity = yield* target.newIdentity();
+      const client = yield* makeClient(api, identity);
+      const slug = newSlug("hc-ui-click");
+
+      yield* Effect.ensuring(
+        Effect.gen(function* () {
+          yield* registerIdentityIntegration(client, slug, "https://identity.example.com");
+          const operation = yield* getMeOperation(client, slug);
+
+          yield* browser.session(identity, async ({ page, step }) => {
+            const sheet = page.getByRole("dialog");
+            const operationInput = page.locator("#health-check-operation");
+            const identityInput = page.locator("#health-check-identity");
+
+            await step("Open the health-check editor", async () => {
+              await page.goto(`/integrations/${slug}`, { waitUntil: "networkidle" });
+              await page.getByRole("heading", { level: 3, name: "Health check" }).waitFor();
+              await page.getByRole("button", { name: "Set up" }).click();
+              await operationInput.waitFor();
+            });
+
+            await step(
+              "Click the operation option: it selects and the sheet stays open",
+              async () => {
+                await operationInput.click();
+                await page.getByRole("option").filter({ hasText: "getMe" }).first().click();
+                // Clicking the portaled popup option must NOT dismiss the sheet.
+                await sheet.waitFor();
+                expect(await operationInput.inputValue()).toContain("getMe");
+              },
+            );
+
+            await step("Click the identity option by mouse, then save", async () => {
+              await identityInput.click();
+              await page.getByRole("option").filter({ hasText: "email" }).first().click();
+              await sheet.waitFor();
+              expect(await identityInput.inputValue()).toBe("email");
+              await page.getByRole("button", { name: "Save", exact: true }).click();
+              await operationInput.waitFor({ state: "hidden" });
+            });
+          });
+
+          // The mouse-driven selections persisted: only possible if the option
+          // clicks selected without dismissing the sheet first.
+          const stored = yield* client.integrations.healthCheckGet({ params: { slug } });
+          expect(stored).toEqual({ operation, identityField: "email" });
+        }),
+        client.openapi.removeSpec({ params: { slug } }).pipe(Effect.ignore),
+      );
+    }),
+  ),
+);
+
+// ===========================================================================
+// 7. Edit sheet, scroll: a modal dialog locks body scroll, which freezes the
+//    portaled combobox list. The editor sheet is non-modal so the list scrolls.
+// ===========================================================================
+
+scenario(
+  "Health checks (UI) · the combobox list scrolls inside the edit sheet",
+  {},
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const browser = yield* Browser;
+      const { client: makeClient } = yield* Api;
+      const identity = yield* target.newIdentity();
+      const client = yield* makeClient(api, identity);
+      const slug = newSlug("hc-ui-scroll");
+
+      yield* Effect.ensuring(
+        Effect.gen(function* () {
+          // Many operations so the popup list overflows and must scroll.
+          yield* client.openapi.addSpec({
+            payload: {
+              spec: { kind: "blob", value: largeSpec("https://big.example.com") },
+              slug,
+              baseUrl: "https://big.example.com",
+              authenticationTemplate: [
+                {
+                  slug: "apiKey",
+                  type: "apiKey",
+                  headers: { authorization: ["Bearer ", { type: "variable", name: "token" }] },
+                },
+              ],
+            },
+          });
+
+          yield* browser.session(identity, async ({ page, step }) => {
+            const operationInput = page.locator("#health-check-operation");
+            const list = page.locator("[data-slot='combobox-list']").first();
+
+            await step("Open the operation combobox in the sheet", async () => {
+              await page.goto(`/integrations/${slug}`, { waitUntil: "networkidle" });
+              await page.getByRole("heading", { level: 3, name: "Health check" }).waitFor();
+              await page.getByRole("button", { name: "Set up" }).click();
+              await operationInput.waitFor();
+              await operationInput.click();
+              await list.waitFor();
+            });
+
+            await step("Wheel-scroll the list: it actually moves (not scroll-locked)", async () => {
+              const before = await list.evaluate((el) => el.scrollTop);
+              await list.hover();
+              await page.mouse.wheel(0, 600);
+              // Poll: the wheel scroll must move the list (blocked → stays 0).
+              await page.waitForFunction(
+                (start) => {
+                  const el = document.querySelector("[data-slot='combobox-list']");
+                  return el != null && el.scrollTop > start + 20;
+                },
+                before,
+                { timeout: 5000 },
+              );
+              const after = await list.evaluate((el) => el.scrollTop);
+              expect(after, "the list scrolled past its starting offset").toBeGreaterThan(before);
+              // The sheet stayed open through the scroll interaction.
+              await page.getByRole("dialog").waitFor();
+            });
+          });
+        }),
+        client.openapi.removeSpec({ params: { slug } }).pipe(Effect.ignore),
+      );
+    }),
+  ),
+);

--- a/e2e/scenarios/health-checks.test.ts
+++ b/e2e/scenarios/health-checks.test.ts
@@ -1,13 +1,14 @@
 // Cross-target: connection health checks, the feature that answers "has this
-// credential expired?" (the Google 7-day dev-token case) in one declared probe.
-// Entirely through the typed client:
+// credential expired?" (the Google 7-day dev-token case) and "whose account is
+// this?" in one declared probe. Entirely through the typed client:
 //
 //   1. register an OpenAPI integration whose `GET /me` is auth-gated,
 //   2. CONFIGURE a health check by picking that operation (the same flow the
 //      user drives in the editor: list candidates, ranked GET-first, then set),
-//   3. CHECK a SAVED connection and watch its status flip healthy -> expired
-//      when the stored key stops working,
-//   4. confirm a connection with no configured check reports `unknown`.
+//   3. VALIDATE a pasted key without saving it (the key-first connect flow) and
+//      watch the probe derive the connection identity from the live response,
+//   4. CHECK a SAVED connection and watch its status flip healthy -> expired
+//      when the stored key stops working.
 //
 // The upstream API is a real node:http server started inside the scenario on
 // 127.0.0.1 that gates `GET /me` on a bearer token: a generic "bring your own
@@ -30,14 +31,14 @@ const api = composePluginApi([openApiHttpPlugin()] as const);
 type Client = HttpApiClient.ForApi<typeof api>;
 
 const TEMPLATE = AuthTemplateSlug.make("apiKey");
-const ACCOUNT_EMAIL = "alice@example.com";
+const IDENTITY = "alice@example.com";
 
 const newSlug = (prefix: string) =>
   IntegrationSlug.make(`${prefix}-${randomBytes(4).toString("hex")}`);
 
-/** OpenAPI 3 spec with an auth-gated GET (`/me`, the obvious health check) plus a
- *  destructive POST so the candidate ranking has something to sort the GET ahead
- *  of. */
+/** OpenAPI 3 spec with an auth-gated identity GET (`/me`, the obvious health
+ *  check) plus a destructive POST so the candidate ranking has something to sort
+ *  the GET ahead of. */
 const identitySpec = (baseUrl: string): string =>
   JSON.stringify({
     openapi: "3.0.3",
@@ -73,6 +74,72 @@ const identitySpec = (baseUrl: string): string =>
     },
   });
 
+/** OpenAPI 3 spec whose `GET /me` response mirrors Vercel's `getAuthUser`: the
+ *  account is a `oneOf` of two object variants, the obvious identity scalars
+ *  (`email`, `id`) sit behind a large nested object, and one field (`limited`)
+ *  exists only on the second variant. A naive walker that follows only the first
+ *  union branch (and descends the nested object until a field cap) drops both
+ *  `user.email` and `user.limited`; the projector must merge branches and emit
+ *  shallow fields first. No live server needed (candidate projection is static). */
+const discriminatedUnionSpec = (baseUrl: string): string => {
+  // 60 nested scalars, listed before `email`, so a depth-first walk blows the
+  // field cap inside `profile` before it ever reaches the top-level identity.
+  const profileProps: Record<string, unknown> = {};
+  for (let i = 0; i < 60; i++) profileProps[`field${i}`] = { type: "string" };
+  return JSON.stringify({
+    openapi: "3.0.3",
+    info: { title: "Union Identity API", version: "1.0.0" },
+    servers: [{ url: baseUrl }],
+    paths: {
+      "/me": {
+        get: {
+          operationId: "getAuthUser",
+          summary: "The current account",
+          responses: {
+            "200": {
+              description: "The authenticated account",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      user: {
+                        oneOf: [
+                          { $ref: "#/components/schemas/AccountFull" },
+                          { $ref: "#/components/schemas/AccountLimited" },
+                        ],
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    components: {
+      schemas: {
+        AccountFull: {
+          type: "object",
+          properties: {
+            profile: { type: "object", properties: profileProps },
+            email: { type: "string" },
+            id: { type: "string" },
+          },
+        },
+        AccountLimited: {
+          type: "object",
+          properties: {
+            email: { type: "string" },
+            limited: { type: "boolean" },
+          },
+        },
+      },
+    },
+  });
+};
+
 /** A real node:http identity API on 127.0.0.1. `GET /me` returns the account
  *  JSON only when the bearer token matches `validToken`; any other token is a
  *  401 (the "the dev token got revoked" case the health check classifies as
@@ -89,7 +156,7 @@ const serveIdentityApi = (validToken: string) =>
             return;
           }
           response.writeHead(200, { "content-type": "application/json" });
-          response.end(JSON.stringify({ email: ACCOUNT_EMAIL, login: "alice" }));
+          response.end(JSON.stringify({ email: IDENTITY, login: "alice" }));
           return;
         }
         response.writeHead(404, { "content-type": "application/json" });
@@ -130,9 +197,9 @@ const registerIdentityIntegration = (client: Client, slug: IntegrationSlug, base
     },
   });
 
-/** The stored operation name for the GET probe (openapi prefixes it by tag, e.g.
- *  `me.getMe`), discovered the same way the editor does: from the ranked
- *  candidate list. */
+/** The stored operation name for the GET identity probe (openapi prefixes it by
+ *  tag, e.g. `me.getMe`), discovered the same way the editor does: from the
+ *  ranked candidate list. */
 const getMeOperation = (client: Client, slug: IntegrationSlug) =>
   Effect.gen(function* () {
     const candidates = yield* client.integrations.healthCheckCandidates({ params: { slug } });
@@ -142,7 +209,7 @@ const getMeOperation = (client: Client, slug: IntegrationSlug) =>
   });
 
 scenario(
-  "Health checks · the editor ranks the non-destructive GET ahead of the destructive POST",
+  "Health checks · configuring a check, then validating a key derives the connection identity",
   {},
   Effect.scoped(
     Effect.gen(function* () {
@@ -152,14 +219,14 @@ scenario(
       const client = yield* makeClient(api, identity);
       const goodToken = `gk_${randomBytes(8).toString("hex")}`;
       const server = yield* serveIdentityApi(goodToken);
-      const slug = newSlug("hc-rank");
+      const slug = newSlug("hc-validate");
 
       yield* Effect.ensuring(
         Effect.gen(function* () {
           yield* registerIdentityIntegration(client, slug, server.url);
 
           // The editor offers the integration's operations, ranked so the
-          // non-destructive GET endpoint floats to the top.
+          // non-destructive GET identity endpoint floats to the top.
           const candidates = yield* client.integrations.healthCheckCandidates({
             params: { slug },
           });
@@ -169,7 +236,7 @@ scenario(
             return yield* Effect.die("identity spec should expose a GET and a POST candidate");
           }
           // Operations are stored tag-prefixed (e.g. `me.getMe`); match the suffix.
-          expect(get.operation.split(".").at(-1), "the GET is offered").toBe("getMe");
+          expect(get.operation.split(".").at(-1), "the identity GET is offered").toBe("getMe");
           expect(post.operation.split(".").at(-1), "the destructive POST is offered").toBe(
             "sendMessage",
           );
@@ -177,18 +244,37 @@ scenario(
             candidates[0]?.operation,
             "the non-destructive GET ranks ahead of the destructive POST",
           ).toBe(get.operation);
-          expect(get.destructive, "the GET probe is non-destructive").toBe(false);
+          expect(get.destructive, "the GET identity probe is non-destructive").toBe(false);
           expect(post.destructive, "the POST is flagged destructive").toBe(true);
+          const operation = get.operation;
 
-          // Pick it: just the operation (a pure liveness probe).
+          // Pick it: the operation plus the dot-path to the identity field.
           yield* client.integrations.healthCheckSet({
             params: { slug },
-            payload: { spec: { operation: get.operation } },
+            payload: { spec: { operation, identityField: "email" } },
           });
           const stored = yield* client.integrations.healthCheckGet({ params: { slug } });
           expect(stored, "the chosen health check round-trips").toEqual({
-            operation: get.operation,
+            operation,
+            identityField: "email",
           });
+
+          // Key-first connect: a pasted key is probed WITHOUT saving, and the
+          // probe surfaces the identity the UI fills the connection name from.
+          const healthy = yield* client.connections.validate({
+            payload: { owner: "org", integration: slug, template: TEMPLATE, value: goodToken },
+          });
+          expect(healthy.status, "a live key validates as healthy").toBe("healthy");
+          expect(healthy.httpStatus, "the probe saw the 200").toBe(200);
+          expect(healthy.identity, "the identity is derived from the response body").toBe(IDENTITY);
+
+          // A revoked / wrong key validates as expired, with no identity.
+          const expired = yield* client.connections.validate({
+            payload: { owner: "org", integration: slug, template: TEMPLATE, value: "wrong-key" },
+          });
+          expect(expired.status, "a rejected key validates as expired").toBe("expired");
+          expect(expired.httpStatus, "the probe saw the 401").toBe(401);
+          expect(expired.identity, "no identity is surfaced for a rejected key").toBeUndefined();
         }),
         client.openapi.removeSpec({ params: { slug } }).pipe(Effect.ignore),
       );
@@ -216,10 +302,10 @@ scenario(
           const operation = yield* getMeOperation(client, slug);
           yield* client.integrations.healthCheckSet({
             params: { slug },
-            payload: { spec: { operation } },
+            payload: { spec: { operation, identityField: "email" } },
           });
 
-          // A connection holding the live key checks out healthy.
+          // A connection holding the live key checks out healthy, identity and all.
           yield* client.connections.create({
             payload: {
               owner: "org",
@@ -234,6 +320,7 @@ scenario(
           });
           expect(healthy.status, "the saved connection's live key is healthy").toBe("healthy");
           expect(healthy.httpStatus, "the saved probe saw the 200").toBe(200);
+          expect(healthy.identity, "the saved probe derives the account identity").toBe(IDENTITY);
 
           // Re-creating the same (owner, integration, name) replaces the stored
           // key in place: now the connection holds a key the server rejects.
@@ -251,6 +338,7 @@ scenario(
           });
           expect(expired.status, "the same connection now reads as expired").toBe("expired");
           expect(expired.httpStatus, "the saved probe saw the 401").toBe(401);
+          expect(expired.identity, "an expired connection surfaces no identity").toBeUndefined();
         }),
         Effect.gen(function* () {
           yield* client.connections
@@ -258,6 +346,56 @@ scenario(
             .pipe(Effect.ignore);
           yield* client.openapi.removeSpec({ params: { slug } }).pipe(Effect.ignore);
         }),
+      );
+    }),
+  ),
+);
+
+scenario(
+  "Health checks · the identity picker surfaces shallow fields across a discriminated union",
+  {},
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const { client: makeClient } = yield* Api;
+      const identity = yield* target.newIdentity();
+      const client = yield* makeClient(api, identity);
+      const slug = newSlug("hc-union");
+
+      yield* Effect.ensuring(
+        Effect.gen(function* () {
+          yield* client.openapi.addSpec({
+            payload: {
+              spec: { kind: "blob", value: discriminatedUnionSpec("https://union.example.com") },
+              slug,
+              baseUrl: "https://union.example.com",
+              authenticationTemplate: [
+                {
+                  slug: "apiKey",
+                  type: "apiKey",
+                  headers: { authorization: ["Bearer ", { type: "variable", name: "token" }] },
+                },
+              ],
+            },
+          });
+
+          // The identity picker is fed by the GET candidate's projected response
+          // fields. They must include the shallow identity scalar even though it
+          // sits behind a 60-field nested object...
+          const candidates = yield* client.integrations.healthCheckCandidates({ params: { slug } });
+          const get = candidates.find((candidate) => candidate.method === "get");
+          if (!get) return yield* Effect.die("union spec exposed no GET candidate");
+          const paths = (get.responseFields ?? []).map((field) => field.path);
+          expect(paths, "the shallow identity scalar is offered, not starved by nesting").toContain(
+            "user.email",
+          );
+          // ...and the field that exists ONLY on the second union variant, proving
+          // every branch contributes (not just the first).
+          expect(paths, "a field unique to the second union branch is offered").toContain(
+            "user.limited",
+          );
+        }),
+        client.openapi.removeSpec({ params: { slug } }).pipe(Effect.ignore),
       );
     }),
   ),

--- a/e2e/scenarios/health-checks.test.ts
+++ b/e2e/scenarios/health-checks.test.ts
@@ -1,0 +1,315 @@
+// Cross-target: connection health checks, the feature that answers "has this
+// credential expired?" (the Google 7-day dev-token case) in one declared probe.
+// Entirely through the typed client:
+//
+//   1. register an OpenAPI integration whose `GET /me` is auth-gated,
+//   2. CONFIGURE a health check by picking that operation (the same flow the
+//      user drives in the editor: list candidates, ranked GET-first, then set),
+//   3. CHECK a SAVED connection and watch its status flip healthy -> expired
+//      when the stored key stops working,
+//   4. confirm a connection with no configured check reports `unknown`.
+//
+// The upstream API is a real node:http server started inside the scenario on
+// 127.0.0.1 that gates `GET /me` on a bearer token: a generic "bring your own
+// OpenAPI" integration, so the generic openapi health-check path is exercised
+// rather than any one provider's quirks.
+import { randomBytes } from "node:crypto";
+import { createServer } from "node:http";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import type { HttpApiClient } from "effect/unstable/httpapi";
+import { composePluginApi } from "@executor-js/api/server";
+import { openApiHttpPlugin } from "@executor-js/plugin-openapi/api";
+import { AuthTemplateSlug, ConnectionName, IntegrationSlug } from "@executor-js/sdk/shared";
+
+import { scenario } from "../src/scenario";
+import { Api, Target } from "../src/services";
+
+const api = composePluginApi([openApiHttpPlugin()] as const);
+type Client = HttpApiClient.ForApi<typeof api>;
+
+const TEMPLATE = AuthTemplateSlug.make("apiKey");
+const ACCOUNT_EMAIL = "alice@example.com";
+
+const newSlug = (prefix: string) =>
+  IntegrationSlug.make(`${prefix}-${randomBytes(4).toString("hex")}`);
+
+/** OpenAPI 3 spec with an auth-gated GET (`/me`, the obvious health check) plus a
+ *  destructive POST so the candidate ranking has something to sort the GET ahead
+ *  of. */
+const identitySpec = (baseUrl: string): string =>
+  JSON.stringify({
+    openapi: "3.0.3",
+    info: { title: "Identity API", version: "1.0.0" },
+    servers: [{ url: baseUrl }],
+    paths: {
+      "/me": {
+        get: {
+          operationId: "getMe",
+          summary: "The current account",
+          responses: {
+            "200": {
+              description: "The authenticated account",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: { email: { type: "string" }, login: { type: "string" } },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      "/messages": {
+        post: {
+          operationId: "sendMessage",
+          summary: "Send a message",
+          responses: { "201": { description: "created" } },
+        },
+      },
+    },
+  });
+
+/** A real node:http identity API on 127.0.0.1. `GET /me` returns the account
+ *  JSON only when the bearer token matches `validToken`; any other token is a
+ *  401 (the "the dev token got revoked" case the health check classifies as
+ *  expired). Closed by the scope's finalizer. */
+const serveIdentityApi = (validToken: string) =>
+  Effect.acquireRelease(
+    Effect.callback<{ readonly url: string; readonly close: () => void }>((resume) => {
+      const server = createServer((request, response) => {
+        const authorized = request.headers["authorization"] === `Bearer ${validToken}`;
+        if (request.method === "GET" && (request.url ?? "").startsWith("/me")) {
+          if (!authorized) {
+            response.writeHead(401, { "content-type": "application/json" });
+            response.end(JSON.stringify({ error: "invalid_token" }));
+            return;
+          }
+          response.writeHead(200, { "content-type": "application/json" });
+          response.end(JSON.stringify({ email: ACCOUNT_EMAIL, login: "alice" }));
+          return;
+        }
+        response.writeHead(404, { "content-type": "application/json" });
+        response.end(JSON.stringify({ error: "not_found" }));
+      });
+      server.listen(0, "127.0.0.1", () => {
+        const address = server.address();
+        const port = typeof address === "object" && address ? address.port : 0;
+        resume(
+          Effect.succeed({
+            url: `http://127.0.0.1:${port}`,
+            close: () => {
+              server.close();
+              server.closeAllConnections();
+            },
+          }),
+        );
+      });
+    }),
+    (server) => Effect.sync(server.close),
+  );
+
+/** Register the identity integration against `baseUrl` with a bearer-token auth
+ *  method (single `token` input → connection `value`). Returns the slug. */
+const registerIdentityIntegration = (client: Client, slug: IntegrationSlug, baseUrl: string) =>
+  client.openapi.addSpec({
+    payload: {
+      spec: { kind: "blob", value: identitySpec(baseUrl) },
+      slug,
+      baseUrl,
+      authenticationTemplate: [
+        {
+          slug: "apiKey",
+          type: "apiKey",
+          headers: { authorization: ["Bearer ", { type: "variable", name: "token" }] },
+        },
+      ],
+    },
+  });
+
+/** The stored operation name for the GET probe (openapi prefixes it by tag, e.g.
+ *  `me.getMe`), discovered the same way the editor does: from the ranked
+ *  candidate list. */
+const getMeOperation = (client: Client, slug: IntegrationSlug) =>
+  Effect.gen(function* () {
+    const candidates = yield* client.integrations.healthCheckCandidates({ params: { slug } });
+    const getMe = candidates.find((candidate) => candidate.method === "get");
+    if (!getMe) return yield* Effect.die("identity spec exposed no GET candidate");
+    return getMe.operation;
+  });
+
+scenario(
+  "Health checks · the editor ranks the non-destructive GET ahead of the destructive POST",
+  {},
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const { client: makeClient } = yield* Api;
+      const identity = yield* target.newIdentity();
+      const client = yield* makeClient(api, identity);
+      const goodToken = `gk_${randomBytes(8).toString("hex")}`;
+      const server = yield* serveIdentityApi(goodToken);
+      const slug = newSlug("hc-rank");
+
+      yield* Effect.ensuring(
+        Effect.gen(function* () {
+          yield* registerIdentityIntegration(client, slug, server.url);
+
+          // The editor offers the integration's operations, ranked so the
+          // non-destructive GET endpoint floats to the top.
+          const candidates = yield* client.integrations.healthCheckCandidates({
+            params: { slug },
+          });
+          const get = candidates.find((candidate) => candidate.method === "get");
+          const post = candidates.find((candidate) => candidate.method === "post");
+          if (!get || !post) {
+            return yield* Effect.die("identity spec should expose a GET and a POST candidate");
+          }
+          // Operations are stored tag-prefixed (e.g. `me.getMe`); match the suffix.
+          expect(get.operation.split(".").at(-1), "the GET is offered").toBe("getMe");
+          expect(post.operation.split(".").at(-1), "the destructive POST is offered").toBe(
+            "sendMessage",
+          );
+          expect(
+            candidates[0]?.operation,
+            "the non-destructive GET ranks ahead of the destructive POST",
+          ).toBe(get.operation);
+          expect(get.destructive, "the GET probe is non-destructive").toBe(false);
+          expect(post.destructive, "the POST is flagged destructive").toBe(true);
+
+          // Pick it: just the operation (a pure liveness probe).
+          yield* client.integrations.healthCheckSet({
+            params: { slug },
+            payload: { spec: { operation: get.operation } },
+          });
+          const stored = yield* client.integrations.healthCheckGet({ params: { slug } });
+          expect(stored, "the chosen health check round-trips").toEqual({
+            operation: get.operation,
+          });
+        }),
+        client.openapi.removeSpec({ params: { slug } }).pipe(Effect.ignore),
+      );
+    }),
+  ),
+);
+
+scenario(
+  "Health checks · a saved connection reports healthy, then expired when its key stops working",
+  {},
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const { client: makeClient } = yield* Api;
+      const identity = yield* target.newIdentity();
+      const client = yield* makeClient(api, identity);
+      const goodToken = `gk_${randomBytes(8).toString("hex")}`;
+      const server = yield* serveIdentityApi(goodToken);
+      const slug = newSlug("hc-saved");
+      const name = ConnectionName.make("main");
+
+      yield* Effect.ensuring(
+        Effect.gen(function* () {
+          yield* registerIdentityIntegration(client, slug, server.url);
+          const operation = yield* getMeOperation(client, slug);
+          yield* client.integrations.healthCheckSet({
+            params: { slug },
+            payload: { spec: { operation } },
+          });
+
+          // A connection holding the live key checks out healthy.
+          yield* client.connections.create({
+            payload: {
+              owner: "org",
+              name,
+              integration: slug,
+              template: TEMPLATE,
+              value: goodToken,
+            },
+          });
+          const healthy = yield* client.connections.checkHealth({
+            params: { owner: "org", integration: slug, name },
+          });
+          expect(healthy.status, "the saved connection's live key is healthy").toBe("healthy");
+          expect(healthy.httpStatus, "the saved probe saw the 200").toBe(200);
+
+          // Re-creating the same (owner, integration, name) replaces the stored
+          // key in place: now the connection holds a key the server rejects.
+          yield* client.connections.create({
+            payload: {
+              owner: "org",
+              name,
+              integration: slug,
+              template: TEMPLATE,
+              value: "rotated-away",
+            },
+          });
+          const expired = yield* client.connections.checkHealth({
+            params: { owner: "org", integration: slug, name },
+          });
+          expect(expired.status, "the same connection now reads as expired").toBe("expired");
+          expect(expired.httpStatus, "the saved probe saw the 401").toBe(401);
+        }),
+        Effect.gen(function* () {
+          yield* client.connections
+            .remove({ params: { owner: "org", integration: slug, name } })
+            .pipe(Effect.ignore);
+          yield* client.openapi.removeSpec({ params: { slug } }).pipe(Effect.ignore);
+        }),
+      );
+    }),
+  ),
+);
+
+scenario(
+  "Health checks · a connection with no configured check reports unknown, not a failure",
+  {},
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const { client: makeClient } = yield* Api;
+      const identity = yield* target.newIdentity();
+      const client = yield* makeClient(api, identity);
+      const goodToken = `gk_${randomBytes(8).toString("hex")}`;
+      const server = yield* serveIdentityApi(goodToken);
+      const slug = newSlug("hc-unknown");
+      const name = ConnectionName.make("main");
+
+      yield* Effect.ensuring(
+        Effect.gen(function* () {
+          // No healthCheckSet: the integration declares no probe.
+          yield* registerIdentityIntegration(client, slug, server.url);
+          expect(
+            yield* client.integrations.healthCheckGet({ params: { slug } }),
+            "an integration with no configured check reports none",
+          ).toBeNull();
+
+          yield* client.connections.create({
+            payload: {
+              owner: "org",
+              name,
+              integration: slug,
+              template: TEMPLATE,
+              value: goodToken,
+            },
+          });
+          const result = yield* client.connections.checkHealth({
+            params: { owner: "org", integration: slug, name },
+          });
+          expect(result.status, "with no check configured the status is unknown").toBe("unknown");
+          expect(result.detail ?? "", "the result explains why it is unknown").toContain(
+            "No health check configured",
+          );
+        }),
+        Effect.gen(function* () {
+          yield* client.connections
+            .remove({ params: { owner: "org", integration: slug, name } })
+            .pipe(Effect.ignore);
+          yield* client.openapi.removeSpec({ params: { slug } }).pipe(Effect.ignore);
+        }),
+      );
+    }),
+  ),
+);

--- a/packages/core/api/src/connections/api.ts
+++ b/packages/core/api/src/connections/api.ts
@@ -16,6 +16,8 @@ import {
   ConnectionName,
   ConnectionNotFoundError,
   CredentialProviderNotRegisteredError,
+  HealthCheckResult,
+  HealthCheckSpec,
   IntegrationNotFoundError,
   IntegrationSlug,
   InternalError,
@@ -92,6 +94,31 @@ const UpdateConnectionPayload = Schema.Struct({
 
 const CreateConnectionPayload = Schema.Struct({
   ...CommonCreateFields,
+  value: Schema.optional(Schema.String),
+  values: Schema.optional(Schema.Record(Schema.String, Schema.String)),
+  from: Schema.optional(
+    Schema.Struct({
+      provider: ProviderKey,
+      id: ProviderItemId,
+    }),
+  ),
+}).check(
+  Schema.makeFilter((payload) =>
+    [payload.value, payload.values, payload.from].filter(Predicate.isNotUndefined).length === 1
+      ? undefined
+      : "Expected exactly one credential origin",
+  ),
+);
+
+// Validate an in-flight credential WITHOUT saving it (the key-first connect
+// flow). Same origin shape as create, plus an optional `spec` override so the
+// editor can preview a candidate against a live key. No `name` — the point is
+// to derive one from the identity the probe returns.
+const ValidateConnectionPayload = Schema.Struct({
+  owner: Owner,
+  integration: IntegrationSlug,
+  template: AuthTemplateSlug,
+  spec: Schema.optional(HealthCheckSpec),
   value: Schema.optional(Schema.String),
   values: Schema.optional(Schema.Record(Schema.String, Schema.String)),
   from: Schema.optional(
@@ -185,5 +212,26 @@ export const ConnectionsApi = HttpApiGroup.make("connections")
       params: ConnectionParams,
       success: Schema.Array(ToolResponse),
       error: [InternalError, ConnectionNotFound, IntegrationNotFound],
+    }),
+  )
+  // Run the integration's declared health check against a SAVED connection: is
+  // this credential still alive (Google's 7-day dev-token revocation), and whose
+  // account is it? Returns a classified status + optional identity, never an
+  // error for an auth wall (that surfaces as `status: "expired"`).
+  .add(
+    HttpApiEndpoint.post("checkHealth", "/connections/:owner/:integration/:name/health", {
+      params: ConnectionParams,
+      success: HealthCheckResult,
+      error: [InternalError, ConnectionNotFound, IntegrationNotFound],
+    }),
+  )
+  // Run the health check against an IN-FLIGHT credential without saving it (the
+  // key-first connect flow): confirm the pasted key works and surface the
+  // identity the UI derives a connection name from before anything persists.
+  .add(
+    HttpApiEndpoint.post("validate", "/connections/validate", {
+      payload: ValidateConnectionPayload,
+      success: HealthCheckResult,
+      error: [InternalError, IntegrationNotFound],
     }),
   );

--- a/packages/core/api/src/handlers/connections.ts
+++ b/packages/core/api/src/handlers/connections.ts
@@ -44,7 +44,9 @@ const toHealthResponse = (r: HealthCheckResult) => ({
   status: r.status,
   checkedAt: r.checkedAt,
   ...(r.httpStatus !== undefined ? { httpStatus: r.httpStatus } : {}),
+  ...(r.identity !== undefined ? { identity: r.identity } : {}),
   ...(r.detail !== undefined ? { detail: r.detail } : {}),
+  ...(r.responseSample !== undefined ? { responseSample: r.responseSample } : {}),
 });
 
 export const ConnectionsHandlers = HttpApiBuilder.group(ExecutorApi, "connections", (handlers) =>

--- a/packages/core/api/src/handlers/connections.ts
+++ b/packages/core/api/src/handlers/connections.ts
@@ -7,7 +7,9 @@ import {
   type Connection,
   type ConnectionRef,
   type CreateConnectionInput,
+  type HealthCheckResult,
   type Tool,
+  type ValidateConnectionInput,
 } from "@executor-js/sdk";
 
 import { ExecutorApi } from "../api";
@@ -36,6 +38,13 @@ const toolToResponse = (t: Tool) => ({
   name: String(t.name),
   pluginId: t.pluginId,
   description: t.description,
+});
+
+const toHealthResponse = (r: HealthCheckResult) => ({
+  status: r.status,
+  checkedAt: r.checkedAt,
+  ...(r.httpStatus !== undefined ? { httpStatus: r.httpStatus } : {}),
+  ...(r.detail !== undefined ? { detail: r.detail } : {}),
 });
 
 export const ConnectionsHandlers = HttpApiBuilder.group(ExecutorApi, "connections", (handlers) =>
@@ -128,6 +137,31 @@ export const ConnectionsHandlers = HttpApiBuilder.group(ExecutorApi, "connection
             name: path.name,
           });
           return tools.map(toolToResponse);
+        }),
+      ),
+    )
+    .handle("checkHealth", ({ params: path }) =>
+      capture(
+        Effect.gen(function* () {
+          const executor = yield* ExecutorService;
+          const result = yield* executor.connections.checkHealth({
+            owner: path.owner,
+            integration: path.integration,
+            name: path.name,
+          });
+          return toHealthResponse(result);
+        }),
+      ),
+    )
+    .handle("validate", ({ payload }) =>
+      capture(
+        Effect.gen(function* () {
+          const executor = yield* ExecutorService;
+          // The payload mirrors `ValidateConnectionInput`: owner/integration/
+          // template/spec plus a single credential origin (`value` | `values` |
+          // `from`). Pass it through verbatim.
+          const result = yield* executor.connections.validate(payload as ValidateConnectionInput);
+          return toHealthResponse(result);
         }),
       ),
     ),

--- a/packages/core/api/src/handlers/integrations.ts
+++ b/packages/core/api/src/handlers/integrations.ts
@@ -79,5 +79,30 @@ export const IntegrationsHandlers = HttpApiBuilder.group(ExecutorApi, "integrati
           }));
         }),
       ),
+    )
+    .handle("healthCheckGet", ({ params: path }) =>
+      capture(
+        Effect.gen(function* () {
+          const executor = yield* ExecutorService;
+          return yield* executor.integrations.healthCheck.get(path.slug);
+        }),
+      ),
+    )
+    .handle("healthCheckCandidates", ({ params: path }) =>
+      capture(
+        Effect.gen(function* () {
+          const executor = yield* ExecutorService;
+          return yield* executor.integrations.healthCheck.candidates(path.slug);
+        }),
+      ),
+    )
+    .handle("healthCheckSet", ({ params: path, payload }) =>
+      capture(
+        Effect.gen(function* () {
+          const executor = yield* ExecutorService;
+          yield* executor.integrations.healthCheck.set(path.slug, payload.spec);
+          return { ok: true };
+        }),
+      ),
     ),
 );

--- a/packages/core/api/src/integrations/api.ts
+++ b/packages/core/api/src/integrations/api.ts
@@ -11,6 +11,8 @@
 import { HttpApiEndpoint, HttpApiGroup } from "effect/unstable/httpapi";
 import { Schema } from "effect";
 import {
+  HealthCheckCandidate,
+  HealthCheckSpec,
   IntegrationDetectionResult,
   IntegrationNotFoundError,
   IntegrationRemovalNotAllowedError,
@@ -88,6 +90,12 @@ const DetectRequest = Schema.Struct({
   url: Schema.String.check(Schema.isMaxLength(2_048)),
 });
 
+// Set (or clear, with null) the integration's declared health check. The spec
+// lives inside the owning plugin's opaque config; core only routes it.
+const SetHealthCheckPayload = Schema.Struct({
+  spec: Schema.NullOr(HealthCheckSpec),
+});
+
 // ---------------------------------------------------------------------------
 // Error schemas with HTTP status annotations
 // ---------------------------------------------------------------------------
@@ -135,5 +143,31 @@ export const IntegrationsApi = HttpApiGroup.make("integrations")
       payload: DetectRequest,
       success: Schema.Array(IntegrationDetectionResult),
       error: InternalError,
+    }),
+  )
+  // The integration's currently declared health check (null when none is set).
+  .add(
+    HttpApiEndpoint.get("healthCheckGet", "/integrations/:slug/health-check", {
+      params: IntegrationParams,
+      success: Schema.NullOr(HealthCheckSpec),
+      error: InternalError,
+    }),
+  )
+  // Operations the user can pick as the health check, ranked non-destructive +
+  // fewest-required-args first so the obvious identity endpoint floats to the top.
+  .add(
+    HttpApiEndpoint.get("healthCheckCandidates", "/integrations/:slug/health-check/candidates", {
+      params: IntegrationParams,
+      success: Schema.Array(HealthCheckCandidate),
+      error: [InternalError, IntegrationNotFound],
+    }),
+  )
+  // Persist (or clear) the integration's health check.
+  .add(
+    HttpApiEndpoint.put("healthCheckSet", "/integrations/:slug/health-check", {
+      params: IntegrationParams,
+      payload: SetHealthCheckPayload,
+      success: Schema.Struct({ ok: Schema.Boolean }),
+      error: [InternalError, IntegrationNotFound],
     }),
   );

--- a/packages/core/sdk/src/connection.ts
+++ b/packages/core/sdk/src/connection.ts
@@ -8,6 +8,7 @@ import type {
   ProviderItemId,
   ProviderKey,
 } from "./ids";
+import type { HealthCheckSpec } from "./health-check";
 
 /* A Connection is THE saved credential — secret, account, and connection are one
  * concept — bound to exactly ONE integration (born wired; there is no unwired
@@ -93,6 +94,19 @@ export type CreateConnectionInput = {
   readonly template: AuthTemplateSlug;
   readonly identityLabel?: string | null;
   readonly description?: string | null;
+} & ConnectionValueInput;
+
+/** Validate an in-flight credential WITHOUT saving it (the key-first connect
+ *  flow). Resolves the pasted value(s) the same way `create` would, then runs
+ *  the integration's declared health check so the UI can confirm the key works
+ *  and derive a connection name from the returned identity before anything is
+ *  persisted. `spec` overrides the integration's declared check (used by the
+ *  editor to preview a candidate against a live key). */
+export type ValidateConnectionInput = {
+  readonly owner: Owner;
+  readonly integration: IntegrationSlug;
+  readonly template: AuthTemplateSlug;
+  readonly spec?: HealthCheckSpec;
 } & ConnectionValueInput;
 
 /** Edit a connection's user-curated metadata. Only the provided fields change;

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -25,7 +25,9 @@ import type {
   CreateConnectionInput,
   ConnectionValueInput,
   UpdateConnectionInput,
+  ValidateConnectionInput,
 } from "./connection";
+import type { HealthCheckCandidate, HealthCheckResult, HealthCheckSpec } from "./health-check";
 import {
   coreSchema,
   isToolPolicyAction,
@@ -256,6 +258,29 @@ export type Executor<TPlugins extends readonly AnyPlugin[] = readonly []> = {
     readonly detect: (
       url: string,
     ) => Effect.Effect<readonly IntegrationDetectionResult[], StorageFailure>;
+    /** The integration's declared health check: which authenticated operation a
+     *  connection runs to prove its credential is alive and surface whose
+     *  account it is. Configured by the user the same way auth methods are. */
+    readonly healthCheck: {
+      /** The currently declared check, or null when none is configured (or the
+       *  owning plugin has no health-check capability). */
+      readonly get: (
+        slug: IntegrationSlug,
+      ) => Effect.Effect<HealthCheckSpec | null, StorageFailure>;
+      /** The operations a user can pick from, ranked non-destructive-first then
+       *  fewest required arguments. Empty when the plugin has no candidates. */
+      readonly candidates: (
+        slug: IntegrationSlug,
+      ) => Effect.Effect<
+        readonly HealthCheckCandidate[],
+        IntegrationNotFoundError | StorageFailure
+      >;
+      /** Declare (or clear, with `null`) the health check for the integration. */
+      readonly set: (
+        slug: IntegrationSlug,
+        spec: HealthCheckSpec | null,
+      ) => Effect.Effect<void, IntegrationNotFoundError | StorageFailure>;
+    };
   };
 
   readonly connections: {
@@ -288,6 +313,23 @@ export type Executor<TPlugins extends readonly AnyPlugin[] = readonly []> = {
       readonly Tool[],
       ConnectionNotFoundError | IntegrationNotFoundError | StorageFailure
     >;
+    /** Run the integration's declared health check against a saved connection:
+     *  classify the credential (healthy / expired / degraded / unknown) and
+     *  extract its identity for display. Never throws on an auth wall or upstream
+     *  error: those come back as a `HealthCheckResult` with the matching status. */
+    readonly checkHealth: (
+      ref: ConnectionRef,
+    ) => Effect.Effect<
+      HealthCheckResult,
+      ConnectionNotFoundError | IntegrationNotFoundError | StorageFailure
+    >;
+    /** Validate an in-flight credential WITHOUT saving it (key-first connect):
+     *  resolve the pasted value(s), run the health check, and return the result
+     *  so the caller can confirm the key works and derive a name from the
+     *  identity before creating the connection. */
+    readonly validate: (
+      input: ValidateConnectionInput,
+    ) => Effect.Effect<HealthCheckResult, IntegrationNotFoundError | StorageFailure>;
   };
 
   /** Shared OAuth service. Hosts use this through the core HTTP OAuth group;
@@ -1698,6 +1740,39 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
       }
     };
 
+    // Project a row's declared health check via the owning plugin's
+    // `describeHealthCheck` hook. Pure (no I/O); degrades a plugin throw to
+    // `null` like the other catalog projectors.
+    const describeHealthCheckForRow = (row: IntegrationRow): HealthCheckSpec | null => {
+      const runtime = runtimes.get(row.plugin_id);
+      const describe = runtime?.plugin.describeHealthCheck;
+      if (!describe) return null;
+      const record = rowToIntegrationRecord(row);
+      // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: plugin-authored projector must never fail the catalog read
+      try {
+        return describe(record);
+      } catch {
+        return null;
+      }
+    };
+
+    // The health-check hooks are typed `Effect<_, unknown>` at the PluginSpec
+    // boundary (each plugin owns its own error shape). Fold that channel into a
+    // StorageError so the public health-check surface stays StorageFailure-typed.
+    // A genuine storage failure surfaces here; an auth wall or upstream error is
+    // a SUCCESSFUL `HealthCheckResult` (status expired/degraded), not a failure.
+    const foldPluginFailure = <A>(
+      effect: Effect.Effect<A, unknown>,
+      message: string,
+    ): Effect.Effect<A, StorageFailure> =>
+      effect.pipe(
+        Effect.catch((cause: unknown) =>
+          isStorageFailure(cause)
+            ? Effect.fail(cause)
+            : Effect.fail(new StorageError({ message, cause })),
+        ),
+      );
+
     const integrationsList = (): Effect.Effect<readonly Integration[], StorageFailure> =>
       core
         .findMany("integration", {})
@@ -1843,6 +1918,54 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
           if (result) results.push(result);
         }
         return results;
+      });
+
+    // ------------------------------------------------------------------
+    // Health checks — dispatch to the owning plugin's hooks.
+    // ------------------------------------------------------------------
+
+    const integrationHealthCheckGet = (
+      slug: IntegrationSlug,
+    ): Effect.Effect<HealthCheckSpec | null, StorageFailure> =>
+      findIntegrationRow(slug).pipe(
+        Effect.map((row) => (row ? describeHealthCheckForRow(row) : null)),
+      );
+
+    const integrationHealthCheckCandidates = (
+      slug: IntegrationSlug,
+    ): Effect.Effect<readonly HealthCheckCandidate[], IntegrationNotFoundError | StorageFailure> =>
+      Effect.gen(function* () {
+        const row = yield* findIntegrationRow(slug);
+        if (!row) return yield* new IntegrationNotFoundError({ slug });
+        const runtime = runtimes.get(row.plugin_id);
+        const list = runtime?.plugin.listHealthCheckCandidates;
+        if (!runtime || !list) return [];
+        const record = rowToIntegrationRecord(row, describeAuthMethodsForRow(row));
+        return yield* foldPluginFailure(
+          list({ ctx: runtime.ctx, integration: record }),
+          `Listing health-check candidates for "${slug}" failed.`,
+        );
+      });
+
+    const integrationSetHealthCheck = (
+      slug: IntegrationSlug,
+      spec: HealthCheckSpec | null,
+    ): Effect.Effect<void, IntegrationNotFoundError | StorageFailure> =>
+      Effect.gen(function* () {
+        const row = yield* findIntegrationRow(slug);
+        if (!row) return yield* new IntegrationNotFoundError({ slug });
+        const runtime = runtimes.get(row.plugin_id);
+        const set = runtime?.plugin.setHealthCheck;
+        if (!runtime || !set) {
+          return yield* new StorageError({
+            message: `Plugin "${row.plugin_id}" does not support health checks.`,
+            cause: undefined,
+          });
+        }
+        yield* foldPluginFailure(
+          set({ ctx: runtime.ctx, integration: slug, spec }),
+          `Setting the health check for "${slug}" failed.`,
+        );
       });
 
     // ------------------------------------------------------------------
@@ -2410,6 +2533,114 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
           return yield* new IntegrationNotFoundError({ slug: ref.integration });
         }
         return yield* produceConnectionTools(integrationRow, ref);
+      });
+
+    // No health-check capability ⇒ "unknown" rather than an error: the caller
+    // can still render the connection, just without a liveness verdict.
+    const unknownHealth = (): HealthCheckResult => ({ status: "unknown", checkedAt: Date.now() });
+
+    // Resolve an in-flight credential's value map (key-first validation) without
+    // saving anything. Mirrors `resolveConnectionValues` for the saved-row path:
+    // pasted `value`/`values` are used directly; `from` origins resolve through
+    // their provider. Single-secret sugar lands on the `token` variable.
+    const resolveInFlightValues = (
+      input: ConnectionValueInput,
+    ): Effect.Effect<Record<string, string | null>, StorageFailure> =>
+      Effect.gen(function* () {
+        const out: Record<string, string | null> = {};
+        for (const { variable, origin } of normalizeConnectionInputs(input)) {
+          if ("value" in origin) {
+            out[variable] = origin.value;
+            continue;
+          }
+          const provider = credentialProviders.get(String(origin.from.provider));
+          if (!provider) {
+            return yield* new StorageError({
+              message: `Credential provider "${origin.from.provider}" is not registered.`,
+              cause: undefined,
+            });
+          }
+          out[variable] = yield* provider.get(origin.from.id);
+        }
+        return out;
+      });
+
+    const connectionCheckHealth = (
+      ref: ConnectionRef,
+    ): Effect.Effect<
+      HealthCheckResult,
+      ConnectionNotFoundError | IntegrationNotFoundError | StorageFailure
+    > =>
+      Effect.gen(function* () {
+        const connectionRow = yield* findConnectionRow(ref);
+        if (!connectionRow) {
+          return yield* new ConnectionNotFoundError({
+            owner: ref.owner,
+            integration: ref.integration,
+            name: ref.name,
+          });
+        }
+        const integrationRow = yield* findIntegrationRow(ref.integration);
+        if (!integrationRow) {
+          return yield* new IntegrationNotFoundError({ slug: ref.integration });
+        }
+        const runtime = runtimes.get(integrationRow.plugin_id);
+        const check = runtime?.plugin.checkHealth;
+        if (!runtime || !check) return unknownHealth();
+
+        const values = yield* foldResolutionFailure(resolveConnectionValues(connectionRow));
+        const record = rowToIntegrationRecord(
+          integrationRow,
+          describeAuthMethodsForRow(integrationRow),
+        );
+        const credential: ToolInvocationCredential = {
+          owner: connectionRow.owner as Owner,
+          integration: ref.integration,
+          connection: ConnectionName.make(connectionRow.name),
+          template: AuthTemplateSlug.make(connectionRow.template),
+          value: values[PRIMARY_INPUT_VARIABLE] ?? null,
+          values,
+          config: record.config,
+        };
+        return yield* foldPluginFailure(
+          check({ ctx: runtime.ctx, integration: record, credential }),
+          `Health check for connection "${ref.name}" failed.`,
+        );
+      });
+
+    const connectionValidate = (
+      input: ValidateConnectionInput,
+    ): Effect.Effect<HealthCheckResult, IntegrationNotFoundError | StorageFailure> =>
+      Effect.gen(function* () {
+        const integrationRow = yield* findIntegrationRow(input.integration);
+        if (!integrationRow) {
+          return yield* new IntegrationNotFoundError({ slug: input.integration });
+        }
+        const runtime = runtimes.get(integrationRow.plugin_id);
+        const check = runtime?.plugin.checkHealth;
+        if (!runtime || !check) return unknownHealth();
+
+        const values = yield* resolveInFlightValues(input);
+        const record = rowToIntegrationRecord(
+          integrationRow,
+          describeAuthMethodsForRow(integrationRow),
+        );
+        const credential: ToolInvocationCredential = {
+          owner: input.owner,
+          integration: input.integration,
+          // No connection exists yet (key-first); a synthetic name keeps the
+          // credential shape whole. The probe authenticates on values+template,
+          // not on this name (it only appears in upstream-error messages).
+          connection: ConnectionName.make("(unsaved)"),
+          template: input.template,
+          value: values[PRIMARY_INPUT_VARIABLE] ?? null,
+          values,
+          config: record.config,
+        };
+        return yield* foldPluginFailure(
+          check({ ctx: runtime.ctx, integration: record, credential, spec: input.spec }),
+          `Validating credential for "${input.integration}" failed.`,
+        );
       });
 
     // ------------------------------------------------------------------
@@ -3272,6 +3503,11 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
         update: integrationsUpdatePublic,
         remove: integrationsRemove,
         detect: integrationsDetect,
+        healthCheck: {
+          get: integrationHealthCheckGet,
+          candidates: integrationHealthCheckCandidates,
+          set: integrationSetHealthCheck,
+        },
       },
       connections: {
         create: connectionsCreate,
@@ -3280,6 +3516,8 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
         update: connectionsUpdate,
         remove: connectionsRemove,
         refresh: connectionsRefresh,
+        checkHealth: connectionCheckHealth,
+        validate: connectionValidate,
       },
       oauth,
       tools: {

--- a/packages/core/sdk/src/health-check.ts
+++ b/packages/core/sdk/src/health-check.ts
@@ -1,0 +1,122 @@
+// ---------------------------------------------------------------------------
+// @executor-js/sdk health-check vocabulary — browser-safe.
+//
+// A health check is a single declared, authenticated operation a connection can
+// run to answer one question: "is this credential still alive?". The plugin owns
+// WHICH operation (it lives in the plugin's opaque integration config, picked by
+// the user the same way auth methods are configured); core owns the shared
+// vocabulary below so every surface (API, React, plugins) speaks the same shapes.
+//
+// The probe runs an operation with optional pinned `args` (some liveness
+// endpoints need a fixed parameter; e.g. Google's People API needs
+// `resourceName=people/me`), maps the HTTP status to a `HealthStatus`, and
+// reports it. Everything here is pure Effect/Schema with no server/node imports
+// so it is safe to import from React.
+// ---------------------------------------------------------------------------
+
+import { Schema } from "effect";
+
+// ---------------------------------------------------------------------------
+// Status — the four states a connection can be in. `expired` is the one this
+// whole feature exists for (Google's 7-day dev-token revocation): the credential
+// authenticated fine yesterday and now returns 401/403. `degraded` covers any
+// other non-2xx (upstream 5xx, a 404 on a mis-picked operation); `unknown` is
+// "never checked / no health check configured".
+// ---------------------------------------------------------------------------
+
+export const HealthStatus = Schema.Literals(["healthy", "expired", "degraded", "unknown"]);
+export type HealthStatus = typeof HealthStatus.Type;
+
+// ---------------------------------------------------------------------------
+// HealthCheckSpec — the persisted configuration: which operation to run and any
+// pinned arguments. Stored inside the owning plugin's opaque integration config;
+// core never parses it (the plugin reads it back in `checkHealth`).
+// ---------------------------------------------------------------------------
+
+export const HealthCheckSpec = Schema.Struct({
+  /** The tool / operation name to invoke (the plugin maps this to its binding). */
+  operation: Schema.String,
+  /** Pinned arguments merged into the probe call. Required for liveness
+   *  endpoints that take a fixed parameter (e.g. People API `resourceName`). */
+  args: Schema.optional(Schema.Record(Schema.String, Schema.Unknown)),
+});
+export type HealthCheckSpec = typeof HealthCheckSpec.Type;
+
+// ---------------------------------------------------------------------------
+// HealthCheckResult — the outcome of running a probe. `httpStatus` and `detail`
+// are diagnostic.
+// ---------------------------------------------------------------------------
+
+export const HealthCheckResult = Schema.Struct({
+  status: HealthStatus,
+  /** The HTTP status the probe observed, when the check ran against HTTP. */
+  httpStatus: Schema.optional(Schema.Number),
+  /** Epoch ms the check ran. */
+  checkedAt: Schema.Number,
+  /** Human-readable diagnostic (error message, "no health check configured"). */
+  detail: Schema.optional(Schema.String),
+});
+export type HealthCheckResult = typeof HealthCheckResult.Type;
+
+// ---------------------------------------------------------------------------
+// HealthCheckCandidate — one operation the user can pick as the health check,
+// projected from the plugin's stored operations. The editor lists these ranked
+// (non-destructive first, then fewest required args) so the obvious "GET /me"
+// style endpoint floats to the top.
+// ---------------------------------------------------------------------------
+
+export const HealthCheckCandidateParameter = Schema.Struct({
+  name: Schema.String,
+  /** Where the parameter is carried (e.g. "query", "path", "header"). */
+  location: Schema.String,
+  required: Schema.Boolean,
+  description: Schema.optional(Schema.String),
+});
+export type HealthCheckCandidateParameter = typeof HealthCheckCandidateParameter.Type;
+
+export const HealthCheckCandidate = Schema.Struct({
+  /** The operation / tool name to store as `HealthCheckSpec.operation`. */
+  operation: Schema.String,
+  /** HTTP method, lower-cased ("get", "post", …), for display + ranking. */
+  method: Schema.String,
+  /** How many parameters are required to call it (ranking key: fewer is better). */
+  requiredArgCount: Schema.Number,
+  /** True for mutating methods (post/put/patch/delete) — ranked last and shown
+   *  with a warning, since a health check should be safe to run repeatedly. */
+  destructive: Schema.Boolean,
+  /** Operation summary / description for display, when known. */
+  summary: Schema.optional(Schema.String),
+  /** The operation's parameters, so the editor can offer pinned-arg inputs. */
+  parameters: Schema.optional(Schema.Array(HealthCheckCandidateParameter)),
+});
+export type HealthCheckCandidate = typeof HealthCheckCandidate.Type;
+
+// ---------------------------------------------------------------------------
+// Pure helpers — shared so classification behaves identically wherever a probe
+// is interpreted.
+// ---------------------------------------------------------------------------
+
+/** Map an HTTP status to a health state: 2xx healthy, 401/403 expired (the auth
+ *  wall), everything else degraded. */
+export const classifyHttpStatus = (status: number): HealthStatus => {
+  if (status >= 200 && status < 300) return "healthy";
+  if (status === 401 || status === 403) return "expired";
+  return "degraded";
+};
+
+/** Stable ranking for the candidate list: non-destructive before destructive,
+ *  then fewest required args, then by method (get first), then alphabetical.
+ *  Returns a negative/zero/positive comparator value. */
+export const compareHealthCheckCandidates = (
+  a: HealthCheckCandidate,
+  b: HealthCheckCandidate,
+): number => {
+  if (a.destructive !== b.destructive) return a.destructive ? 1 : -1;
+  if (a.requiredArgCount !== b.requiredArgCount) return a.requiredArgCount - b.requiredArgCount;
+  if (a.method !== b.method) {
+    if (a.method === "get") return -1;
+    if (b.method === "get") return 1;
+    return a.method < b.method ? -1 : 1;
+  }
+  return a.operation < b.operation ? -1 : a.operation > b.operation ? 1 : 0;
+};

--- a/packages/core/sdk/src/health-check.ts
+++ b/packages/core/sdk/src/health-check.ts
@@ -2,16 +2,17 @@
 // @executor-js/sdk health-check vocabulary — browser-safe.
 //
 // A health check is a single declared, authenticated operation a connection can
-// run to answer one question: "is this credential still alive?". The plugin owns
-// WHICH operation (it lives in the plugin's opaque integration config, picked by
-// the user the same way auth methods are configured); core owns the shared
-// vocabulary below so every surface (API, React, plugins) speaks the same shapes.
+// run to answer two questions at once: "is this credential still alive?" and
+// "whose account is this?". The plugin owns WHICH operation (it lives in the
+// plugin's opaque integration config, picked by the user the same way auth
+// methods are configured); core owns the shared vocabulary below so every
+// surface (API, React, plugins) speaks the same shapes.
 //
-// The probe runs an operation with optional pinned `args` (some liveness
-// endpoints need a fixed parameter; e.g. Google's People API needs
-// `resourceName=people/me`), maps the HTTP status to a `HealthStatus`, and
-// reports it. Everything here is pure Effect/Schema with no server/node imports
-// so it is safe to import from React.
+// The probe runs an operation with optional pinned `args` (Google's People API
+// needs `resourceName=people/me`; there is no zero-arg identity endpoint), maps
+// the HTTP status to a `HealthStatus`, and extracts a display `identity` from a
+// dot-path on the response body. Everything here is pure Effect/Schema with no
+// server/node imports so it is safe to import from React.
 // ---------------------------------------------------------------------------
 
 import { Schema } from "effect";
@@ -28,33 +29,58 @@ export const HealthStatus = Schema.Literals(["healthy", "expired", "degraded", "
 export type HealthStatus = typeof HealthStatus.Type;
 
 // ---------------------------------------------------------------------------
-// HealthCheckSpec — the persisted configuration: which operation to run and any
-// pinned arguments. Stored inside the owning plugin's opaque integration config;
-// core never parses it (the plugin reads it back in `checkHealth`).
+// HealthCheckSpec — the persisted configuration: which operation to run, any
+// pinned arguments, and the dot-path to the identity field. Stored inside the
+// owning plugin's opaque integration config; core never parses it (the plugin
+// reads it back in `checkHealth`).
 // ---------------------------------------------------------------------------
 
 export const HealthCheckSpec = Schema.Struct({
   /** The tool / operation name to invoke (the plugin maps this to its binding). */
   operation: Schema.String,
-  /** Pinned arguments merged into the probe call. Required for liveness
+  /** Pinned arguments merged into the probe call. Required for identity
    *  endpoints that take a fixed parameter (e.g. People API `resourceName`). */
   args: Schema.optional(Schema.Record(Schema.String, Schema.Unknown)),
+  /** Dot-path into the successful response body whose value is shown as the
+   *  connection's identity (e.g. `emailAddresses.0.value`, `user.login`). */
+  identityField: Schema.optional(Schema.String),
 });
 export type HealthCheckSpec = typeof HealthCheckSpec.Type;
 
 // ---------------------------------------------------------------------------
+// HealthCheckResponseSample — one scalar leaf from the actual response body,
+// `path` (the dot-path that would resolve it) plus `value` (a truncated string
+// rendering). The live preview shows these so the user can see what the chosen
+// operation really returns and pick the right identity field. Sampled from the
+// real response, so it works even when a spec's response schema is thin/absent.
+// ---------------------------------------------------------------------------
+
+export const HealthCheckResponseSample = Schema.Struct({
+  path: Schema.String,
+  value: Schema.String,
+});
+export type HealthCheckResponseSample = typeof HealthCheckResponseSample.Type;
+
+// ---------------------------------------------------------------------------
 // HealthCheckResult — the outcome of running a probe. `httpStatus` and `detail`
-// are diagnostic.
+// are diagnostic; `identity` is the extracted display value when the check
+// succeeded and an `identityField` was configured (and resolved); `responseSample`
+// carries a bounded set of the actual returned fields for the live preview.
 // ---------------------------------------------------------------------------
 
 export const HealthCheckResult = Schema.Struct({
   status: HealthStatus,
   /** The HTTP status the probe observed, when the check ran against HTTP. */
   httpStatus: Schema.optional(Schema.Number),
+  /** Display identity extracted from `identityField`, when present. */
+  identity: Schema.optional(Schema.String),
   /** Epoch ms the check ran. */
   checkedAt: Schema.Number,
   /** Human-readable diagnostic (error message, "no health check configured"). */
   detail: Schema.optional(Schema.String),
+  /** Bounded sample of scalar fields from the response body, for the live
+   *  preview ("show me what this operation returns"). */
+  responseSample: Schema.optional(Schema.Array(HealthCheckResponseSample)),
 });
 export type HealthCheckResult = typeof HealthCheckResult.Type;
 
@@ -62,7 +88,7 @@ export type HealthCheckResult = typeof HealthCheckResult.Type;
 // HealthCheckCandidate — one operation the user can pick as the health check,
 // projected from the plugin's stored operations. The editor lists these ranked
 // (non-destructive first, then fewest required args) so the obvious "GET /me"
-// style endpoint floats to the top.
+// style identity endpoint floats to the top.
 // ---------------------------------------------------------------------------
 
 export const HealthCheckCandidateParameter = Schema.Struct({
@@ -73,6 +99,19 @@ export const HealthCheckCandidateParameter = Schema.Struct({
   description: Schema.optional(Schema.String),
 });
 export type HealthCheckCandidateParameter = typeof HealthCheckCandidateParameter.Type;
+
+// ---------------------------------------------------------------------------
+// HealthCheckResponseField — one scalar leaf the candidate operation can return,
+// projected from its response schema: `path` (the dot-path to set as
+// `HealthCheckSpec.identityField`) and a `type` display label ("string",
+// "number", "string[]", …). Feeds the typed identity picker.
+// ---------------------------------------------------------------------------
+
+export const HealthCheckResponseField = Schema.Struct({
+  path: Schema.String,
+  type: Schema.String,
+});
+export type HealthCheckResponseField = typeof HealthCheckResponseField.Type;
 
 export const HealthCheckCandidate = Schema.Struct({
   /** The operation / tool name to store as `HealthCheckSpec.operation`. */
@@ -88,12 +127,15 @@ export const HealthCheckCandidate = Schema.Struct({
   summary: Schema.optional(Schema.String),
   /** The operation's parameters, so the editor can offer pinned-arg inputs. */
   parameters: Schema.optional(Schema.Array(HealthCheckCandidateParameter)),
+  /** Scalar leaves from the operation's response schema, for the typed identity
+   *  picker. Projected via `projectResponseFields`. */
+  responseFields: Schema.optional(Schema.Array(HealthCheckResponseField)),
 });
 export type HealthCheckCandidate = typeof HealthCheckCandidate.Type;
 
 // ---------------------------------------------------------------------------
-// Pure helpers — shared so classification behaves identically wherever a probe
-// is interpreted.
+// Pure helpers — shared so classification + identity extraction behave
+// identically wherever a probe is interpreted.
 // ---------------------------------------------------------------------------
 
 /** Map an HTTP status to a health state: 2xx healthy, 401/403 expired (the auth
@@ -102,6 +144,28 @@ export const classifyHttpStatus = (status: number): HealthStatus => {
   if (status >= 200 && status < 300) return "healthy";
   if (status === 401 || status === 403) return "expired";
   return "degraded";
+};
+
+/** Resolve a dot-path (`a.b.0.c`) against a JSON value and coerce the leaf to a
+ *  display string. Numeric segments index arrays. Returns undefined when the
+ *  path is empty, missing, or lands on a non-scalar. */
+export const extractIdentity = (data: unknown, dotpath?: string): string | undefined => {
+  if (dotpath == null || dotpath.length === 0) return undefined;
+  let current: unknown = data;
+  for (const segment of dotpath.split(".")) {
+    if (current == null) return undefined;
+    if (Array.isArray(current)) {
+      const index = Number(segment);
+      if (!Number.isInteger(index) || index < 0 || index >= current.length) return undefined;
+      current = current[index];
+      continue;
+    }
+    if (typeof current !== "object") return undefined;
+    current = (current as Record<string, unknown>)[segment];
+  }
+  if (typeof current === "string") return current;
+  if (typeof current === "number" || typeof current === "boolean") return String(current);
+  return undefined;
 };
 
 /** Stable ranking for the candidate list: non-destructive before destructive,
@@ -119,4 +183,204 @@ export const compareHealthCheckCandidates = (
     return a.method < b.method ? -1 : 1;
   }
   return a.operation < b.operation ? -1 : a.operation > b.operation ? 1 : 0;
+};
+
+// ---------------------------------------------------------------------------
+// Response-field projection — two pure walkers that feed the typed identity
+// picker and the live preview. `projectResponseFields` walks a (normalized)
+// response SCHEMA to enumerate selectable identity paths; `extractResponseFields`
+// walks an actual response BODY so the preview can show what the operation
+// really returns even when the schema is thin or absent.
+// ---------------------------------------------------------------------------
+
+const SCALAR_TYPE_LABELS: Record<string, string> = {
+  string: "string",
+  number: "number",
+  integer: "number",
+  boolean: "boolean",
+};
+
+/** Pick the first non-null entry of an OpenAPI `type` (which may be a union like
+ *  `["string", "null"]`), as a string or undefined. */
+const primaryType = (raw: unknown): string | undefined => {
+  if (Array.isArray(raw)) {
+    const found = raw.find((x) => typeof x === "string" && x !== "null");
+    return typeof found === "string" ? found : undefined;
+  }
+  return typeof raw === "string" ? raw : undefined;
+};
+
+/** Flatten one schema node's composition into a single effective shape: follow
+ *  `$ref`s and merge the properties of EVERY `allOf`/`oneOf`/`anyOf` member, so a
+ *  discriminated union (or multi-member allOf) contributes the union of all its
+ *  branches' fields, not just the first. Returns the merged properties, any array
+ *  `items`, a scalar type label (when the node is a leaf), and the set of refs
+ *  followed (so children inherit a cycle guard). */
+const flattenSchemaShape = (
+  node: unknown,
+  defs: Record<string, unknown>,
+  seenRefs: ReadonlySet<string>,
+): {
+  readonly props: Map<string, unknown>;
+  readonly items: unknown;
+  readonly scalarType: string | undefined;
+  readonly refs: ReadonlySet<string>;
+} => {
+  const props = new Map<string, unknown>();
+  let items: unknown = undefined;
+  let scalarType: string | undefined;
+  const refs = new Set<string>(seenRefs);
+  // Bounded work queue over composition members (refs + allOf/oneOf/anyOf) at
+  // this one level; the guard bounds pathological self-referential composition.
+  const stack: unknown[] = [node];
+  let guard = 0;
+  while (stack.length > 0 && guard++ < 500) {
+    const current = stack.pop();
+    if (current == null || typeof current !== "object") continue;
+    const s = current as Record<string, unknown>;
+
+    const ref = s["$ref"];
+    if (typeof ref === "string") {
+      const name = ref.startsWith("#/$defs/") ? ref.slice("#/$defs/".length) : undefined;
+      if (name !== undefined && !refs.has(name)) {
+        refs.add(name);
+        const target = defs[name];
+        if (target != null && typeof target === "object") stack.push(target);
+      }
+      continue;
+    }
+
+    for (const key of ["allOf", "oneOf", "anyOf"] as const) {
+      const members = s[key];
+      if (Array.isArray(members)) for (const member of members) stack.push(member);
+    }
+
+    const type = primaryType(s["type"]);
+    if (type !== undefined && SCALAR_TYPE_LABELS[type] !== undefined)
+      scalarType = SCALAR_TYPE_LABELS[type];
+    if (items === undefined && s["items"] !== undefined) items = s["items"];
+    const ownProps = s["properties"];
+    if (ownProps != null && typeof ownProps === "object") {
+      for (const [key, child] of Object.entries(ownProps as Record<string, unknown>)) {
+        if (!props.has(key)) props.set(key, child);
+      }
+    }
+  }
+  return { props, items, scalarType, refs };
+};
+
+/**
+ * Enumerate the scalar leaves of a response schema as selectable identity paths.
+ * Returns dot-paths (`a.b.0.c`) paired with a display type label. Array items use
+ * the literal `"0"` segment to match `extractIdentity`'s numeric-index
+ * convention. Resolves `#/$defs/X` refs against `defs` with a cycle guard, and
+ * merges ALL `allOf`/`oneOf`/`anyOf` members so discriminated-union branches each
+ * contribute their fields. Traverses BREADTH-FIRST so shallow scalars (`email`,
+ * `id`, `username`) are emitted before deep nested fields and aren't starved by
+ * the field cap. Bounded to depth 5 and 50 (deduped) fields.
+ */
+export const projectResponseFields = (
+  schema: unknown,
+  defs: Record<string, unknown> = {},
+): HealthCheckResponseField[] => {
+  const fields: HealthCheckResponseField[] = [];
+  const seenPaths = new Set<string>();
+  const MAX_DEPTH = 5;
+  const MAX_FIELDS = 50;
+  const MAX_FRONTIER = 2000;
+
+  type Item = {
+    readonly node: unknown;
+    readonly path: string;
+    readonly depth: number;
+    readonly seenRefs: ReadonlySet<string>;
+  };
+
+  let frontier: Item[] = [{ node: schema, path: "", depth: 0, seenRefs: new Set<string>() }];
+  while (frontier.length > 0 && fields.length < MAX_FIELDS) {
+    const nextFrontier: Item[] = [];
+    for (const item of frontier) {
+      if (fields.length >= MAX_FIELDS) break;
+      if (item.node == null || typeof item.node !== "object") continue;
+      const { props, items, scalarType, refs } = flattenSchemaShape(item.node, defs, item.seenRefs);
+
+      // Object: queue children one level deeper (shallow fields emit first).
+      if (props.size > 0) {
+        for (const [key, child] of props) {
+          if (nextFrontier.length >= MAX_FRONTIER) break;
+          nextFrontier.push({
+            node: child,
+            path: item.path === "" ? key : `${item.path}.${key}`,
+            depth: item.depth + 1,
+            seenRefs: refs,
+          });
+        }
+        continue;
+      }
+      // Array: descend into items with the numeric-index segment.
+      if (items !== undefined) {
+        nextFrontier.push({
+          node: items,
+          path: item.path === "" ? "0" : `${item.path}.0`,
+          depth: item.depth + 1,
+          seenRefs: refs,
+        });
+        continue;
+      }
+      // Scalar leaf.
+      if (scalarType !== undefined && item.path !== "" && !seenPaths.has(item.path)) {
+        seenPaths.add(item.path);
+        fields.push({ path: item.path, type: scalarType });
+      }
+    }
+    frontier = nextFrontier.filter((item) => item.depth <= MAX_DEPTH);
+  }
+  return fields;
+};
+
+/**
+ * Walk an actual JSON response body and return its scalar leaves as
+ * `{ path, value }` rows (value stringified + truncated). Drives the live
+ * preview's "show me what this returns" list. Bounded to depth 4, 25 fields,
+ * and ~120-char values.
+ */
+export const extractResponseFields = (data: unknown): HealthCheckResponseSample[] => {
+  const out: HealthCheckResponseSample[] = [];
+  const MAX_DEPTH = 4;
+  const MAX_FIELDS = 25;
+  const MAX_VALUE = 120;
+
+  const render = (v: string): string => (v.length > MAX_VALUE ? `${v.slice(0, MAX_VALUE)}...` : v);
+
+  const visit = (node: unknown, path: string, depth: number) => {
+    if (out.length >= MAX_FIELDS || node == null) return;
+
+    if (Array.isArray(node)) {
+      if (depth >= MAX_DEPTH) return;
+      for (let i = 0; i < node.length; i++) {
+        if (out.length >= MAX_FIELDS) break;
+        visit(node[i], path === "" ? String(i) : `${path}.${i}`, depth + 1);
+      }
+      return;
+    }
+
+    if (typeof node === "object") {
+      if (depth >= MAX_DEPTH) return;
+      for (const [key, child] of Object.entries(node as Record<string, unknown>)) {
+        if (out.length >= MAX_FIELDS) break;
+        visit(child, path === "" ? key : `${path}.${key}`, depth + 1);
+      }
+      return;
+    }
+
+    if (
+      path !== "" &&
+      (typeof node === "string" || typeof node === "number" || typeof node === "boolean")
+    ) {
+      out.push({ path, value: render(String(node)) });
+    }
+  };
+
+  visit(data, "", 0);
+  return out;
 };

--- a/packages/core/sdk/src/index.ts
+++ b/packages/core/sdk/src/index.ts
@@ -92,6 +92,7 @@ export type {
   ConnectionValueInput,
   CreateConnectionInput,
   UpdateConnectionInput,
+  ValidateConnectionInput,
 } from "./connection";
 export type { Tool, ToolDef, ToolListFilter, ToolAnnotations } from "./tool";
 
@@ -100,6 +101,17 @@ export type { CredentialProvider, ProviderEntry } from "./provider";
 
 // Public projections / detection.
 export { ToolSchemaView, IntegrationDetectionResult } from "./types";
+
+// Health-check vocabulary (pure Schema + helpers).
+export {
+  HealthStatus,
+  HealthCheckSpec,
+  HealthCheckResult,
+  HealthCheckCandidate,
+  HealthCheckCandidateParameter,
+  classifyHttpStatus,
+  compareHealthCheckCandidates,
+} from "./health-check";
 
 // Core schema.
 export {
@@ -292,6 +304,9 @@ export {
   type ResolveToolsInput,
   type ResolveToolsResult,
   type ToolInvocationCredential,
+  type HealthCheckInput,
+  type HealthCheckCandidatesInput,
+  type SetHealthCheckInput,
   type Elicit,
   definePlugin,
   tool,

--- a/packages/core/sdk/src/index.ts
+++ b/packages/core/sdk/src/index.ts
@@ -107,10 +107,15 @@ export {
   HealthStatus,
   HealthCheckSpec,
   HealthCheckResult,
+  HealthCheckResponseSample,
   HealthCheckCandidate,
   HealthCheckCandidateParameter,
+  HealthCheckResponseField,
   classifyHttpStatus,
+  extractIdentity,
   compareHealthCheckCandidates,
+  projectResponseFields,
+  extractResponseFields,
 } from "./health-check";
 
 // Core schema.

--- a/packages/core/sdk/src/plugin.ts
+++ b/packages/core/sdk/src/plugin.ts
@@ -19,6 +19,7 @@ import type {
   IntegrationDisplayDescriptor,
   RegisterIntegrationInput,
 } from "./integration";
+import type { HealthCheckCandidate, HealthCheckResult, HealthCheckSpec } from "./health-check";
 import type { ToolInvocationRow } from "./core-schema";
 import type {
   AuthTemplateSlug,
@@ -253,6 +254,42 @@ export interface ToolInvocationCredential {
   readonly values: Record<string, string | null>;
   /** The integration's stored config, for template rendering. */
   readonly config: IntegrationConfig;
+}
+
+// ---------------------------------------------------------------------------
+// Health-check hook inputs. A health check is a single declared authenticated
+// operation a connection runs to prove its credential is still alive and to
+// surface whose account it is. The plugin owns which operation (stored in its
+// opaque config); core dispatches these hooks.
+// ---------------------------------------------------------------------------
+
+/** Input to `checkHealth` — run the configured (or overridden) probe against a
+ *  resolved credential. The credential may come from a saved connection OR from
+ *  in-flight values (key-first validation, before the connection is saved). */
+export interface HealthCheckInput<TStore = unknown> {
+  readonly ctx: PluginCtx<TStore>;
+  /** The catalog record (with opaque config) whose health is being checked. */
+  readonly integration: IntegrationRecord;
+  /** The resolved credential to authenticate the probe. */
+  readonly credential: ToolInvocationCredential;
+  /** Optional spec override. When omitted, the plugin uses the health check
+   *  stored in its own config; an override lets the editor test a candidate
+   *  before saving it. */
+  readonly spec?: HealthCheckSpec;
+}
+
+/** Input to `listHealthCheckCandidates` — the operations a user can pick. */
+export interface HealthCheckCandidatesInput<TStore = unknown> {
+  readonly ctx: PluginCtx<TStore>;
+  readonly integration: IntegrationRecord;
+}
+
+/** Input to `setHealthCheck` — persist or clear an integration's health check. */
+export interface SetHealthCheckInput<TStore = unknown> {
+  readonly ctx: PluginCtx<TStore>;
+  readonly integration: IntegrationSlug;
+  /** The new health check, or null to clear it. */
+  readonly spec: HealthCheckSpec | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -500,6 +537,28 @@ export interface PluginSpec<
   readonly describeIntegrationDisplay?: (
     integration: IntegrationRecord,
   ) => IntegrationDisplayDescriptor;
+
+  /** Project this plugin's opaque integration config into the configured health
+   *  check, when one is set. Synchronous and pure (the config is already
+   *  loaded); must tolerate a malformed/foreign config blob by returning null.
+   *  Absent ⇒ core reports "no health check configured". */
+  readonly describeHealthCheck?: (integration: IntegrationRecord) => HealthCheckSpec | null;
+
+  /** List the operations a user can pick as this integration's health check,
+   *  ranked best-first (non-destructive, fewest required args). */
+  readonly listHealthCheckCandidates?: (
+    input: HealthCheckCandidatesInput<TStore>,
+  ) => Effect.Effect<readonly HealthCheckCandidate[], unknown>;
+
+  /** Persist (or clear, with a null spec) the integration's health check in the
+   *  plugin's opaque config. Mirrors `integrationConfigure`'s read-modify-write. */
+  readonly setHealthCheck?: (input: SetHealthCheckInput<TStore>) => Effect.Effect<void, unknown>;
+
+  /** Run the configured (or overridden) health check against a resolved
+   *  credential and classify the outcome into a `HealthCheckResult`. */
+  readonly checkHealth?: (
+    input: HealthCheckInput<TStore>,
+  ) => Effect.Effect<HealthCheckResult, unknown>;
 
   /** URL autodetection hook for onboarding. */
   readonly detect?: (input: {

--- a/packages/core/sdk/src/shared.ts
+++ b/packages/core/sdk/src/shared.ts
@@ -110,6 +110,7 @@ export {
   HealthCheckCandidate,
   HealthCheckCandidateParameter,
   classifyHttpStatus,
+  extractIdentity,
   compareHealthCheckCandidates,
 } from "./health-check";
 

--- a/packages/core/sdk/src/shared.ts
+++ b/packages/core/sdk/src/shared.ts
@@ -43,6 +43,7 @@ export type {
   ConnectionValueInput,
   CreateConnectionInput,
   UpdateConnectionInput,
+  ValidateConnectionInput,
 } from "./connection";
 export type { CredentialProvider, ProviderEntry } from "./provider";
 export type { Tool, ToolDef, ToolListFilter, ToolAnnotations } from "./tool";
@@ -100,6 +101,17 @@ export type { ToolPolicyAction } from "./core-schema";
 export { ToolSchemaView, IntegrationDetectionResult } from "./types";
 
 export { OAUTH_CALLBACK_ORG_QUERY_PARAM } from "./oauth";
+
+// Health-check vocabulary (pure Schema + helpers).
+export {
+  HealthStatus,
+  HealthCheckSpec,
+  HealthCheckResult,
+  HealthCheckCandidate,
+  HealthCheckCandidateParameter,
+  classifyHttpStatus,
+  compareHealthCheckCandidates,
+} from "./health-check";
 
 // OAuth wire contracts (data + tagged errors; the flow impl is server-only).
 export {

--- a/packages/plugins/google/src/sdk/config.ts
+++ b/packages/plugins/google/src/sdk/config.ts
@@ -1,4 +1,5 @@
 import { Option, Schema } from "effect";
+import { HealthCheckSpec } from "@executor-js/sdk/core";
 import { AuthenticationSchema, type Authentication } from "@executor-js/plugin-openapi";
 
 export const GoogleIntegrationConfigSchema = Schema.Struct({
@@ -9,6 +10,9 @@ export const GoogleIntegrationConfigSchema = Schema.Struct({
   headers: Schema.optional(Schema.Record(Schema.String, Schema.String)),
   queryParams: Schema.optional(Schema.Record(Schema.String, Schema.String)),
   authenticationTemplate: Schema.optional(Schema.Array(AuthenticationSchema)),
+  // The declared health check survives the plugin's own decode (updateBundle
+  // read-modify-write); the OpenAPI backing reads/writes it via the base config.
+  healthCheck: Schema.optional(HealthCheckSpec),
 });
 
 export type GoogleIntegrationConfig = Omit<

--- a/packages/plugins/google/src/sdk/plugin.ts
+++ b/packages/plugins/google/src/sdk/plugin.ts
@@ -11,6 +11,7 @@ import {
   mergeAuthTemplates,
   sha256Hex,
   type AuthMethodDescriptor,
+  type HealthCheckSpec,
   type Integration,
   type IntegrationConfig,
   type IntegrationRecord,
@@ -18,13 +19,17 @@ import {
 } from "@executor-js/sdk/core";
 import { describeApiKeyAuthMethod } from "@executor-js/sdk/http-auth";
 import {
+  checkHealthOpenApi,
   compileOpenApiSpec,
+  describeHealthCheckOpenApi,
   invokeOpenApiBackedTool,
+  listHealthCheckCandidatesOpenApi,
   makeDefaultOpenapiStore,
   normalizeOpenApiAuthInputs,
   openApiStoredOperationsFromCompiled,
   resolveOpenApiBackedAnnotations,
   resolveOpenApiBackedTools,
+  setHealthCheckOpenApi,
   type Authentication,
   type AuthenticationInput,
   type OpenapiStore,
@@ -37,6 +42,35 @@ import {
 } from "./discovery";
 import { decodeGoogleIntegrationConfig, type GoogleIntegrationConfig } from "./config";
 import { googleOpenApiBundlePreset } from "./presets";
+
+/** The default health check for a Google bundle: the People API identity call
+ *  (`people.get` with the required `resourceName`/`personFields` pinned), when
+ *  the bundle includes the People API. People API is the canonical Google
+ *  identity endpoint; if it isn't bundled, no default is written (the editor
+ *  remains available). The user can adjust the identity field via the editor. */
+const defaultGoogleHealthCheck = (
+  urls: readonly string[],
+  definitions: readonly {
+    readonly toolPath: string;
+    readonly operation: { readonly method: string; readonly pathTemplate: string };
+  }[],
+): HealthCheckSpec | undefined => {
+  const hasPeopleApi = urls.some((url) => url.includes("/people/"));
+  if (!hasPeopleApi) return undefined;
+  const peopleGet = definitions.find(
+    (def) =>
+      def.operation.method.toLowerCase() === "get" &&
+      (def.toolPath === "people.people.get" ||
+        def.operation.pathTemplate === "/v1/{+resourceName}"),
+  );
+  return peopleGet
+    ? {
+        operation: peopleGet.toolPath,
+        args: { resourceName: "people/me", personFields: "names,emailAddresses" },
+        identityField: "emailAddresses.0.value",
+      }
+    : undefined;
+};
 
 export interface GoogleBundleConfig {
   readonly urls: readonly string[];
@@ -133,6 +167,11 @@ const makeGooglePluginExtension = (
       }
 
       const specHash = yield* sha256Hex(conversion.specText);
+      // Default the health check to the People API identity call
+      // (`people.get` with `resourceName=people/me`) when the bundle includes
+      // the People API, so connections report alive/expired + identity out of the
+      // box. The user can adjust the operation / identity field via the editor.
+      const defaultHealthCheck = defaultGoogleHealthCheck(urls, compiled.definitions);
       const integrationConfig: GoogleIntegrationConfig = {
         specHash,
         googleDiscoveryUrls: urls,
@@ -140,10 +179,10 @@ const makeGooglePluginExtension = (
         ...(conversion.authenticationTemplate
           ? { authenticationTemplate: conversion.authenticationTemplate }
           : {}),
+        ...(defaultHealthCheck ? { healthCheck: defaultHealthCheck } : {}),
       };
 
       yield* ctx.storage.putSpec(specHash, conversion.specText);
-      yield* ctx.storage.putDefs(specHash, JSON.stringify(compiled.hoistedDefs));
 
       yield* ctx.transaction(
         Effect.gen(function* () {
@@ -184,7 +223,6 @@ const makeGooglePluginExtension = (
 
       const specHash = yield* sha256Hex(conversion.specText);
       yield* ctx.storage.putSpec(specHash, conversion.specText);
-      yield* ctx.storage.putDefs(specHash, JSON.stringify(compiled.hoistedDefs));
 
       const nextConfig: GoogleIntegrationConfig = {
         ...current,
@@ -319,6 +357,23 @@ export const googlePlugin = definePlugin((options?: GooglePluginOptions) => ({
       ctx,
       integration: String(integration),
       toolRows,
+    }),
+
+  // Health checks reuse the OpenAPI backing (same store + config superset). The
+  // People API identity call is auto-defaulted at addBundle when present, and the
+  // user can adjust the operation / identity field via the editor.
+  describeHealthCheck: describeHealthCheckOpenApi,
+  listHealthCheckCandidates: (input) =>
+    listHealthCheckCandidatesOpenApi({ ctx: input.ctx, integration: input.integration }),
+  setHealthCheck: (input) =>
+    setHealthCheckOpenApi({ ctx: input.ctx, integration: input.integration, spec: input.spec }),
+  checkHealth: (input) =>
+    checkHealthOpenApi({
+      ctx: input.ctx,
+      integration: input.integration,
+      credential: input.credential,
+      spec: input.spec,
+      httpClientLayer: options?.httpClientLayer ?? input.ctx.httpClientLayer,
     }),
 
   removeConnection: () => Effect.void,

--- a/packages/plugins/mcp/src/sdk/connection.ts
+++ b/packages/plugins/mcp/src/sdk/connection.ts
@@ -17,6 +17,7 @@ import { HttpClient, HttpClientRequest } from "effect/unstable/http";
 
 import type { McpRemoteIntegrationConfig, McpStdioIntegrationConfig } from "./types";
 import { McpConnectionError, McpOAuthReauthorizationRequired } from "./errors";
+import { httpStatusFromCause } from "./http-status";
 
 // ---------------------------------------------------------------------------
 // Connection type
@@ -198,8 +199,18 @@ const connectClient = (input: {
 
     yield* Effect.tryPromise({
       try: () => client.connect(transportInstance),
-      catch: (cause) =>
-        connectionFailure(input.transport, `Failed connecting via ${input.transport}`, cause),
+      catch: (cause) => {
+        // Surface the handshake HTTP status (e.g. 401/403) in the message so the
+        // liveness health check can classify a rejected credential as expired
+        // rather than a generic connection failure.
+        const status = httpStatusFromCause(cause);
+        const suffix = status === undefined ? "" : ` (HTTP ${status})`;
+        return connectionFailure(
+          input.transport,
+          `Failed connecting via ${input.transport}${suffix}`,
+          cause,
+        );
+      },
     }).pipe(
       Effect.withSpan("plugin.mcp.connection.handshake", {
         attributes: { "plugin.mcp.transport": input.transport },

--- a/packages/plugins/mcp/src/sdk/http-status.ts
+++ b/packages/plugins/mcp/src/sdk/http-status.ts
@@ -1,0 +1,36 @@
+// ---------------------------------------------------------------------------
+// Extract the HTTP status from an MCP SDK transport error. The SDK surfaces
+// transport failures two ways: a `StreamableHTTPError` subclass carrying a
+// numeric `code`, and an SSE POST failure whose message embeds `(HTTP nnn)`.
+// Shared by the invoke path (classifies tool-call failures) and the connect
+// path (so a 401/403 during the handshake reaches the liveness health check).
+// ---------------------------------------------------------------------------
+
+import { Option, Schema } from "effect";
+
+import { StreamableHTTPError } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+const SsePostErrorCause = Schema.Struct({ message: Schema.String });
+const decodeSsePostErrorCause = Schema.decodeUnknownOption(SsePostErrorCause);
+
+// Matches the SDK's SSEClientTransport POST-failure message (sse.js); re-verify
+// on SDK bumps. A format drift just yields undefined (generic error, no crash).
+const statusFromSsePostError = (cause: unknown): number | undefined =>
+  Option.match(decodeSsePostErrorCause(cause), {
+    onNone: () => undefined,
+    onSome: ({ message }) => {
+      const match = /^Error POSTing to endpoint \(HTTP ([1-5][0-9]{2})\):/.exec(message);
+      if (!match) return undefined;
+      return Number(match[1]);
+    },
+  });
+
+const statusFromStreamableHttpError = (cause: unknown): number | undefined => {
+  // oxlint-disable-next-line executor/no-instanceof-tagged-error -- boundary: MCP SDK exposes transport HTTP failures as this Error subclass; protocol errors can carry the same numeric code
+  if (!(cause instanceof StreamableHTTPError)) return undefined;
+  const code = cause.code;
+  return code !== undefined && code >= 100 && code <= 599 ? code : undefined;
+};
+
+export const httpStatusFromCause = (cause: unknown): number | undefined =>
+  statusFromStreamableHttpError(cause) ?? statusFromSsePostError(cause);

--- a/packages/plugins/mcp/src/sdk/invoke.ts
+++ b/packages/plugins/mcp/src/sdk/invoke.ts
@@ -13,7 +13,6 @@
 
 import { Cause, Effect, Exit, Option, Predicate, Schema } from "effect";
 
-import { StreamableHTTPError } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { ElicitRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 
 import {
@@ -26,6 +25,7 @@ import {
 
 import { McpConnectionError, McpInvocationError, McpOAuthReauthorizationRequired } from "./errors";
 import type { McpConnection, McpConnector } from "./connection";
+import { httpStatusFromCause } from "./http-status";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -36,31 +36,6 @@ const decodeArgsRecord = Schema.decodeUnknownOption(ArgsRecord);
 
 const argsRecord = (value: unknown): Record<string, unknown> =>
   Option.getOrElse(decodeArgsRecord(value), () => ({}));
-
-const SsePostErrorCause = Schema.Struct({ message: Schema.String });
-const decodeSsePostErrorCause = Schema.decodeUnknownOption(SsePostErrorCause);
-
-// Matches the SDK's SSEClientTransport POST-failure message (sse.js); re-verify
-// on SDK bumps. A format drift just yields undefined (generic error, no crash).
-const statusFromSsePostError = (cause: unknown): number | undefined =>
-  Option.match(decodeSsePostErrorCause(cause), {
-    onNone: () => undefined,
-    onSome: ({ message }) => {
-      const match = /^Error POSTing to endpoint \(HTTP ([1-5][0-9]{2})\):/.exec(message);
-      if (!match) return undefined;
-      return Number(match[1]);
-    },
-  });
-
-const statusFromStreamableHttpError = (cause: unknown): number | undefined => {
-  // oxlint-disable-next-line executor/no-instanceof-tagged-error -- boundary: MCP SDK exposes transport HTTP failures as this Error subclass; protocol errors can carry the same numeric code
-  if (!(cause instanceof StreamableHTTPError)) return undefined;
-  const code = cause.code;
-  return code !== undefined && code >= 100 && code <= 599 ? code : undefined;
-};
-
-const httpStatusFromCause = (cause: unknown): number | undefined =>
-  statusFromStreamableHttpError(cause) ?? statusFromSsePostError(cause);
 
 // ---------------------------------------------------------------------------
 // Elicitation bridge — decode incoming MCP ElicitRequest, route through

--- a/packages/plugins/mcp/src/sdk/plugin.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.ts
@@ -15,6 +15,7 @@ import {
   tool,
   ToolResult,
   type AuthMethodDescriptor,
+  type HealthCheckResult,
   type Integration,
   type IntegrationConfig,
   type IntegrationRecord,
@@ -63,6 +64,21 @@ import {
 } from "./types";
 
 const MCP_PLUGIN_ID = "mcp" as const;
+
+/** Classify a failed liveness probe. An auth wall (OAuth re-authorization, or a
+ *  401/403 surfaced into the connect message) means the credential is expired;
+ *  anything else (server down, wrong transport) is degraded, not a credential
+ *  problem. */
+const mcpLivenessFailureStatus = (message: string): "expired" | "degraded" => {
+  const lower = message.toLowerCase();
+  const authWalled =
+    lower.includes("oauth re-authorization") ||
+    lower.includes("(http 401)") ||
+    lower.includes("(http 403)") ||
+    lower.includes("unauthorized") ||
+    lower.includes("forbidden");
+  return authWalled ? "expired" : "degraded";
+};
 
 const legacyOAuthClientSlugCandidate = (value: string): string | null => {
   const slug = value
@@ -1164,6 +1180,51 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
         }
         return out;
       }),
+
+    // Liveness-only health check. MCP has no usable identity source (no
+    // id_token/userinfo, no standard whoami), so this answers "is this
+    // credential still alive?" by dialing the server and listing tools (the same
+    // path resolveTools uses); identity stays the user-supplied connection label.
+    // Only checkHealth is implemented (no candidates/describe/set), so the
+    // operation/identity editor stays hidden while the status dot + "Check now"
+    // light up.
+    checkHealth: ({ credential }) =>
+      Effect.gen(function* () {
+        const parsed = parseMcpIntegrationConfig(credential.config);
+        if (!parsed) {
+          return { status: "unknown" as const, checkedAt: Date.now() } satisfies HealthCheckResult;
+        }
+        const connector = yield* buildConnectorInput(
+          parsed,
+          credential.values,
+          credential.template === null ? null : String(credential.template),
+          allowStdio,
+        ).pipe(Effect.map((ci) => createMcpConnector(ci)));
+
+        return yield* discoverTools(connector).pipe(
+          Effect.map(
+            () =>
+              ({ status: "healthy" as const, checkedAt: Date.now() }) satisfies HealthCheckResult,
+          ),
+          Effect.catchTag("McpToolDiscoveryError", (error) =>
+            Effect.succeed({
+              status: mcpLivenessFailureStatus(error.message),
+              checkedAt: Date.now(),
+              detail: error.message,
+            } satisfies HealthCheckResult),
+          ),
+        );
+      }).pipe(
+        // buildConnectorInput rejects (e.g. stdio disabled / missing config).
+        Effect.catchTag("McpConnectionError", (error) =>
+          Effect.succeed({
+            status: mcpLivenessFailureStatus(error.message),
+            checkedAt: Date.now(),
+            detail: error.message,
+          } satisfies HealthCheckResult),
+        ),
+        Effect.withSpan("mcp.plugin.check_health"),
+      ),
 
     describeAuthMethods: describeMcpAuthMethods,
     describeIntegrationDisplay: describeMcpIntegrationDisplay,

--- a/packages/plugins/microsoft/src/sdk/graph.ts
+++ b/packages/plugins/microsoft/src/sdk/graph.ts
@@ -2,7 +2,7 @@ import { Effect, Option, Schema } from "effect";
 import type { Layer } from "effect";
 import { HttpClient, HttpClientRequest } from "effect/unstable/http";
 
-import { AuthTemplateSlug } from "@executor-js/sdk/core";
+import { AuthTemplateSlug, HealthCheckSpec } from "@executor-js/sdk/core";
 import {
   AuthenticationSchema,
   OpenApiParseError,
@@ -95,6 +95,7 @@ const MicrosoftGraphIntegrationConfigSchema = Schema.Struct({
   microsoftGraphAuthorizationUrl: Schema.optional(Schema.String),
   microsoftGraphTokenUrl: Schema.optional(Schema.String),
   microsoftGraphClientCredentialsTokenUrl: Schema.optional(Schema.String),
+  healthCheck: Schema.optional(HealthCheckSpec),
 });
 
 const decodeMicrosoftConfig = Schema.decodeUnknownOption(MicrosoftGraphIntegrationConfigSchema);

--- a/packages/plugins/microsoft/src/sdk/plugin.ts
+++ b/packages/plugins/microsoft/src/sdk/plugin.ts
@@ -19,7 +19,11 @@ import {
 } from "@executor-js/sdk/core";
 import { describeApiKeyAuthMethod } from "@executor-js/sdk/http-auth";
 import {
+  checkHealthOpenApi,
   compileAndPersistOpenApiSpecStreaming,
+  describeHealthCheckOpenApi,
+  listHealthCheckCandidatesOpenApi,
+  setHealthCheckOpenApi,
   decodeOpenApiIntegrationConfig,
   invokeOpenApiBackedTool,
   makeDefaultOpenapiStore,
@@ -371,6 +375,22 @@ export const microsoftPlugin = definePlugin((options?: MicrosoftPluginOptions) =
       ctx,
       integration: String(integration),
       toolRows,
+    }),
+
+  // Health checks reuse the OpenAPI backing (same store + config superset). The
+  // user picks the identity operation (e.g. GET /me) via the editor.
+  describeHealthCheck: describeHealthCheckOpenApi,
+  listHealthCheckCandidates: (input) =>
+    listHealthCheckCandidatesOpenApi({ ctx: input.ctx, integration: input.integration }),
+  setHealthCheck: (input) =>
+    setHealthCheckOpenApi({ ctx: input.ctx, integration: input.integration, spec: input.spec }),
+  checkHealth: (input) =>
+    checkHealthOpenApi({
+      ctx: input.ctx,
+      integration: input.integration,
+      credential: input.credential,
+      spec: input.spec,
+      httpClientLayer: options?.httpClientLayer ?? input.ctx.httpClientLayer,
     }),
 
   removeConnection: () => Effect.void,

--- a/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
@@ -107,8 +107,10 @@ export default function AddOpenApiSource(props: {
 
   // Optional health check drafted while adding. Empty `hcOperation` means "not
   // drafted": we then leave the integration's auto-detected default untouched
-  // rather than persisting a blank.
+  // rather than persisting a blank. No live preview here (no integration/key
+  // exists pre-creation, and `validateConnection` requires a persisted one).
   const [hcOperation, setHcOperation] = useState("");
+  const [hcIdentityField, setHcIdentityField] = useState("");
   const [hcArgs, setHcArgs] = useState<Record<string, string>>({});
 
   const doPreview = useAtomSet(previewOpenApiSpec, { mode: "promiseExit" });
@@ -230,9 +232,10 @@ export default function AddOpenApiSource(props: {
 
   const onHcOperationChange = (next: string) => {
     setHcOperation(next);
-    // Args are operation-specific; drop them so none dangle onto a freshly
-    // picked operation.
+    // Args and identity path are operation-specific; drop them so neither
+    // dangles onto a freshly picked operation.
     setHcArgs({});
+    setHcIdentityField("");
   };
   const onHcArgChange = (name: string, value: string) =>
     setHcArgs((prev) => ({ ...prev, [name]: value }));
@@ -323,12 +326,14 @@ export default function AddOpenApiSource(props: {
     // place. A failure here is non-fatal: the integration is already created and
     // the check stays editable from its detail page, so surface it and move on.
     if (hcOperation.length > 0) {
+      const identity = hcIdentityField.trim();
       const argEntries = Object.entries(hcArgs)
         .map(([key, value]) => [key, value.trim()] as const)
         .filter(([, value]) => value.length > 0);
       const spec: HealthCheckSpec = {
         operation: hcOperation,
         ...(argEntries.length > 0 ? { args: Object.fromEntries(argEntries) } : {}),
+        ...(identity.length > 0 ? { identityField: identity } : {}),
       };
       const exit = await doSetHealthCheck({
         params: { slug: integration },
@@ -436,7 +441,8 @@ export default function AddOpenApiSource(props: {
             <h3 className="text-sm font-medium text-foreground">Health check (optional)</h3>
             <p className="text-[11px] text-muted-foreground">
               One read-only call Executor runs to tell whether a connection's credential is still
-              alive. You can change this later from the integration page.
+              alive and, optionally, whose account it is. You can change this later, and run a live
+              preview against a key, from the integration page.
             </p>
           </div>
           <HealthCheckConfigFields
@@ -444,6 +450,8 @@ export default function AddOpenApiSource(props: {
             selected={hcSelected}
             operation={hcOperation}
             onOperationChange={onHcOperationChange}
+            identityField={hcIdentityField}
+            onIdentityFieldChange={setHcIdentityField}
             args={hcArgs}
             onArgChange={onHcArgChange}
             disabled={adding}

--- a/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
@@ -4,13 +4,19 @@ import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Option from "effect/Option";
 
-import { IntegrationSlug } from "@executor-js/sdk/shared";
-import { integrationWriteKeys } from "@executor-js/react/api/reactivity-keys";
+import {
+  IntegrationSlug,
+  type HealthCheckCandidate,
+  type HealthCheckSpec,
+} from "@executor-js/sdk/shared";
+import { integrationWriteKeys, healthCheckWriteKeys } from "@executor-js/react/api/reactivity-keys";
+import { setIntegrationHealthCheck } from "@executor-js/react/api/atoms";
 import {
   slugifyNamespace,
   useIntegrationIdentity,
 } from "@executor-js/react/plugins/integration-identity";
 import { Button } from "@executor-js/react/components/button";
+import { HealthCheckConfigFields } from "@executor-js/react/components/health-check-editor";
 import {
   AuthMethodListEditor,
   useAuthMethodList,
@@ -99,8 +105,15 @@ export default function AddOpenApiSource(props: {
   const [adding, setAdding] = useState(false);
   const [addError, setAddError] = useState<string | null>(null);
 
+  // Optional health check drafted while adding. Empty `hcOperation` means "not
+  // drafted": we then leave the integration's auto-detected default untouched
+  // rather than persisting a blank.
+  const [hcOperation, setHcOperation] = useState("");
+  const [hcArgs, setHcArgs] = useState<Record<string, string>>({});
+
   const doPreview = useAtomSet(previewOpenApiSpec, { mode: "promiseExit" });
   const doAdd = useAtomSet(addOpenApiSpec, { mode: "promiseExit" });
+  const doSetHealthCheck = useAtomSet(setIntegrationHealthCheck, { mode: "promiseExit" });
 
   // Keep the latest handleAnalyze in a ref so the debounced effect doesn't need
   // it as a dependency (it closes over fresh state).
@@ -196,15 +209,47 @@ export default function AddOpenApiSource(props: {
     return templates;
   }, [authMethodList.rows]);
 
+  // Health-check candidates from the bounded preview (top-ranked operations with
+  // their response fields). The picker is freeform, so a custom op is still
+  // reachable when the spec exposes none.
+  const healthCheckCandidates = useMemo<readonly HealthCheckCandidate[]>(
+    () => preview?.healthCheckCandidates ?? [],
+    [preview?.healthCheckCandidates],
+  );
+  const hcSelected = useMemo(
+    () => healthCheckCandidates.find((c) => c.operation === hcOperation) ?? null,
+    [healthCheckCandidates, hcOperation],
+  );
+  const hcRequiredParams = useMemo(
+    () => (hcSelected?.parameters ?? []).filter((p) => p.required),
+    [hcSelected],
+  );
+  const hcMissingRequired = hcRequiredParams.some(
+    (p) => (hcArgs[p.name] ?? "").trim().length === 0,
+  );
+
+  const onHcOperationChange = (next: string) => {
+    setHcOperation(next);
+    // Args are operation-specific; drop them so none dangle onto a freshly
+    // picked operation.
+    setHcArgs({});
+  };
+  const onHcArgChange = (name: string, value: string) =>
+    setHcArgs((prev) => ({ ...prev, [name]: value }));
+
   // Pre-empt the API's `IntegrationAlreadyExistsError`: adding an integration
   // whose slug already exists clobbers the existing one's connections/policies,
   // so the API blocks it. Surface that here from the tenant-scoped catalog list.
   const slugAlreadyExists = useSlugAlreadyExists(resolvedSourceId);
 
   // The base URL is optional when the spec declares servers (resolved per call);
-  // required only when it doesn't.
+  // required only when it doesn't. A drafted health check must have its required
+  // args filled (an empty draft, `hcOperation === ""`, imposes no constraint).
   const canAdd =
-    preview !== null && !slugAlreadyExists && (!previewHasNoServers || resolvedBaseUrl.length > 0);
+    preview !== null &&
+    !slugAlreadyExists &&
+    (!previewHasNoServers || resolvedBaseUrl.length > 0) &&
+    !(hcOperation.length > 0 && hcMissingRequired);
 
   // ---- Handlers ----
 
@@ -271,6 +316,32 @@ export default function AddOpenApiSource(props: {
     if (!integration) {
       setAdding(false);
       return;
+    }
+
+    // Persist the drafted health check only when the user actively picked an
+    // operation; otherwise leave the integration's auto-detected default in
+    // place. A failure here is non-fatal: the integration is already created and
+    // the check stays editable from its detail page, so surface it and move on.
+    if (hcOperation.length > 0) {
+      const argEntries = Object.entries(hcArgs)
+        .map(([key, value]) => [key, value.trim()] as const)
+        .filter(([, value]) => value.length > 0);
+      const spec: HealthCheckSpec = {
+        operation: hcOperation,
+        ...(argEntries.length > 0 ? { args: Object.fromEntries(argEntries) } : {}),
+      };
+      const exit = await doSetHealthCheck({
+        params: { slug: integration },
+        payload: { spec },
+        reactivityKeys: healthCheckWriteKeys,
+      });
+      if (Exit.isFailure(exit)) {
+        setAddError(
+          errorMessageFromExit(exit, "Integration added, but saving the health check failed"),
+        );
+        setAdding(false);
+        return;
+      }
     }
 
     props.onComplete(String(integration));
@@ -357,6 +428,28 @@ export default function AddOpenApiSource(props: {
           emptyHint="No authentication detected. Add a method, or add the integration without auth and connect an account from the integration page later."
           footerHint="Every method here is registered with the integration. Connect an account from the integration page after adding."
         />
+      )}
+
+      {preview && healthCheckCandidates.length > 0 && (
+        <section className="space-y-4">
+          <div className="space-y-1">
+            <h3 className="text-sm font-medium text-foreground">Health check (optional)</h3>
+            <p className="text-[11px] text-muted-foreground">
+              One read-only call Executor runs to tell whether a connection's credential is still
+              alive. You can change this later from the integration page.
+            </p>
+          </div>
+          <HealthCheckConfigFields
+            candidates={healthCheckCandidates}
+            selected={hcSelected}
+            operation={hcOperation}
+            onOperationChange={onHcOperationChange}
+            args={hcArgs}
+            onArgChange={onHcArgChange}
+            disabled={adding}
+            idPrefix="add-health-check"
+          />
+        </section>
       )}
 
       {preview && slugAlreadyExists && !adding && <SlugCollisionAlert slug={resolvedSourceId} />}

--- a/packages/plugins/openapi/src/react/OpenApiAccountsPanel.tsx
+++ b/packages/plugins/openapi/src/react/OpenApiAccountsPanel.tsx
@@ -6,8 +6,13 @@ import { AuthTemplateSlug, IntegrationSlug } from "@executor-js/sdk/shared";
 import type { IntegrationAccountHandoff } from "@executor-js/sdk/client";
 
 import { AccountsSection } from "@executor-js/react/components/accounts-section";
-import { HealthCheckEditor } from "@executor-js/react/components/health-check-editor";
+import {
+  HealthCheckEditor,
+  type HealthCheckLivePreview,
+} from "@executor-js/react/components/health-check-editor";
 import { integrationWriteKeys } from "@executor-js/react/api/reactivity-keys";
+import { useOrganizationId } from "@executor-js/react/api/organization-context";
+import { defaultConnectionOwnerForHost } from "@executor-js/react/plugins/connection-owner";
 import type { AuthMethod, Placement } from "@executor-js/react/lib/auth-placements";
 import {
   useCustomMethodActions,
@@ -104,6 +109,20 @@ export default function OpenApiAccountsPanel(props: {
     configure,
   });
 
+  // Live-preview context for the health-check edit sheet: probe as the host's
+  // default owner against the integration's API-key auth methods (the only kind
+  // a pasted test key can validate). OAuth/none methods can't be previewed with
+  // a key, so they're filtered out; with no apikey method the sheet hides the
+  // preview block entirely.
+  const organizationId = useOrganizationId();
+  const livePreview = useMemo<HealthCheckLivePreview | undefined>(() => {
+    const templates = methods
+      .filter((m) => m.kind === "apikey")
+      .map((m) => ({ template: m.template, label: m.label }));
+    if (templates.length === 0) return undefined;
+    return { owner: defaultConnectionOwnerForHost(organizationId), templates };
+  }, [methods, organizationId]);
+
   return (
     <div className="mx-auto max-w-3xl space-y-8 px-6 py-8">
       <AccountsSection
@@ -114,7 +133,7 @@ export default function OpenApiAccountsPanel(props: {
         createCustomMethod={createCustomMethod}
         removeCustomMethod={removeCustomMethod}
       />
-      <HealthCheckEditor integration={slug} />
+      <HealthCheckEditor integration={slug} livePreview={livePreview} />
     </div>
   );
 }

--- a/packages/plugins/openapi/src/react/OpenApiAccountsPanel.tsx
+++ b/packages/plugins/openapi/src/react/OpenApiAccountsPanel.tsx
@@ -6,6 +6,7 @@ import { AuthTemplateSlug, IntegrationSlug } from "@executor-js/sdk/shared";
 import type { IntegrationAccountHandoff } from "@executor-js/sdk/client";
 
 import { AccountsSection } from "@executor-js/react/components/accounts-section";
+import { HealthCheckEditor } from "@executor-js/react/components/health-check-editor";
 import { integrationWriteKeys } from "@executor-js/react/api/reactivity-keys";
 import type { AuthMethod, Placement } from "@executor-js/react/lib/auth-placements";
 import {
@@ -113,6 +114,7 @@ export default function OpenApiAccountsPanel(props: {
         createCustomMethod={createCustomMethod}
         removeCustomMethod={removeCustomMethod}
       />
+      <HealthCheckEditor integration={slug} />
     </div>
   );
 }

--- a/packages/plugins/openapi/src/sdk/backing.ts
+++ b/packages/plugins/openapi/src/sdk/backing.ts
@@ -7,6 +7,14 @@ import {
   ToolName,
   ToolResult,
   authToolFailure,
+  classifyHttpStatus,
+  compareHealthCheckCandidates,
+  type HealthCheckCandidate,
+  type HealthCheckResult,
+  type HealthCheckSpec,
+  type IntegrationConfig,
+  type IntegrationRecord,
+  type IntegrationSlug,
   type PluginCtx,
   type ResolveToolsResult,
   type StorageFailure,
@@ -28,7 +36,7 @@ import {
   streamOperationBindingsFromStructure,
 } from "./extract";
 import { compileToolDefinitions, type ToolDefinition } from "./definitions";
-import { annotationsForOperation, invokeWithLayer } from "./invoke";
+import { annotationsForOperation, invokeWithLayer, REQUIRE_APPROVAL } from "./invoke";
 import { parse, type ParsedDocument } from "./parse";
 import { parseEntry, structuralSplit, type KeepPathItem, type SpecStructure } from "./split";
 import { type OpenapiStore, type StoredOperation } from "./store";
@@ -663,3 +671,215 @@ export const resolveOpenApiBackedAnnotations = (input: {
     }
     return out;
   });
+
+// ---------------------------------------------------------------------------
+// Health checks — the declared liveness probe for a connection.
+// ---------------------------------------------------------------------------
+
+/** Resolve the invocation binding for a health-check operation. Unlike the tool
+ *  invoke path we do not need `responseBody` (the probe reads the raw response),
+ *  so the stored binding is enough; only recompile the spec when it is missing
+ *  (e.g. an operation added to the spec but not yet persisted). */
+const resolveHealthCheckBinding = (
+  ctx: PluginCtx<OpenapiStore>,
+  integration: string,
+  operation: string,
+  config: OpenApiIntegrationConfig | null,
+): Effect.Effect<OperationBinding | undefined, StorageFailure> =>
+  Effect.gen(function* () {
+    const stored = (yield* ctx.storage.getOperation(integration, operation))?.binding;
+    if (stored) return stored;
+    if (!config) return undefined;
+    const specText = yield* loadOpenApiSpecText(ctx.storage, config).pipe(
+      Effect.catch(() => Effect.succeed(null)),
+    );
+    if (specText == null) return undefined;
+    const compiled = yield* compileOpenApiSpec(specText).pipe(
+      Effect.catch(() => Effect.succeed(null)),
+    );
+    if (!compiled) return undefined;
+    return openApiStoredOperationsFromCompiled(integration, compiled).find(
+      (op) => op.toolName === operation,
+    )?.binding;
+  });
+
+/** Run the configured (or overridden) probe against a resolved credential and
+ *  classify the outcome. Never fails for credential/upstream reasons: a rejected
+ *  credential is a `HealthCheckResult` with `status: "expired"`, not an error. */
+export const checkHealthOpenApi = (input: {
+  readonly ctx: PluginCtx<OpenapiStore>;
+  readonly integration: IntegrationRecord;
+  readonly credential: ToolInvocationCredential;
+  readonly spec?: HealthCheckSpec;
+  readonly httpClientLayer: Layer.Layer<HttpClient.HttpClient, never, never>;
+}): Effect.Effect<HealthCheckResult, StorageFailure> =>
+  Effect.gen(function* () {
+    const checkedAt = Date.now();
+    const config = decodeOpenApiIntegrationConfig(input.integration.config);
+    const spec = input.spec ?? config?.healthCheck;
+    if (!spec) {
+      return {
+        status: "unknown",
+        checkedAt,
+        detail: "No health check configured.",
+      } satisfies HealthCheckResult;
+    }
+
+    const integration = String(input.integration.slug);
+    const binding = yield* resolveHealthCheckBinding(
+      input.ctx,
+      integration,
+      spec.operation,
+      config,
+    );
+    if (!binding) {
+      return {
+        status: "unknown",
+        checkedAt,
+        detail: `Health check operation "${spec.operation}" not found on "${integration}".`,
+      } satisfies HealthCheckResult;
+    }
+
+    const headers: Record<string, string> = { ...(config?.headers ?? {}) };
+    const queryParams: Record<string, string> = { ...(config?.queryParams ?? {}) };
+
+    const template = (config?.authenticationTemplate ?? []).find(
+      (entry) => String(entry.slug) === String(input.credential.template),
+    );
+    if (template) {
+      const missing = requiredTemplateVariables(template).filter((name) => {
+        const value = input.credential.values[name];
+        return value == null || value === "";
+      });
+      if (missing.length > 0) {
+        return {
+          status: "expired",
+          checkedAt,
+          detail: `Connection "${input.credential.connection}" has no resolvable credential value.`,
+        } satisfies HealthCheckResult;
+      }
+      const rendered = renderAuthTemplate(template, input.credential.values);
+      Object.assign(headers, rendered.headers);
+      Object.assign(queryParams, rendered.queryParams);
+    }
+
+    // `invokeWithLayer` fails only with the typed `OpenApiInvocationError`
+    // (transport / body-read failures before an HTTP status); fold it onto the
+    // success channel so a dead upstream reads as `degraded`, not a thrown error.
+    const probe = yield* invokeWithLayer(
+      binding,
+      { ...(spec.args ?? {}) } as Record<string, unknown>,
+      config?.baseUrl ?? "",
+      headers,
+      queryParams,
+      input.httpClientLayer,
+    ).pipe(
+      Effect.map((result) => ({ ok: true as const, result })),
+      Effect.catch((failure) => Effect.succeed({ ok: false as const, failure })),
+    );
+
+    if (!probe.ok) {
+      return {
+        status: "degraded",
+        checkedAt,
+        detail: `Health check request failed: ${probe.failure.message}`,
+      } satisfies HealthCheckResult;
+    }
+
+    const status = classifyHttpStatus(probe.result.status);
+    return {
+      status,
+      httpStatus: probe.result.status,
+      checkedAt,
+      ...(status === "healthy"
+        ? {}
+        : { detail: extractOpenApiUpstreamMessage(probe.result.error, probe.result.status) }),
+    } satisfies HealthCheckResult;
+  });
+
+/** List the operations a user can pick as the health check, ranked
+ *  non-destructive-first then fewest-required-args so the obvious "GET /me"
+ *  style endpoint floats to the top. Recompiles the spec once (best-effort)
+ *  to recover human summaries the stored binding does not keep. */
+export const listHealthCheckCandidatesOpenApi = (input: {
+  readonly ctx: PluginCtx<OpenapiStore>;
+  readonly integration: IntegrationRecord;
+}): Effect.Effect<readonly HealthCheckCandidate[], StorageFailure> =>
+  Effect.gen(function* () {
+    const integration = String(input.integration.slug);
+    const operations = yield* input.ctx.storage.listOperations(integration);
+    const config = decodeOpenApiIntegrationConfig(input.integration.config);
+
+    const summaries = new Map<string, string>();
+    if (config) {
+      const specText = yield* loadOpenApiSpecText(input.ctx.storage, config).pipe(
+        Effect.catch(() => Effect.succeed(null)),
+      );
+      const compiled =
+        specText == null
+          ? null
+          : yield* compileOpenApiSpec(specText).pipe(Effect.catch(() => Effect.succeed(null)));
+      if (compiled) {
+        for (const def of compiled.definitions) {
+          const summary =
+            Option.getOrUndefined(def.operation.summary) ??
+            Option.getOrUndefined(def.operation.description);
+          if (summary) summaries.set(def.toolPath, summary);
+        }
+      }
+    }
+
+    const candidates = operations.map((op): HealthCheckCandidate => {
+      const method = op.binding.method.toLowerCase();
+      const parameters = op.binding.parameters.map((parameter) => ({
+        name: parameter.name,
+        location: parameter.location,
+        required: parameter.required,
+        ...(Option.isSome(parameter.description)
+          ? { description: parameter.description.value }
+          : {}),
+      }));
+      return {
+        operation: op.toolName,
+        method,
+        requiredArgCount: op.binding.parameters.filter((parameter) => parameter.required).length,
+        destructive: REQUIRE_APPROVAL.has(method),
+        summary: summaries.get(op.toolName) ?? `${method.toUpperCase()} ${op.binding.pathTemplate}`,
+        ...(parameters.length > 0 ? { parameters } : {}),
+      };
+    });
+    return [...candidates].sort(compareHealthCheckCandidates);
+  });
+
+/** Persist (or clear, when `spec` is null) the integration's health check.
+ *  Read-modify-write of the opaque config inside a transaction, mirroring
+ *  `configure`. */
+export const setHealthCheckOpenApi = (input: {
+  readonly ctx: PluginCtx<OpenapiStore>;
+  readonly integration: IntegrationSlug;
+  readonly spec: HealthCheckSpec | null;
+}): Effect.Effect<void, StorageFailure> =>
+  input.ctx.transaction(
+    Effect.gen(function* () {
+      const record = yield* input.ctx.core.integrations.get(input.integration);
+      if (!record) return;
+      // Guard: only touch configs that decode as the openapi shape. Merge over
+      // the RAW config object (not the decoded one, which strips unknown keys)
+      // so provider supersets (Microsoft presets, Google discovery URLs) survive
+      // a health-check write. `healthCheck: undefined` drops the key on JSON
+      // serialization, clearing the stored health check.
+      if (decodeOpenApiIntegrationConfig(record.config) === null) return;
+      const raw = (record.config ?? {}) as Record<string, unknown>;
+      const next = input.spec
+        ? { ...raw, healthCheck: input.spec }
+        : { ...raw, healthCheck: undefined };
+      yield* input.ctx.core.integrations.update(input.integration, {
+        config: next as IntegrationConfig,
+      });
+    }),
+  );
+
+/** Pure projector: the health check declared in the integration's config, or
+ *  null when none is configured. */
+export const describeHealthCheckOpenApi = (record: IntegrationRecord): HealthCheckSpec | null =>
+  decodeOpenApiIntegrationConfig(record.config)?.healthCheck ?? null;

--- a/packages/plugins/openapi/src/sdk/backing.ts
+++ b/packages/plugins/openapi/src/sdk/backing.ts
@@ -9,7 +9,11 @@ import {
   authToolFailure,
   classifyHttpStatus,
   compareHealthCheckCandidates,
+  extractIdentity,
+  extractResponseFields,
+  projectResponseFields,
   type HealthCheckCandidate,
+  type HealthCheckResponseField,
   type HealthCheckResult,
   type HealthCheckSpec,
   type IntegrationConfig,
@@ -673,7 +677,7 @@ export const resolveOpenApiBackedAnnotations = (input: {
   });
 
 // ---------------------------------------------------------------------------
-// Health checks — the declared liveness probe for a connection.
+// Health checks — the declared liveness/identity probe for a connection.
 // ---------------------------------------------------------------------------
 
 /** Resolve the invocation binding for a health-check operation. Unlike the tool
@@ -787,10 +791,17 @@ export const checkHealthOpenApi = (input: {
     }
 
     const status = classifyHttpStatus(probe.result.status);
+    const identity =
+      status === "healthy" ? extractIdentity(probe.result.data, spec.identityField) : undefined;
+    // Sample the actual returned body (success body, else the error body) so the
+    // live preview can show what the operation returns regardless of status.
+    const responseSample = extractResponseFields(probe.result.data ?? probe.result.error);
     return {
       status,
       httpStatus: probe.result.status,
+      ...(identity !== undefined ? { identity } : {}),
       checkedAt,
+      ...(responseSample.length > 0 ? { responseSample } : {}),
       ...(status === "healthy"
         ? {}
         : { detail: extractOpenApiUpstreamMessage(probe.result.error, probe.result.status) }),
@@ -799,7 +810,7 @@ export const checkHealthOpenApi = (input: {
 
 /** List the operations a user can pick as the health check, ranked
  *  non-destructive-first then fewest-required-args so the obvious "GET /me"
- *  style endpoint floats to the top. Recompiles the spec once (best-effort)
+ *  identity endpoint floats to the top. Recompiles the spec once (best-effort)
  *  to recover human summaries the stored binding does not keep. */
 export const listHealthCheckCandidatesOpenApi = (input: {
   readonly ctx: PluginCtx<OpenapiStore>;
@@ -811,6 +822,7 @@ export const listHealthCheckCandidatesOpenApi = (input: {
     const config = decodeOpenApiIntegrationConfig(input.integration.config);
 
     const summaries = new Map<string, string>();
+    const responseFieldsByTool = new Map<string, readonly HealthCheckResponseField[]>();
     if (config) {
       const specText = yield* loadOpenApiSpecText(input.ctx.storage, config).pipe(
         Effect.catch(() => Effect.succeed(null)),
@@ -825,6 +837,13 @@ export const listHealthCheckCandidatesOpenApi = (input: {
             Option.getOrUndefined(def.operation.summary) ??
             Option.getOrUndefined(def.operation.description);
           if (summary) summaries.set(def.toolPath, summary);
+          // `outputSchema` is NOT pre-normalized; `hoistedDefs` ARE, so normalize
+          // the schema before walking refs against them.
+          const fields = projectResponseFields(
+            normalizeOpenApiRefs(Option.getOrUndefined(def.operation.outputSchema)),
+            compiled.hoistedDefs,
+          );
+          if (fields.length > 0) responseFieldsByTool.set(def.toolPath, fields);
         }
       }
     }
@@ -839,6 +858,7 @@ export const listHealthCheckCandidatesOpenApi = (input: {
           ? { description: parameter.description.value }
           : {}),
       }));
+      const responseFields = responseFieldsByTool.get(op.toolName);
       return {
         operation: op.toolName,
         method,
@@ -846,6 +866,7 @@ export const listHealthCheckCandidatesOpenApi = (input: {
         destructive: REQUIRE_APPROVAL.has(method),
         summary: summaries.get(op.toolName) ?? `${method.toUpperCase()} ${op.binding.pathTemplate}`,
         ...(parameters.length > 0 ? { parameters } : {}),
+        ...(responseFields && responseFields.length > 0 ? { responseFields } : {}),
       };
     });
     return [...candidates].sort(compareHealthCheckCandidates);

--- a/packages/plugins/openapi/src/sdk/config.ts
+++ b/packages/plugins/openapi/src/sdk/config.ts
@@ -5,6 +5,7 @@ import {
   renderAuthPlacements,
   requiredPlacementVariables,
 } from "@executor-js/sdk/http-auth";
+import { HealthCheckSpec } from "@executor-js/sdk/core";
 
 import type { Authentication } from "./types";
 
@@ -51,6 +52,10 @@ export const OpenApiIntegrationConfigSchema = Schema.Struct({
   queryParams: Schema.optional(Schema.Record(Schema.String, Schema.String)),
   /** The auth methods a connection's value can be applied through. */
   authenticationTemplate: Schema.optional(Schema.Array(AuthenticationSchema)),
+  /** The declared health check: which operation a connection runs to prove its
+   *  credential is alive and surface whose account it is. Picked by the user
+   *  the same way auth methods are configured. Absent = no health check. */
+  healthCheck: Schema.optional(HealthCheckSpec),
 });
 
 export type OpenApiIntegrationConfig = Omit<

--- a/packages/plugins/openapi/src/sdk/index.ts
+++ b/packages/plugins/openapi/src/sdk/index.ts
@@ -15,19 +15,23 @@ export {
 export { invoke, invokeWithLayer, annotationsForOperation } from "./invoke";
 export {
   buildDefsJsonStreaming,
+  checkHealthOpenApi,
   compileAndPersistOpenApiOperations,
   compileAndPersistOpenApiSpec,
   compileAndPersistOpenApiSpecStreaming,
   compileOpenApiDocument,
   compileOpenApiSpec,
+  describeHealthCheckOpenApi,
   extractOpenApiUpstreamMessage,
   invokeOpenApiBackedTool,
+  listHealthCheckCandidatesOpenApi,
   loadOpenApiSpecText,
   normalizeOpenApiRefs,
   openApiStoredOperationsFromCompiled,
   openApiToolDefsFromCompiled,
   resolveOpenApiBackedAnnotations,
   resolveOpenApiBackedTools,
+  setHealthCheckOpenApi,
   type CompiledOpenApiSpec,
   type OpenApiPersistResult,
 } from "./backing";

--- a/packages/plugins/openapi/src/sdk/invoke.ts
+++ b/packages/plugins/openapi/src/sdk/invoke.ts
@@ -815,7 +815,7 @@ export const invokeWithLayer = (
 // Derive annotations from HTTP method
 // ---------------------------------------------------------------------------
 
-const REQUIRE_APPROVAL = new Set(["post", "put", "patch", "delete"]);
+export const REQUIRE_APPROVAL = new Set(["post", "put", "patch", "delete"]);
 
 export const annotationsForOperation = (
   method: string,

--- a/packages/plugins/openapi/src/sdk/plugin.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.ts
@@ -32,11 +32,15 @@ import type { Authentication } from "./types";
 import { normalizeOpenApiAuthInputs, type AuthenticationInput } from "./types";
 import { ApiKeyAuthTemplate, describeApiKeyAuthMethod } from "@executor-js/sdk/http-auth";
 import {
+  checkHealthOpenApi,
   compileOpenApiSpec,
+  describeHealthCheckOpenApi,
   invokeOpenApiBackedTool,
+  listHealthCheckCandidatesOpenApi,
   openApiStoredOperationsFromCompiled,
   resolveOpenApiBackedAnnotations,
   resolveOpenApiBackedTools,
+  setHealthCheckOpenApi,
 } from "./backing";
 
 // ---------------------------------------------------------------------------
@@ -783,6 +787,23 @@ export const openApiPlugin = definePlugin((options?: OpenApiPluginOptions) => {
 
     describeAuthMethods: describeOpenApiAuthMethods,
     describeIntegrationDisplay: describeOpenApiIntegrationDisplay,
+
+    // Health checks: the declared liveness/identity probe. `describeHealthCheck`
+    // is a pure projector off the opaque config; the rest run operations or
+    // read-modify-write the config, so they thread the plugin's http layer / ctx.
+    describeHealthCheck: describeHealthCheckOpenApi,
+    listHealthCheckCandidates: (input) =>
+      listHealthCheckCandidatesOpenApi({ ctx: input.ctx, integration: input.integration }),
+    setHealthCheck: (input) =>
+      setHealthCheckOpenApi({ ctx: input.ctx, integration: input.integration, spec: input.spec }),
+    checkHealth: (input) =>
+      checkHealthOpenApi({
+        ctx: input.ctx,
+        integration: input.integration,
+        credential: input.credential,
+        spec: input.spec,
+        httpClientLayer: options?.httpClientLayer ?? input.ctx.httpClientLayer,
+      }),
 
     // Produce one tool per spec operation. Spec-derived, identical for every
     // connection on the integration - so `getValue` is never called here. The

--- a/packages/plugins/openapi/src/sdk/preview.ts
+++ b/packages/plugins/openapi/src/sdk/preview.ts
@@ -1,10 +1,25 @@
 import { Effect, Option, Predicate } from "effect";
 import { Schema } from "effect";
 
+import { HealthCheckCandidate, compareHealthCheckCandidates } from "@executor-js/sdk/core";
+
 import { parse, resolveSpecText, type ParsedDocument } from "./parse";
 import { extract } from "./extract";
+import { compileToolDefinitions } from "./definitions";
 import { DocResolver } from "./openapi-utils";
-import { HttpMethod, ServerInfo, type ExtractionResult } from "./types";
+import { HttpMethod, ServerInfo, type ExtractedOperation, type ExtractionResult } from "./types";
+
+// Mutating HTTP methods — mirrors `REQUIRE_APPROVAL` in `./invoke` but kept
+// inline so this browser-safe preview module never pulls in the HTTP execution
+// path. A health check should be safe to re-run, so these rank last.
+const DESTRUCTIVE_METHODS = new Set(["post", "put", "patch", "delete"]);
+
+// Cap on health-check candidate METADATA carried in the preview, so the add
+// screen's operation picker can search the whole spec (not just a top few).
+// Building this is cheap (the rank/sort already runs over every operation); only
+// the payload grows, so the cap bounds Graph-sized specs (16k+ ops) to the
+// top-ranked 1000. Beyond that, the picker stays freeform (type an exact op).
+const MAX_PREVIEW_CANDIDATES = 1000;
 
 // ---------------------------------------------------------------------------
 // OAuth 2.0 flows — one entry per supported grant type
@@ -151,6 +166,9 @@ export const SpecPreview = Schema.Struct({
   headerPresets: Schema.Array(HeaderPreset),
   /** OAuth2 presets — one per (oauth2 scheme × supported flow) combination */
   oauth2Presets: Schema.Array(OAuth2Preset),
+  /** Top-ranked health-check candidates (bounded), so the add screen can offer a
+   *  typed operation picker before the integration is registered. */
+  healthCheckCandidates: Schema.Array(HealthCheckCandidate),
 });
 export type SpecPreview = typeof SpecPreview.Type;
 
@@ -168,6 +186,7 @@ export const SpecPreviewSummary = Schema.Struct({
   authStrategies: Schema.Array(AuthStrategy),
   headerPresets: Schema.Array(HeaderPreset),
   oauth2Presets: Schema.Array(OAuth2Preset),
+  healthCheckCandidates: Schema.Array(HealthCheckCandidate),
 });
 export type SpecPreviewSummary = typeof SpecPreviewSummary.Type;
 
@@ -183,6 +202,7 @@ export const specPreviewSummary = (preview: SpecPreview): SpecPreviewSummary =>
     authStrategies: preview.authStrategies,
     headerPresets: preview.headerPresets,
     oauth2Presets: preview.oauth2Presets,
+    healthCheckCandidates: preview.healthCheckCandidates,
   });
 
 // ---------------------------------------------------------------------------
@@ -404,6 +424,57 @@ const collectTags = (result: ExtractionResult): string[] => {
 };
 
 // ---------------------------------------------------------------------------
+// Health-check candidates (bounded) for the add screen
+// ---------------------------------------------------------------------------
+
+/**
+ * Project the top-ranked health-check candidates from a parsed doc + its
+ * extracted operations, so the add screen can offer a typed operation picker
+ * before registration.
+ *
+ * Tool paths are computed on the FULL operation set (`compileToolDefinitions`
+ * collision resolution is stateful, so they must match the paths the operations
+ * get at registration). Candidates are ranked and sliced to
+ * `MAX_PREVIEW_CANDIDATES` (enough for the operation picker to search the whole
+ * spec).
+ */
+const buildPreviewHealthCheckCandidates = (
+  _doc: ParsedDocument,
+  operations: readonly ExtractedOperation[],
+): HealthCheckCandidate[] => {
+  if (operations.length === 0) return [];
+
+  const definitions = compileToolDefinitions(operations);
+
+  return definitions
+    .map((def): HealthCheckCandidate => {
+      const op = def.operation;
+      const method = op.method.toLowerCase();
+      const parameters = op.parameters.map((parameter) => ({
+        name: parameter.name,
+        location: parameter.location,
+        required: parameter.required,
+        ...(Option.isSome(parameter.description)
+          ? { description: parameter.description.value }
+          : {}),
+      }));
+      return {
+        operation: def.toolPath,
+        method,
+        requiredArgCount: op.parameters.filter((parameter) => parameter.required).length,
+        destructive: DESTRUCTIVE_METHODS.has(method),
+        summary:
+          Option.getOrUndefined(op.summary) ??
+          Option.getOrUndefined(op.description) ??
+          `${method.toUpperCase()} ${op.pathTemplate}`,
+        ...(parameters.length > 0 ? { parameters } : {}),
+      };
+    })
+    .sort(compareHealthCheckCandidates)
+    .slice(0, MAX_PREVIEW_CANDIDATES);
+};
+
+// ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
@@ -448,6 +519,7 @@ export const previewSpecText = Effect.fn("OpenApi.previewSpecText")(function* (s
     authStrategies,
     headerPresets: buildHeaderPresets(securitySchemes, authStrategies),
     oauth2Presets: buildOAuth2Presets(securitySchemes),
+    healthCheckCandidates: buildPreviewHealthCheckCandidates(doc, result.operations),
   });
 });
 

--- a/packages/plugins/openapi/src/sdk/preview.ts
+++ b/packages/plugins/openapi/src/sdk/preview.ts
@@ -1,11 +1,16 @@
 import { Effect, Option, Predicate } from "effect";
 import { Schema } from "effect";
 
-import { HealthCheckCandidate, compareHealthCheckCandidates } from "@executor-js/sdk/core";
+import {
+  HealthCheckCandidate,
+  compareHealthCheckCandidates,
+  projectResponseFields,
+} from "@executor-js/sdk/core";
 
 import { parse, resolveSpecText, type ParsedDocument } from "./parse";
 import { extract } from "./extract";
 import { compileToolDefinitions } from "./definitions";
+import { normalizeOpenApiRefs } from "./backing";
 import { DocResolver } from "./openapi-utils";
 import { HttpMethod, ServerInfo, type ExtractedOperation, type ExtractionResult } from "./types";
 
@@ -20,6 +25,12 @@ const DESTRUCTIVE_METHODS = new Set(["post", "put", "patch", "delete"]);
 // the payload grows, so the cap bounds Graph-sized specs (16k+ ops) to the
 // top-ranked 1000. Beyond that, the picker stays freeform (type an exact op).
 const MAX_PREVIEW_CANDIDATES = 1000;
+
+// Cap on how many carried candidates get their response schema WALKED for the
+// typed identity picker. Walking is the only expensive part, so it stays small:
+// the top-ranked survivors get typed identity fields; the long tail is
+// metadata-only and its identity picker falls back to a freeform dot-path.
+const MAX_PREVIEW_RESPONSE_FIELD_CANDIDATES = 50;
 
 // ---------------------------------------------------------------------------
 // OAuth 2.0 flows — one entry per supported grant type
@@ -167,7 +178,7 @@ export const SpecPreview = Schema.Struct({
   /** OAuth2 presets — one per (oauth2 scheme × supported flow) combination */
   oauth2Presets: Schema.Array(OAuth2Preset),
   /** Top-ranked health-check candidates (bounded), so the add screen can offer a
-   *  typed operation picker before the integration is registered. */
+   *  typed operation + identity picker before the integration is registered. */
   healthCheckCandidates: Schema.Array(HealthCheckCandidate),
 });
 export type SpecPreview = typeof SpecPreview.Type;
@@ -429,24 +440,25 @@ const collectTags = (result: ExtractionResult): string[] => {
 
 /**
  * Project the top-ranked health-check candidates from a parsed doc + its
- * extracted operations, so the add screen can offer a typed operation picker
- * before registration.
+ * extracted operations, so the add screen can offer a typed operation/identity
+ * picker before registration.
  *
  * Tool paths are computed on the FULL operation set (`compileToolDefinitions`
  * collision resolution is stateful, so they must match the paths the operations
- * get at registration). Candidates are ranked and sliced to
- * `MAX_PREVIEW_CANDIDATES` (enough for the operation picker to search the whole
- * spec).
+ * get at registration). Candidates are ranked, sliced to `MAX_PREVIEW_CANDIDATES`
+ * (enough for the operation picker to search the whole spec), and only the
+ * top `MAX_PREVIEW_RESPONSE_FIELD_CANDIDATES` get their response schema walked for
+ * the typed identity field; the rest stay metadata-only (freeform identity).
  */
 const buildPreviewHealthCheckCandidates = (
-  _doc: ParsedDocument,
+  doc: ParsedDocument,
   operations: readonly ExtractedOperation[],
 ): HealthCheckCandidate[] => {
   if (operations.length === 0) return [];
 
   const definitions = compileToolDefinitions(operations);
 
-  return definitions
+  const ranked = definitions
     .map((def): HealthCheckCandidate => {
       const op = def.operation;
       const method = op.method.toLowerCase();
@@ -472,6 +484,30 @@ const buildPreviewHealthCheckCandidates = (
     })
     .sort(compareHealthCheckCandidates)
     .slice(0, MAX_PREVIEW_CANDIDATES);
+
+  // Walk response schemas only for the top survivors (the realistic health-check
+  // picks). `outputSchema` is NOT pre-normalized; the hoisted `$defs` ARE, so
+  // normalize the schema first. The rest are returned metadata-only so the
+  // operation picker still lists them while keeping schema walking bounded.
+  const hoistedDefs: Record<string, unknown> = {};
+  const rawSchemas = doc.components?.schemas;
+  if (rawSchemas) {
+    for (const [name, schema] of Object.entries(rawSchemas)) {
+      hoistedDefs[name] = normalizeOpenApiRefs(schema);
+    }
+  }
+  const operationByToolPath = new Map(definitions.map((def) => [def.toolPath, def.operation]));
+
+  return ranked.map((candidate, index): HealthCheckCandidate => {
+    if (index >= MAX_PREVIEW_RESPONSE_FIELD_CANDIDATES) return candidate;
+    const op = operationByToolPath.get(candidate.operation);
+    if (!op) return candidate;
+    const responseFields = projectResponseFields(
+      normalizeOpenApiRefs(Option.getOrUndefined(op.outputSchema)),
+      hoistedDefs,
+    );
+    return responseFields.length > 0 ? { ...candidate, responseFields } : candidate;
+  });
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/react/src/api/atoms.tsx
+++ b/packages/react/src/api/atoms.tsx
@@ -76,6 +76,25 @@ export const integrationAtom = (slug: IntegrationSlug) =>
     (integrations) => integrations.find((i) => i.slug === slug) ?? null,
   );
 
+/** The integration's currently declared health check (null when none is set).
+ *  Backs the editor's "current selection" and the status surfaces deciding
+ *  whether a connection can be probed at all. */
+export const integrationHealthCheckAtom = (slug: IntegrationSlug) =>
+  ExecutorApiClient.query("integrations", "healthCheckGet", {
+    params: { slug },
+    timeToLive: "30 seconds",
+    reactivityKeys: [ReactivityKey.healthChecks],
+  });
+
+/** Operations the user can pick as the health check, server-ranked
+ *  (non-destructive + fewest-required-args first). Backs the editor picker. */
+export const integrationHealthCheckCandidatesAtom = (slug: IntegrationSlug) =>
+  ExecutorApiClient.query("integrations", "healthCheckCandidates", {
+    params: { slug },
+    timeToLive: "5 minutes",
+    reactivityKeys: [ReactivityKey.integrations],
+  });
+
 // ---------------------------------------------------------------------------
 // Connections — owner-scoped credentials (was `secrets` + `connections`).
 // ---------------------------------------------------------------------------
@@ -147,11 +166,27 @@ export const updateConnection = ExecutorApiClient.mutation("connections", "updat
 
 export const refreshConnection = ExecutorApiClient.mutation("connections", "refresh");
 
+/** Probe a SAVED connection's health on demand (the "Check now" button). A
+ *  read-only probe: returns a classified `HealthCheckResult`, persists nothing,
+ *  so no reactivity keys. */
+export const checkConnectionHealth = ExecutorApiClient.mutation("connections", "checkHealth");
+
+/** Validate an IN-FLIGHT credential without saving it (the key-first connect
+ *  flow). Returns the probe result the UI derives a connection name from. */
+export const validateConnection = ExecutorApiClient.mutation("connections", "validate");
+
 export const updateIntegration = ExecutorApiClient.mutation("integrations", "update");
 
 export const removeIntegration = ExecutorApiClient.mutation("integrations", "remove");
 
 export const detectIntegration = ExecutorApiClient.mutation("integrations", "detect");
+
+/** Set or clear an integration's declared health check.
+ *  Pass `reactivityKeys: healthCheckWriteKeys` at the call site. */
+export const setIntegrationHealthCheck = ExecutorApiClient.mutation(
+  "integrations",
+  "healthCheckSet",
+);
 
 // ---------------------------------------------------------------------------
 // OAuth — v2 flow. `start` runs a registered client to mint a connection for an

--- a/packages/react/src/api/reactivity-keys.tsx
+++ b/packages/react/src/api/reactivity-keys.tsx
@@ -28,6 +28,8 @@ export const ReactivityKey = {
   policies: "policies",
   /** Registered OAuth clients (apps). */
   oauthClients: "oauth-clients",
+  /** An integration's declared health check (the operation/identity-field spec). */
+  healthChecks: "health-checks",
   // cloud-only resources
   orgMembers: "org:members",
   orgDomains: "org:domains",
@@ -46,6 +48,13 @@ export const connectionWriteKeys = [ReactivityKey.connections, ReactivityKey.too
 
 /** Mutations that register / replace an OAuth client (app). */
 export const oauthClientWriteKeys = [ReactivityKey.oauthClients] as const;
+
+/** Mutations that set/clear an integration's health check. Touches `integrations`
+ *  so any integration view re-reads (the spec is derived from integration config). */
+export const healthCheckWriteKeys = [
+  ReactivityKey.healthChecks,
+  ReactivityKey.integrations,
+] as const;
 
 /** Mutations that mutate tool policies. Also touches `tools` because
  *  `tools.list` filters blocked tools — adding/removing a `block`

--- a/packages/react/src/components/accounts-section.tsx
+++ b/packages/react/src/components/accounts-section.tsx
@@ -2,18 +2,26 @@ import { useEffect, useMemo, useState } from "react";
 import { useAtomValue, useAtomSet } from "@effect/atom-react";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 import * as Exit from "effect/Exit";
-import { IntegrationSlug, type Connection, type Owner } from "@executor-js/sdk/shared";
+import {
+  IntegrationSlug,
+  type Connection,
+  type HealthCheckResult,
+  type HealthStatus,
+  type Owner,
+} from "@executor-js/sdk/shared";
 import type { IntegrationAccountHandoff } from "@executor-js/sdk/client";
 import { toast } from "sonner";
 
 import {
   addConnectionOptimistic,
+  checkConnectionHealth,
   connectionsForIntegrationAtom,
   refreshConnection,
   removeConnectionOptimistic,
   startOAuth,
 } from "../api/atoms";
 import { connectionWriteKeys } from "../api/reactivity-keys";
+import { HEALTH_INDICATOR_COLOR, HEALTH_STATUS_LABEL } from "../lib/health-display";
 import { messageFromExit } from "../api/error-reporting";
 import { ownerLabel, useOwnerDisplay } from "../api/owner-display";
 import { trackEvent } from "../api/analytics";
@@ -68,16 +76,67 @@ function AccountRow(props: {
   readonly onRemove: () => void;
 }) {
   const { connection, needsReconsent } = props;
+  // A live probe result, once "Check now" has run, drives the status indicator.
+  const [probe, setProbe] = useState<HealthCheckResult | null>(null);
+  const [checking, setChecking] = useState(false);
+  const doCheck = useAtomSet(checkConnectionHealth, { mode: "promiseExit" });
+
+  // Status comes only from a live probe ("Check now"). We deliberately do NOT
+  // derive expiry from the stored `expiresAt`: that's the access-token lifetime,
+  // which refreshes, so a passive countdown / "expired" reads as alarming but
+  // means nothing. Until a probe runs the connection is "Unchecked".
+  const status: HealthStatus = probe?.status ?? "unknown";
+  const indicator = HEALTH_INDICATOR_COLOR[status];
+
   const displayLabel =
     connection.identityLabel && connection.identityLabel.length > 0
       ? connection.identityLabel
       : String(connection.name);
 
+  const expired = status === "expired";
+
+  const handleCheck = async () => {
+    if (checking) return;
+    setChecking(true);
+    const exit = await doCheck({
+      params: {
+        owner: connection.owner,
+        integration: connection.integration,
+        name: connection.name,
+      },
+    });
+    setChecking(false);
+    if (Exit.isFailure(exit)) {
+      toast.error(messageFromExit(exit, "Health check failed"));
+      return;
+    }
+    setProbe(exit.value);
+    if (exit.value.status === "healthy") {
+      toast.success("Connection is healthy");
+    } else if (exit.value.status === "expired") {
+      toast.error("Connection expired — reconnect to restore access");
+    } else if (exit.value.status === "degraded") {
+      toast.warning(exit.value.detail ?? "Connection check returned an error");
+    } else {
+      toast.message("No health check is configured for this integration");
+    }
+  };
+
   return (
     <CardStackEntry className="flex-wrap items-start">
       <CardStackEntryContent>
         <CardStackEntryTitle className="flex min-w-0 items-center gap-2">
+          <span
+            aria-label={`Status: ${HEALTH_STATUS_LABEL[status]}`}
+            title={HEALTH_STATUS_LABEL[status]}
+            className={`size-2 shrink-0 rounded-full ${indicator.dot}`}
+          />
           <span className="truncate">{displayLabel}</span>
+          {expired ? (
+            <Badge variant="destructive" className="shrink-0">
+              Expired
+            </Badge>
+          ) : null}
           {needsReconsent ? (
             <Badge
               variant="outline"
@@ -117,6 +176,13 @@ function AccountRow(props: {
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end" className="w-40">
+            <DropdownMenuItem
+              className="text-sm"
+              disabled={checking}
+              onClick={() => void handleCheck()}
+            >
+              {checking ? "Checking…" : "Check now"}
+            </DropdownMenuItem>
             <DropdownMenuItem className="text-sm" onClick={props.onEdit}>
               Edit
             </DropdownMenuItem>

--- a/packages/react/src/components/accounts-section.tsx
+++ b/packages/react/src/components/accounts-section.tsx
@@ -88,10 +88,14 @@ function AccountRow(props: {
   const status: HealthStatus = probe?.status ?? "unknown";
   const indicator = HEALTH_INDICATOR_COLOR[status];
 
-  const displayLabel =
-    connection.identityLabel && connection.identityLabel.length > 0
+  // Prefer a probed identity (the live account), then the stored label, then the
+  // connection name. The probe is the whole point: it shows WHICH account this is.
+  const identity =
+    (probe?.identity && probe.identity.length > 0 ? probe.identity : null) ??
+    (connection.identityLabel && connection.identityLabel.length > 0
       ? connection.identityLabel
-      : String(connection.name);
+      : null);
+  const displayLabel = identity ?? String(connection.name);
 
   const expired = status === "expired";
 
@@ -112,7 +116,9 @@ function AccountRow(props: {
     }
     setProbe(exit.value);
     if (exit.value.status === "healthy") {
-      toast.success("Connection is healthy");
+      toast.success(
+        exit.value.identity ? `Healthy — ${exit.value.identity}` : "Connection is healthy",
+      );
     } else if (exit.value.status === "expired") {
       toast.error("Connection expired — reconnect to restore access");
     } else if (exit.value.status === "degraded") {

--- a/packages/react/src/components/add-account-modal.tsx
+++ b/packages/react/src/components/add-account-modal.tsx
@@ -649,7 +649,7 @@ function KeyValidationStatus(props: {
     );
   }
   if (!props.result) return null;
-  const { status, detail } = props.result;
+  const { status, identity, detail } = props.result;
   const indicator = HEALTH_INDICATOR_COLOR[status];
   const tone = status === "healthy" ? "text-muted-foreground" : "text-destructive";
   return (
@@ -657,6 +657,12 @@ function KeyValidationStatus(props: {
       <span aria-hidden className={`mt-[3px] size-2 shrink-0 rounded-full ${indicator.dot}`} />
       <span className="min-w-0">
         <span className="font-medium">{HEALTH_STATUS_LABEL[status]}</span>
+        {status === "healthy" && identity ? (
+          <>
+            {" · "}
+            <span className="text-foreground">{identity}</span>
+          </>
+        ) : null}
         {status !== "healthy" && detail ? <span className="block opacity-80">{detail}</span> : null}
       </span>
     </div>
@@ -714,7 +720,11 @@ function AddAccountModalView(props: AddAccountModalProps) {
   const [validating, setValidating] = useState(false);
   const [validationResult, setValidationResult] = useState<HealthCheckResult | null>(null);
   const [hcOperation, setHcOperation] = useState("");
+  const [hcIdentityField, setHcIdentityField] = useState("");
   const [hcArgs, setHcArgs] = useState<Record<string, string>>({});
+  // Whether the display name was auto-filled from a probed identity (so a later
+  // probe may overwrite it, but a hand-typed name is never clobbered).
+  const [nameAutofilled, setNameAutofilled] = useState(false);
   // Explicit create-time choice (no ambient owner). Cloud defaults to Personal;
   // local/desktop hide the picker and save to the one local workspace.
   const [owner, setOwner] = useState<Owner>(defaultOwner);
@@ -1108,12 +1118,14 @@ function AddAccountModalView(props: AddAccountModalProps) {
     let inlineSpec: HealthCheckSpec | undefined;
     if (!hasHealthCheck) {
       if (hcOperation.length === 0 || hcMissingRequired) return;
+      const identityPath = hcIdentityField.trim();
       const argEntries = Object.entries(hcArgs)
         .map(([key, value]) => [key, value.trim()] as const)
         .filter(([, value]) => value.length > 0);
       inlineSpec = {
         operation: hcOperation,
         ...(argEntries.length > 0 ? { args: Object.fromEntries(argEntries) } : {}),
+        ...(identityPath.length > 0 ? { identityField: identityPath } : {}),
       };
     }
     setValidating(true);
@@ -1145,6 +1157,18 @@ function AddAccountModalView(props: AddAccountModalProps) {
         reactivityKeys: healthCheckWriteKeys,
       });
       if (Exit.isSuccess(saved)) toast.success("Saved as this integration's health check");
+    }
+    // Derive the connection name from the probed identity, unless the user
+    // hand-typed one (only fill when empty or a prior auto-fill).
+    const probedIdentity = result.identity?.trim();
+    if (
+      result.status === "healthy" &&
+      probedIdentity &&
+      probedIdentity.length > 0 &&
+      (label.trim().length === 0 || nameAutofilled)
+    ) {
+      setLabel(probedIdentity);
+      setNameAutofilled(true);
     }
   };
 
@@ -1421,14 +1445,22 @@ function AddAccountModalView(props: AddAccountModalProps) {
                 <StepHeader
                   index={1}
                   label="Display name"
-                  hint="how you'll tell accounts apart"
+                  hint={
+                    canCheckKey
+                      ? "auto-filled when you check the key"
+                      : "how you'll tell accounts apart"
+                  }
                   htmlFor="connection-name"
                 />
                 <Input
                   id="connection-name"
                   placeholder={connectionLabelForHost("", owner, integrationName, organizationId)}
                   value={label}
-                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => setLabel(e.target.value)}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                    setLabel(e.target.value);
+                    // A hand-typed name takes over: a later probe won't overwrite it.
+                    setNameAutofilled(false);
+                  }}
                 />
                 <p className="text-xs text-muted-foreground">
                   This connection will be callable as{" "}
@@ -1649,6 +1681,12 @@ function AddAccountModalView(props: AddAccountModalProps) {
                                         onOperationChange={(next) => {
                                           setHcOperation(next);
                                           setHcArgs({});
+                                          setHcIdentityField("");
+                                          clearKeyCheck();
+                                        }}
+                                        identityField={hcIdentityField}
+                                        onIdentityFieldChange={(path) => {
+                                          setHcIdentityField(path);
                                           clearKeyCheck();
                                         }}
                                         args={hcArgs}

--- a/packages/react/src/components/add-account-modal.tsx
+++ b/packages/react/src/components/add-account-modal.tsx
@@ -8,6 +8,8 @@ import {
   OAuthClientSlug,
   ProviderItemId,
   ProviderKey,
+  type HealthCheckResult,
+  type HealthCheckSpec,
   type OAuthClientSummary,
   type Owner,
 } from "@executor-js/sdk/shared";
@@ -17,15 +19,25 @@ import { toast } from "sonner";
 import {
   addConnectionOptimistic,
   connectionsAllAtom,
+  integrationHealthCheckAtom,
+  integrationHealthCheckCandidatesAtom,
   oauthClientsOptimisticAtom,
   probeOAuth,
   providerItemsAtom,
   providersAtom,
   registerDynamicOAuthClient,
   removeOAuthClientOptimistic,
+  setIntegrationHealthCheck,
   startOAuth,
+  validateConnection,
 } from "../api/atoms";
-import { connectionWriteKeys, oauthClientWriteKeys } from "../api/reactivity-keys";
+import {
+  connectionWriteKeys,
+  healthCheckWriteKeys,
+  oauthClientWriteKeys,
+} from "../api/reactivity-keys";
+import { HEALTH_INDICATOR_COLOR, HEALTH_STATUS_LABEL } from "../lib/health-display";
+import { HealthCheckConfigFields } from "./health-check-editor";
 import { messageFromExit } from "../api/error-reporting";
 import { trackEvent } from "../api/analytics";
 import { useOrganizationId } from "../api/organization-context";
@@ -619,6 +631,38 @@ export function AddAccountModal(props: AddAccountModalProps) {
   return props.open ? <AddAccountModalView {...props} /> : null;
 }
 
+// ---------------------------------------------------------------------------
+// Key-check status: the inline line under the credential field that reports the
+// live probe result. `validating` shows a neutral "Checking..."; a result shows
+// the status dot + label, and any upstream detail for a non-healthy verdict.
+// ---------------------------------------------------------------------------
+function KeyValidationStatus(props: {
+  readonly validating: boolean;
+  readonly result: HealthCheckResult | null;
+}) {
+  if (props.validating) {
+    return (
+      <p className="flex items-center gap-2 text-xs text-muted-foreground">
+        <span className="size-2 shrink-0 animate-pulse rounded-full bg-muted-foreground/50" />
+        Checking the key...
+      </p>
+    );
+  }
+  if (!props.result) return null;
+  const { status, detail } = props.result;
+  const indicator = HEALTH_INDICATOR_COLOR[status];
+  const tone = status === "healthy" ? "text-muted-foreground" : "text-destructive";
+  return (
+    <div className={`flex items-start gap-2 text-xs ${tone}`}>
+      <span aria-hidden className={`mt-[3px] size-2 shrink-0 rounded-full ${indicator.dot}`} />
+      <span className="min-w-0">
+        <span className="font-medium">{HEALTH_STATUS_LABEL[status]}</span>
+        {status !== "healthy" && detail ? <span className="block opacity-80">{detail}</span> : null}
+      </span>
+    </div>
+  );
+}
+
 function AddAccountModalView(props: AddAccountModalProps) {
   const {
     integration,
@@ -662,6 +706,15 @@ function AddAccountModalView(props: AddAccountModalProps) {
   const [credentialOrigin, setCredentialOrigin] = useState<CredentialOrigin>("paste");
   const [onePasswordItemId, setOnePasswordItemId] = useState("");
   const [label, setLabel] = useState("");
+  // Key check: the in-flight probe state and its last result. When the
+  // integration has no configured health check, `hcOperation`/`hcArgs` hold an
+  // inline-drafted check the user picks to test the key against (and which we
+  // save as the integration's check once it comes back healthy). All of this
+  // lives in the view, so closing the modal unmounts and resets it.
+  const [validating, setValidating] = useState(false);
+  const [validationResult, setValidationResult] = useState<HealthCheckResult | null>(null);
+  const [hcOperation, setHcOperation] = useState("");
+  const [hcArgs, setHcArgs] = useState<Record<string, string>>({});
   // Explicit create-time choice (no ambient owner). Cloud defaults to Personal;
   // local/desktop hide the picker and save to the one local workspace.
   const [owner, setOwner] = useState<Owner>(defaultOwner);
@@ -692,6 +745,19 @@ function AddAccountModalView(props: AddAccountModalProps) {
     mode: "promiseExit",
   });
   const doRemoveOAuthClient = useAtomSet(removeOAuthClientOptimistic, { mode: "promise" });
+  const doValidate = useAtomSet(validateConnection, { mode: "promiseExit" });
+  const doSetHealthCheck = useAtomSet(setIntegrationHealthCheck, { mode: "promiseExit" });
+
+  // The integration's declared health check + its candidate operations. When a
+  // check is configured we probe against it; when not, the user picks one of the
+  // candidates inline to test the key (and we save it).
+  const healthCheckResult = useAtomValue(integrationHealthCheckAtom(integration));
+  const hasHealthCheck =
+    AsyncResult.isSuccess(healthCheckResult) && healthCheckResult.value !== null;
+  const candidatesResult = useAtomValue(integrationHealthCheckCandidatesAtom(integration));
+  const healthCheckCandidates = AsyncResult.isSuccess(candidatesResult)
+    ? candidatesResult.value
+    : [];
 
   // Full registered-app summaries (carry endpoints + resource the picker's
   // lightweight options omit) and the connection→app usage map that powers the
@@ -791,6 +857,21 @@ function AddAccountModalView(props: AddAccountModalProps) {
 
   const isOAuth = method?.kind === "oauth";
   const isNoAuth = method?.kind === "none";
+
+  // Key check (pasteable credentials only): offer it whenever the integration
+  // either has a configured check OR exposes candidate operations to test
+  // against. The inline-picked candidate (when no check is configured) drives
+  // both the probe and what we save as the integration's health check.
+  const hcSelected = healthCheckCandidates.find((c) => c.operation === hcOperation) ?? null;
+  const hcRequiredParams = (hcSelected?.parameters ?? []).filter((p) => p.required);
+  const hcMissingRequired = hcRequiredParams.some(
+    (p) => (hcArgs[p.name] ?? "").trim().length === 0,
+  );
+  const canCheckKey = !isOAuth && !isNoAuth && (hasHealthCheck || healthCheckCandidates.length > 0);
+  // True when we have something to probe against: a configured check, or a
+  // complete inline-picked candidate.
+  const keyCheckReady = hasHealthCheck || (hcOperation.length > 0 && !hcMissingRequired);
+
   // The distinct credential inputs the selected method needs — one per variable
   // across its placements. A single-input method yields one field (`token`); a
   // multi-input method (e.g. Datadog) yields one per key. Two placements sharing
@@ -1002,6 +1083,69 @@ function AddAccountModalView(props: AddAccountModalProps) {
     }
     toast.success("Connection added");
     close();
+  };
+
+  // A pasted credential (or the picked operation) changed; the prior verdict is
+  // stale. Clear it so the status line doesn't show a result for a key/operation
+  // that is no longer what's in the form.
+  const clearKeyCheck = (): void => {
+    if (validationResult !== null) setValidationResult(null);
+  };
+
+  // Check the key works: probe the pasted credential WITHOUT saving the
+  // connection. When the integration has a configured health check we run it;
+  // otherwise we run the inline-picked candidate and, if it comes back healthy,
+  // save it as the integration's health check (so it's configured "then").
+  const handleValidate = async () => {
+    const payloadOrigin = createCredentialPayloadOrigin({
+      origin: credentialOrigin,
+      inputs: credentialInputs,
+      values,
+      onePasswordItemId,
+      singleInput,
+    });
+    if (!method || payloadOrigin === null || validating) return;
+    let inlineSpec: HealthCheckSpec | undefined;
+    if (!hasHealthCheck) {
+      if (hcOperation.length === 0 || hcMissingRequired) return;
+      const argEntries = Object.entries(hcArgs)
+        .map(([key, value]) => [key, value.trim()] as const)
+        .filter(([, value]) => value.length > 0);
+      inlineSpec = {
+        operation: hcOperation,
+        ...(argEntries.length > 0 ? { args: Object.fromEntries(argEntries) } : {}),
+      };
+    }
+    setValidating(true);
+    const exit = await doValidate({
+      payload: {
+        owner,
+        integration,
+        template: method.template,
+        ...(inlineSpec ? { spec: inlineSpec } : {}),
+        ...("from" in payloadOrigin
+          ? { from: payloadOrigin.from }
+          : { values: payloadOrigin.values }),
+      },
+    });
+    setValidating(false);
+    if (Exit.isFailure(exit)) {
+      setValidationResult(null);
+      toast.error(messageFromExit(exit, "Couldn't check the key"));
+      return;
+    }
+    const result = exit.value;
+    setValidationResult(result);
+    // Set it "then": a freshly-picked operation that probes healthy becomes the
+    // integration's health check, so the editor + status surfaces pick it up.
+    if (inlineSpec && result.status === "healthy") {
+      const saved = await doSetHealthCheck({
+        params: { slug: integration },
+        payload: { spec: inlineSpec },
+        reactivityKeys: healthCheckWriteKeys,
+      });
+      if (Exit.isSuccess(saved)) toast.success("Saved as this integration's health check");
+    }
   };
 
   const handleOAuthConnect = async () => {
@@ -1466,19 +1610,82 @@ function AddAccountModalView(props: AddAccountModalProps) {
                               </div>
                             )
                           ) : (
-                            <CredentialValueFields
-                              inputs={credentialInputs}
-                              singleInput={singleInput}
-                              values={values}
-                              onValuesChange={setValues}
-                              origin={credentialOrigin}
-                              onOriginChange={(next) => {
-                                setCredentialOrigin(next);
-                                if (next === "paste") setOnePasswordItemId("");
-                              }}
-                              onePasswordItemId={onePasswordItemId}
-                              onOnePasswordItemIdChange={setOnePasswordItemId}
-                            />
+                            <div className="space-y-2">
+                              <CredentialValueFields
+                                inputs={credentialInputs}
+                                singleInput={singleInput}
+                                values={values}
+                                onValuesChange={(next) => {
+                                  setValues(next);
+                                  clearKeyCheck();
+                                }}
+                                origin={credentialOrigin}
+                                onOriginChange={(next) => {
+                                  setCredentialOrigin(next);
+                                  if (next === "paste") setOnePasswordItemId("");
+                                  clearKeyCheck();
+                                }}
+                                onePasswordItemId={onePasswordItemId}
+                                onOnePasswordItemIdChange={(next) => {
+                                  setOnePasswordItemId(next);
+                                  clearKeyCheck();
+                                }}
+                              />
+                              {/* Check the key works before saving. Runs the
+                              integration's health check, or an operation you pick
+                              here (which we then save as the check). */}
+                              {canCheckKey ? (
+                                <div className="flex flex-col gap-2">
+                                  {!hasHealthCheck ? (
+                                    <div className="space-y-2 rounded-md border border-border/60 bg-muted/20 p-3">
+                                      <p className="text-xs text-muted-foreground">
+                                        Pick a read-only operation to test the key against. We save
+                                        it as this integration's health check.
+                                      </p>
+                                      <HealthCheckConfigFields
+                                        candidates={healthCheckCandidates}
+                                        selected={hcSelected}
+                                        operation={hcOperation}
+                                        onOperationChange={(next) => {
+                                          setHcOperation(next);
+                                          setHcArgs({});
+                                          clearKeyCheck();
+                                        }}
+                                        args={hcArgs}
+                                        onArgChange={(name, value) => {
+                                          setHcArgs((prev) => ({ ...prev, [name]: value }));
+                                          clearKeyCheck();
+                                        }}
+                                        disabled={validating}
+                                        idPrefix="connect-health-check"
+                                      />
+                                    </div>
+                                  ) : null}
+                                  <div className="flex items-center justify-between gap-2">
+                                    <Button
+                                      type="button"
+                                      variant="outline"
+                                      size="sm"
+                                      disabled={
+                                        credentialPayloadOrigin === null ||
+                                        validating ||
+                                        !keyCheckReady
+                                      }
+                                      onClick={() => void handleValidate()}
+                                    >
+                                      {validating ? "Checking..." : "Check the key works"}
+                                    </Button>
+                                    <span className="text-xs text-muted-foreground">
+                                      Confirms the key authenticates.
+                                    </span>
+                                  </div>
+                                  <KeyValidationStatus
+                                    validating={validating}
+                                    result={validationResult}
+                                  />
+                                </div>
+                              ) : null}
+                            </div>
                           )}
                           {isOAuth && oauthPopup.error ? (
                             <p className="text-xs text-destructive">{oauthPopup.error}</p>

--- a/packages/react/src/components/combobox.tsx
+++ b/packages/react/src/components/combobox.tsx
@@ -103,7 +103,11 @@ function ComboboxContent({
         align={align}
         alignOffset={alignOffset}
         anchor={anchor}
-        className="isolate z-50"
+        // `pointer-events-auto` re-enables interaction when the popup is portaled
+        // out of a modal dialog (Radix sets `pointer-events: none` on the body
+        // for modal dialogs/sheets; without this the portaled list can't be
+        // scrolled or clicked). Harmless outside a dialog (auto is the default).
+        className="isolate z-50 pointer-events-auto"
       >
         <ComboboxPrimitive.Popup
           data-slot="combobox-content"

--- a/packages/react/src/components/combobox.tsx
+++ b/packages/react/src/components/combobox.tsx
@@ -268,6 +268,11 @@ export interface FreeformComboboxOption {
   readonly description?: React.ReactNode;
 }
 
+/** How many options the popup renders at once. base-ui slices the filtered list
+ *  to this, so a multi-thousand-operation spec stays cheap: the empty-query open
+ *  shows the top slice, and typing narrows to the top matches. */
+const FREEFORM_COMBOBOX_LIMIT = 100;
+
 function FreeformCombobox(props: {
   readonly value: string;
   readonly onValueChange: (value: string) => void;
@@ -277,25 +282,62 @@ function FreeformCombobox(props: {
   readonly className?: string;
   readonly inputClassName?: string;
   readonly disabled?: boolean;
+  /** Forwarded to the underlying text input so a `<Label htmlFor>` can target it
+   *  (and tests get a stable selector). */
+  readonly id?: string;
 }) {
   const valueOption = props.value.trim();
-  const options =
-    valueOption.length > 0 && !props.options.some((option) => option.value === valueOption)
-      ? [{ value: valueOption, label: valueOption }, ...props.options]
-      : props.options;
+  const propsOptions = props.options;
+  const options = React.useMemo<readonly FreeformComboboxOption[]>(
+    () =>
+      valueOption.length > 0 && !propsOptions.some((option) => option.value === valueOption)
+        ? [{ value: valueOption, label: valueOption }, ...propsOptions]
+        : propsOptions,
+    [valueOption, propsOptions],
+  );
   const selectedValue = options.some((option) => option.value === props.value) ? props.value : null;
+
+  const byValue = React.useMemo(() => {
+    const map = new Map<string, FreeformComboboxOption>();
+    for (const option of options) map.set(option.value, option);
+    return map;
+  }, [options]);
+  const items = React.useMemo(() => options.map((option) => option.value), [options]);
+
+  // base-ui only filters the popup when the list renders from `items` (the
+  // function-child / closed-template path below); a statically-mapped list never
+  // narrows as you type. Match the query against the value AND its string
+  // label/description, so typing a summary word or the human label finds the
+  // option, not just its raw id.
+  const filter = React.useCallback(
+    (item: string, query: string) => {
+      const needle = query.trim().toLowerCase();
+      if (needle === "") return true;
+      const option = byValue.get(item);
+      const haystacks = [
+        item,
+        typeof option?.label === "string" ? option.label : "",
+        typeof option?.description === "string" ? option.description : "",
+      ];
+      return haystacks.some((part) => part.toLowerCase().includes(needle));
+    },
+    [byValue],
+  );
 
   return (
     <Combobox
-      items={options.map((option) => option.value)}
+      items={items}
       inputValue={props.value}
       value={selectedValue}
+      filter={filter}
+      limit={FREEFORM_COMBOBOX_LIMIT}
       onInputValueChange={props.onValueChange}
       onValueChange={(value) => {
         if (value !== null) props.onValueChange(value);
       }}
     >
       <ComboboxInput
+        id={props.id}
         placeholder={props.placeholder}
         className={props.className}
         inputClassName={props.inputClassName}
@@ -305,18 +347,21 @@ function FreeformCombobox(props: {
       <ComboboxContent>
         <ComboboxEmpty>{props.emptyLabel ?? "No options"}</ComboboxEmpty>
         <ComboboxList>
-          {options.map((option) => (
-            <ComboboxItem key={option.value} value={option.value}>
-              <div className="min-w-0 flex-1">
-                <div className="truncate">{option.label ?? option.value}</div>
-                {option.description && (
-                  <div className="mt-0.5 truncate text-[10px] text-muted-foreground">
-                    {option.description}
-                  </div>
-                )}
-              </div>
-            </ComboboxItem>
-          ))}
+          {(item: string) => {
+            const option = byValue.get(item);
+            return (
+              <ComboboxItem key={item} value={item}>
+                <div className="min-w-0 flex-1">
+                  <div className="truncate">{option?.label ?? item}</div>
+                  {option?.description && (
+                    <div className="mt-0.5 truncate text-[10px] text-muted-foreground">
+                      {option.description}
+                    </div>
+                  )}
+                </div>
+              </ComboboxItem>
+            );
+          }}
         </ComboboxList>
       </ComboboxContent>
     </Combobox>

--- a/packages/react/src/components/health-check-editor.tsx
+++ b/packages/react/src/components/health-check-editor.tsx
@@ -483,7 +483,12 @@ function HealthCheckEditorSheet(props: {
   const canPreview = livePreview !== undefined && livePreview.templates.length > 0;
 
   return (
-    <Sheet open={open} onOpenChange={onOpenChange}>
+    // Non-modal: a modal Radix dialog locks body scroll (react-remove-scroll)
+    // and disables outside pointer events, which kills the combobox popup
+    // (portaled to <body>, outside the dialog subtree) - it can't be scrolled or
+    // clicked. The overlay still renders and the dismissal guard still keeps the
+    // sheet open while interacting with the popup.
+    <Sheet open={open} onOpenChange={onOpenChange} modal={false}>
       <SheetContent side="right">
         <SheetHeader>
           <SheetTitle>Health check</SheetTitle>

--- a/packages/react/src/components/health-check-editor.tsx
+++ b/packages/react/src/components/health-check-editor.tsx
@@ -3,9 +3,13 @@ import { useAtomValue, useAtomSet } from "@effect/atom-react";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 import * as Exit from "effect/Exit";
 import {
+  type AuthTemplateSlug,
   type HealthCheckCandidate,
+  type HealthCheckResult,
   type HealthCheckSpec,
+  type HealthStatus,
   type IntegrationSlug,
+  type Owner,
 } from "@executor-js/sdk/shared";
 import { toast } from "sonner";
 
@@ -13,6 +17,7 @@ import {
   integrationHealthCheckAtom,
   integrationHealthCheckCandidatesAtom,
   setIntegrationHealthCheck,
+  validateConnection,
 } from "../api/atoms";
 import { healthCheckWriteKeys } from "../api/reactivity-keys";
 import { messageFromExit } from "../api/error-reporting";
@@ -20,6 +25,7 @@ import { Button } from "./button";
 import { FreeformCombobox, type FreeformComboboxOption } from "./combobox";
 import { Input } from "./input";
 import { Label } from "./label";
+import { NativeSelect, NativeSelectOption } from "./native-select";
 import {
   Sheet,
   SheetContent,
@@ -31,18 +37,37 @@ import {
 
 // ---------------------------------------------------------------------------
 // Health-check editor: the integration-level configuration for "what single
-// authenticated call tells us a connection is still alive". It is the same shape
-// as configuring an auth method: pick one of the integration's operations (ranked
-// so the obvious read-only endpoint floats up) and optionally pin the required
-// arguments (Google's People API needs `resourceName=people/me`).
+// authenticated call tells us a connection is still alive and (optionally) whose
+// account it is". It is the same shape as configuring an auth method: pick one of
+// the integration's operations (ranked so the obvious read-only identity endpoint
+// floats up), optionally pin the required arguments (Google's People API needs
+// `resourceName=people/me`), and optionally name a response field to show as the
+// account identity.
 //
-// The check is run per-connection elsewhere (the AccountRow "Check now" probe);
-// this surface only declares it.
+// Identity is a facet, not the point: with no identity field the check degrades
+// to a pure "alive / expired" probe. The typed identity picker and the live
+// preview (a real probe against a pasted test key, showing the response) exist so
+// the user can SEE what the operation returns and pick the right field.
+//
+// The check is run per-connection elsewhere (the AccountRow "Check now" probe and
+// the key-first connect validation); this surface only declares it.
 //
 // It hides itself when the owning integration exposes no candidate operations AND
 // none is configured (i.e. the plugin has no health-check capability), so it
 // costs nothing on integrations that can't support it.
 // ---------------------------------------------------------------------------
+
+/** Context the edit sheet needs to run a live preview: which owner to probe as
+ *  and the credential auth-templates a pasted test key can be validated against.
+ *  Absent (or empty) on surfaces with no persisted integration yet (the add
+ *  screen), where the preview is suppressed. */
+export interface HealthCheckLivePreview {
+  readonly owner: Owner;
+  readonly templates: ReadonlyArray<{
+    readonly template: AuthTemplateSlug;
+    readonly label: string;
+  }>;
+}
 
 /** "GET /users/me" style label for a candidate, with a writes marker so a
  *  mutating operation picked as a health check reads as the hazard it is. */
@@ -61,10 +86,24 @@ const specSummary = (
   return match ? `${match.method.toUpperCase()} ${spec.operation}` : spec.operation;
 };
 
+const STATUS_LABEL: Record<HealthStatus, string> = {
+  healthy: "Healthy",
+  expired: "Expired",
+  degraded: "Degraded",
+  unknown: "Unknown",
+};
+
+const STATUS_CLASS: Record<HealthStatus, string> = {
+  healthy: "text-emerald-600 dark:text-emerald-400",
+  expired: "text-destructive",
+  degraded: "text-amber-600 dark:text-amber-500",
+  unknown: "text-muted-foreground",
+};
+
 // ---------------------------------------------------------------------------
-// HealthCheckConfigFields: the presentational operation + pinned-arg form,
-// shared by the edit sheet and the add-integration screen so the two stay in
-// lockstep. State (and the `selected` candidate) is owned by the parent; this
+// HealthCheckConfigFields: the presentational operation + identity + pinned-arg
+// form, shared by the edit sheet and the add-integration screen so the two stay
+// in lockstep. State (and the `selected` candidate) is owned by the parent; this
 // component only renders and reports edits.
 // ---------------------------------------------------------------------------
 
@@ -73,12 +112,14 @@ function HealthCheckConfigFields(props: {
   readonly selected: HealthCheckCandidate | null;
   readonly operation: string;
   readonly onOperationChange: (operation: string) => void;
+  readonly identityField: string;
+  readonly onIdentityFieldChange: (path: string) => void;
   readonly args: Record<string, string>;
   readonly onArgChange: (name: string, value: string) => void;
   readonly disabled?: boolean;
   readonly idPrefix: string;
 }) {
-  const { candidates, selected, operation, args, disabled, idPrefix } = props;
+  const { candidates, selected, operation, identityField, args, disabled, idPrefix } = props;
 
   const operationOptions = useMemo<FreeformComboboxOption[]>(
     () =>
@@ -88,6 +129,25 @@ function HealthCheckConfigFields(props: {
         description: c.summary,
       })),
     [candidates],
+  );
+
+  // The identity picker is a typed combobox over the operation's response fields,
+  // with a leading "None" that clears the field (pure health check). It stays
+  // freeform so a custom dot-path the projector missed is still reachable.
+  const identityOptions = useMemo<FreeformComboboxOption[]>(
+    () => [
+      {
+        value: "",
+        label: "None - health check only",
+        description: "Status only, no account identity",
+      },
+      ...(selected?.responseFields ?? []).map((f) => ({
+        value: f.path,
+        label: f.path,
+        description: f.type,
+      })),
+    ],
+    [selected],
   );
 
   const requiredParams = useMemo(
@@ -123,7 +183,7 @@ function HealthCheckConfigFields(props: {
           <div className="space-y-0.5">
             <p className="text-sm font-medium">Required arguments</p>
             <p className="text-xs text-muted-foreground">
-              Pinned into every probe. A liveness endpoint often needs a fixed value here (for
+              Pinned into every probe. An identity endpoint often needs a fixed value here (for
               example <span className="font-mono">resourceName</span> ={" "}
               <span className="font-mono">people/me</span>).
             </p>
@@ -152,7 +212,172 @@ function HealthCheckConfigFields(props: {
           ))}
         </div>
       ) : null}
+
+      <div className="space-y-1.5">
+        <Label htmlFor={`${idPrefix}-identity`}>Identity field</Label>
+        <FreeformCombobox
+          id={`${idPrefix}-identity`}
+          value={identityField}
+          onValueChange={props.onIdentityFieldChange}
+          options={identityOptions}
+          placeholder="None - health check only"
+          emptyLabel="No response fields detected"
+          disabled={disabled}
+        />
+        <p className="text-xs text-muted-foreground">
+          Optional. Pick a response field whose value labels the connected account (
+          <span className="font-mono">user.login</span>,{" "}
+          <span className="font-mono">emailAddresses.0.value</span>). Leave as{" "}
+          <span className="font-mono">None</span> for a pure health check. Numeric segments index
+          arrays.
+        </p>
+      </div>
     </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Live preview: runs the drafted check against a pasted test key WITHOUT
+// saving it (the same `validateConnection` probe the key-first connect uses),
+// then shows the real response so the user can confirm the status and see which
+// field carries the identity. Edit-sheet only: it needs a persisted integration
+// and a credential template, neither of which exists on the add screen.
+// ---------------------------------------------------------------------------
+
+function HealthCheckLivePreviewBlock(props: {
+  readonly integration: IntegrationSlug;
+  readonly preview: HealthCheckLivePreview;
+  readonly operation: string;
+  readonly identityField: string;
+  readonly args: Record<string, string>;
+  readonly disabled: boolean;
+}) {
+  const { integration, preview, operation, identityField, args, disabled } = props;
+  const doValidate = useAtomSet(validateConnection, { mode: "promiseExit" });
+
+  const [value, setValue] = useState("");
+  const [template, setTemplate] = useState<string>(preview.templates[0]?.template ?? "");
+  const [running, setRunning] = useState(false);
+  const [result, setResult] = useState<HealthCheckResult | null>(null);
+
+  const handlePreview = async () => {
+    const credential = value.trim();
+    if (operation.length === 0 || credential.length === 0) return;
+    const slug = (template || preview.templates[0]?.template) as AuthTemplateSlug | undefined;
+    if (slug === undefined) return;
+    const identity = identityField.trim();
+    const argEntries = Object.entries(args)
+      .map(([key, v]) => [key, v.trim()] as const)
+      .filter(([, v]) => v.length > 0);
+    const spec: HealthCheckSpec = {
+      operation,
+      ...(argEntries.length > 0 ? { args: Object.fromEntries(argEntries) } : {}),
+      ...(identity.length > 0 ? { identityField: identity } : {}),
+    };
+    setRunning(true);
+    const exit = await doValidate({
+      payload: { owner: preview.owner, integration, template: slug, value: credential, spec },
+    });
+    setRunning(false);
+    if (Exit.isFailure(exit)) {
+      setResult(null);
+      toast.error(messageFromExit(exit, "Couldn't run the preview"));
+      return;
+    }
+    setResult(exit.value);
+  };
+
+  return (
+    <div className="space-y-3 rounded-md border border-border/60 bg-muted/20 p-3">
+      <div className="space-y-0.5">
+        <p className="text-sm font-medium">Live preview</p>
+        <p className="text-xs text-muted-foreground">
+          Paste a test credential to run this check now. Nothing is saved; the response below is
+          what the operation returns.
+        </p>
+      </div>
+
+      {preview.templates.length > 1 ? (
+        <div className="space-y-1.5">
+          <Label htmlFor="health-check-preview-template">Auth method</Label>
+          <NativeSelect
+            id="health-check-preview-template"
+            className="w-full text-sm"
+            value={template}
+            disabled={disabled || running}
+            onChange={(e: React.ChangeEvent<HTMLSelectElement>) => setTemplate(e.target.value)}
+          >
+            {preview.templates.map((t) => (
+              <NativeSelectOption key={String(t.template)} value={String(t.template)}>
+                {t.label}
+              </NativeSelectOption>
+            ))}
+          </NativeSelect>
+        </div>
+      ) : null}
+
+      <div className="space-y-1.5">
+        <Label htmlFor="health-check-preview-key">Test credential</Label>
+        <div className="flex gap-2">
+          <Input
+            id="health-check-preview-key"
+            type="password"
+            value={value}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setValue(e.target.value)}
+            placeholder="Paste a key to probe"
+            disabled={disabled || running}
+            className="flex-1"
+          />
+          <Button
+            variant="outline"
+            onClick={() => void handlePreview()}
+            disabled={disabled || running || operation.length === 0 || value.trim().length === 0}
+          >
+            {running ? "Running..." : "Preview"}
+          </Button>
+        </div>
+      </div>
+
+      {result ? (
+        <div className="space-y-2">
+          <p className="text-sm">
+            Status:{" "}
+            <span className={`font-medium ${STATUS_CLASS[result.status]}`}>
+              {STATUS_LABEL[result.status]}
+            </span>
+            {result.httpStatus !== undefined ? (
+              <span className="ml-1.5 text-xs text-muted-foreground">
+                (HTTP {result.httpStatus})
+              </span>
+            ) : null}
+          </p>
+          {identityField.trim().length > 0 ? (
+            <p className="text-sm">
+              Resolves to:{" "}
+              {result.identity ? (
+                <span className="font-mono">{result.identity}</span>
+              ) : (
+                <span className="text-muted-foreground">no value at this field</span>
+              )}
+            </p>
+          ) : null}
+          {result.detail ? <p className="text-xs text-muted-foreground">{result.detail}</p> : null}
+          {result.responseSample && result.responseSample.length > 0 ? (
+            <div className="space-y-1">
+              <p className="text-xs font-medium text-muted-foreground">Response</p>
+              <dl className="space-y-0.5 rounded border border-border/50 bg-background/60 p-2 font-mono text-[11px]">
+                {result.responseSample.map((row) => (
+                  <div key={row.path} className="flex gap-2">
+                    <dt className="shrink-0 text-muted-foreground">{row.path}</dt>
+                    <dd className="min-w-0 truncate text-foreground">{row.value}</dd>
+                  </div>
+                ))}
+              </dl>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
   );
 }
 
@@ -160,13 +385,15 @@ function HealthCheckEditorSheet(props: {
   readonly integration: IntegrationSlug;
   readonly spec: HealthCheckSpec | null;
   readonly candidates: readonly HealthCheckCandidate[];
+  readonly livePreview?: HealthCheckLivePreview;
   readonly open: boolean;
   readonly onOpenChange: (open: boolean) => void;
 }) {
-  const { integration, spec, candidates, open, onOpenChange } = props;
+  const { integration, spec, candidates, livePreview, open, onOpenChange } = props;
   const doSet = useAtomSet(setIntegrationHealthCheck, { mode: "promiseExit" });
 
   const [operation, setOperation] = useState("");
+  const [identityField, setIdentityField] = useState("");
   // Pinned argument values keyed by parameter name; stored as strings (the form
   // input value) and trimmed/dropped when empty at save.
   const [args, setArgs] = useState<Record<string, string>>({});
@@ -176,6 +403,7 @@ function HealthCheckEditorSheet(props: {
   useEffect(() => {
     if (!open) return;
     setOperation(spec?.operation ?? candidates[0]?.operation ?? "");
+    setIdentityField(spec?.identityField ?? "");
     setArgs(
       spec?.args
         ? Object.fromEntries(
@@ -201,9 +429,10 @@ function HealthCheckEditorSheet(props: {
 
   const onOperationChange = (next: string) => {
     setOperation(next);
-    // Parameters differ per operation; drop the prior pick's pinned args so none
-    // dangle onto a new op.
+    // Parameters and the response shape differ per operation; drop the prior
+    // pick's pinned args and identity path so neither dangles onto a new op.
     setArgs({});
+    setIdentityField("");
   };
 
   const onArgChange = (name: string, value: string) =>
@@ -212,12 +441,14 @@ function HealthCheckEditorSheet(props: {
   const handleSave = async () => {
     if (operation.length === 0) return;
     setSaving(true);
+    const identity = identityField.trim();
     const argEntries = Object.entries(args)
       .map(([key, value]) => [key, value.trim()] as const)
       .filter(([, value]) => value.length > 0);
     const nextSpec: HealthCheckSpec = {
       operation,
       ...(argEntries.length > 0 ? { args: Object.fromEntries(argEntries) } : {}),
+      ...(identity.length > 0 ? { identityField: identity } : {}),
     };
     const exit = await doSet({
       params: { slug: integration },
@@ -249,6 +480,8 @@ function HealthCheckEditorSheet(props: {
     onOpenChange(false);
   };
 
+  const canPreview = livePreview !== undefined && livePreview.templates.length > 0;
+
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent side="right">
@@ -256,7 +489,7 @@ function HealthCheckEditorSheet(props: {
           <SheetTitle>Health check</SheetTitle>
           <SheetDescription>
             One read-only call Executor runs to tell whether a connection's credential is still
-            alive. A 401 or 403 marks the connection expired.
+            alive and, optionally, whose account it is. A 401 or 403 marks the connection expired.
           </SheetDescription>
         </SheetHeader>
 
@@ -266,11 +499,24 @@ function HealthCheckEditorSheet(props: {
             selected={selected}
             operation={operation}
             onOperationChange={onOperationChange}
+            identityField={identityField}
+            onIdentityFieldChange={setIdentityField}
             args={args}
             onArgChange={onArgChange}
             disabled={saving}
             idPrefix="health-check"
           />
+
+          {canPreview ? (
+            <HealthCheckLivePreviewBlock
+              integration={integration}
+              preview={livePreview}
+              operation={operation}
+              identityField={identityField}
+              args={args}
+              disabled={saving}
+            />
+          ) : null}
         </div>
 
         <SheetFooter>
@@ -294,8 +540,11 @@ function HealthCheckEditorSheet(props: {
   );
 }
 
-export function HealthCheckEditor(props: { readonly integration: IntegrationSlug }) {
-  const { integration } = props;
+export function HealthCheckEditor(props: {
+  readonly integration: IntegrationSlug;
+  readonly livePreview?: HealthCheckLivePreview;
+}) {
+  const { integration, livePreview } = props;
   const specResult = useAtomValue(integrationHealthCheckAtom(integration));
   const candidatesResult = useAtomValue(integrationHealthCheckCandidatesAtom(integration));
   const [open, setOpen] = useState(false);
@@ -315,15 +564,27 @@ export function HealthCheckEditor(props: { readonly integration: IntegrationSlug
       <div className="space-y-1">
         <h3 className="text-sm font-medium">Health check</h3>
         <p className="text-xs text-muted-foreground">
-          A read-only call Executor runs to tell whether a connection's credential is still alive.
+          A read-only call Executor runs to tell whether a connection's credential is still alive
+          and, optionally, whose account it is.
         </p>
       </div>
       <div className="flex items-center justify-between gap-3 rounded-md border border-border/60 bg-muted/30 px-3 py-2.5">
         <div className="min-w-0 space-y-0.5">
           {spec ? (
-            <p className="truncate font-mono text-xs text-foreground">
-              {specSummary(spec, candidates)}
-            </p>
+            <>
+              <p className="truncate font-mono text-xs text-foreground">
+                {specSummary(spec, candidates)}
+              </p>
+              {spec.identityField ? (
+                <p className="truncate text-xs text-muted-foreground">
+                  Identity: <span className="font-mono">{spec.identityField}</span>
+                </p>
+              ) : (
+                <p className="truncate text-xs text-muted-foreground">
+                  Health check only (no identity).
+                </p>
+              )}
+            </>
           ) : (
             <p className="text-xs text-muted-foreground">No health check configured.</p>
           )}
@@ -336,6 +597,7 @@ export function HealthCheckEditor(props: { readonly integration: IntegrationSlug
         integration={integration}
         spec={spec}
         candidates={candidates}
+        livePreview={livePreview}
         open={open}
         onOpenChange={setOpen}
       />
@@ -344,5 +606,5 @@ export function HealthCheckEditor(props: { readonly integration: IntegrationSlug
 }
 
 // Re-exported so the add-integration screen can compose the same operation +
-// pinned-arg form without the sheet chrome.
+// identity form without the sheet/live-preview chrome.
 export { HealthCheckConfigFields };

--- a/packages/react/src/components/health-check-editor.tsx
+++ b/packages/react/src/components/health-check-editor.tsx
@@ -1,0 +1,348 @@
+import { useEffect, useMemo, useState } from "react";
+import { useAtomValue, useAtomSet } from "@effect/atom-react";
+import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
+import * as Exit from "effect/Exit";
+import {
+  type HealthCheckCandidate,
+  type HealthCheckSpec,
+  type IntegrationSlug,
+} from "@executor-js/sdk/shared";
+import { toast } from "sonner";
+
+import {
+  integrationHealthCheckAtom,
+  integrationHealthCheckCandidatesAtom,
+  setIntegrationHealthCheck,
+} from "../api/atoms";
+import { healthCheckWriteKeys } from "../api/reactivity-keys";
+import { messageFromExit } from "../api/error-reporting";
+import { Button } from "./button";
+import { FreeformCombobox, type FreeformComboboxOption } from "./combobox";
+import { Input } from "./input";
+import { Label } from "./label";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "./sheet";
+
+// ---------------------------------------------------------------------------
+// Health-check editor: the integration-level configuration for "what single
+// authenticated call tells us a connection is still alive". It is the same shape
+// as configuring an auth method: pick one of the integration's operations (ranked
+// so the obvious read-only endpoint floats up) and optionally pin the required
+// arguments (Google's People API needs `resourceName=people/me`).
+//
+// The check is run per-connection elsewhere (the AccountRow "Check now" probe);
+// this surface only declares it.
+//
+// It hides itself when the owning integration exposes no candidate operations AND
+// none is configured (i.e. the plugin has no health-check capability), so it
+// costs nothing on integrations that can't support it.
+// ---------------------------------------------------------------------------
+
+/** "GET /users/me" style label for a candidate, with a writes marker so a
+ *  mutating operation picked as a health check reads as the hazard it is. */
+const candidateLabel = (candidate: HealthCheckCandidate): string => {
+  const head = `${candidate.method.toUpperCase()} ${candidate.operation}`;
+  return candidate.destructive ? `${head} (writes)` : head;
+};
+
+/** The summary line for the configured spec: the operation, prefixed with its
+ *  method when we can still find it among the candidates. */
+const specSummary = (
+  spec: HealthCheckSpec,
+  candidates: readonly HealthCheckCandidate[],
+): string => {
+  const match = candidates.find((c) => c.operation === spec.operation);
+  return match ? `${match.method.toUpperCase()} ${spec.operation}` : spec.operation;
+};
+
+// ---------------------------------------------------------------------------
+// HealthCheckConfigFields: the presentational operation + pinned-arg form,
+// shared by the edit sheet and the add-integration screen so the two stay in
+// lockstep. State (and the `selected` candidate) is owned by the parent; this
+// component only renders and reports edits.
+// ---------------------------------------------------------------------------
+
+function HealthCheckConfigFields(props: {
+  readonly candidates: readonly HealthCheckCandidate[];
+  readonly selected: HealthCheckCandidate | null;
+  readonly operation: string;
+  readonly onOperationChange: (operation: string) => void;
+  readonly args: Record<string, string>;
+  readonly onArgChange: (name: string, value: string) => void;
+  readonly disabled?: boolean;
+  readonly idPrefix: string;
+}) {
+  const { candidates, selected, operation, args, disabled, idPrefix } = props;
+
+  const operationOptions = useMemo<FreeformComboboxOption[]>(
+    () =>
+      candidates.map((c) => ({
+        value: c.operation,
+        label: candidateLabel(c),
+        description: c.summary,
+      })),
+    [candidates],
+  );
+
+  const requiredParams = useMemo(
+    () => (selected?.parameters ?? []).filter((p) => p.required),
+    [selected],
+  );
+
+  return (
+    <>
+      <div className="space-y-1.5">
+        <Label htmlFor={`${idPrefix}-operation`}>Operation</Label>
+        <FreeformCombobox
+          id={`${idPrefix}-operation`}
+          value={operation}
+          onValueChange={props.onOperationChange}
+          options={operationOptions}
+          placeholder={candidates.length === 0 ? "No operations available" : "Pick an operation"}
+          emptyLabel="No matching operations"
+          disabled={disabled}
+        />
+        {selected?.summary ? (
+          <p className="text-xs text-muted-foreground">{selected.summary}</p>
+        ) : null}
+        {selected?.destructive ? (
+          <p className="text-xs text-destructive">
+            This operation writes data. Prefer a read-only (GET) operation for a health check.
+          </p>
+        ) : null}
+      </div>
+
+      {requiredParams.length > 0 ? (
+        <div className="space-y-3">
+          <div className="space-y-0.5">
+            <p className="text-sm font-medium">Required arguments</p>
+            <p className="text-xs text-muted-foreground">
+              Pinned into every probe. A liveness endpoint often needs a fixed value here (for
+              example <span className="font-mono">resourceName</span> ={" "}
+              <span className="font-mono">people/me</span>).
+            </p>
+          </div>
+          {requiredParams.map((param) => (
+            <div key={param.name} className="space-y-1.5">
+              <Label htmlFor={`${idPrefix}-arg-${param.name}`}>
+                {param.name}
+                <span className="ml-1.5 text-xs font-normal text-muted-foreground">
+                  ({param.location})
+                </span>
+              </Label>
+              <Input
+                id={`${idPrefix}-arg-${param.name}`}
+                value={args[param.name] ?? ""}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  props.onArgChange(param.name, e.target.value)
+                }
+                placeholder={param.description ?? `Value for ${param.name}`}
+                disabled={disabled}
+              />
+              {param.description ? (
+                <p className="text-xs text-muted-foreground">{param.description}</p>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </>
+  );
+}
+
+function HealthCheckEditorSheet(props: {
+  readonly integration: IntegrationSlug;
+  readonly spec: HealthCheckSpec | null;
+  readonly candidates: readonly HealthCheckCandidate[];
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+}) {
+  const { integration, spec, candidates, open, onOpenChange } = props;
+  const doSet = useAtomSet(setIntegrationHealthCheck, { mode: "promiseExit" });
+
+  const [operation, setOperation] = useState("");
+  // Pinned argument values keyed by parameter name; stored as strings (the form
+  // input value) and trimmed/dropped when empty at save.
+  const [args, setArgs] = useState<Record<string, string>>({});
+  const [saving, setSaving] = useState(false);
+
+  // Re-seed the drafts from the persisted spec each time the sheet opens.
+  useEffect(() => {
+    if (!open) return;
+    setOperation(spec?.operation ?? candidates[0]?.operation ?? "");
+    setArgs(
+      spec?.args
+        ? Object.fromEntries(
+            Object.entries(spec.args).map(([key, value]) => [
+              key,
+              value == null ? "" : String(value),
+            ]),
+          )
+        : {},
+    );
+  }, [open, spec, candidates]);
+
+  const selected = useMemo(
+    () => candidates.find((c) => c.operation === operation) ?? null,
+    [candidates, operation],
+  );
+
+  const requiredParams = useMemo(
+    () => (selected?.parameters ?? []).filter((p) => p.required),
+    [selected],
+  );
+  const missingRequired = requiredParams.some((p) => (args[p.name] ?? "").trim().length === 0);
+
+  const onOperationChange = (next: string) => {
+    setOperation(next);
+    // Parameters differ per operation; drop the prior pick's pinned args so none
+    // dangle onto a new op.
+    setArgs({});
+  };
+
+  const onArgChange = (name: string, value: string) =>
+    setArgs((prev) => ({ ...prev, [name]: value }));
+
+  const handleSave = async () => {
+    if (operation.length === 0) return;
+    setSaving(true);
+    const argEntries = Object.entries(args)
+      .map(([key, value]) => [key, value.trim()] as const)
+      .filter(([, value]) => value.length > 0);
+    const nextSpec: HealthCheckSpec = {
+      operation,
+      ...(argEntries.length > 0 ? { args: Object.fromEntries(argEntries) } : {}),
+    };
+    const exit = await doSet({
+      params: { slug: integration },
+      payload: { spec: nextSpec },
+      reactivityKeys: healthCheckWriteKeys,
+    });
+    setSaving(false);
+    if (Exit.isFailure(exit)) {
+      toast.error(messageFromExit(exit, "Failed to save health check"));
+      return;
+    }
+    toast.success("Health check saved");
+    onOpenChange(false);
+  };
+
+  const handleClear = async () => {
+    setSaving(true);
+    const exit = await doSet({
+      params: { slug: integration },
+      payload: { spec: null },
+      reactivityKeys: healthCheckWriteKeys,
+    });
+    setSaving(false);
+    if (Exit.isFailure(exit)) {
+      toast.error(messageFromExit(exit, "Failed to clear health check"));
+      return;
+    }
+    toast.success("Health check cleared");
+    onOpenChange(false);
+  };
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="right">
+        <SheetHeader>
+          <SheetTitle>Health check</SheetTitle>
+          <SheetDescription>
+            One read-only call Executor runs to tell whether a connection's credential is still
+            alive. A 401 or 403 marks the connection expired.
+          </SheetDescription>
+        </SheetHeader>
+
+        <div className="flex-1 space-y-5 overflow-y-auto px-4">
+          <HealthCheckConfigFields
+            candidates={candidates}
+            selected={selected}
+            operation={operation}
+            onOperationChange={onOperationChange}
+            args={args}
+            onArgChange={onArgChange}
+            disabled={saving}
+            idPrefix="health-check"
+          />
+        </div>
+
+        <SheetFooter>
+          <Button
+            onClick={() => void handleSave()}
+            disabled={saving || operation.length === 0 || missingRequired}
+          >
+            {saving ? "Saving..." : "Save"}
+          </Button>
+          {spec ? (
+            <Button variant="outline" onClick={() => void handleClear()} disabled={saving}>
+              Clear
+            </Button>
+          ) : null}
+          <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={saving}>
+            Cancel
+          </Button>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+export function HealthCheckEditor(props: { readonly integration: IntegrationSlug }) {
+  const { integration } = props;
+  const specResult = useAtomValue(integrationHealthCheckAtom(integration));
+  const candidatesResult = useAtomValue(integrationHealthCheckCandidatesAtom(integration));
+  const [open, setOpen] = useState(false);
+
+  const spec = AsyncResult.isSuccess(specResult) ? specResult.value : null;
+  const candidates: readonly HealthCheckCandidate[] = AsyncResult.isSuccess(candidatesResult)
+    ? candidatesResult.value
+    : [];
+
+  // No capability (no candidate operations) and nothing configured: render
+  // nothing. This also covers the still-loading window, so the section doesn't
+  // flash an empty shell before the candidates arrive.
+  if (candidates.length === 0 && spec === null) return null;
+
+  return (
+    <section className="space-y-3">
+      <div className="space-y-1">
+        <h3 className="text-sm font-medium">Health check</h3>
+        <p className="text-xs text-muted-foreground">
+          A read-only call Executor runs to tell whether a connection's credential is still alive.
+        </p>
+      </div>
+      <div className="flex items-center justify-between gap-3 rounded-md border border-border/60 bg-muted/30 px-3 py-2.5">
+        <div className="min-w-0 space-y-0.5">
+          {spec ? (
+            <p className="truncate font-mono text-xs text-foreground">
+              {specSummary(spec, candidates)}
+            </p>
+          ) : (
+            <p className="text-xs text-muted-foreground">No health check configured.</p>
+          )}
+        </div>
+        <Button variant="outline" size="sm" onClick={() => setOpen(true)}>
+          {spec ? "Edit" : "Set up"}
+        </Button>
+      </div>
+      <HealthCheckEditorSheet
+        integration={integration}
+        spec={spec}
+        candidates={candidates}
+        open={open}
+        onOpenChange={setOpen}
+      />
+    </section>
+  );
+}
+
+// Re-exported so the add-integration screen can compose the same operation +
+// pinned-arg form without the sheet chrome.
+export { HealthCheckConfigFields };

--- a/packages/react/src/components/sheet.tsx
+++ b/packages/react/src/components/sheet.tsx
@@ -38,11 +38,18 @@ function SheetOverlay({
   );
 }
 
+// base-ui popups (combobox/select) portal their list OUTSIDE the dialog content,
+// so clicking an option reads as an interaction outside the sheet and would
+// dismiss it before the selection lands. Keep the sheet open for interactions
+// that originate inside such a popup.
+const PORTALED_POPUP_SELECTOR = "[data-slot='combobox-content'],[data-slot='select-content']";
+
 function SheetContent({
   className,
   children,
   side = "right",
   showCloseButton = true,
+  onInteractOutside,
   ...props
 }: React.ComponentProps<typeof SheetPrimitive.Content> & {
   side?: "top" | "right" | "bottom" | "left";
@@ -53,6 +60,13 @@ function SheetContent({
       <SheetOverlay />
       <SheetPrimitive.Content
         data-slot="sheet-content"
+        onInteractOutside={(event) => {
+          const target = event.detail.originalEvent.target;
+          if (target instanceof Element && target.closest(PORTALED_POPUP_SELECTOR)) {
+            event.preventDefault();
+          }
+          onInteractOutside?.(event);
+        }}
         className={cn(
           "fixed z-50 flex flex-col gap-4 bg-background shadow-lg transition ease-in-out data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:animate-in data-[state=open]:duration-500",
           side === "right" &&

--- a/packages/react/src/lib/health-display.ts
+++ b/packages/react/src/lib/health-display.ts
@@ -1,0 +1,39 @@
+// Shared display strings + colors for connection health. Several surfaces (the
+// AccountRow status dot, the "Check now" result, the health-check editor preview)
+// render the same `HealthStatus`, so the labels and indicator colors live here:
+// a rename or palette change happens in one place. Mirrors the convention of
+// `policy-display.ts`.
+
+import type { HealthStatus } from "@executor-js/sdk/shared";
+
+/** State form — badge text, indicator tooltips, "what is the current state". */
+export const HEALTH_STATUS_LABEL: Record<HealthStatus, string> = {
+  healthy: "Healthy",
+  expired: "Expired",
+  degraded: "Degraded",
+  unknown: "Unchecked",
+};
+
+/** Dot + ring color classes for the per-connection indicator. `unknown` is the
+ *  neutral never-probed state; `expired` reuses the destructive token so it reads
+ *  the same as a blocked policy. */
+export const HEALTH_INDICATOR_COLOR: Record<
+  HealthStatus,
+  { readonly dot: string; readonly ring: string }
+> = {
+  healthy: { dot: "bg-emerald-500", ring: "ring-emerald-500/70" },
+  expired: { dot: "bg-destructive", ring: "ring-destructive/70" },
+  degraded: { dot: "bg-amber-500", ring: "ring-amber-500/70" },
+  unknown: { dot: "bg-muted-foreground/40", ring: "ring-muted-foreground/40" },
+};
+
+/** Badge variant per status — semantic color via the Badge component. */
+export const HEALTH_BADGE_VARIANT: Record<
+  HealthStatus,
+  "default" | "secondary" | "outline" | "destructive"
+> = {
+  healthy: "secondary",
+  expired: "destructive",
+  degraded: "outline",
+  unknown: "outline",
+};

--- a/scripts/oxlint-plugin-executor/rules/require-reactivity-keys.js
+++ b/scripts/oxlint-plugin-executor/rules/require-reactivity-keys.js
@@ -17,6 +17,10 @@ const readOnlyMutations = new Set([
   "resolveSecret",
   "detectSource",
   "getDomainVerificationLink",
+  // Health-check probes: they hit the live upstream and return a result, but
+  // persist nothing, so there is no cached query for them to invalidate.
+  "validateConnection",
+  "checkConnectionHealth",
 ]);
 
 export default {


### PR DESCRIPTION
The operation/identity comboboxes portal their popup to `<body>`, outside the sheet's dialog subtree, so a modal Radix sheet froze them: body `pointer-events` were disabled (couldn't click/select) and `react-remove-scroll` locked wheel scroll.

- The editor sheet is non-modal, which drops both locks while keeping the dim overlay.
- The popup gets `pointer-events: auto` (defensive for any modal-dialog combobox).
- The sheet stays open when an interaction originates inside a combobox popup, so clicking an option no longer dismisses it.

Adds e2e guards that click and wheel-scroll the popup inside the sheet.

Stacked on #1109.

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #1108
2. #1111
3. #1112
4. #1109
5. **#1110** 👈 current
<!-- stack:links:end -->