### PR TITLE
Add changesets for the 1.5.19 patch release

### DIFF
--- a/.changeset/google-media-binary-downloads.md
+++ b/.changeset/google-media-binary-downloads.md
@@ -1,0 +1,7 @@
+---
+"executor": patch
+---
+
+Google media downloads (Drive file contents, exports, and other binary
+endpoints) are now returned as binary responses instead of being decoded as
+text, so files come back intact. Emit them with `emit(result.data)`.

--- a/.changeset/harden-browser-opener.md
+++ b/.changeset/harden-browser-opener.md
@@ -1,0 +1,9 @@
+---
+"executor": patch
+---
+
+The CLI now validates that a URL is `http`/`https` before handing it to the
+operating system's browser opener, and on Windows opens it via
+`rundll32 url.dll,FileProtocolHandler` instead of `cmd /c start`. This removes a
+path where a crafted URL could be interpreted as a shell command. `executor
+login` and the "open in browser" prompts behave the same for normal URLs.

--- a/.changeset/hosted-egress-guard-hardening.md
+++ b/.changeset/hosted-egress-guard-hardening.md
@@ -1,0 +1,9 @@
+---
+"executor": patch
+---
+
+Hardened the hosted egress guard. Outbound requests from OAuth token exchanges,
+MCP transports, and GraphQL/Google/Microsoft discovery now all route through the
+guard, and the guard resolves DNS before connecting so a hostname that points at
+a private or loopback address is blocked rather than only literal private IPs.
+This tightens SSRF protection for hosted and cloud execution.


### PR DESCRIPTION
Adds changesets for the changes that have landed on `main` since 1.5.18 so the release workflow opens a Version Packages PR for 1.5.19.

Included (each is a user-facing changelog entry):

- **Harden browser opener commands** (#1099): validate `http`/`https` before invoking the OS opener and use `rundll32 url.dll,FileProtocolHandler` on Windows instead of `cmd /c start`.
- **Hosted egress guard hardening** (#1100, #1106): route OAuth token exchanges, MCP transports, and GraphQL/Google/Microsoft discovery through the guard, and resolve DNS before connecting so hostnames pointing at private/loopback addresses are blocked.
- **Google media downloads as binary** (#1096): media/file-content endpoints return binary instead of being decoded as text.

`adjust pricing` (#1107) and the marketing badge change are cloud/marketing only and ship via their own deploys, so they get no npm changeset.

Once merged, `release.yml` opens the Version Packages PR; merging that bumps the release group to 1.5.19 and publishes.