### PR TITLE
Add a Docs link reachable from inside the app

### DIFF
--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -175,6 +175,8 @@ import embeddedWebUI from "./embedded-web-ui.gen";
 
 const { version: CLI_VERSION } = await import("../package.json");
 const DEFAULT_PORT = 4788;
+/** Canonical public docs (Mintlify), matching the web shell's DEFAULT_DOCS_URL. */
+const DOCS_URL = "https://executor.sh/docs";
 const DEFAULT_BASE_URL = `http://localhost:${DEFAULT_PORT}`;
 const DAEMON_BOOT_TIMEOUT_MS = 15_000;
 const DAEMON_BOOT_POLL_MS = 150;
@@ -2863,6 +2865,17 @@ const openCommand = Command.make("open", {}, () => openRunningLocalWebApp()).pip
   Command.withDescription("Open the running Executor web app in your browser, already signed in"),
 );
 
+/**
+ * `executor docs` — open the documentation in the browser. The URL is printed
+ * first so it stays usable on headless machines where no opener is available.
+ */
+const docsCommand = Command.make("docs", {}, () =>
+  Effect.gen(function* () {
+    console.log(`Opening ${DOCS_URL}`);
+    yield* openInBrowser(DOCS_URL);
+  }),
+).pipe(Command.withDescription("Open the Executor documentation in your browser"));
+
 const root = Command.make("executor").pipe(
   Command.withSubcommands([
     callCommand,
@@ -2878,6 +2891,7 @@ const root = Command.make("executor").pipe(
     serviceCommand,
     mcpCommand,
     openCommand,
+    docsCommand,
   ] as const),
   Command.withDescription("Executor local CLI"),
 );

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -822,6 +822,10 @@ const installApplicationMenu = () => {
         label: "Report a Problem…",
         click: () => void reportAProblem(),
       },
+      {
+        label: "Documentation",
+        click: () => void shell.openExternal("https://executor.sh/docs"),
+      },
       { type: "separator" },
       ...(isMac
         ? ([

--- a/e2e/scenarios/docs-link.test.ts
+++ b/e2e/scenarios/docs-link.test.ts
@@ -1,0 +1,36 @@
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+
+import { scenario } from "../src/scenario";
+import { Browser, Target } from "../src/services";
+
+// A user inside the console should be able to reach the documentation without
+// leaving the app for the marketing site (the original friction: docs were
+// only discoverable from the home page). The shell renders a persistent Docs
+// link in the sidebar footer that opens the published docs in a new tab.
+scenario(
+  "Shell · the sidebar links to the docs from inside the app",
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const browser = yield* Browser;
+    const identity = yield* target.newIdentity();
+
+    yield* browser.session(identity, async ({ page, step }) => {
+      await step("Open the console", async () => {
+        await page.goto("/", { waitUntil: "networkidle" });
+        await page.getByText("Integrations").first().waitFor();
+      });
+
+      await step("The sidebar exposes a Docs link", async () => {
+        const docs = page.getByRole("link", { name: "Docs", exact: true });
+        await docs.waitFor();
+        expect(
+          await docs.getAttribute("href"),
+          "Docs link points at the published documentation",
+        ).toBe("https://executor.sh/docs");
+        expect(await docs.getAttribute("target"), "Docs open in a new tab").toBe("_blank");
+      });
+    });
+  }),
+);

--- a/packages/app/src/web/shell.tsx
+++ b/packages/app/src/web/shell.tsx
@@ -403,6 +403,14 @@ function SidebarContent(props: {
       <div className="shrink-0 border-t border-sidebar-border px-4 py-2.5">
         <div className="flex flex-col gap-1.5 text-xs leading-none">
           <a
+            href="https://executor.sh/docs"
+            target="_blank"
+            rel="noreferrer"
+            className="text-muted-foreground transition-colors hover:text-foreground"
+          >
+            Docs
+          </a>
+          <a
             href={`${VITE_GITHUB_URL}/issues`}
             target="_blank"
             rel="noreferrer"

--- a/packages/react/src/api/analytics.tsx
+++ b/packages/react/src/api/analytics.tsx
@@ -139,6 +139,9 @@ export interface AnalyticsEvents {
     plugin_key?: string;
   };
 
+  // ── Docs / help ──────────────────────────────────────────────────────────
+  docs_opened: { surface: "sidebar" };
+
   // ── Cloud: auth & onboarding ─────────────────────────────────────────────
   login_cta_clicked: {};
   signed_out: {};

--- a/packages/react/src/multiplayer/shell.tsx
+++ b/packages/react/src/multiplayer/shell.tsx
@@ -2,8 +2,10 @@ import { Link, Outlet, useLocation, useParams } from "@tanstack/react-router";
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import { useAtomValue } from "@effect/atom-react";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
+import { BookOpen, ExternalLink } from "lucide-react";
 import type { Integration } from "@executor-js/sdk/shared";
 import { integrationsOptimisticAtom } from "../api/atoms";
+import { trackEvent } from "../api/analytics";
 import { Button } from "../components/button";
 import { Skeleton } from "../components/skeleton";
 import {
@@ -49,6 +51,12 @@ export const defaultShellNavItems: ReadonlyArray<ShellNavItem> = [
   { to: "/policies", label: "Policies" },
 ];
 
+/** Canonical public docs (Mintlify). Same-origin on cloud (executor.sh proxies
+ *  `/docs`); the correct external target for self-host / Cloudflare / local,
+ *  whose `/docs` is Swagger UI rather than the product docs. Hosts can override
+ *  via {@link ShellProps.docsUrl}. */
+export const DEFAULT_DOCS_URL = "https://executor.sh/docs";
+
 // Scope-relative path -> the route id under the optional org segment
 // ("/" -> "/{-$orgSlug}", "/policies" -> "/{-$orgSlug}/policies"). Loosely
 // typed on purpose: host-specific items ("/admin", "/billing") resolve against
@@ -76,6 +84,8 @@ export interface ShellProps {
   readonly orgMenuSlot?: ReactNode;
   /** Injected support button above the account footer (cloud). */
   readonly supportSlot?: ReactNode;
+  /** Docs link target; defaults to {@link DEFAULT_DOCS_URL}. Opens in a new tab. */
+  readonly docsUrl?: string;
   /** Replaces the routed `<Outlet />` (the org-slug gate's in-shell 404). */
   readonly content?: ReactNode;
 }
@@ -109,6 +119,30 @@ function NavItem(props: { to: string; label: string; active: boolean; onNavigate
     >
       {props.label}
     </Link>
+  );
+}
+
+// ── DocsLink ───────────────────────────────────────────────────────────────
+
+/** External link to the documentation. Lives in the sidebar footer (always
+ *  visible, outside the scrollable nav) so docs are reachable from inside the
+ *  app, not only the marketing site. */
+function DocsLink(props: { href: string; onNavigate?: () => void }) {
+  return (
+    <a
+      href={props.href}
+      target="_blank"
+      rel="noopener noreferrer"
+      onClick={() => {
+        trackEvent("docs_opened", { surface: "sidebar" });
+        props.onNavigate?.();
+      }}
+      className="group flex items-center gap-2.5 rounded-md px-2.5 py-1.5 text-sm text-sidebar-foreground transition-colors hover:bg-sidebar-active/60 hover:text-foreground"
+    >
+      <BookOpen className="size-4 shrink-0" />
+      <span className="flex-1">Docs</span>
+      <ExternalLink className="size-3 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100" />
+    </a>
   );
 }
 
@@ -302,6 +336,10 @@ function SidebarContent(
 
         <IntegrationList pathname={props.pathname} onNavigate={props.onNavigate} />
       </nav>
+
+      <div className="shrink-0 border-t border-sidebar-border p-2">
+        <DocsLink href={props.docsUrl ?? DEFAULT_DOCS_URL} onNavigate={props.onNavigate} />
+      </div>
 
       {props.supportSlot && <div className="shrink-0 px-2 pb-2">{props.supportSlot}</div>}
 


### PR DESCRIPTION
## Why

Documentation was only discoverable from the marketing home page (you had to leave the app, or open it in incognito, to find it). This makes the docs reachable from every product surface.

## What

- **Web hosts (cloud, self-host, Cloudflare):** a persistent **Docs** link in the shared shell sidebar footer, opening the published docs in a new tab. A `docs_opened` analytics event lets cloud measure whether the link gets used (no-op on hosts that mount no analytics client).
- **CLI:** `executor docs` opens the docs in the browser. The URL is printed first so it stays usable on headless machines where no opener is available.
- **Desktop:** a native **Documentation** item in the application menu (next to Check for Updates / Report a Problem), plus a **Docs** link in the local app sidebar footer (which also improves the local app UI).

The docs URL defaults to the canonical public docs site, which is same-origin on cloud (the worker proxies `/docs`) and the correct external target for self-host / Cloudflare / local, whose `/docs` is the API reference rather than the product docs. Hosts can override via a `docsUrl` prop on the shared shell.

## Verification

- New e2e scenario `Shell · the sidebar links to the docs from inside the app` (`e2e/scenarios/docs-link.test.ts`) drives the console and asserts the Docs link is present, points at the docs, and opens in a new tab. Green on the cloud target.
- `executor docs` and `executor --help` verified by hand (the command is listed and prints the docs URL).
- `format:check`, `lint`, and `typecheck` pass across the affected packages.

## Coverage gaps

- The browser e2e capability is cloud-only today, so the scenario proves the web link on cloud; the same shared component renders it on self-host and Cloudflare. The desktop native-menu item and the local-app footer link are covered by typecheck and manual inspection, not e2e.