### PR TITLE
feat(sdk): add cache primitive

### DIFF
--- a/.changeset/polite-caches-pull.md
+++ b/.changeset/polite-caches-pull.md
@@ -1,0 +1,5 @@
+---
+"executor": patch
+---
+
+Add a host-provided cache primitive to the SDK executor surface. Hosts can now pass an Effect KeyValueStore to `createExecutor`, while executors without one use an in-memory fallback.

--- a/packages/core/api/src/server/scoped-executor.ts
+++ b/packages/core/api/src/server/scoped-executor.ts
@@ -32,6 +32,7 @@
 // ---------------------------------------------------------------------------
 
 import { Context, Effect, Option } from "effect";
+import * as KeyValueStore from "effect/unstable/persistence/KeyValueStore";
 
 import {
   createExecutor,
@@ -205,6 +206,7 @@ export const makeScopedExecutor = <
     const { db, blobs } = yield* DbProvider;
     const { plugins: pluginsFactory } = yield* PluginsProvider;
     const config = yield* HostConfig;
+    const cache = yield* Effect.serviceOption(KeyValueStore.KeyValueStore);
     // Explicit config wins; otherwise fall back to the request origin if a host
     // provided one (HTTP middleware / MCP session DO). Stays `undefined` for
     // non-request callers — `coreTools.webBaseUrl` is optional and only the
@@ -255,6 +257,10 @@ export const makeScopedExecutor = <
       subject: Subject.make(accountId),
       db,
       blobs,
+      ...Option.match(cache, {
+        onNone: () => ({}),
+        onSome: (store) => ({ cache: store }),
+      }),
       plugins,
       httpClientLayer,
       fetch: hostedFetch,

--- a/packages/core/sdk/src/executor-cache.test.ts
+++ b/packages/core/sdk/src/executor-cache.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+
+import { createExecutor, type Executor } from "./executor";
+import { Tenant } from "./ids";
+
+const MEMORY_CACHE_CAPACITY = 2_048;
+const MEMORY_CACHE_TTL_MS = 10 * 60 * 1000;
+
+const makeExecutor = Effect.acquireRelease(
+  createExecutor({
+    tenant: Tenant.make("test-tenant"),
+    onElicitation: "accept-all",
+  }),
+  (executor) => executor.close().pipe(Effect.ignore),
+);
+
+const withFakeNow = <A, E, R>(
+  initialNow: number,
+  run: (clock: { readonly advance: (ms: number) => void }) => Effect.Effect<A, E, R>,
+): Effect.Effect<A, E, R> =>
+  Effect.acquireUseRelease(
+    Effect.sync(() => {
+      const originalNow = Date.now;
+      let now = initialNow;
+      Date.now = () => now;
+      return {
+        advance: (ms: number) => {
+          now += ms;
+        },
+        restore: () => {
+          Date.now = originalNow;
+        },
+      };
+    }),
+    (clock) => run({ advance: clock.advance }),
+    (clock) => Effect.sync(clock.restore),
+  );
+
+describe("executor cache", () => {
+  it.effect("uses an in-memory fallback when no cache is configured", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const executor = yield* makeExecutor;
+
+        yield* executor.cache.set("a", "value");
+        expect(yield* executor.cache.get("a")).toBe("value");
+
+        yield* executor.cache.remove("a");
+        expect(yield* executor.cache.get("a")).toBeUndefined();
+      }),
+    ),
+  );
+
+  it.effect("expires fallback entries by TTL on get and size", () =>
+    withFakeNow(1_000, ({ advance }) =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          const executor = yield* makeExecutor;
+
+          yield* executor.cache.set("a", "value");
+          expect(yield* executor.cache.size).toBe(1);
+
+          advance(MEMORY_CACHE_TTL_MS);
+
+          expect(yield* executor.cache.get("a")).toBeUndefined();
+          expect(yield* executor.cache.size).toBe(0);
+        }),
+      ),
+    ),
+  );
+
+  it.effect("refreshes fallback LRU position when an existing key is written", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const executor: Executor = yield* makeExecutor;
+
+        yield* executor.cache.set("a", "old");
+        for (let index = 0; index < MEMORY_CACHE_CAPACITY - 1; index += 1) {
+          yield* executor.cache.set(`key-${index}`, String(index));
+        }
+
+        yield* executor.cache.set("a", "new");
+        yield* executor.cache.set("overflow", "value");
+
+        expect(yield* executor.cache.get("a")).toBe("new");
+        expect(yield* executor.cache.get("key-0")).toBeUndefined();
+        expect(yield* executor.cache.get("key-1")).toBe("1");
+      }),
+    ),
+  );
+});

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -457,6 +457,7 @@ const makeMemoryCacheStore = (): KeyValueStore.KeyValueStore => {
       Effect.sync(() => {
         const now = Date.now();
         evictExpired(now);
+        rows.delete(key);
         rows.set(key, { value, expiresAt: now + MEMORY_CACHE_TTL_MS });
         evictCapacity();
       }),

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -1,4 +1,5 @@
 import { Effect, Inspectable, Layer, Option, Predicate, Schema } from "effect";
+import * as KeyValueStore from "effect/unstable/persistence/KeyValueStore";
 import { FetchHttpClient, type HttpClient } from "effect/unstable/http";
 import { fumadb } from "@executor-js/fumadb";
 import { memoryAdapter } from "@executor-js/fumadb/adapters/memory";
@@ -319,6 +320,8 @@ export type Executor<TPlugins extends readonly AnyPlugin[] = readonly []> = {
   ) => Effect.Effect<unknown, ExecuteError>;
 
   readonly close: () => Effect.Effect<void, StorageFailure>;
+
+  readonly cache: KeyValueStore.KeyValueStore;
 } & PluginExtensions<TPlugins>;
 
 export interface ExecutorDb {
@@ -346,6 +349,7 @@ export interface ExecutorConfig<TPlugins extends readonly AnyPlugin[] = readonly
    * values stay out of the relational tier.
    */
   readonly blobs?: BlobStore;
+  readonly cache?: KeyValueStore.KeyValueStore;
   readonly plugins?: TPlugins;
   /** Config-level credential providers, merged with every
    *  `plugin.credentialProviders`. Config providers register first, so the
@@ -417,6 +421,58 @@ const validateExecutorDbTables = (required: FumaTables, actual: FumaTables): voi
 
 const storageFailureFromUnknown = (message: string, cause: unknown): StorageFailure =>
   isStorageFailure(cause) ? cause : new StorageError({ message, cause });
+
+const MEMORY_CACHE_CAPACITY = 2_048;
+const MEMORY_CACHE_TTL_MS = 10 * 60 * 1000;
+
+const makeMemoryCacheStore = (): KeyValueStore.KeyValueStore => {
+  const rows = new Map<string, { readonly value: string; readonly expiresAt: number }>();
+  const evictExpired = (now: number): void => {
+    for (const [key, entry] of rows) {
+      if (entry.expiresAt <= now) rows.delete(key);
+    }
+  };
+  const evictCapacity = (): void => {
+    while (rows.size > MEMORY_CACHE_CAPACITY) {
+      const oldest = rows.keys().next().value;
+      if (oldest === undefined) break;
+      rows.delete(oldest);
+    }
+  };
+  return KeyValueStore.makeStringOnly({
+    get: (key) =>
+      Effect.sync(() => {
+        const now = Date.now();
+        const entry = rows.get(key);
+        if (entry === undefined) return undefined;
+        if (entry.expiresAt <= now) {
+          rows.delete(key);
+          return undefined;
+        }
+        rows.delete(key);
+        rows.set(key, entry);
+        return entry.value;
+      }),
+    set: (key, value) =>
+      Effect.sync(() => {
+        const now = Date.now();
+        evictExpired(now);
+        rows.set(key, { value, expiresAt: now + MEMORY_CACHE_TTL_MS });
+        evictCapacity();
+      }),
+    remove: (key) =>
+      Effect.sync(() => {
+        rows.delete(key);
+      }),
+    clear: Effect.sync(() => {
+      rows.clear();
+    }),
+    size: Effect.sync(() => {
+      evictExpired(Date.now());
+      return rows.size;
+    }),
+  });
+};
 
 const pluginStorageFailure = (pluginId: string, hook: string, cause: unknown): StorageFailure =>
   storageFailureFromUnknown(`${hook} failed for plugin ${pluginId}`, cause);
@@ -1277,6 +1333,7 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
     const fuma = makeFumaClient(rootDb);
     const core = makeCoreDb(fuma);
     const blobs = config.blobs ?? makeFumaBlobStore(fuma);
+    const cacheStore = config.cache ?? makeMemoryCacheStore();
     const transaction = <A, E>(effect: Effect.Effect<A, E>) => fuma.transaction(effect);
 
     // Populated once, never mutated after startup.
@@ -3299,6 +3356,7 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
       },
       execute,
       close,
+      cache: cacheStore,
     };
 
     const toExecutor = (value: unknown): Executor<TPlugins> => value as Executor<TPlugins>;

--- a/packages/core/sdk/src/test-config.ts
+++ b/packages/core/sdk/src/test-config.ts
@@ -1,4 +1,5 @@
 import { Context, Effect, Layer } from "effect";
+import type * as KeyValueStore from "effect/unstable/persistence/KeyValueStore";
 import { withQueryContext } from "@executor-js/fumadb/query";
 import { collectTables, createExecutor, type Executor, type ExecutorConfig } from "./executor";
 import type { FumaDb } from "./fuma-runtime";
@@ -118,6 +119,7 @@ export type TestConfigOptions<TPlugins extends readonly AnyPlugin[] = readonly [
   readonly backend?: TestDatabaseBackend;
   readonly dataDir?: string;
   readonly coreTools?: ExecutorConfig<TPlugins>["coreTools"];
+  readonly cache?: KeyValueStore.KeyValueStore;
   /** Override the OAuth callback URL. Pass `null` to construct an executor with
    *  no OAuth callback (exercises the fail-loud redirect path). */
   readonly redirectUri?: string | null;
@@ -155,6 +157,7 @@ export const makeTestConfig = <const TPlugins extends readonly AnyPlugin[] = rea
     db,
     plugins: options?.plugins,
     coreTools: options?.coreTools,
+    cache: options?.cache,
     testDb,
     // Tests default to auto-accepting elicitation prompts.
     onElicitation: "accept-all",

--- a/packages/hosts/cloudflare/package.json
+++ b/packages/hosts/cloudflare/package.json
@@ -8,6 +8,10 @@
       "types": "./src/blob-store.ts",
       "default": "./src/blob-store.ts"
     },
+    "./key-value-store": {
+      "types": "./src/key-value-store.ts",
+      "default": "./src/key-value-store.ts"
+    },
     "./mcp/worker-transport": {
       "types": "./src/mcp/worker-transport.ts",
       "default": "./src/mcp/worker-transport.ts"

--- a/packages/hosts/cloudflare/src/key-value-store.test.ts
+++ b/packages/hosts/cloudflare/src/key-value-store.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+import type { KVNamespace } from "@cloudflare/workers-types";
+
+import { makeCloudflareKeyValueStore } from "./key-value-store";
+
+const makeFakeKv = (
+  pageSize: number,
+): {
+  readonly kv: KVNamespace;
+  readonly values: Map<string, string>;
+  readonly maxConcurrentDeletes: () => number;
+} => {
+  const values = new Map<string, string>();
+  let activeDeletes = 0;
+  let maxActiveDeletes = 0;
+
+  // oxlint-disable-next-line executor/no-double-cast -- test double: only the KV slice the adapter calls is implemented
+  const kv = {
+    get: async (key: string) => values.get(key) ?? null,
+    put: async (key: string, value: string) => {
+      values.set(key, value);
+    },
+    delete: async (key: string) => {
+      activeDeletes += 1;
+      maxActiveDeletes = Math.max(maxActiveDeletes, activeDeletes);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      values.delete(key);
+      activeDeletes -= 1;
+    },
+    list: async (options?: { readonly cursor?: string }) => {
+      const offset = options?.cursor === undefined ? 0 : Number(options.cursor);
+      const keys = [...values.keys()].sort().slice(offset, offset + pageSize);
+      const nextOffset = offset + pageSize;
+      const listComplete = nextOffset >= values.size;
+
+      return {
+        keys: keys.map((name) => ({ name })),
+        list_complete: listComplete,
+        cursor: listComplete ? "" : String(nextOffset),
+      };
+    },
+  } as unknown as KVNamespace;
+
+  return {
+    kv,
+    values,
+    maxConcurrentDeletes: () => maxActiveDeletes,
+  };
+};
+
+describe("makeCloudflareKeyValueStore", () => {
+  it.effect("round-trips string values", () =>
+    Effect.gen(function* () {
+      const { kv } = makeFakeKv(10);
+      const store = makeCloudflareKeyValueStore(kv);
+
+      yield* store.set("a", "value");
+      expect(yield* store.get("a")).toBe("value");
+
+      yield* store.remove("a");
+      expect(yield* store.get("a")).toBeUndefined();
+    }),
+  );
+
+  it.effect("counts paginated keys", () =>
+    Effect.gen(function* () {
+      const { values, kv } = makeFakeKv(2);
+      values.set("a", "1");
+      values.set("b", "2");
+      values.set("c", "3");
+
+      const store = makeCloudflareKeyValueStore(kv);
+      expect(yield* store.size).toBe(3);
+    }),
+  );
+
+  it.effect("clears paginated keys in bounded parallel batches", () =>
+    Effect.gen(function* () {
+      const { values, kv, maxConcurrentDeletes } = makeFakeKv(25);
+      for (let index = 0; index < 75; index += 1) {
+        values.set(`key-${index.toString().padStart(2, "0")}`, String(index));
+      }
+
+      const store = makeCloudflareKeyValueStore(kv);
+      yield* store.clear;
+
+      expect(values.size).toBe(0);
+      expect(maxConcurrentDeletes()).toBeGreaterThan(1);
+      expect(maxConcurrentDeletes()).toBeLessThanOrEqual(50);
+    }),
+  );
+});

--- a/packages/hosts/cloudflare/src/key-value-store.ts
+++ b/packages/hosts/cloudflare/src/key-value-store.ts
@@ -1,0 +1,66 @@
+import { Effect, Layer } from "effect";
+import * as KeyValueStore from "effect/unstable/persistence/KeyValueStore";
+import type { KVNamespace } from "@cloudflare/workers-types";
+
+const KV_DELETE_CONCURRENCY = 50;
+
+const storeError = (method: string, key: string | undefined, cause: unknown) =>
+  new KeyValueStore.KeyValueStoreError({
+    method,
+    key,
+    message: `Cloudflare KV ${method} failed`,
+    cause,
+  });
+
+const listKeys = async (kv: KVNamespace): Promise<ReadonlyArray<string>> => {
+  const keys: Array<string> = [];
+  let cursor: string | undefined;
+
+  do {
+    const page = await kv.list({ cursor });
+    keys.push(...page.keys.map((key) => key.name));
+    cursor = page.list_complete ? undefined : page.cursor;
+  } while (cursor !== undefined);
+
+  return keys;
+};
+
+const deleteKeys = async (kv: KVNamespace, keys: ReadonlyArray<string>): Promise<void> => {
+  for (let index = 0; index < keys.length; index += KV_DELETE_CONCURRENCY) {
+    await Promise.all(
+      keys.slice(index, index + KV_DELETE_CONCURRENCY).map((key) => kv.delete(key)),
+    );
+  }
+};
+
+export const makeCloudflareKeyValueStore = (kv: KVNamespace): KeyValueStore.KeyValueStore =>
+  KeyValueStore.makeStringOnly({
+    get: (key) =>
+      Effect.tryPromise({
+        try: async () => (await kv.get(key)) ?? undefined,
+        catch: (cause) => storeError("get", key, cause),
+      }),
+    set: (key, value) =>
+      Effect.tryPromise({
+        try: () => kv.put(key, value),
+        catch: (cause) => storeError("set", key, cause),
+      }),
+    remove: (key) =>
+      Effect.tryPromise({
+        try: () => kv.delete(key),
+        catch: (cause) => storeError("remove", key, cause),
+      }),
+    clear: Effect.tryPromise({
+      try: async () => deleteKeys(kv, await listKeys(kv)),
+      catch: (cause) => storeError("clear", undefined, cause),
+    }),
+    size: Effect.tryPromise({
+      try: async () => (await listKeys(kv)).length,
+      catch: (cause) => storeError("size", undefined, cause),
+    }),
+  });
+
+export const layerCloudflareKeyValueStore = (
+  kv: KVNamespace,
+): Layer.Layer<KeyValueStore.KeyValueStore> =>
+  Layer.succeed(KeyValueStore.KeyValueStore, makeCloudflareKeyValueStore(kv));


### PR DESCRIPTION
## Summary

- Add a generic SDK cache primitive backed by Effect `KeyValueStore`.
- Let hosts provide durable cache storage through `ExecutorConfig.cache`, while default executors get a bounded in-memory fallback.
- Add a reusable Cloudflare KV adapter export without wiring host app config that upstream `main` does not currently declare.

## Changes

- `packages/core/sdk/src/executor.ts`
  - Imports `effect/unstable/persistence/KeyValueStore`.
  - Adds `ExecutorConfig.cache?: KeyValueStore.KeyValueStore`.
  - Adds `Executor.cache: KeyValueStore.KeyValueStore`.
  - Creates a default in-memory string-only `KeyValueStore` with TTL and capacity eviction.
  - Installs the resolved cache store on the returned executor object.
- `packages/core/sdk/src/test-config.ts`
  - Allows tests to pass a cache store through `makeTestConfig` and `makeTestWorkspaceHarness`.
- `packages/core/api/src/server/scoped-executor.ts`
  - Reads an optional `KeyValueStore.KeyValueStore` service from the Effect context.
  - Passes it to `createExecutor` only when a host layer provides one.
- `packages/hosts/cloudflare/src/key-value-store.ts`
  - Adds `makeCloudflareKeyValueStore(kv)` over Cloudflare `KVNamespace`.
  - Adds `layerCloudflareKeyValueStore(kv)` for host boot layer composition.
  - Maps KV failures into `KeyValueStore.KeyValueStoreError`.
  - Implements paginated `size` and bounded parallel `clear`.
- `packages/hosts/cloudflare/package.json`
  - Exports `@executor-js/cloudflare/key-value-store`.
- `.changeset/polite-caches-pull.md`
  - Records the public SDK surface change through the fixed release group.

## AST-level outline

```ts
// SDK public config
interface ExecutorConfig<TPlugins> {
  tenant: Tenant
  subject?: Subject
  db?: ExecutorDbInput | ExecutorDbFactory
  blobs?: BlobStore
  cache?: KeyValueStore.KeyValueStore
  plugins?: TPlugins
}

// SDK public executor value
type Executor<TPlugins> = {
  integrations: ...
  connections: ...
  oauth: OAuthService
  tools: ...
  providers: ...
  policies: ...
  execute: ...
  close: ...
  cache: KeyValueStore.KeyValueStore
} & PluginExtensions<TPlugins>

// createExecutor resolution
const blobs = config.blobs ?? makeFumaBlobStore(fuma)
const cacheStore = config.cache ?? makeMemoryCacheStore()

return Object.assign({ ..., cache: cacheStore }, extensions)
```

```ts
// API host seam
const cache = yield* Effect.serviceOption(KeyValueStore.KeyValueStore)

yield* createExecutor({
  tenant,
  subject,
  db,
  blobs,
  ...Option.match(cache, {
    onNone: () => ({}),
    onSome: (store) => ({ cache: store }),
  }),
  plugins,
})
```

```ts
// Cloudflare host package adapter
makeCloudflareKeyValueStore(kv)
  -> KeyValueStore.makeStringOnly({ get, set, remove, clear, size })

layerCloudflareKeyValueStore(kv)
  -> Layer.succeed(KeyValueStore.KeyValueStore, makeCloudflareKeyValueStore(kv))
```

## Call-stack trace

### Host-provided cache path

```ts
host boot layer
  -> Layer.succeed(KeyValueStore.KeyValueStore, hostStore)
  -> makeScopedExecutor(accountId, organizationId, organizationName)
     -> Effect.serviceOption(KeyValueStore.KeyValueStore)
     -> createExecutor({ cache: hostStore, ... })
        -> const cacheStore = config.cache
        -> executor.cache = cacheStore
```

### Default cache path

```ts
createExecutor({ cache: undefined, ... })
  -> makeMemoryCacheStore()
     -> KeyValueStore.makeStringOnly({ get, set, remove, clear, size })
  -> executor.cache = inMemoryStore
```

### Cloudflare adapter path

```ts
makeCloudflareKeyValueStore(env.CACHE)
  -> store.get(key) calls kv.get(key)
  -> store.set(key, value) calls kv.put(key, value)
  -> store.remove(key) calls kv.delete(key)
  -> store.size lists all pages and counts names
  -> store.clear lists all pages and deletes keys in batches of 50
```

## Usage / pseudocode

```ts
import { Effect } from "effect";
import { layerCloudflareKeyValueStore } from "@executor-js/cloudflare/key-value-store";
import { KeyValueStore } from "effect/unstable/persistence/KeyValueStore";

const cacheLayer = layerCloudflareKeyValueStore(env.CACHE);

const program = Effect.gen(function* () {
  const store = yield* KeyValueStore;
  yield* store.set("catalog:revision", "v1");

  const executor = yield* createExecutor({
    tenant,
    subject,
    db,
    cache: store,
    plugins,
    onElicitation: "accept-all",
  });

  yield* executor.cache.set("plugin:derived-view", "...");
});

yield* program.pipe(Effect.provide(cacheLayer));
```

## Tests

- `bunx oxfmt --check packages/core/sdk/src/executor.ts packages/core/sdk/src/test-config.ts packages/core/api/src/server/scoped-executor.ts packages/hosts/cloudflare/src/key-value-store.ts packages/hosts/cloudflare/src/key-value-store.test.ts packages/hosts/cloudflare/package.json .changeset/polite-caches-pull.md`
- `git diff --check`
- `bunx oxlint -c .oxlintrc.jsonc --deny-warnings packages/core/sdk/src/executor.ts packages/core/sdk/src/test-config.ts packages/core/api/src/server/scoped-executor.ts packages/hosts/cloudflare/src/key-value-store.ts packages/hosts/cloudflare/src/key-value-store.test.ts`
- `bun run --cwd packages/core/sdk typecheck`
- `bun run --cwd packages/core/api typecheck`
- `bun run --cwd packages/hosts/cloudflare test -- src/key-value-store.test.ts`
- `bun run --cwd packages/hosts/cloudflare typecheck`
- `bun run typecheck`

## Validation notes

- Root `bun run format:check` and root `bun run lint` currently scan `.scratchpad` and fail on existing scratchpad files outside this PR. Touched-file format and lint checks pass.
- Root `bun run test` runs the suite but currently prints two unrelated `apps/cloud` auth expectation failures where the received identity includes `organizationSlug`. The cache primitive diff does not touch `apps/cloud`.

## Deferred scope

- No tool-schema cache consumers.
- No `tools.list` cache consumer.
- No tool manifest changes.
- No semantic-search-specific cache work.
- No Cloudflare app `CACHE` binding wiring because upstream `main` does not currently declare a `CACHE` binding in `CloudflareEnv` or `wrangler.jsonc`.
