### PR TITLE
Clear macOS traffic lights in the desktop mobile headers

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -403,7 +403,13 @@ const createWindow = async (conn: SidecarConnection) => {
     y: windowState.y,
     width: windowState.width,
     height: windowState.height,
-    minWidth: 720,
+    // Keep the window at or above the responsive layout's mobile breakpoint
+    // (Tailwind `md` = 768px). Below it the web shell switches to the mobile
+    // header, whose far-left hamburger would render under the native macOS
+    // traffic lights (issue #1125). Staying >= 768 means the desktop always
+    // renders the sidebar layout, so the lights only ever sit over the sidebar
+    // header, which is offset to clear them (.desktop-macos-titlebar).
+    minWidth: 768,
     minHeight: 480,
     show: false,
     backgroundColor: "#0a0a0a",

--- a/e2e/desktop/traffic-light-overlap.test.ts
+++ b/e2e/desktop/traffic-light-overlap.test.ts
@@ -1,16 +1,20 @@
-// Regression for issue #1125: on the macOS desktop app, when the window is
-// narrowed below the mobile breakpoint (768px; window minWidth is 720) the
-// responsive header's hamburger button — and, once the menu sheet is opened,
-// its "executor Beta" title — used to render at the far-left (x≈12) where the
-// native macOS traffic-light window controls live. The app offsets the
-// *desktop* sidebar header by 88px (.desktop-macos-titlebar in globals.css) to
-// clear the traffic lights; the fix gives the *mobile* top bar (shell.tsx) and
-// the mobile sheet header the same offset so their content clears the lights.
+// Regression for issue #1125: on the macOS desktop app the native traffic-light
+// window controls are drawn over the frameless web content at
+// trafficLightPosition {x:16,y:17} (apps/desktop/src/main/index.ts) — three
+// 12px buttons with 20px center spacing, occupying x ∈ [16, 68].
 //
-// The macOS traffic lights are drawn at trafficLightPosition {x:16,y:17}
-// (apps/desktop/src/main/index.ts) — three 12px buttons with 20px center
-// spacing, so they occupy x ∈ [16, 68]. After the fix, the hamburger button
-// and the sheet brand must start to the RIGHT of that zone.
+// The original bug: the window minWidth was 720 but the web layout switches to
+// the mobile header at the 768px breakpoint, so narrowing the window into the
+// 720–767 band rendered the mobile hamburger (and, with the menu open, the
+// "executor Beta" brand) at the far left, directly under the lights.
+//
+// The fix has two parts, both asserted here:
+//   1. minWidth is now 768, so the desktop never drops into the mobile layout —
+//      the lights only ever sit over the desktop sidebar header. This proves
+//      the mobile hamburger bar is NOT present at the minimum width.
+//   2. The sidebar header is offset 88px to clear the lights, and the macOS
+//      sidebar is widened (.desktop-macos-sidebar) so the brand wordmark and
+//      the server-connection menu both clear the lights without colliding.
 //
 // Launches the REAL Electron app via Playwright against a throwaway HOME (same
 // harness as local-auth-mcp.test.ts). Captures via CDP page.screenshot:
@@ -40,8 +44,11 @@ const appDir = fileURLToPath(new URL("../../apps/desktop/", import.meta.url));
 const electronBinary = createRequire(join(appDir, "package.json"))("electron") as string;
 
 // Rightmost edge of the traffic-light cluster (left edges 16/36/56, +12px) plus
-// a small margin. Header content must start at or beyond this to be clickable.
+// a small margin. Header content must start at or beyond this to clear them.
 const TRAFFIC_LIGHTS_RIGHT = 72;
+// The window minWidth: the narrowest the desktop window can get, and the worst
+// case for fitting the sidebar header alongside the lights.
+const MIN_WIDTH = 768;
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
@@ -86,18 +93,14 @@ const captureBoth = async (page: Page, runDir: string, state: string) => {
   await page.evaluate(REMOVE_LIGHTS_JS);
 };
 
-// Assert an element's left edge clears the native traffic-light cluster.
-const expectClearsTrafficLights = async (locator: Locator, label: string) => {
-  const box = await locator.boundingBox();
-  expect(box, `${label}: has a bounding box`).not.toBeNull();
-  expect(
-    box!.x,
-    `${label}: left edge (${Math.round(box!.x)}px) clears the traffic lights (≥ ${TRAFFIC_LIGHTS_RIGHT}px)`,
-  ).toBeGreaterThanOrEqual(TRAFFIC_LIGHTS_RIGHT);
+const box = async (locator: Locator, label: string) => {
+  const b = await locator.boundingBox();
+  expect(b, `${label}: has a bounding box`).not.toBeNull();
+  return b!;
 };
 
 scenario(
-  "Desktop · #1125 mobile headers clear the macOS traffic lights at narrow width",
+  "Desktop · #1125 the desktop stays out of the mobile layout and the sidebar header clears the macOS traffic lights",
   { timeout: 300_000 },
   Effect.gen(function* () {
     const runDir = yield* RunDir;
@@ -112,41 +115,68 @@ const run = async (runDir: string) => {
     const page = await app.firstWindow({ timeout: 120_000 });
     await page.waitForLoadState("domcontentloaded");
 
-    // The 88px offset is gated on this class; without it the assertions below
-    // would be meaningless, so prove it is active before trusting them.
+    // The offset is gated on this class; without it the assertions below would
+    // be meaningless, so prove it is active before trusting them.
     const isMacDesktop = await page.evaluate(() =>
       document.documentElement.classList.contains("executor-desktop-macos"),
     );
     expect(isMacDesktop, "renderer applied the macOS desktop class").toBe(true);
 
-    // Narrow the window below the 768px mobile breakpoint. 730 is the realistic
-    // worst case given the 720 minWidth. (Height clamps to the display.)
-    await app.evaluate(async ({ BrowserWindow }) => {
+    // Try to shrink below the mobile breakpoint. The minWidth fix must clamp the
+    // window at 768, so the desktop can never drop into the mobile layout. We ask
+    // for 700 (the old reachable band) and assert it clamps up.
+    const clampedWidth = await app.evaluate(async ({ BrowserWindow }) => {
       const win = BrowserWindow.getAllWindows()[0]!;
-      win.setSize(730, 800);
-      win.setPosition(80, 40);
+      win.setPosition(60, 40);
+      win.setSize(700, 800);
       win.show();
       win.focus();
+      return win.getSize()[0];
     });
+    expect(
+      clampedWidth,
+      `window cannot shrink below the mobile breakpoint (clamped to ${clampedWidth}px)`,
+    ).toBeGreaterThanOrEqual(MIN_WIDTH);
 
-    // At 730px we're in mobile layout: the hamburger button proves it rendered.
-    const hamburger = page.getByRole("button", { name: "Open navigation" });
-    await hamburger.waitFor({ timeout: 60_000 });
+    const sidebar = page.locator("aside.desktop-macos-sidebar");
+    await sidebar.waitFor({ timeout: 60_000 });
     await sleep(800);
 
-    // Collapsed state: the hamburger button must clear the traffic lights.
-    await captureBoth(page, runDir, "01-collapsed");
-    await expectClearsTrafficLights(hamburger, "mobile hamburger button");
+    // Part 1: at the minimum width the mobile phone bar must NOT be shown, so
+    // its hamburger can never land under the lights.
+    const hamburgerVisible = await page
+      .getByRole("button", { name: "Open navigation" })
+      .isVisible();
+    expect(hamburgerVisible, "mobile hamburger bar is hidden on the desktop at minimum width").toBe(
+      false,
+    );
+    const sidebarVisible = await sidebar.isVisible();
+    expect(sidebarVisible, "desktop sidebar is visible at minimum width").toBe(true);
 
-    // Open the mobile menu sheet: its "executor Beta" brand must clear too.
-    await hamburger.click();
-    const sheet = page.locator("div.fixed.inset-0.z-50");
-    await sheet.getByRole("button", { name: "Close navigation" }).first().waitFor({
-      timeout: 30_000,
-    });
-    await sleep(500);
-    await captureBoth(page, runDir, "02-menu-open");
-    await expectClearsTrafficLights(sheet.locator("a").first(), "mobile sheet brand");
+    await captureBoth(page, runDir, "01-sidebar-header");
+
+    // Part 2a: the brand wordmark clears the traffic-light cluster.
+    const header = sidebar.locator(".desktop-macos-titlebar");
+    const brand = await box(header.locator("a").first(), "sidebar brand");
+    expect(
+      Math.round(brand.x),
+      `sidebar brand left edge (${Math.round(brand.x)}px) clears the lights (>= ${TRAFFIC_LIGHTS_RIGHT}px)`,
+    ).toBeGreaterThanOrEqual(TRAFFIC_LIGHTS_RIGHT);
+
+    // Part 2b: the server-connection menu sits clear of the brand (no collision
+    // with the "Beta" badge, the bug in the screenshot) and stays inside the
+    // sidebar.
+    const menu = await box(
+      header.locator('button[aria-label^="Select Executor server"]'),
+      "server-connection menu",
+    );
+    const asideBox = await box(sidebar, "sidebar");
+    const gap = Math.round(menu.x - (brand.x + brand.width));
+    expect(gap, `server menu does not overlap the brand (gap ${gap}px)`).toBeGreaterThanOrEqual(8);
+    expect(
+      Math.round(menu.x + menu.width),
+      "server menu stays within the sidebar",
+    ).toBeLessThanOrEqual(Math.round(asideBox.x + asideBox.width));
   } finally {
     await app.close().catch(() => {});
     rmSync(home, { recursive: true, force: true });

--- a/e2e/desktop/traffic-light-overlap.test.ts
+++ b/e2e/desktop/traffic-light-overlap.test.ts
@@ -1,0 +1,154 @@
+// Regression for issue #1125: on the macOS desktop app, when the window is
+// narrowed below the mobile breakpoint (768px; window minWidth is 720) the
+// responsive header's hamburger button — and, once the menu sheet is opened,
+// its "executor Beta" title — used to render at the far-left (x≈12) where the
+// native macOS traffic-light window controls live. The app offsets the
+// *desktop* sidebar header by 88px (.desktop-macos-titlebar in globals.css) to
+// clear the traffic lights; the fix gives the *mobile* top bar (shell.tsx) and
+// the mobile sheet header the same offset so their content clears the lights.
+//
+// The macOS traffic lights are drawn at trafficLightPosition {x:16,y:17}
+// (apps/desktop/src/main/index.ts) — three 12px buttons with 20px center
+// spacing, so they occupy x ∈ [16, 68]. After the fix, the hamburger button
+// and the sheet brand must start to the RIGHT of that zone.
+//
+// Launches the REAL Electron app via Playwright against a throwaway HOME (same
+// harness as local-auth-mcp.test.ts). Captures via CDP page.screenshot:
+//   - <state>-webview.png : the real, unmodified rendered content.
+//   - <state>-overlap.png : the same view with the native macOS traffic lights
+//                           drawn at their CONFIGURED position so the cleared
+//                           gap is visible. (We draw them rather than
+//                           screen-capture them because the e2e host is a
+//                           GPU-less virtual framebuffer: macOS does not
+//                           composite the window's native chrome onto the
+//                           captured surface, so `screencapture` returns only
+//                           wallpaper. CDP renderer screenshots are unaffected.)
+import { mkdtempSync, rmSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import { _electron, type ElectronApplication, type Locator, type Page } from "playwright";
+
+import { scenario } from "../src/scenario";
+import { RunDir } from "../src/services";
+
+const appDir = fileURLToPath(new URL("../../apps/desktop/", import.meta.url));
+const electronBinary = createRequire(join(appDir, "package.json"))("electron") as string;
+
+// Rightmost edge of the traffic-light cluster (left edges 16/36/56, +12px) plus
+// a small margin. Header content must start at or beyond this to be clickable.
+const TRAFFIC_LIGHTS_RIGHT = 72;
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+const launchDesktop = async (home: string): Promise<ElectronApplication> =>
+  _electron.launch({
+    executablePath: electronBinary,
+    args: [appDir],
+    cwd: appDir,
+    env: { ...process.env, HOME: home },
+    timeout: 120_000,
+  });
+
+// Draw the native macOS traffic lights at the app's configured
+// trafficLightPosition. Faithful geometry: 12px buttons, 20px center spacing,
+// group origin (16,17). Removed before each "real" capture so it stays
+// unmodified, re-added for the "overlap" capture.
+const TRAFFIC_LIGHTS_JS = `(() => {
+  const host = document.createElement('div');
+  host.id = '__repro_1125_trafficlights';
+  host.style.cssText =
+    'position:fixed;top:0;left:0;z-index:2147483647;pointer-events:none';
+  const dot = (left, color) => {
+    const d = document.createElement('div');
+    d.style.cssText =
+      'position:absolute;width:12px;height:12px;border-radius:50%;top:17px;left:' +
+      left + 'px;background:' + color + ';box-shadow:inset 0 0 0 0.5px rgba(0,0,0,.25)';
+    return d;
+  };
+  host.appendChild(dot(16, '#FF5F57'));
+  host.appendChild(dot(36, '#FEBC2E'));
+  host.appendChild(dot(56, '#28C840'));
+  document.body.appendChild(host);
+})()`;
+
+const REMOVE_LIGHTS_JS = `document.getElementById('__repro_1125_trafficlights')?.remove()`;
+
+const captureBoth = async (page: Page, runDir: string, state: string) => {
+  await page.evaluate(REMOVE_LIGHTS_JS);
+  await page.screenshot({ path: join(runDir, `${state}-webview.png`) });
+  await page.evaluate(TRAFFIC_LIGHTS_JS);
+  await page.screenshot({ path: join(runDir, `${state}-overlap.png`) });
+  await page.evaluate(REMOVE_LIGHTS_JS);
+};
+
+// Assert an element's left edge clears the native traffic-light cluster.
+const expectClearsTrafficLights = async (locator: Locator, label: string) => {
+  const box = await locator.boundingBox();
+  expect(box, `${label}: has a bounding box`).not.toBeNull();
+  expect(
+    box!.x,
+    `${label}: left edge (${Math.round(box!.x)}px) clears the traffic lights (≥ ${TRAFFIC_LIGHTS_RIGHT}px)`,
+  ).toBeGreaterThanOrEqual(TRAFFIC_LIGHTS_RIGHT);
+};
+
+scenario(
+  "Desktop · #1125 mobile headers clear the macOS traffic lights at narrow width",
+  { timeout: 300_000 },
+  Effect.gen(function* () {
+    const runDir = yield* RunDir;
+    yield* Effect.promise(() => run(runDir));
+  }),
+);
+
+const run = async (runDir: string) => {
+  const home = mkdtempSync(join(tmpdir(), "executor-repro-1125-"));
+  const app = await launchDesktop(home);
+  try {
+    const page = await app.firstWindow({ timeout: 120_000 });
+    await page.waitForLoadState("domcontentloaded");
+
+    // The 88px offset is gated on this class; without it the assertions below
+    // would be meaningless, so prove it is active before trusting them.
+    const isMacDesktop = await page.evaluate(() =>
+      document.documentElement.classList.contains("executor-desktop-macos"),
+    );
+    expect(isMacDesktop, "renderer applied the macOS desktop class").toBe(true);
+
+    // Narrow the window below the 768px mobile breakpoint. 730 is the realistic
+    // worst case given the 720 minWidth. (Height clamps to the display.)
+    await app.evaluate(async ({ BrowserWindow }) => {
+      const win = BrowserWindow.getAllWindows()[0]!;
+      win.setSize(730, 800);
+      win.setPosition(80, 40);
+      win.show();
+      win.focus();
+    });
+
+    // At 730px we're in mobile layout: the hamburger button proves it rendered.
+    const hamburger = page.getByRole("button", { name: "Open navigation" });
+    await hamburger.waitFor({ timeout: 60_000 });
+    await sleep(800);
+
+    // Collapsed state: the hamburger button must clear the traffic lights.
+    await captureBoth(page, runDir, "01-collapsed");
+    await expectClearsTrafficLights(hamburger, "mobile hamburger button");
+
+    // Open the mobile menu sheet: its "executor Beta" brand must clear too.
+    await hamburger.click();
+    const sheet = page.locator("div.fixed.inset-0.z-50");
+    await sheet.getByRole("button", { name: "Close navigation" }).first().waitFor({
+      timeout: 30_000,
+    });
+    await sleep(500);
+    await captureBoth(page, runDir, "02-menu-open");
+    await expectClearsTrafficLights(sheet.locator("a").first(), "mobile sheet brand");
+  } finally {
+    await app.close().catch(() => {});
+    rmSync(home, { recursive: true, force: true });
+  }
+};

--- a/packages/app/src/web/shell.tsx
+++ b/packages/app/src/web/shell.tsx
@@ -473,7 +473,7 @@ export function Shell() {
     <div className="flex h-screen overflow-hidden">
       <CommandPalette />
       {/* Desktop sidebar */}
-      <aside className="hidden w-52 shrink-0 border-r border-sidebar-border bg-sidebar md:flex md:flex-col lg:w-56">
+      <aside className="desktop-macos-sidebar hidden w-52 shrink-0 border-r border-sidebar-border bg-sidebar md:flex md:flex-col lg:w-56">
         <SidebarContent
           pathname={pathname}
           updateAvailable={updateAvailable}
@@ -493,8 +493,8 @@ export function Shell() {
             onClick={() => setMobileSidebarOpen(false)}
           />
           <div className="relative flex h-full w-[84vw] max-w-xs flex-col border-r border-sidebar-border bg-sidebar shadow-2xl">
-            <div className="desktop-macos-titlebar flex h-12 shrink-0 items-center justify-between border-b border-sidebar-border px-4">
-              <Link to="/{-$orgSlug}" className="desktop-macos-no-drag flex items-center gap-1.5">
+            <div className="flex h-12 shrink-0 items-center justify-between border-b border-sidebar-border px-4">
+              <Link to="/{-$orgSlug}" className="flex items-center gap-1.5">
                 <span className="font-display text-base tracking-tight text-foreground">
                   executor
                 </span>
@@ -507,7 +507,7 @@ export function Shell() {
                 size="icon-sm"
                 aria-label="Close navigation"
                 onClick={() => setMobileSidebarOpen(false)}
-                className="desktop-macos-no-drag text-sidebar-foreground hover:bg-sidebar-active hover:text-foreground"
+                className="text-sidebar-foreground hover:bg-sidebar-active hover:text-foreground"
               >
                 <svg viewBox="0 0 16 16" className="size-3.5">
                   <path
@@ -534,13 +534,13 @@ export function Shell() {
       {/* Main content */}
       <main className="flex min-h-0 flex-1 flex-col min-w-0 overflow-hidden">
         {/* Mobile top bar */}
-        <div className="desktop-macos-titlebar flex h-12 shrink-0 items-center justify-between border-b border-border bg-background px-4 md:hidden">
+        <div className="flex h-12 shrink-0 items-center justify-between border-b border-border bg-background px-4 md:hidden">
           <Button
             variant="outline"
             size="icon-sm"
             aria-label="Open navigation"
             onClick={() => setMobileSidebarOpen(true)}
-            className="desktop-macos-no-drag bg-card hover:bg-accent/50"
+            className="bg-card hover:bg-accent/50"
           >
             <svg viewBox="0 0 16 16" className="size-4">
               <path
@@ -551,7 +551,7 @@ export function Shell() {
               />
             </svg>
           </Button>
-          <Link to="/{-$orgSlug}" className="desktop-macos-no-drag flex items-center gap-1.5">
+          <Link to="/{-$orgSlug}" className="flex items-center gap-1.5">
             <span className="font-display text-base tracking-tight text-foreground">executor</span>
           </Link>
           <div className="w-8 shrink-0" />

--- a/packages/app/src/web/shell.tsx
+++ b/packages/app/src/web/shell.tsx
@@ -349,7 +349,7 @@ function SidebarContent(props: {
   return (
     <>
       {props.showBrand !== false && (
-        <div className="desktop-macos-sidebar-header flex h-12 shrink-0 items-center gap-2 border-b border-sidebar-border px-4">
+        <div className="desktop-macos-titlebar flex h-12 shrink-0 items-center gap-2 border-b border-sidebar-border px-4">
           <Link
             to="/{-$orgSlug}"
             className="desktop-macos-no-drag flex shrink-0 items-center gap-1.5"
@@ -493,8 +493,8 @@ export function Shell() {
             onClick={() => setMobileSidebarOpen(false)}
           />
           <div className="relative flex h-full w-[84vw] max-w-xs flex-col border-r border-sidebar-border bg-sidebar shadow-2xl">
-            <div className="flex h-12 shrink-0 items-center justify-between border-b border-sidebar-border px-4">
-              <Link to="/{-$orgSlug}" className="flex items-center gap-1.5">
+            <div className="desktop-macos-titlebar flex h-12 shrink-0 items-center justify-between border-b border-sidebar-border px-4">
+              <Link to="/{-$orgSlug}" className="desktop-macos-no-drag flex items-center gap-1.5">
                 <span className="font-display text-base tracking-tight text-foreground">
                   executor
                 </span>
@@ -507,7 +507,7 @@ export function Shell() {
                 size="icon-sm"
                 aria-label="Close navigation"
                 onClick={() => setMobileSidebarOpen(false)}
-                className="text-sidebar-foreground hover:bg-sidebar-active hover:text-foreground"
+                className="desktop-macos-no-drag text-sidebar-foreground hover:bg-sidebar-active hover:text-foreground"
               >
                 <svg viewBox="0 0 16 16" className="size-3.5">
                   <path
@@ -534,13 +534,13 @@ export function Shell() {
       {/* Main content */}
       <main className="flex min-h-0 flex-1 flex-col min-w-0 overflow-hidden">
         {/* Mobile top bar */}
-        <div className="flex h-12 shrink-0 items-center justify-between border-b border-border bg-background px-4 md:hidden">
+        <div className="desktop-macos-titlebar flex h-12 shrink-0 items-center justify-between border-b border-border bg-background px-4 md:hidden">
           <Button
             variant="outline"
             size="icon-sm"
             aria-label="Open navigation"
             onClick={() => setMobileSidebarOpen(true)}
-            className="bg-card hover:bg-accent/50"
+            className="desktop-macos-no-drag bg-card hover:bg-accent/50"
           >
             <svg viewBox="0 0 16 16" className="size-4">
               <path
@@ -551,7 +551,7 @@ export function Shell() {
               />
             </svg>
           </Button>
-          <Link to="/{-$orgSlug}" className="flex items-center gap-1.5">
+          <Link to="/{-$orgSlug}" className="desktop-macos-no-drag flex items-center gap-1.5">
             <span className="font-display text-base tracking-tight text-foreground">executor</span>
           </Link>
           <div className="w-8 shrink-0" />

--- a/packages/react/src/styles/globals.css
+++ b/packages/react/src/styles/globals.css
@@ -149,7 +149,12 @@
   }
 }
 
-.executor-desktop-macos .desktop-macos-sidebar-header {
+/* Headers that sit at the top-left of the desktop window land under the native
+   macOS traffic-light controls (trafficLightPosition {x:16,y:17} in
+   apps/desktop/src/main/index.ts). Offset them so their content clears the
+   lights, and make the freed strip draggable like a native title bar. Applies
+   to the desktop sidebar header and the responsive mobile headers alike. */
+.executor-desktop-macos .desktop-macos-titlebar {
   -webkit-app-region: drag;
   padding-left: 88px;
 }

--- a/packages/react/src/styles/globals.css
+++ b/packages/react/src/styles/globals.css
@@ -149,11 +149,12 @@
   }
 }
 
-/* Headers that sit at the top-left of the desktop window land under the native
-   macOS traffic-light controls (trafficLightPosition {x:16,y:17} in
-   apps/desktop/src/main/index.ts). Offset them so their content clears the
-   lights, and make the freed strip draggable like a native title bar. Applies
-   to the desktop sidebar header and the responsive mobile headers alike. */
+/* The sidebar header sits at the top-left of the desktop window, under the
+   native macOS traffic-light controls (trafficLightPosition {x:16,y:17} in
+   apps/desktop/src/main/index.ts). Offset its content past the lights and make
+   the freed strip draggable like a native title bar. The desktop window stays
+   at or above the mobile breakpoint (minWidth 768), so the sidebar header is
+   the only header the lights ever overlap. */
 .executor-desktop-macos .desktop-macos-titlebar {
   -webkit-app-region: drag;
   padding-left: 88px;
@@ -161,6 +162,13 @@
 
 .executor-desktop-macos .desktop-macos-no-drag {
   -webkit-app-region: no-drag;
+}
+
+/* The 88px title-bar offset eats into the sidebar's width; without extra room
+   the brand wordmark and the server-connection menu collide. Widen the macOS
+   sidebar so both clear the traffic lights with comfortable spacing. */
+.executor-desktop-macos .desktop-macos-sidebar {
+  width: 15rem;
 }
 
 .dark {


### PR DESCRIPTION
Fixes #1125.

## Problem

On the macOS desktop app the native traffic-light window controls are overlaid on the frameless web content at `trafficLightPosition: {x:16, y:17}` (`apps/desktop/src/main/index.ts`). The window `minWidth` was 720, but the responsive web shell switches to the mobile header at the 768px breakpoint, so dragging the window into the 720 to 767px band rendered the mobile UI on the desktop: the hamburger button (and, with the menu open, the "executor Beta" brand) landed at the far-left, under the traffic lights.

## Fix

Two parts:

1. Raise the desktop window `minWidth` to 768. The window can no longer drop below the responsive breakpoint, so the desktop never renders the phone-style header. The traffic lights then only ever sit over the desktop sidebar header, which already offsets its content 88px to clear them. This is the more native outcome: a desktop app that doesn't show a phone bar.

2. That 88px offset eats into the 208px sidebar, so the brand wordmark and the server-connection menu collided (the server icon overlapped the `Beta` badge). Widen the macOS sidebar (`.desktop-macos-sidebar`, 15rem) so both clear the lights with comfortable spacing.

The earlier mobile-header offset is reverted: with the window kept at or above the breakpoint it is unreachable on the desktop, and the mobile headers carry no traffic lights on the web. Everything stays gated behind the existing `.executor-desktop-macos` class, so web, cloud, and self-host are unaffected.

## Before / after

The sidebar header at the minimum window width, with the traffic lights drawn at their configured position:

![Sidebar header before and after: the server icon stops overlapping the Beta badge once the macOS sidebar is widened](https://raw.githubusercontent.com/RhysSullivan/executor/e2e-media/1125-sidebar-header-fit-64424e29.png)

For reference, the original bug at narrow width (now unreachable on the desktop, since the window stays >= 768px): the mobile hamburger under the lights.

![Original bug: the mobile hamburger renders under the traffic lights at narrow width](https://raw.githubusercontent.com/RhysSullivan/executor/e2e-media/1125-collapsed-mobile-bar-traffic-lights-460379c3.png)

## Verification

- `format:check`, `lint`, and `typecheck` all pass.
- Desktop e2e regression (`e2e/desktop/traffic-light-overlap.test.ts`) launches the real Electron app against a throwaway HOME and asserts: the window clamps at 768px when asked to go narrower; the mobile hamburger bar is hidden; the sidebar header brand clears the traffic-light cluster; and the server-connection menu sits clear of the brand and inside the sidebar. It captures the sidebar header screenshots (real render plus an overlay with the lights drawn at their configured position, since the GPU-less e2e framebuffer cannot screen-capture native window chrome).

Run it with `node node_modules/.bin/vitest run --project desktop -t "1125"` from `e2e/` (must run under Node, not bun, or Playwright's Electron CDP attach hangs).
