### PR TITLE
perf: reduce /api/tools server time on the read path

### DIFF
--- a/.changeset/reduce-api-tools-server-time.md
+++ b/.changeset/reduce-api-tools-server-time.md
@@ -1,0 +1,6 @@
+---
+"@executor-js/sdk": patch
+"@executor-js/plugin-openapi": patch
+---
+
+Reduce `tools.list` server time. The read path now skips the stale-connection-tools sync once every connection is synced at the current revision watermark (cached per binding and busted by any new config revision), instead of scanning connections on every call. The openapi operation store also filters `listOperations` by integration at the storage layer (a key-prefix `LIKE` covering both the hashed and legacy key schemes) rather than reading the whole collection and filtering in memory.

--- a/packages/core/sdk/src/executor.test.ts
+++ b/packages/core/sdk/src/executor.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "@effect/vitest";
 import { Data, Effect, Predicate, Result } from "effect";
+import { withQueryContext } from "@executor-js/fumadb/query";
 
 import { ToolNotFoundError } from "./errors";
+import { StorageError } from "./fuma-runtime";
 import {
   AuthTemplateSlug,
   ConnectionName,
@@ -9,13 +11,16 @@ import {
   OAuthClientSlug,
   ProviderItemId,
   ProviderKey,
+  Subject,
+  Tenant,
   ToolAddress,
   ToolName,
 } from "./ids";
-import { definePlugin } from "./plugin";
+import { collectTables, createExecutor } from "./executor";
+import { definePlugin, type AnyPlugin } from "./plugin";
 import type { CredentialProvider } from "./provider";
 import { IntegrationDetectionResult } from "./types";
-import { makeTestExecutor } from "./testing";
+import { createSqliteTestFumaDb, makeTestExecutor } from "./testing";
 import { serveOAuthTestServer } from "./testing/oauth-test-server";
 
 // removed: v1 secret browser-handoff, source.configure, case-insensitive tool-id
@@ -94,6 +99,9 @@ const demoPlugin = definePlugin(() => ({
         description: "Demo",
         config: {},
       }),
+    // Stamp the integration's `config_revised_at` so every other binding's
+    // connections fall behind and reconverge on their next read.
+    reviseConfig: (rev: number) => ctx.core.integrations.update(INTEG, { config: { rev } }),
     storagePut: (owner: "org" | "user", key: string, value: string) =>
       ctx.storage.put(owner, key, value),
     storageList: () => ctx.storage.list(),
@@ -469,6 +477,169 @@ describe("createExecutor", () => {
           String(suggestion).startsWith(`tools.${INTEG}.org.${CONN}.`),
         ),
       ).toBe(true);
+    }),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Stale-connection-tools sync: the read path (`tools.list`) must converge a
+// connection whose catalog predates its integration's last config revision,
+// but must NOT re-scan connections on every read once everything is synced at
+// the current revision watermark.
+// ---------------------------------------------------------------------------
+
+const FLAKY = IntegrationSlug.make("flaky");
+
+// Build an executor over a real SQLite DB whose adapter counts how many reads
+// hit each table. The counter is installed on the adapter BEFORE the query
+// context is layered on, so every derived contextual query forwards to it.
+const makeCountingExecutor = <const TPlugins extends readonly AnyPlugin[]>(input: {
+  readonly tenant: string;
+  readonly subject: string;
+  readonly plugins: TPlugins;
+}) =>
+  Effect.gen(function* () {
+    const tables = collectTables();
+    const real = yield* Effect.promise(() =>
+      createSqliteTestFumaDb({ tables, namespace: "executor_test" }),
+    );
+    const counts: Record<string, number> = {};
+    // Count reads per table at the adapter seam, BEFORE the query context is
+    // layered on, so every derived contextual query forwards through it.
+    const adapter = real.db.internal;
+    const realFindMany = adapter.findMany.bind(adapter);
+    adapter.findMany = (table, options) => {
+      counts[table.ormName] = (counts[table.ormName] ?? 0) + 1;
+      return realFindMany(table, options);
+    };
+    const db = withQueryContext(real.db, { tenant: input.tenant, subject: input.subject });
+    const executor = yield* createExecutor({
+      tenant: Tenant.make(input.tenant),
+      subject: Subject.make(input.subject),
+      db,
+      plugins: input.plugins,
+      onElicitation: "accept-all",
+    });
+    return {
+      executor,
+      counts,
+      reset: () => {
+        for (const key of Object.keys(counts)) counts[key] = 0;
+      },
+      close: () =>
+        executor.close().pipe(Effect.ignore, Effect.andThen(Effect.promise(() => real.close()))),
+    };
+  });
+
+// A plugin whose resolveTools can be toggled to fail, to exercise the
+// best-effort retry path (a failed rebuild must not be cached as "synced").
+const makeFlakyPlugin = () => {
+  let fail = false;
+  return definePlugin(() => ({
+    id: "flaky" as const,
+    credentialProviders: [memoryProvider()],
+    storage: () => ({}),
+    resolveTools: () =>
+      fail
+        ? Effect.fail(new StorageError({ message: "resolveTools boom", cause: undefined }))
+        : Effect.succeed({
+            tools: [{ name: ToolName.make("ping"), description: "ping" }],
+            definitions: {},
+          }),
+    invokeTool: ({ toolRow }) => Effect.succeed({ ran: toolRow.name }),
+    extension: (ctx) => ({
+      seed: () => ctx.core.integrations.register({ slug: FLAKY, description: "Flaky", config: {} }),
+      reviseConfig: (rev: number) => ctx.core.integrations.update(FLAKY, { config: { rev } }),
+      setFail: (value: boolean) =>
+        Effect.sync(() => {
+          fail = value;
+        }),
+    }),
+  }))();
+};
+
+describe("syncStaleConnectionTools", () => {
+  it.effect(
+    "skips the connection scan once synced at the current revision, re-scans on a new one",
+    () =>
+      Effect.gen(function* () {
+        const harness = yield* makeCountingExecutor({
+          tenant: "wm-skip-tenant",
+          subject: "wm-skip-subject",
+          plugins: [demoPlugin] as const,
+        });
+        yield* harness.executor.demo.seed();
+        yield* harness.executor.connections.create({
+          owner: "org",
+          name: CONN,
+          integration: INTEG,
+          template: TEMPLATE,
+          from: { provider: ProviderKey.make("memory"), id: ProviderItemId.make("v") },
+        });
+        // Revise config so the freshly-created connection is now stale.
+        yield* harness.executor.demo.reviseConfig(1);
+
+        // First read converges: it scans connections and rebuilds the stale one.
+        harness.reset();
+        yield* harness.executor.tools.list();
+        expect(harness.counts.connection ?? 0).toBeGreaterThanOrEqual(1);
+
+        // Second read at the same watermark skips the connection scan entirely
+        // (it still reads the integration watermark).
+        harness.reset();
+        yield* harness.executor.tools.list();
+        expect(harness.counts.connection ?? 0).toBe(0);
+        expect(harness.counts.integration ?? 0).toBeGreaterThanOrEqual(1);
+
+        // A new revision moves the watermark and busts the cache: re-scan.
+        yield* harness.executor.demo.reviseConfig(2);
+        harness.reset();
+        yield* harness.executor.tools.list();
+        expect(harness.counts.connection ?? 0).toBeGreaterThanOrEqual(1);
+
+        yield* harness.close();
+      }),
+  );
+
+  it.effect("retries on the next read when a rebuild fails (does not cache failures)", () =>
+    Effect.gen(function* () {
+      const flaky = makeFlakyPlugin();
+      const harness = yield* makeCountingExecutor({
+        tenant: "wm-retry-tenant",
+        subject: "wm-retry-subject",
+        plugins: [flaky] as const,
+      });
+      yield* harness.executor.flaky.seed();
+      yield* harness.executor.connections.create({
+        owner: "org",
+        name: CONN,
+        integration: FLAKY,
+        template: TEMPLATE,
+        from: { provider: ProviderKey.make("memory"), id: ProviderItemId.make("v") },
+      });
+
+      // Make the next rebuild fail, then revise so the connection is stale.
+      yield* harness.executor.flaky.setFail(true);
+      yield* harness.executor.flaky.reviseConfig(1);
+
+      // Two reads at the same watermark: both must scan (the failed rebuild is
+      // never cached as synced).
+      harness.reset();
+      yield* harness.executor.tools.list();
+      expect(harness.counts.connection ?? 0).toBeGreaterThanOrEqual(1);
+
+      harness.reset();
+      yield* harness.executor.tools.list();
+      expect(harness.counts.connection ?? 0).toBeGreaterThanOrEqual(1);
+
+      // Once it can succeed, the connection converges and the next read skips.
+      yield* harness.executor.flaky.setFail(false);
+      yield* harness.executor.tools.list();
+      harness.reset();
+      yield* harness.executor.tools.list();
+      expect(harness.counts.connection ?? 0).toBe(0);
+
+      yield* harness.close();
     }),
   );
 });

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -383,6 +383,38 @@ export interface ExecutorConfig<TPlugins extends readonly AnyPlugin[] = readonly
 }
 
 // ---------------------------------------------------------------------------
+// Stale-connection-tools sync watermark cache.
+//
+// `tools.list` lazily reconverges connections whose tool catalog predates their
+// integration's last config revision. Detecting that needs a read of the
+// revised integrations (the watermark) plus a scan of their connections. The
+// connection scan is pure waste once everything is already synced at the
+// current watermark, which is the steady state (a config revision stamps
+// `config_revised_at` permanently). We cache, per binding, the highest
+// watermark at which the binding was confirmed fully synced: while the freshly
+// read watermark is unchanged, the connection scan is skipped.
+//
+// The cache is keyed by the underlying DB handle (a WeakMap), then by
+// tenant+subject. In production every per-request scoped executor in an isolate
+// shares one long-lived DB handle, so the cache survives executor rebuilds and
+// the saving lands. Each test builds a fresh DB object, so tests are naturally
+// isolated (no cross-test contamination) and the entry is GC'd with the handle.
+// The watermark is always read fresh, so a revision on any isolate busts the
+// cache on the next read — convergence stays correct.
+// ---------------------------------------------------------------------------
+
+const staleSyncWatermarkCache = new WeakMap<object, Map<string, number>>();
+
+const staleSyncWatermarkFor = (handle: object): Map<string, number> => {
+  let byBinding = staleSyncWatermarkCache.get(handle);
+  if (!byBinding) {
+    byBinding = new Map();
+    staleSyncWatermarkCache.set(handle, byBinding);
+  }
+  return byBinding;
+};
+
+// ---------------------------------------------------------------------------
 // collectTables — return the executor-owned Fuma table set. Plugins persist
 // through host-owned facades (`pluginStorage`, `blobs`) instead of contributing
 // table definitions, so the schema is fixed and plugin-independent.
@@ -820,13 +852,34 @@ const makePluginStorageFacade = (input: {
   const tenant = String(input.owner.tenant);
 
   const whereFor =
-    (collection: string, key?: string): CoreWhere =>
+    (collection: string, key?: string, keyPrefixes?: readonly string[]): CoreWhere =>
     (b: AnyCb) =>
       b.and(
         b("plugin_id", "=", input.pluginId),
         b("collection", "=", collection),
         key === undefined ? true : b("key", "=", key),
+        // Push a key-prefix scan to the storage layer (`key LIKE 'prefix%'`)
+        // so a prefixed list reads only its slice instead of the whole
+        // collection. `LIKE` treats `_`/`%` in a prefix as wildcards, so this
+        // can over-match; callers keep an exact `startsWith` (and any data
+        // guard) to stay correct.
+        keyPrefixes === undefined || keyPrefixes.length === 0
+          ? true
+          : b.or(...keyPrefixes.map((prefix) => b("key", "starts with", prefix))),
       );
+
+  // Collect the effective key prefixes for a list/query: the single `keyPrefix`
+  // plus any `keyPrefixes`, deduped. Returns undefined when there are none.
+  const collectKeyPrefixes = (input: {
+    readonly keyPrefix?: string;
+    readonly keyPrefixes?: readonly string[];
+  }): readonly string[] | undefined => {
+    const all = [
+      ...(input.keyPrefix === undefined ? [] : [input.keyPrefix]),
+      ...(input.keyPrefixes ?? []),
+    ];
+    return all.length === 0 ? undefined : [...new Set(all)];
+  };
 
   const whereOwner = (owner: Owner, collection: string, key: string): CoreWhere => {
     const os = ownerSubject(owner);
@@ -1119,14 +1172,17 @@ const makePluginStorageFacade = (input: {
       getForOwnerImpl(storageInput.owner, storageInput.collection, storageInput.key),
     list: (storageInput) =>
       Effect.gen(function* () {
+        const keyPrefixes = collectKeyPrefixes(storageInput);
         const rows = yield* input.core.findMany("plugin_storage", {
-          where: whereFor(storageInput.collection),
+          where: whereFor(storageInput.collection, undefined, keyPrefixes),
         });
         return sortByOwnerPrecedence(rows)
           .filter((row) =>
-            storageInput.keyPrefix === undefined
+            // Exact prefix guard: the DB `LIKE` clause narrows the scan but can
+            // over-match on `_`/`%`, so re-check with `startsWith`.
+            keyPrefixes === undefined
               ? true
-              : row.key.startsWith(storageInput.keyPrefix),
+              : keyPrefixes.some((prefix) => row.key.startsWith(prefix)),
           )
           .map((row) => pluginStorageEntryFromRow(row));
       }),
@@ -2435,17 +2491,33 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
     // every other subject converges here, on their own read, under their own
     // binding. Best-effort: a failed rebuild leaves the stale-but-working
     // catalog in place and retries on the next read.
+    //
+    // The revised-integration read is the watermark; once every connection is
+    // synced past the current watermark we cache it and skip the connection
+    // scan on subsequent reads until a new revision moves the watermark.
+    const staleSyncCache = staleSyncWatermarkFor(rootDbUntyped);
+    const staleSyncCacheKey = `${tenant} ${subject ?? ""}`;
     const syncStaleConnectionTools = Effect.gen(function* () {
       const revised = yield* core.findMany("integration", {
         where: (b: AnyCb) => b.isNotNull("config_revised_at"),
       });
       if (revised.length === 0) return;
+      const watermark = revised.reduce(
+        (max, row) => Math.max(max, Number(row.config_revised_at)),
+        0,
+      );
+      // Already confirmed everything synced at this watermark: skip the scan.
+      if (staleSyncCache.get(staleSyncCacheKey) === watermark) return;
+
       const revisedAt = new Map(
         revised.map((row) => [row.slug, Number(row.config_revised_at)] as const),
       );
       const connections = yield* core.findMany("connection", {
         where: (b: AnyCb) => b.or(...revised.map((row) => b("integration", "=", row.slug))),
       });
+      // Only cache the watermark when every stale connection rebuilt cleanly; a
+      // failed rebuild stays uncached so the next read retries it.
+      let allClean = true;
       for (const connection of connections) {
         const revisedTime = revisedAt.get(connection.integration);
         if (revisedTime === undefined) continue;
@@ -2459,7 +2531,12 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
           integration: IntegrationSlug.make(connection.integration),
           name: ConnectionName.make(connection.name),
         }).pipe(
-          Effect.catch(() => Effect.succeed([] as readonly Tool[])),
+          Effect.catch(() =>
+            Effect.sync(() => {
+              allClean = false;
+              return [] as readonly Tool[];
+            }),
+          ),
           Effect.withSpan("executor.tools.sync_stale", {
             attributes: {
               "executor.integration": connection.integration,
@@ -2468,6 +2545,7 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
           }),
         );
       }
+      if (allClean) staleSyncCache.set(staleSyncCacheKey, watermark);
     });
 
     const toolsList = (filter?: ToolListFilter): Effect.Effect<readonly Tool[], StorageFailure> =>

--- a/packages/core/sdk/src/plugin-storage.test.ts
+++ b/packages/core/sdk/src/plugin-storage.test.ts
@@ -78,6 +78,8 @@ const executionHistoryPlugin = definePlugin(() => ({
         owner,
         entries: keys.map((key) => ({ collection: toolCalls.name, key })),
       }),
+    list: (input: { readonly keyPrefix?: string; readonly keyPrefixes?: readonly string[] }) =>
+      ctx.pluginStorage.list({ collection: toolCalls.name, ...input }),
     get: (key: string) => ctx.storage.toolCalls.get({ key }),
     getForOwner: (owner: Owner, key: string) => ctx.storage.toolCalls.getForOwner({ owner, key }),
     query: (input?: PluginStorageCollectionQueryInput<typeof toolCalls>) =>
@@ -291,6 +293,51 @@ describe("plugin storage collections", () => {
         ["shared", "org", "shell"],
         ["shared", "user", "browser"],
       ]);
+    }),
+  );
+
+  it.effect("list narrows the scan to keys matching any of keyPrefixes", () =>
+    Effect.gen(function* () {
+      // Mirrors the openapi operation store: keys carry an integration prefix
+      // (v2 `op.<hash>.` plus the legacy plaintext `<slug>.`). `list` must push
+      // the prefixes to the storage layer and return only matching keys.
+      const executor = yield* makeTestExecutor({
+        backend: "sqlite",
+        plugins: [executionHistoryPlugin] as const,
+      });
+      const seed = (key: string) =>
+        executor.executionHistory.record(
+          "org",
+          key,
+          call({
+            runId: "run-prefix",
+            toolId: "shell",
+            status: "ok",
+            startedAt: "2026-05-29T10:00:00.000Z",
+          }),
+        );
+      yield* seed("op.aaaaaaaaaaaaa.one");
+      yield* seed("op.aaaaaaaaaaaaa.two");
+      yield* seed("op.bbbbbbbbbbbbb.three");
+      yield* seed("microsoft_graph.legacy");
+      yield* seed("other_int.legacy");
+
+      const matched = yield* executor.executionHistory.list({
+        keyPrefixes: ["op.aaaaaaaaaaaaa.", "microsoft_graph."],
+      });
+      expect(matched.map((row) => row.key).sort()).toEqual([
+        "microsoft_graph.legacy",
+        "op.aaaaaaaaaaaaa.one",
+        "op.aaaaaaaaaaaaa.two",
+      ]);
+
+      // Back-compat: a single keyPrefix still works.
+      const single = yield* executor.executionHistory.list({ keyPrefix: "op.bbbbbbbbbbbbb." });
+      expect(single.map((row) => row.key)).toEqual(["op.bbbbbbbbbbbbb.three"]);
+
+      // No prefixes => whole collection.
+      const all = yield* executor.executionHistory.list({});
+      expect(all).toHaveLength(5);
     }),
   );
 

--- a/packages/core/sdk/src/plugin-storage.ts
+++ b/packages/core/sdk/src/plugin-storage.ts
@@ -107,6 +107,13 @@ export interface PluginStorageScopedKeyInput extends PluginStorageKeyInput {
 export interface PluginStorageListInput {
   readonly collection: string;
   readonly keyPrefix?: string;
+  /** Restrict the scan to keys starting with any of these prefixes, pushed to
+   *  the storage layer (a key `starts with` / `LIKE 'prefix%'` clause) instead
+   *  of scanning the whole collection. A row matches if it starts with
+   *  `keyPrefix` or any entry here; callers that need an exact-value invariant
+   *  (e.g. distinguishing two integrations whose key prefixes collide under
+   *  `LIKE` wildcards) must still guard on the row data. */
+  readonly keyPrefixes?: readonly string[];
 }
 
 export interface PluginStoragePutInput extends PluginStorageScopedKeyInput {

--- a/packages/plugins/openapi/src/sdk/store.test.ts
+++ b/packages/plugins/openapi/src/sdk/store.test.ts
@@ -7,119 +7,145 @@ import {
   type PluginBlobStore,
   type PluginStorageEntry,
   type PluginStorageFacade,
+  type PluginStorageListInput,
   type StorageDeps,
 } from "@executor-js/sdk/core";
 
 import { makeDefaultOpenapiStore } from "./store";
 import { OperationBinding } from "./types";
 
+const binding = () =>
+  OperationBinding.make({
+    method: "get",
+    servers: [],
+    pathTemplate: "/things",
+    parameters: [],
+    requestBody: Option.none(),
+    responseBody: Option.none(),
+  });
+
+/** In-memory `PluginStorageFacade` for testing the openapi store in isolation,
+ *  honoring `keyPrefix`/`keyPrefixes` the same way the real facade does and
+ *  recording every `list` input so tests can assert how the scan was narrowed. */
+const makeInMemoryPluginStorage = () => {
+  const rows = new Map<string, PluginStorageEntry>();
+  const capturedKeys: string[] = [];
+  const listInputs: PluginStorageListInput[] = [];
+  const storageKey = (collection: string, key: string) => `${collection}\0${key}`;
+  const now = new Date();
+  const makeEntry = <T>(input: {
+    readonly owner: "org" | "user";
+    readonly collection: string;
+    readonly key: string;
+    readonly data: T;
+  }): PluginStorageEntry<T> => ({
+    id: storageKey(input.collection, input.key),
+    owner: input.owner,
+    pluginId: "openapi",
+    collection: input.collection,
+    key: input.key,
+    data: input.data,
+    createdAt: now,
+    updatedAt: now,
+  });
+  const prefixesOf = (input: PluginStorageListInput): readonly string[] | undefined => {
+    const all = [
+      ...(input.keyPrefix === undefined ? [] : [input.keyPrefix]),
+      ...(input.keyPrefixes ?? []),
+    ];
+    return all.length === 0 ? undefined : all;
+  };
+  const pluginStorage: PluginStorageFacade = {
+    collection: () => ({
+      get: () => Effect.succeed(null),
+      getForOwner: () => Effect.succeed(null),
+      list: () => Effect.succeed([]),
+      put: (input) =>
+        Effect.succeed(
+          makeEntry({ owner: input.owner, collection: "unused", key: input.key, data: input.data }),
+        ),
+      query: () => Effect.succeed([]),
+      count: () => Effect.succeed(0),
+      remove: () => Effect.void,
+    }),
+    get: <T = unknown>(input: { readonly collection: string; readonly key: string }) =>
+      Effect.succeed(
+        (rows.get(storageKey(input.collection, input.key)) as PluginStorageEntry<T> | undefined) ??
+          null,
+      ),
+    getForOwner: <T = unknown>(input: { readonly collection: string; readonly key: string }) =>
+      Effect.succeed(
+        (rows.get(storageKey(input.collection, input.key)) as PluginStorageEntry<T> | undefined) ??
+          null,
+      ),
+    list: <T = unknown>(input: PluginStorageListInput) =>
+      Effect.sync(() => {
+        listInputs.push(input);
+        const prefixes = prefixesOf(input);
+        return [...rows.values()].filter(
+          (row) =>
+            row.collection === input.collection &&
+            (prefixes === undefined || prefixes.some((prefix) => row.key.startsWith(prefix))),
+        ) as PluginStorageEntry<T>[];
+      }),
+    put: <T = unknown>(input: {
+      readonly owner: "org" | "user";
+      readonly collection: string;
+      readonly key: string;
+      readonly data: unknown;
+    }) => {
+      const entry = makeEntry<T>({ ...input, data: input.data as T });
+      rows.set(storageKey(input.collection, input.key), entry);
+      return Effect.succeed(entry);
+    },
+    putMany: (input) =>
+      Effect.sync(() => {
+        for (const entry of input.entries) {
+          capturedKeys.push(entry.key);
+          rows.set(
+            storageKey(entry.collection, entry.key),
+            makeEntry({
+              owner: input.owner,
+              collection: entry.collection,
+              key: entry.key,
+              data: entry.data,
+            }),
+          );
+        }
+      }),
+    remove: (input) =>
+      Effect.sync(() => {
+        rows.delete(storageKey(input.collection, input.key));
+      }),
+    removeMany: (input) =>
+      Effect.sync(() => {
+        for (const entry of input.entries) {
+          rows.delete(storageKey(entry.collection, entry.key));
+        }
+      }),
+  };
+  return { pluginStorage, rows, capturedKeys, listInputs, storageKey };
+};
+
+const blobs: PluginBlobStore = {
+  get: () => Effect.succeed(null),
+  put: () => Effect.void,
+  delete: () => Effect.void,
+  has: () => Effect.succeed(false),
+};
+
+const makeStore = (pluginStorage: PluginStorageFacade) =>
+  makeDefaultOpenapiStore({
+    owner: { tenant: Tenant.make("tenant"), subject: Subject.make("subject") },
+    blobs,
+    pluginStorage,
+  } satisfies StorageDeps);
+
 describe("OpenAPI operation store", () => {
   it.effect("bounds operation storage keys while preserving tool-name lookup", () =>
     Effect.gen(function* () {
-      const rows = new Map<string, PluginStorageEntry>();
-      const capturedKeys: string[] = [];
-      const storageKey = (collection: string, key: string) => `${collection}\0${key}`;
-      const now = new Date();
-      const makeEntry = <T>(input: {
-        readonly owner: "org" | "user";
-        readonly collection: string;
-        readonly key: string;
-        readonly data: T;
-      }): PluginStorageEntry<T> => ({
-        id: storageKey(input.collection, input.key),
-        owner: input.owner,
-        pluginId: "openapi",
-        collection: input.collection,
-        key: input.key,
-        data: input.data,
-        createdAt: now,
-        updatedAt: now,
-      });
-      const pluginStorage: PluginStorageFacade = {
-        collection: () => ({
-          get: () => Effect.succeed(null),
-          getForOwner: () => Effect.succeed(null),
-          list: () => Effect.succeed([]),
-          put: (input) =>
-            Effect.succeed(
-              makeEntry({
-                owner: input.owner,
-                collection: "unused",
-                key: input.key,
-                data: input.data,
-              }),
-            ),
-          query: () => Effect.succeed([]),
-          count: () => Effect.succeed(0),
-          remove: () => Effect.void,
-        }),
-        get: <T = unknown>(input: { readonly collection: string; readonly key: string }) =>
-          Effect.succeed(
-            (rows.get(storageKey(input.collection, input.key)) as
-              | PluginStorageEntry<T>
-              | undefined) ?? null,
-          ),
-        getForOwner: <T = unknown>(input: { readonly collection: string; readonly key: string }) =>
-          Effect.succeed(
-            (rows.get(storageKey(input.collection, input.key)) as
-              | PluginStorageEntry<T>
-              | undefined) ?? null,
-          ),
-        list: <T = unknown>(input: { readonly collection: string; readonly keyPrefix?: string }) =>
-          Effect.succeed(
-            [...rows.values()].filter(
-              (row) =>
-                row.collection === input.collection &&
-                (input.keyPrefix === undefined || row.key.startsWith(input.keyPrefix)),
-            ) as PluginStorageEntry<T>[],
-          ),
-        put: <T = unknown>(input: {
-          readonly owner: "org" | "user";
-          readonly collection: string;
-          readonly key: string;
-          readonly data: unknown;
-        }) => {
-          const entry = makeEntry<T>({ ...input, data: input.data as T });
-          rows.set(storageKey(input.collection, input.key), entry);
-          return Effect.succeed(entry);
-        },
-        putMany: (input) =>
-          Effect.sync(() => {
-            for (const entry of input.entries) {
-              capturedKeys.push(entry.key);
-              rows.set(
-                storageKey(entry.collection, entry.key),
-                makeEntry({
-                  owner: input.owner,
-                  collection: entry.collection,
-                  key: entry.key,
-                  data: entry.data,
-                }),
-              );
-            }
-          }),
-        remove: (input) =>
-          Effect.sync(() => {
-            rows.delete(storageKey(input.collection, input.key));
-          }),
-        removeMany: (input) =>
-          Effect.sync(() => {
-            for (const entry of input.entries) {
-              rows.delete(storageKey(entry.collection, entry.key));
-            }
-          }),
-      };
-      const blobs: PluginBlobStore = {
-        get: () => Effect.succeed(null),
-        put: () => Effect.void,
-        delete: () => Effect.void,
-        has: () => Effect.succeed(false),
-      };
-      const store = makeDefaultOpenapiStore({
-        owner: { tenant: Tenant.make("tenant"), subject: Subject.make("subject") },
-        blobs,
-        pluginStorage,
-      } satisfies StorageDeps);
+      const { pluginStorage, capturedKeys } = makeInMemoryPluginStorage();
+      const store = makeStore(pluginStorage);
       const toolName = `users.${"veryLongSegment.".repeat(40)}get`;
 
       yield* store.putOperations("microsoft_graph", [
@@ -144,6 +170,73 @@ describe("OpenAPI operation store", () => {
       const operation = yield* store.getOperation("microsoft_graph", toolName);
       expect(operation?.toolName).toBe(toolName);
       expect(operation?.binding.pathTemplate).toBe("/users/{userId}/messages");
+    }),
+  );
+
+  it.effect("listOperations returns only the requested integration's operations", () =>
+    Effect.gen(function* () {
+      const { pluginStorage } = makeInMemoryPluginStorage();
+      const store = makeStore(pluginStorage);
+
+      yield* store.putOperations("github", [
+        { integration: "github", toolName: "issues.list", binding: binding() },
+        { integration: "github", toolName: "repos.get", binding: binding() },
+      ]);
+      yield* store.putOperations("slack", [
+        { integration: "slack", toolName: "chat.post", binding: binding() },
+      ]);
+
+      const github = yield* store.listOperations("github");
+      expect(github.map((op) => op.toolName).sort()).toEqual(["issues.list", "repos.get"]);
+
+      const slack = yield* store.listOperations("slack");
+      expect(slack.map((op) => op.toolName)).toEqual(["chat.post"]);
+    }),
+  );
+
+  it.effect("listOperations narrows the scan by integration via keyPrefixes", () =>
+    Effect.gen(function* () {
+      const { pluginStorage, listInputs } = makeInMemoryPluginStorage();
+      const store = makeStore(pluginStorage);
+
+      yield* store.putOperations("github", [
+        { integration: "github", toolName: "issues.list", binding: binding() },
+      ]);
+      listInputs.length = 0;
+
+      yield* store.listOperations("github");
+
+      // The store must push integration-scoped prefixes (v2 hashed + legacy
+      // plaintext) to the storage layer instead of scanning the whole
+      // collection unprefixed.
+      expect(listInputs).toHaveLength(1);
+      const prefixes = listInputs[0]!.keyPrefixes ?? [];
+      expect(prefixes.some((p) => p.startsWith("op."))).toBe(true);
+      expect(prefixes).toContain("github.");
+      // No bare unprefixed full-collection scan.
+      expect(listInputs[0]!.keyPrefix === undefined && prefixes.length === 0).toBe(false);
+    }),
+  );
+
+  it.effect("listOperations still returns legacy-keyed rows for the integration", () =>
+    Effect.gen(function* () {
+      const { pluginStorage, rows, storageKey } = makeInMemoryPluginStorage();
+      const store = makeStore(pluginStorage);
+
+      // Seed a v2 row through the store, then relocate it under the legacy
+      // plaintext key (`<integration>.<tool>`) to simulate un-migrated data.
+      yield* store.putOperations("github", [
+        { integration: "github", toolName: "legacy.tool", binding: binding() },
+      ]);
+      const v2Entry = [...rows.entries()].find(([, row]) => row.collection === "operation");
+      expect(v2Entry).toBeDefined();
+      const [v2StorageKey, entry] = v2Entry!;
+      rows.delete(v2StorageKey);
+      const legacyKey = "github.legacy.tool";
+      rows.set(storageKey("operation", legacyKey), { ...entry, key: legacyKey, id: legacyKey });
+
+      const ops = yield* store.listOperations("github");
+      expect(ops.map((op) => op.toolName)).toEqual(["legacy.tool"]);
     }),
   );
 });

--- a/packages/plugins/openapi/src/sdk/store.ts
+++ b/packages/plugins/openapi/src/sdk/store.ts
@@ -149,7 +149,16 @@ export const makeDefaultOpenapiStore = ({ pluginStorage, blobs }: StorageDeps): 
 
   const listRows = (integration: string) =>
     pluginStorage
-      .list({ collection: OPERATION_COLLECTION })
+      .list({
+        collection: OPERATION_COLLECTION,
+        // Narrow the scan to this integration at the storage layer instead of
+        // reading every operation row and filtering in JS. Cover both key
+        // schemes: the v2 hashed prefix (`op.<hash(integration)>.`) and the
+        // legacy plaintext prefix (`<integration>.`). The `data.integration`
+        // guard below stays the source of truth (the legacy prefix can
+        // over-match under `LIKE` wildcards / hash-prefix collisions).
+        keyPrefixes: [`${OPERATION_KEY_VERSION}.${stableKeyHash(integration)}.`, `${integration}.`],
+      })
       .pipe(
         Effect.map((rows: readonly PluginStorageEntry[]) =>
           rows.filter((row) => rowToOperation(row)?.integration === integration),


### PR DESCRIPTION
## Summary

Sub-task of #3 (Fix A): cut `/api/tools` server time, the measured long pole on the web UI.

Both issues called out in #4 were verified against the code first, then fixed TDD-style.

### 1. Skip the stale-sync scan on reads (`packages/core/sdk`)

`tools.list` ran `syncStaleConnectionTools` unconditionally: a read of revised integrations plus a connection scan, on every call. Because `config_revised_at` stays set after the first config change, the steady state was two full reads that rebuilt nothing.

Now the read of revised integrations doubles as a **revision watermark**. Once every connection is confirmed synced at the current watermark, that is cached per binding and the connection scan is skipped until a new revision moves the watermark:

- The cache is a `WeakMap` keyed by the underlying DB handle, then by tenant+subject. In production every per-request scoped executor in an isolate shares one long-lived handle, so the cache survives executor rebuilds and the saving lands; each test builds a fresh DB object, so entries are naturally isolated (no cross-test contamination) and GC'd with the handle.
- The watermark is read fresh every call, so a revision on any isolate busts the cache on the next read. Lazy cross-subject convergence stays correct.
- A failed rebuild is left uncached so the next read retries it (best-effort behavior preserved).

Net: steady-state `tools.list` drops from two table reads to one.

### 2. Filter `listOperations` at the storage layer (`packages/plugins/openapi`)

`listOperations` read the whole `operation` collection and filtered by integration in memory. Even passing a key prefix did not reach the DB (the facade applied it in JS after a full scan).

- Added `keyPrefixes` to the plugin-storage list input; the facade now pushes `key starts with` clauses to the storage layer (`LIKE 'prefix%'`).
- The store passes both the v2 hashed prefix (`op.<hash>.`) and the legacy plaintext prefix (`<slug>.`), keeping the `data.integration` JS guard as the source of truth, so un-migrated legacy rows are never dropped and `LIKE` wildcard over-match is harmless.

## Tests

- New: facade `list` with `keyPrefixes` over real SQLite; openapi store `listOperations` (per-integration, legacy-safe, prefix-narrowing); `syncStaleConnectionTools` skip / cache-bust / retry, driven by a per-table query counter.
- Existing cross-subject convergence coverage (`updateSpec propagates to OTHER subjects' personal connections`) exercises the new cache + `starts with` path on real SQLite and stays green.
- `packages/core/sdk` 352/352, `packages/plugins/openapi` 151/151. `format:check`, `lint`, and typecheck clean.

Closes #4
