### PR TITLE
Fix PostHog MCP OAuth DCR

### DIFF
--- a/.changeset/posthog-mcp-oauth-dcr.md
+++ b/.changeset/posthog-mcp-oauth-dcr.md
@@ -1,0 +1,5 @@
+---
+"executor": patch
+---
+
+Fix the PostHog custom MCP OAuth setup flow so Add connection opens PostHog authorization instead of falling back to manual OAuth app registration.

--- a/e2e/selfhost/posthog-mcp-oauth.test.ts
+++ b/e2e/selfhost/posthog-mcp-oauth.test.ts
@@ -1,0 +1,84 @@
+// Selfhost browser regression for the reported PostHog MCP OAuth dead-end. A
+// real Executor instance adds https://mcp.posthog.com/mcp, then starts the
+// connection flow. The product guarantee: clicking Connect opens PostHog's
+// OAuth authorization page through dynamic client registration, not the
+// bring-your-own OAuth app picker with "Automatic setup unavailable".
+import { randomBytes } from "node:crypto";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import { composePluginApi } from "@executor-js/api/server";
+import { deriveMcpNamespace } from "@executor-js/plugin-mcp";
+import { mcpHttpPlugin } from "@executor-js/plugin-mcp/api";
+import { IntegrationSlug } from "@executor-js/sdk/shared";
+
+import { scenario } from "../src/scenario";
+import { Api, Browser, Target } from "../src/services";
+
+const POSTHOG_MCP_URL = "https://mcp.posthog.com/mcp";
+const api = composePluginApi([mcpHttpPlugin()] as const);
+
+scenario(
+  "MCP OAuth · PostHog starts OAuth from Add connection",
+  { timeout: 180_000 },
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const browser = yield* Browser;
+      const { client: makeApiClient } = yield* Api;
+      const identity = yield* target.newIdentity();
+      const client = yield* makeApiClient(api, identity);
+      const displayName = `PostHog MCP ${randomBytes(3).toString("hex")}`;
+      const slug = IntegrationSlug.make(deriveMcpNamespace({ name: displayName }));
+
+      yield* Effect.gen(function* () {
+        yield* browser.session(identity, async ({ page, step }) => {
+          await step("Open the add-MCP flow pointed at PostHog", async () => {
+            const addUrl = new URL("/integrations/add/mcp", target.baseUrl);
+            addUrl.searchParams.set("url", POSTHOG_MCP_URL);
+            await page.goto(addUrl.toString(), { waitUntil: "networkidle" });
+            await page.getByText("How does this server authenticate?").waitFor({ timeout: 30_000 });
+            await page.getByText("Method 1 · Detected").waitFor();
+            await page.getByText("OAuth metadata is discovered from this server").waitFor();
+          });
+
+          await step("Add the PostHog MCP source", async () => {
+            await page.getByPlaceholder("e.g. Linear").fill(displayName);
+            await page.getByRole("button", { name: "Add source" }).click();
+            await page.waitForURL(/\/integrations\/(?!add\b)[^/?]+$/, { timeout: 30_000 });
+            const landedSlug = new URL(page.url()).pathname.split("/").filter(Boolean).at(-1);
+            expect(landedSlug, "the add flow lands on the created integration").toBe(String(slug));
+            await page.getByText("Connections").first().waitFor();
+          });
+
+          await step("Start OAuth from Add connection", async () => {
+            await page.getByRole("button", { name: "Add connection" }).first().click();
+            await page.getByRole("heading", { name: /Add connection/ }).waitFor();
+            await page.getByRole("tab", { name: "OAuth" }).waitFor();
+
+            const popupPromise = page.waitForEvent("popup", { timeout: 30_000 });
+            await page.getByRole("button", { name: "Connect", exact: true }).click();
+            const popup = await popupPromise;
+            await popup.waitForURL(/^https:\/\/oauth\.posthog\.com\/oauth\/authorize\//, {
+              timeout: 30_000,
+            });
+            await popup.waitForLoadState("domcontentloaded", { timeout: 30_000 });
+
+            const authorizeUrl = new URL(popup.url());
+            expect(authorizeUrl.origin, "OAuth opened PostHog's authorization host").toBe(
+              "https://oauth.posthog.com",
+            );
+            expect(authorizeUrl.pathname, "OAuth opened the authorize endpoint").toBe(
+              "/oauth/authorize/",
+            );
+            expect(
+              authorizeUrl.searchParams.get("resource"),
+              "resource targets the MCP endpoint",
+            ).toBe(POSTHOG_MCP_URL);
+            await popup.close();
+          });
+        });
+      }).pipe(Effect.ensuring(client.mcp.removeServer({ params: { slug } }).pipe(Effect.ignore)));
+    }),
+  ),
+);

--- a/packages/react/src/components/add-account-modal.test.ts
+++ b/packages/react/src/components/add-account-modal.test.ts
@@ -14,6 +14,7 @@ import {
   connectionLabel,
   connectionLabelForHost,
   createCredentialPayloadOrigin,
+  dcrClientNameForIntegration,
   DEFAULT_CONNECTION_OWNER,
   mergeCustomMethods,
   runDcrConnect,
@@ -194,6 +195,11 @@ describe("createCredentialPayloadOrigin", () => {
 });
 
 describe("runDcrConnect", () => {
+  it("names dynamically registered OAuth apps as Executor clients", () => {
+    expect(dcrClientNameForIntegration("PostHog MCP")).toBe("Executor for PostHog MCP");
+    expect(dcrClientNameForIntegration("   ")).toBe("Executor");
+  });
+
   it("auto-registers (no picker) then starts: probe → register → start in order", async () => {
     const calls: string[] = [];
     let registerArgs: RegisterArgs | null = null;
@@ -243,6 +249,7 @@ describe("runDcrConnect", () => {
     expect(registerArgs!.tokenUrl).toBe("https://auth.example.com/token");
     expect(registerArgs!.resource).toBe("https://mcp.example.com/mcp");
     expect(registerArgs!.tokenEndpointAuthMethodsSupported).toEqual(["none"]);
+    expect(registerArgs!.clientName).toBe("Executor for Linear MCP");
     expect(registerArgs!.scopes).toEqual(["mcp.read"]);
     expect(registerArgs!.redirectUri).toBe("https://localhost:5394/api/oauth/callback");
     expect(registerArgs!.originIntegration).toBe(TEST_INTEGRATION);

--- a/packages/react/src/components/add-account-modal.tsx
+++ b/packages/react/src/components/add-account-modal.tsx
@@ -481,6 +481,11 @@ type RunDcrConnectInput = {
   readonly integration: IntegrationSlug;
 };
 
+export const dcrClientNameForIntegration = (integrationName: string): string => {
+  const trimmed = integrationName.trim();
+  return trimmed.length > 0 ? `Executor for ${trimmed}` : "Executor";
+};
+
 /**
  * Run the transparent DCR connect sequence: probe → register → start.
  *
@@ -513,7 +518,7 @@ export async function runDcrConnect(
     resource: probe.resource ?? null,
     scopes,
     tokenEndpointAuthMethodsSupported: probe.tokenEndpointAuthMethodsSupported,
-    clientName: input.integrationName,
+    clientName: dcrClientNameForIntegration(input.integrationName),
     redirectUri: input.redirectUri,
     originIntegration: input.integration,
   });


### PR DESCRIPTION
## Summary

- Prefix dynamically registered OAuth client names with `Executor for ...` instead of sending the integration name verbatim.
- Keep a safe fallback client name of `Executor` when the integration name is blank.
- Add unit coverage and a selfhost e2e repro for the PostHog MCP add-connection OAuth flow.

## Root Cause

PostHog rejects dynamic client registration when `client_name` starts with `posthog`. The add-connection flow used the integration display name directly, so a `PostHog MCP` source failed registration and fell back to the manual OAuth app picker with automatic setup unavailable.

## Watch It

![PostHog MCP OAuth e2e recording](https://raw.githubusercontent.com/RhysSullivan/executor/e2e-media/mcp-oauth-posthog-starts-oauth-from-add-connection-dcf1efb5.gif)

The recording shows adding `https://mcp.posthog.com/mcp`, clicking Add connection, and opening PostHog OAuth with `resource=https://mcp.posthog.com/mcp`.

## Validation

- `PATH=/Users/rhyssullivan/.bun/bin:$PATH ../../node_modules/.bin/vitest run src/components/add-account-modal.test.ts` from `packages/react`, passed 21 tests.
- `PATH=/Users/rhyssullivan/.bun/bin:$PATH ../node_modules/.bin/vitest run --project selfhost selfhost/posthog-mcp-oauth.test.ts` from `e2e`, passed.
- `PATH=/Users/rhyssullivan/.bun/bin:$PATH bunx oxfmt --check packages/react/src/components/add-account-modal.tsx packages/react/src/components/add-account-modal.test.ts e2e/selfhost/posthog-mcp-oauth.test.ts`, passed.

Broad gates were not run.
