### PR TITLE
Fix OAuth callback org scope

### DIFF
--- a/.changeset/oauth-callback-org-scope.md
+++ b/.changeset/oauth-callback-org-scope.md
@@ -1,0 +1,5 @@
+---
+"executor": patch
+---
+
+Fix OAuth callbacks in cloud so they preserve the URL-selected organization when the session cookie points at another org.

--- a/apps/cloud/src/auth/organization.ts
+++ b/apps/cloud/src/auth/organization.ts
@@ -12,6 +12,7 @@
 // ---------------------------------------------------------------------------
 
 import { Effect } from "effect";
+import { EXECUTOR_ORG_SELECTOR_HEADER } from "@executor-js/sdk/shared";
 
 import { UserStoreService } from "./context";
 import { WorkOSClient } from "./workos";
@@ -96,7 +97,7 @@ export const authorizeOrganization = (userId: string, organizationId: string) =>
 // silently re-scopes the other. Scoping per-request from the URL makes each
 // tab independent.
 
-export const ORG_SELECTOR_HEADER = "x-executor-organization";
+export const ORG_SELECTOR_HEADER = EXECUTOR_ORG_SELECTOR_HEADER;
 
 /** The URL-pinned org selector for a request, or `null` to fall back to the session. */
 export const orgSelectorFromRequest = (request: Request): string | null =>

--- a/apps/cloud/src/start.ts
+++ b/apps/cloud/src/start.ts
@@ -1,9 +1,11 @@
 import { createMiddleware, createStart } from "@tanstack/react-start";
+import { OAUTH_CALLBACK_ORG_QUERY_PARAM } from "@executor-js/sdk/shared";
 
 import { cloudApiHandler } from "./app";
 import { isAppOwnedPath } from "./app-paths";
 import { authGateMiddleware } from "./auth/ssr-gate";
 import { parseCookie } from "./auth/cookies";
+import { ORG_SELECTOR_HEADER } from "./auth/organization";
 import { loginPath } from "./auth/return-to";
 import { prepareMcpOrgScope } from "./mcp/mount";
 import {
@@ -39,6 +41,14 @@ const getApp = () => (app ??= cloudApiHandler());
 const SESSION_COOKIE = "wos-session";
 const OAUTH_CALLBACK_PATH = "/api/oauth/callback";
 
+const oauthCallbackOrgScopedRequest = (request: Request): Request => {
+  const orgSelector = new URL(request.url).searchParams.get(OAUTH_CALLBACK_ORG_QUERY_PARAM);
+  if (!orgSelector) return request;
+  const headers = new Headers(request.headers);
+  headers.set(ORG_SELECTOR_HEADER, orgSelector);
+  return new Request(request, { headers });
+};
+
 const oauthCallbackSignInMiddleware = createMiddleware({ type: "request" }).server(
   ({ pathname, request, next }) => {
     if (
@@ -66,7 +76,11 @@ const oauthCallbackSignInMiddleware = createMiddleware({ type: "request" }).serv
 // else, including `/api/*`).
 const appRequestMiddleware = createMiddleware({ type: "request" }).server(
   ({ pathname, request, next }) => {
-    if (isAppOwnedPath(pathname)) return getApp().handler(prepareMcpOrgScope(request));
+    if (isAppOwnedPath(pathname)) {
+      const scopedRequest =
+        pathname === OAUTH_CALLBACK_PATH ? oauthCallbackOrgScopedRequest(request) : request;
+      return getApp().handler(prepareMcpOrgScope(scopedRequest));
+    }
     return next();
   },
 );

--- a/e2e/cloud/oauth-callback-org-scope.test.ts
+++ b/e2e/cloud/oauth-callback-org-scope.test.ts
@@ -1,0 +1,214 @@
+// Cloud-only: OAuth callbacks must preserve the URL-selected organization.
+//
+// A browser session cookie can be pinned to org B while a tab is operating in
+// org A via the URL org selector. OAuth redirects leave the console route and
+// land on /api/oauth/callback, so the callback URL itself must carry the same
+// org selector that was present when oauth.start created the session.
+import { randomBytes } from "node:crypto";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import { composePluginApi } from "@executor-js/api/server";
+import { openApiHttpPlugin } from "@executor-js/plugin-openapi/api";
+import {
+  AuthTemplateSlug,
+  ConnectionName,
+  EXECUTOR_ORG_SELECTOR_HEADER,
+  IntegrationSlug,
+  OAUTH_CALLBACK_ORG_QUERY_PARAM,
+  OAuthClientSlug,
+} from "@executor-js/sdk/shared";
+import { serveOAuthTestServer } from "@executor-js/sdk/testing";
+
+import { scenario } from "../src/scenario";
+import { Api, Browser, Target } from "../src/services";
+import type { Identity } from "../src/target";
+
+const api = composePluginApi([openApiHttpPlugin()] as const);
+
+const unique = (prefix: string) => `${prefix}_${randomBytes(4).toString("hex")}`;
+
+const cookiePair = (response: Response, name: string): string | undefined => {
+  for (const header of response.headers.getSetCookie?.() ?? []) {
+    if (header.startsWith(`${name}=`)) return header.split(";")[0];
+  }
+  return undefined;
+};
+
+const cookieValue = (pair: string): string => {
+  const [, value] = pair.split(/=(.*)/s);
+  if (!value) throw new Error("cookie pair has no value");
+  return value;
+};
+
+const cookieOf = (identity: Identity): string => identity.headers?.cookie ?? "";
+
+const originHeaders = (baseUrl: string) => ({ origin: new URL(baseUrl).origin });
+
+const activeOrg = (baseUrl: string, cookie: string) =>
+  Effect.promise(async () => {
+    const response = await fetch(new URL("/api/auth/me", baseUrl), {
+      headers: { cookie },
+    });
+    if (!response.ok) throw new Error(`/api/auth/me failed (${response.status})`);
+    const body = (await response.json()) as {
+      organization: { id: string; name: string; slug: string } | null;
+    };
+    if (!body.organization) throw new Error("identity has no active organization");
+    return body.organization;
+  });
+
+const createOrganization = (baseUrl: string, cookie: string, name: string) =>
+  Effect.promise(async () => {
+    const response = await fetch(new URL("/api/auth/create-organization", baseUrl), {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        cookie,
+        ...originHeaders(baseUrl),
+      },
+      body: JSON.stringify({ name }),
+    });
+    if (!response.ok) {
+      throw new Error(`/api/auth/create-organization failed (${response.status})`);
+    }
+    const session = cookiePair(response, "wos-session");
+    if (!session) throw new Error("create organization did not refresh the session");
+    const org = (await response.json()) as { id: string; name: string; slug: string };
+    return { org, session };
+  });
+
+const oauthIntegrationSpec = (oauth: {
+  readonly authorizationEndpoint: string;
+  readonly tokenEndpoint: string;
+}) =>
+  ({
+    spec: {
+      kind: "blob" as const,
+      value: JSON.stringify({
+        openapi: "3.0.3",
+        info: { title: "OAuth org scope", version: "1.0.0" },
+        paths: {
+          "/me": {
+            get: {
+              operationId: "getMe",
+              responses: { "200": { description: "the caller" } },
+            },
+          },
+        },
+      }),
+    },
+    baseUrl: "http://127.0.0.1:59999",
+    authenticationTemplate: [
+      {
+        slug: "oauth",
+        kind: "oauth2" as const,
+        authorizationUrl: oauth.authorizationEndpoint,
+        tokenUrl: oauth.tokenEndpoint,
+        scopes: ["read"],
+      },
+    ],
+  }) as const;
+
+scenario(
+  "OAuth callback · URL-scoped org survives a callback while the session cookie points elsewhere",
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const { client: makeApiClient } = yield* Api;
+    const browser = yield* Browser;
+    const oauth = yield* serveOAuthTestServer();
+
+    const identity = yield* target.newIdentity();
+    const sessionA = cookieOf(identity);
+    const orgA = yield* activeOrg(target.baseUrl, sessionA);
+
+    const { org: orgB, session: sessionB } = yield* createOrganization(
+      target.baseUrl,
+      sessionA,
+      `OAuth Callback Org B ${randomBytes(3).toString("hex")}`,
+    );
+    expect(orgB.slug, "the test has two distinct org URLs").not.toBe(orgA.slug);
+
+    const scopedToOrgAWithCookieB: Identity = {
+      ...identity,
+      headers: {
+        cookie: sessionB,
+        [EXECUTOR_ORG_SELECTOR_HEADER]: orgA.slug,
+      },
+      cookies: [{ name: "wos-session", value: cookieValue(sessionB) }],
+    };
+
+    const client = yield* makeApiClient(api, scopedToOrgAWithCookieB);
+
+    const integration = IntegrationSlug.make(unique("oauthscope"));
+    yield* client.openapi.addSpec({
+      payload: { ...oauthIntegrationSpec(oauth), slug: integration },
+    });
+
+    const clientSlug = OAuthClientSlug.make(unique("oauthc"));
+    yield* client.oauth.createClient({
+      payload: {
+        owner: "org",
+        slug: clientSlug,
+        authorizationUrl: oauth.authorizationEndpoint,
+        tokenUrl: oauth.tokenEndpoint,
+        grant: "authorization_code",
+        clientId: "test-client",
+        clientSecret: "test-secret",
+      },
+    });
+
+    const started = yield* client.oauth.start({
+      payload: {
+        client: clientSlug,
+        clientOwner: "org",
+        owner: "org",
+        name: ConnectionName.make("main"),
+        integration,
+        template: AuthTemplateSlug.make("oauth"),
+      },
+    });
+    expect(started.status, "oauth.start begins at the provider").toBe("redirect");
+    const authorizationUrl = started.status === "redirect" ? started.authorizationUrl : "";
+
+    const authorize = yield* Effect.promise(() => fetch(authorizationUrl, { redirect: "manual" }));
+    expect(authorize.status, "the provider asks the user to log in").toBe(302);
+    const consent = yield* Effect.promise(() =>
+      fetch(authorize.headers.get("location") ?? "", {
+        method: "POST",
+        redirect: "manual",
+        headers: {
+          authorization: `Basic ${Buffer.from("alice:password").toString("base64")}`,
+        },
+      }),
+    );
+    expect(consent.status, "provider consent redirects back to Executor").toBe(302);
+    const callback = new URL(consent.headers.get("location") ?? "");
+    const callbackPath = `${callback.pathname}${callback.search}`;
+
+    yield* browser.session(scopedToOrgAWithCookieB, async ({ page, step }) => {
+      await step(
+        "Provider returns to the OAuth callback while the cookie is pinned to org B",
+        async () => {
+          const response = await page.goto(callbackPath, { waitUntil: "networkidle" });
+          expect(response?.status(), "the callback renders its popup result page").toBe(200);
+        },
+      );
+
+      const body = (await page.locator("body").textContent())?.trim() ?? "";
+      expect(
+        body,
+        "the callback completes in the org where oauth.start stored the session",
+      ).toContain("Connected");
+      expect(body, "the callback did not fall through to the cookie-pinned org").not.toContain(
+        "OAuth session expired or not found",
+      );
+    });
+
+    expect(
+      callback.searchParams.get(OAUTH_CALLBACK_ORG_QUERY_PARAM),
+      "the provider callback URL carries the original org selector",
+    ).toBe(orgA.slug);
+  }).pipe(Effect.scoped),
+);

--- a/e2e/cloud/oauth-callback-org-scope.test.ts
+++ b/e2e/cloud/oauth-callback-org-scope.test.ts
@@ -8,12 +8,10 @@ import { randomBytes } from "node:crypto";
 
 import { expect } from "@effect/vitest";
 import { Effect } from "effect";
+import type { Page } from "playwright";
 import { composePluginApi } from "@executor-js/api/server";
 import { openApiHttpPlugin } from "@executor-js/plugin-openapi/api";
 import {
-  AuthTemplateSlug,
-  ConnectionName,
-  EXECUTOR_ORG_SELECTOR_HEADER,
   IntegrationSlug,
   OAUTH_CALLBACK_ORG_QUERY_PARAM,
   OAuthClientSlug,
@@ -44,6 +42,68 @@ const cookieValue = (pair: string): string => {
 const cookieOf = (identity: Identity): string => identity.headers?.cookie ?? "";
 
 const originHeaders = (baseUrl: string) => ({ origin: new URL(baseUrl).origin });
+
+const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+const setWorkosSessionCookie = async (page: Page, baseUrl: string, cookie: string) => {
+  await page.context().addCookies([
+    {
+      name: "wos-session",
+      value: cookieValue(cookie),
+      url: baseUrl,
+    },
+  ]);
+};
+
+const expectOrgShell = async (
+  page: Page,
+  org: { readonly name: string; readonly slug: string },
+) => {
+  await page.waitForURL(
+    (url) => url.pathname === `/${org.slug}` || url.pathname === `/${org.slug}/`,
+    {
+      timeout: 30_000,
+    },
+  );
+  await page.getByRole("button", { name: new RegExp(escapeRegExp(org.name)) }).waitFor();
+  await page.getByRole("heading", { name: "Integrations" }).waitFor();
+};
+
+const installSameWindowOAuthPopup = async (page: Page) => {
+  await page.addInitScript(() => {
+    window.open = () =>
+      ({
+        get closed() {
+          return false;
+        },
+        close() {},
+        focus() {},
+        location: {
+          get href() {
+            return window.location.href;
+          },
+          set href(value: string) {
+            window.location.assign(String(value));
+          },
+        },
+      }) as Window;
+  });
+};
+
+const submitProviderLoginFromPage = async (page: Page): Promise<string> =>
+  fetch(page.url(), {
+    method: "POST",
+    redirect: "manual",
+    headers: {
+      authorization: `Basic ${Buffer.from("alice:password").toString("base64")}`,
+    },
+  }).then((response) => {
+    const location = response.headers.get("location");
+    if (response.status !== 302 || !location) {
+      throw new Error(`provider did not return callback location (${response.status})`);
+    }
+    return new URL(location, page.url()).toString();
+  });
 
 const activeOrg = (baseUrl: string, cookie: string) =>
   Effect.promise(async () => {
@@ -130,16 +190,7 @@ scenario(
     );
     expect(orgB.slug, "the test has two distinct org URLs").not.toBe(orgA.slug);
 
-    const scopedToOrgAWithCookieB: Identity = {
-      ...identity,
-      headers: {
-        cookie: sessionB,
-        [EXECUTOR_ORG_SELECTOR_HEADER]: orgA.slug,
-      },
-      cookies: [{ name: "wos-session", value: cookieValue(sessionB) }],
-    };
-
-    const client = yield* makeApiClient(api, scopedToOrgAWithCookieB);
+    const client = yield* makeApiClient(api, identity);
 
     const integration = IntegrationSlug.make(unique("oauthscope"));
     yield* client.openapi.addSpec({
@@ -159,42 +210,42 @@ scenario(
       },
     });
 
-    const started = yield* client.oauth.start({
-      payload: {
-        client: clientSlug,
-        clientOwner: "org",
-        owner: "org",
-        name: ConnectionName.make("main"),
-        integration,
-        template: AuthTemplateSlug.make("oauth"),
-      },
-    });
-    expect(started.status, "oauth.start begins at the provider").toBe("redirect");
-    const authorizationUrl = started.status === "redirect" ? started.authorizationUrl : "";
+    let callback = new URL("http://invalid.example");
+    yield* browser.session(identity, async ({ page, step }) => {
+      await installSameWindowOAuthPopup(page);
 
-    const authorize = yield* Effect.promise(() => fetch(authorizationUrl, { redirect: "manual" }));
-    expect(authorize.status, "the provider asks the user to log in").toBe(302);
-    const consent = yield* Effect.promise(() =>
-      fetch(authorize.headers.get("location") ?? "", {
-        method: "POST",
-        redirect: "manual",
-        headers: {
-          authorization: `Basic ${Buffer.from("alice:password").toString("base64")}`,
-        },
-      }),
-    );
-    expect(consent.status, "provider consent redirects back to Executor").toBe(302);
-    const callback = new URL(consent.headers.get("location") ?? "");
-    const callbackPath = `${callback.pathname}${callback.search}`;
+      await step("Land in the original organization", async () => {
+        await page.goto(`/${orgA.slug}`, { waitUntil: "networkidle" });
+        await expectOrgShell(page, orgA);
+      });
 
-    yield* browser.session(scopedToOrgAWithCookieB, async ({ page, step }) => {
-      await step(
-        "Provider returns to the OAuth callback while the cookie is pinned to org B",
-        async () => {
-          const response = await page.goto(callbackPath, { waitUntil: "networkidle" });
-          expect(response?.status(), "the callback renders its popup result page").toBe(200);
-        },
-      );
+      await step("The browser session is switched to another organization", async () => {
+        await setWorkosSessionCookie(page, target.baseUrl, sessionB);
+        await page.goto(`/${orgB.slug}`, { waitUntil: "networkidle" });
+        await expectOrgShell(page, orgB);
+      });
+
+      await step("Start OAuth from the original organization's add-connection flow", async () => {
+        await page.goto(`/${orgA.slug}/integrations/${String(integration)}?addAccount=1`, {
+          waitUntil: "networkidle",
+        });
+        await page.getByRole("heading", { name: /Add connection/ }).waitFor({
+          timeout: 30_000,
+        });
+        await page.getByRole("button", { name: "Connect with OAuth" }).click();
+        await page.waitForURL(
+          (url) => url.origin === new URL(oauth.issuerUrl).origin && url.pathname === "/login",
+          { timeout: 30_000 },
+        );
+        await page.getByText("OAuth test login").waitFor();
+      });
+
+      await step("The provider returns to the OAuth callback", async () => {
+        const callbackUrl = await submitProviderLoginFromPage(page);
+        callback = new URL(callbackUrl);
+        const response = await page.goto(callbackUrl, { waitUntil: "networkidle" });
+        expect(response?.status(), "the callback renders its popup result page").toBe(200);
+      });
 
       const body = (await page.locator("body").textContent())?.trim() ?? "";
       expect(

--- a/e2e/scripts/pr-media.ts
+++ b/e2e/scripts/pr-media.ts
@@ -16,13 +16,17 @@
 //   *.png          run screenshot, uploaded as-is
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { existsSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, join, resolve } from "node:path";
+
+import { chromium } from "playwright";
 
 const MEDIA_BRANCH = "e2e-media";
 // Above this GitHub's image proxy stops rendering the gif inline.
 const RENDER_LIMIT_BYTES = 10 * 1024 * 1024;
+const GIF_WIDTH = 960;
+const CHROME_HEIGHT = 40;
 
 const run = (command: string, args: ReadonlyArray<string>): string =>
   execFileSync(command, [...args], {
@@ -36,6 +40,18 @@ interface Artifact {
   readonly path: string;
   readonly label: string;
   readonly slug: string;
+  readonly runDir?: string;
+}
+
+interface Timeline {
+  readonly anchors: { readonly browser?: number };
+  readonly nav?: ReadonlyArray<{ readonly at: number; readonly url: string }>;
+}
+
+interface UrlSegment {
+  readonly from: number;
+  readonly to: number;
+  readonly url: string;
 }
 
 /** A run dir resolves to its recording; a file stands for itself. */
@@ -66,20 +82,206 @@ const resolveArtifact = (input: string): Artifact => {
   } catch {
     // skipped/partial runs still have a recording worth showing
   }
-  return { path: recording, label, slug: basename(path) };
+  return { path: recording, label, slug: basename(path), runDir: path };
 };
 
-const toGif = (artifact: Artifact): string => {
+const videoDuration = (file: string): number =>
+  Number(
+    run("ffprobe", [
+      ...["-v", "quiet", "-show_entries", "format=duration"],
+      ...["-of", "csv=p=0", file],
+    ]).trim(),
+  );
+
+const readTimeline = (artifact: Artifact): Timeline | null => {
+  if (!artifact.runDir) return null;
+  const timelinePath = join(artifact.runDir, "timeline.json");
+  if (!existsSync(timelinePath)) return null;
+  return JSON.parse(readFileSync(timelinePath, "utf8")) as Timeline;
+};
+
+const urlSegments = (artifact: Artifact, duration: number): ReadonlyArray<UrlSegment> => {
+  if (basename(artifact.path) !== "session.mp4") return [];
+  const timeline = readTimeline(artifact);
+  const browserAnchor = timeline?.anchors.browser;
+  if (!timeline || browserAnchor === undefined) return [];
+
+  const nav = [...(timeline.nav ?? [])]
+    .map((entry) => ({
+      at: Math.max(0, (entry.at - browserAnchor) / 1000),
+      url: entry.url,
+    }))
+    .filter((entry) => entry.at <= duration)
+    .sort((a, b) => a.at - b.at);
+
+  if (nav.length === 0) return [{ from: 0, to: duration, url: "about:blank" }];
+  if ((nav[0]?.at ?? 0) <= 0.25) nav[0] = { ...nav[0], at: 0 };
+
+  const segments: UrlSegment[] = [];
+  let cursor = 0;
+  let currentUrl = "about:blank";
+  for (const entry of nav) {
+    if (entry.at > cursor) segments.push({ from: cursor, to: entry.at, url: currentUrl });
+    currentUrl = entry.url;
+    cursor = entry.at;
+  }
+  segments.push({ from: cursor, to: duration, url: currentUrl });
+
+  return segments
+    .filter((segment) => segment.to - segment.from > 0.01)
+    .reduce<UrlSegment[]>((merged, segment) => {
+      const previous = merged.at(-1);
+      if (previous?.url === segment.url && Math.abs(previous.to - segment.from) < 0.01) {
+        merged[merged.length - 1] = { ...previous, to: segment.to };
+      } else {
+        merged.push(segment);
+      }
+      return merged;
+    }, []);
+};
+
+const htmlEscape = (value: string): string =>
+  value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+
+const renderUrlBars = async (
+  segments: ReadonlyArray<UrlSegment>,
+  workDir: string,
+): Promise<ReadonlyArray<{ readonly path: string; readonly segment: UrlSegment }>> => {
+  const browser = await chromium.launch();
+  try {
+    const page = await browser.newPage({
+      viewport: { width: GIF_WIDTH, height: CHROME_HEIGHT },
+      deviceScaleFactor: 1,
+    });
+    const bars: Array<{ path: string; segment: UrlSegment }> = [];
+    for (const [index, segment] of segments.entries()) {
+      const displayUrl = segment.url.replace(/^https?:\/\//, "") || "about:blank";
+      await page.setContent(`<!doctype html>
+<html>
+  <head>
+    <style>
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        width: ${GIF_WIDTH}px;
+        height: ${CHROME_HEIGHT}px;
+        background: #111318;
+        color: #d7dde8;
+        font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+      .chrome {
+        height: ${CHROME_HEIGHT}px;
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 7px 12px;
+        border-bottom: 1px solid #272c36;
+      }
+      .lights {
+        display: flex;
+        gap: 6px;
+        flex: 0 0 auto;
+      }
+      .lights i {
+        width: 10px;
+        height: 10px;
+        border-radius: 50%;
+        display: block;
+      }
+      .lights i:nth-child(1) { background: #ff5f56; }
+      .lights i:nth-child(2) { background: #ffbd2e; }
+      .lights i:nth-child(3) { background: #27c93f; }
+      .urlbar {
+        min-width: 0;
+        flex: 1 1 auto;
+        height: 26px;
+        display: flex;
+        align-items: center;
+        border: 1px solid #313846;
+        border-radius: 6px;
+        background: #0b0d12;
+        padding: 0 10px;
+        color: #d7dde8;
+        font-size: 12px;
+        line-height: 1;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .lock {
+        color: #8b95a7;
+        margin-right: 7px;
+        flex: 0 0 auto;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="chrome">
+      <span class="lights"><i></i><i></i><i></i></span>
+      <div class="urlbar"><span class="lock">url</span>${htmlEscape(displayUrl)}</div>
+    </div>
+  </body>
+</html>`);
+      const path = join(workDir, `urlbar-${index}.png`);
+      await page.screenshot({ path, animations: "disabled" });
+      bars.push({ path, segment });
+    }
+    return bars;
+  } finally {
+    await browser.close();
+  }
+};
+
+const toGif = async (artifact: Artifact): Promise<string> => {
   if (artifact.path.endsWith(".png")) return artifact.path;
   const out = join(tmpdir(), `${artifact.slug}.gif`);
   if (artifact.path.endsWith(".cast")) {
     run("agg", ["--idle-time-limit", "2", "--font-size", "14", artifact.path, out]);
   } else {
     // Two-pass palette keeps UI text crisp at a size GitHub will render.
-    const filter =
-      "fps=8,scale=960:-2:flags=lanczos,split[a][b];" +
-      "[a]palettegen=max_colors=128[p];[b][p]paletteuse=dither=bayer:bayer_scale=5";
-    run("ffmpeg", ["-y", "-loglevel", "error", "-i", artifact.path, "-vf", filter, out]);
+    const duration = videoDuration(artifact.path);
+    const segments = urlSegments(artifact, duration);
+    if (segments.length > 0) {
+      const workDir = mkdtempSync(join(tmpdir(), "pr-media-urlbar-"));
+      try {
+        const bars = await renderUrlBars(segments, workDir);
+        const scaled =
+          `[0:v]fps=8,scale=${GIF_WIDTH}:-2:flags=lanczos,` +
+          `pad=iw:ih+${CHROME_HEIGHT}:0:${CHROME_HEIGHT}:color=0x111318,setsar=1[v0]`;
+        const overlays = bars.map(({ segment }, index) => {
+          const input = index + 1;
+          const previous = `v${index}`;
+          const next = `v${index + 1}`;
+          const from = segment.from.toFixed(3);
+          const to = segment.to.toFixed(3);
+          return `[${previous}][${input}:v]overlay=0:0:enable='between(t,${from},${to})'[${next}]`;
+        });
+        const finalVideo = `v${bars.length}`;
+        const palette =
+          `[${finalVideo}]split[a][b];` +
+          "[a]palettegen=max_colors=128[p];[b][p]paletteuse=dither=bayer:bayer_scale=5[out]";
+        run("ffmpeg", [
+          "-y",
+          "-loglevel",
+          "error",
+          "-i",
+          artifact.path,
+          ...bars.flatMap((bar) => ["-i", bar.path]),
+          "-filter_complex",
+          [scaled, ...overlays, palette].join(";"),
+          "-map",
+          "[out]",
+          out,
+        ]);
+      } finally {
+        rmSync(workDir, { recursive: true, force: true });
+      }
+    } else {
+      const filter =
+        `fps=8,scale=${GIF_WIDTH}:-2:flags=lanczos,split[a][b];` +
+        "[a]palettegen=max_colors=128[p];[b][p]paletteuse=dither=bayer:bayer_scale=5";
+      run("ffmpeg", ["-y", "-loglevel", "error", "-i", artifact.path, "-vf", filter, out]);
+    }
   }
   return out;
 };
@@ -152,7 +354,7 @@ const repo = run("gh", ["repo", "view", "--json", "nameWithOwner", "-q", ".nameW
 const blocks: Array<string> = [];
 for (const input of inputs) {
   const artifact = resolveArtifact(input);
-  const gif = toGif(artifact);
+  const gif = await toGif(artifact);
   const size = statSync(gif).size;
   if (size > RENDER_LIMIT_BYTES) {
     console.error(

--- a/packages/core/api/src/server/oauth-origin.test.ts
+++ b/packages/core/api/src/server/oauth-origin.test.ts
@@ -48,4 +48,14 @@ describe("OAuth web origin resolution", () => {
       }),
     ).toBe("https://executor.sh/api/oauth/callback");
   });
+
+  it("carries the URL org selector in OAuth redirect URLs", () => {
+    expect(
+      buildOAuthRedirectUri({
+        webBaseUrl: "https://executor.sh",
+        oauthCallbackPath: "/api/oauth/callback",
+        orgSlug: "acme",
+      }),
+    ).toBe("https://executor.sh/api/oauth/callback?executor_org=acme");
+  });
 });

--- a/packages/core/api/src/server/scoped-executor.ts
+++ b/packages/core/api/src/server/scoped-executor.ts
@@ -35,6 +35,7 @@ import { Context, Effect, Option } from "effect";
 
 import {
   createExecutor,
+  OAUTH_CALLBACK_ORG_QUERY_PARAM,
   Subject,
   Tenant,
   type AnyPlugin,
@@ -151,8 +152,14 @@ export const resolveScopedWebBaseUrl = (input: {
 export const buildOAuthRedirectUri = (input: {
   readonly webBaseUrl: string | undefined;
   readonly oauthCallbackPath: string;
-}): string | undefined =>
-  input.webBaseUrl ? new URL(input.oauthCallbackPath, input.webBaseUrl).toString() : undefined;
+  readonly orgSlug?: string | null;
+}): string | undefined => {
+  if (!input.webBaseUrl) return undefined;
+  const url = new URL(input.oauthCallbackPath, input.webBaseUrl);
+  const slug = input.orgSlug?.trim();
+  if (slug) url.searchParams.set(OAUTH_CALLBACK_ORG_QUERY_PARAM, slug);
+  return url.toString();
+};
 
 // ---------------------------------------------------------------------------
 // PluginsProvider seam — the per-host (and possibly per-request) plugin array.
@@ -238,6 +245,7 @@ export const makeScopedExecutor = <
     const redirectUri = buildOAuthRedirectUri({
       webBaseUrl,
       oauthCallbackPath: config.oauthCallbackPath,
+      orgSlug,
     });
 
     const plugins = pluginsFactory();

--- a/packages/core/sdk/src/index.ts
+++ b/packages/core/sdk/src/index.ts
@@ -214,7 +214,11 @@ export {
 } from "./plugin-storage";
 
 // OAuth (v2 contracts).
-export { OAUTH2_PROVIDER_KEY, OAUTH2_SESSION_TTL_MS } from "./oauth";
+export {
+  OAUTH2_PROVIDER_KEY,
+  OAUTH2_SESSION_TTL_MS,
+  OAUTH_CALLBACK_ORG_QUERY_PARAM,
+} from "./oauth";
 export {
   OAuthStartError,
   OAuthCompleteError,
@@ -243,6 +247,7 @@ export {
 export {
   DEFAULT_EXECUTOR_SERVER_ORIGIN,
   DEFAULT_EXECUTOR_SERVER_USERNAME,
+  EXECUTOR_ORG_SELECTOR_HEADER,
   apiBaseUrlForServerOrigin,
   getExecutorServerAuthorizationHeader,
   normalizeExecutorServerConnection,

--- a/packages/core/sdk/src/oauth.ts
+++ b/packages/core/sdk/src/oauth.ts
@@ -35,3 +35,6 @@ export const OAUTH2_PROVIDER_KEY = "oauth2" as const;
 
 /** How long a pending authorization stays redeemable. */
 export const OAUTH2_SESSION_TTL_MS = 15 * 60 * 1000;
+
+/** Query parameter used to carry the URL-selected org through OAuth callbacks. */
+export const OAUTH_CALLBACK_ORG_QUERY_PARAM = "executor_org" as const;

--- a/packages/core/sdk/src/server-connection.ts
+++ b/packages/core/sdk/src/server-connection.ts
@@ -2,6 +2,7 @@ import { Option, Schema } from "effect";
 
 export const DEFAULT_EXECUTOR_SERVER_ORIGIN = "http://127.0.0.1:4000";
 export const DEFAULT_EXECUTOR_SERVER_USERNAME = "executor";
+export const EXECUTOR_ORG_SELECTOR_HEADER = "x-executor-organization";
 
 export type ExecutorServerConnectionKind = "http" | "desktop-sidecar";
 export type ExecutorLocalServerKind = "cli-daemon" | "desktop-sidecar" | "foreground";

--- a/packages/core/sdk/src/shared.ts
+++ b/packages/core/sdk/src/shared.ts
@@ -99,6 +99,8 @@ export type { ToolPolicyAction } from "./core-schema";
 // Schema-side views + onboarding autodetect.
 export { ToolSchemaView, IntegrationDetectionResult } from "./types";
 
+export { OAUTH_CALLBACK_ORG_QUERY_PARAM } from "./oauth";
+
 // OAuth wire contracts (data + tagged errors; the flow impl is server-only).
 export {
   type OAuthGrant,
@@ -127,6 +129,7 @@ export { InternalError } from "./api-errors";
 export {
   DEFAULT_EXECUTOR_SERVER_ORIGIN,
   DEFAULT_EXECUTOR_SERVER_USERNAME,
+  EXECUTOR_ORG_SELECTOR_HEADER,
   apiBaseUrlForServerOrigin,
   getExecutorServerAuthorizationHeader,
   normalizeExecutorServerConnection,

--- a/packages/react/src/api/server-connection.tsx
+++ b/packages/react/src/api/server-connection.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { isValidOrgSlug } from "@executor-js/api";
 import {
   DEFAULT_EXECUTOR_SERVER_ORIGIN,
+  EXECUTOR_ORG_SELECTOR_HEADER,
   getExecutorServerAuthorizationHeader as getAuthorizationHeaderForConnection,
   normalizeExecutorServerConnection,
   originFromApiBaseUrl,
@@ -11,6 +12,7 @@ import {
 
 export {
   DEFAULT_EXECUTOR_SERVER_ORIGIN,
+  EXECUTOR_ORG_SELECTOR_HEADER,
   apiBaseUrlForServerOrigin,
   normalizeExecutorServerConnection,
   normalizeExecutorServerOrigin,
@@ -87,7 +89,7 @@ let activeConnection = resolveInitialExecutorServerConnection();
 // `/login`, …) are NOT valid slugs, so a bare path sends no header and the
 // server falls back to the session org. Hosts without slugs (self-host,
 // cloudflare) never produce one either.
-export const EXECUTOR_ORG_HEADER = "x-executor-organization";
+export const EXECUTOR_ORG_HEADER = EXECUTOR_ORG_SELECTOR_HEADER;
 
 export const getActiveOrgSlug = (): string | null => {
   const pathname = globalThis.window?.location?.pathname;

--- a/packages/react/src/plugins/oauth-sign-in.test.ts
+++ b/packages/react/src/plugins/oauth-sign-in.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it } from "@effect/vitest";
+import { OAUTH_CALLBACK_ORG_QUERY_PARAM } from "@executor-js/sdk/shared";
+
+import { oauthCallbackUrl } from "./oauth-sign-in";
+
+const originalWindow = globalThis.window;
+
+const setLocation = (href: string): void => {
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: { location: new URL(href) },
+  });
+};
+
+afterEach(() => {
+  if (originalWindow) {
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: originalWindow,
+    });
+    return;
+  }
+  Reflect.deleteProperty(globalThis, "window");
+});
+
+describe("oauthCallbackUrl", () => {
+  it("returns a relative callback path outside the browser", () => {
+    Reflect.deleteProperty(globalThis, "window");
+    expect(oauthCallbackUrl()).toBe("/api/oauth/callback");
+  });
+
+  it("carries the active org slug from the console URL", () => {
+    setLocation("https://executor.sh/acme/integrations/posthog");
+
+    const url = new URL(oauthCallbackUrl());
+
+    expect(url.toString()).toBe("https://executor.sh/api/oauth/callback?executor_org=acme");
+    expect(url.searchParams.get(OAUTH_CALLBACK_ORG_QUERY_PARAM)).toBe("acme");
+  });
+
+  it("does not add an org selector on bare app routes", () => {
+    setLocation("https://executor.sh/login");
+
+    expect(oauthCallbackUrl()).toBe("https://executor.sh/api/oauth/callback");
+  });
+});

--- a/packages/react/src/plugins/oauth-sign-in.tsx
+++ b/packages/react/src/plugins/oauth-sign-in.tsx
@@ -14,6 +14,7 @@ import {
   type OAuthPopupResult,
 } from "../api/oauth-popup";
 import { connectionWriteKeys } from "../api/reactivity-keys";
+import { getActiveOrgSlug } from "../api/server-connection";
 
 type DesktopBridge = {
   readonly openExternal: (url: string) => Promise<void>;
@@ -30,6 +31,7 @@ const getDesktopBridge = (): DesktopBridge | null => {
 import { Button } from "../components/button";
 import {
   OAUTH_POPUP_MESSAGE_TYPE,
+  OAUTH_CALLBACK_ORG_QUERY_PARAM,
   OAuthState,
   type AuthTemplateSlug,
   type ConnectionName,
@@ -96,7 +98,11 @@ export type StartOAuthAuthorizationInput<TPayload extends OAuthCompletionPayload
 };
 
 export function oauthCallbackUrl(path = "/api/oauth/callback"): string {
-  return typeof window === "undefined" ? path : `${window.location.origin}${path}`;
+  if (typeof window === "undefined") return path;
+  const url = new URL(path, window.location.origin);
+  const orgSlug = getActiveOrgSlug();
+  if (orgSlug) url.searchParams.set(OAUTH_CALLBACK_ORG_QUERY_PARAM, orgSlug);
+  return url.toString();
 }
 
 export function useOAuthPopupFlow<


### PR DESCRIPTION
## Summary

- Carry the URL-selected organization through OAuth callback URLs as `executor_org`, and rehydrate login callbacks into the requested return-to org.
- Stamp `x-executor-organization` on cloud app API calls from the current URL, including MCP approval lookups and resumes.
- Generate MCP browser approval URLs with the session org slug so approval links stay scoped even when the browser cookie points at another org.
- Move cloud domain-verification auth to a request-scoped router middleware so URL org slugs resolve through the same per-request org selector path.
- Add cloud e2e coverage for both OAuth callback and MCP browser approval org-switch flows.

## Watch It

![OAuth callback · URL-scoped org survives a callback while the session cookie points elsewhere (cloud)](https://raw.githubusercontent.com/RhysSullivan/executor/e2e-media/oauth-callback-url-scoped-org-survives-a-callback-while-the-session-cookie-point-e768a20d.gif)

![MCP approval · URL-scoped org survives approval while the session cookie points elsewhere (cloud)](https://raw.githubusercontent.com/RhysSullivan/executor/e2e-media/mcp-approval-url-scoped-org-survives-approval-while-the-session-cookie-points-el-2e39b5bf.gif)

## Verification

- `vitest run src/api.request-scope.node.test.ts src/auth/org-selector-auth.node.test.ts src/org/handlers.test.ts` in `apps/cloud`
- `vitest run src/envelope.test.ts` in `packages/hosts/mcp`
- `tsgo --noEmit` in `apps/cloud`, `apps/host-cloudflare`, and `packages/hosts/mcp`
- `tsc --noEmit` in `e2e`
- targeted `oxlint`
- `vitest run --project cloud cloud/oauth-callback-org-scope.test.ts` in `e2e`
- `vitest run --project cloud cloud/mcp-browser-approval-org-scope.test.ts` in `e2e`
- `bun e2e/scripts/pr-media.ts e2e/runs/cloud/mcp-approval-url-scoped-org-survives-approval-while-the-session-cookie-points-el`
