### PR TITLE
Add Google Photos preset with binary-safe uploads

### DIFF
--- a/.changeset/google-photos-openapi-presets.md
+++ b/.changeset/google-photos-openapi-presets.md
@@ -1,0 +1,6 @@
+---
+"@executor-js/plugin-google": patch
+"@executor-js/plugin-openapi": patch
+---
+
+Add a Google Photos preset with raw upload support and binary-safe `bodyBase64` handling.

--- a/e2e/scenarios/google-photos-preset-ui.test.ts
+++ b/e2e/scenarios/google-photos-preset-ui.test.ts
@@ -1,0 +1,43 @@
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+
+import { scenario } from "../src/scenario";
+import { Browser, Target } from "../src/services";
+
+scenario(
+  "Google Photos: the focused preset opens a Photos-scoped add flow",
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const browser = yield* Browser;
+    const identity = yield* target.newIdentity();
+
+    yield* browser.session(identity, async ({ page, step }) => {
+      await step("Find the Google Photos preset from the integrations picker", async () => {
+        await page.goto("/integrations", { waitUntil: "networkidle" });
+        await page.getByRole("button", { name: "Connect" }).click();
+        const dialog = page.getByRole("dialog", { name: "Connect an integration" });
+        await dialog.waitFor();
+        await dialog.getByPlaceholder(/Search or paste a URL/).fill("google photos");
+        await dialog.getByRole("link", { name: /^Google Photos\b/ }).waitFor();
+      });
+
+      await step("Open the Google Photos scoped add flow", async () => {
+        const dialog = page.getByRole("dialog", { name: "Connect an integration" });
+        await dialog.getByRole("link", { name: /^Google Photos\b/ }).click();
+        await page.waitForURL(/\/integrations\/add\/google/);
+        await page.getByRole("heading", { name: "Add Google" }).waitFor();
+      });
+
+      await step("The Photos preset defaults to the focused namespace and products", async () => {
+        await page.locator('input[value="Google Photos"]').waitFor();
+        await page.locator('input[value="google_photos"]').waitFor();
+        await page.getByText("Google Photos Library").first().waitFor();
+        await page.getByText("Google Photos Picker").first().waitFor();
+        await page.getByText("2 Google APIs").waitFor();
+        expect(await page.locator('input[value="Google"]').count()).toBe(0);
+        expect(await page.locator('input[value="google"]').count()).toBe(0);
+      });
+    });
+  }),
+);

--- a/packages/plugins/google/src/react/AddGoogleSource.tsx
+++ b/packages/plugins/google/src/react/AddGoogleSource.tsx
@@ -20,7 +20,12 @@ import { OpenApiSourceDetailsFields } from "@executor-js/plugin-openapi/react";
 
 import { addGoogleBundle } from "./atoms";
 import { GoogleProductPicker } from "./GoogleProductPicker";
-import { googleOpenApiPresets, type GoogleOpenApiPreset } from "../sdk/presets";
+import {
+  GOOGLE_PHOTOS_PRESET_ID,
+  googleOpenApiPresets,
+  googlePhotosPresetIds,
+  type GoogleOpenApiPreset,
+} from "../sdk/presets";
 
 const GOOGLE_BUNDLE_FAVICON = "https://fonts.gstatic.com/s/i/productlogos/googleg/v6/192px.svg";
 
@@ -43,10 +48,12 @@ const googleBundleUrls = (
 export default function AddGoogleSource(props: {
   onComplete: (slug?: string) => void;
   onCancel: () => void;
+  initialPreset?: string;
   initialNamespace?: string;
 }) {
+  const isGooglePhotosPreset = props.initialPreset === GOOGLE_PHOTOS_PRESET_ID;
   const [selectedPresetIds, setSelectedPresetIds] = useState<ReadonlySet<string>>(
-    googleBundleDefaultPresetIds,
+    isGooglePhotosPreset ? new Set(googlePhotosPresetIds) : googleBundleDefaultPresetIds,
   );
   const [customDiscoveryUrls, setCustomDiscoveryUrls] = useState<readonly string[]>([]);
   const [baseUrl, setBaseUrl] = useState("");
@@ -55,8 +62,9 @@ export default function AddGoogleSource(props: {
   const [addError, setAddError] = useState<string | null>(null);
 
   const identity = useIntegrationIdentity({
-    fallbackName: "Google",
-    fallbackNamespace: props.initialNamespace ?? "google",
+    fallbackName: isGooglePhotosPreset ? "Google Photos" : "Google",
+    fallbackNamespace:
+      props.initialNamespace ?? (isGooglePhotosPreset ? "google_photos" : "google"),
   });
 
   const bundleDiscoveryUrls = useMemo(
@@ -87,9 +95,15 @@ export default function AddGoogleSource(props: {
 
   const doAdd = useAtomSet(addGoogleBundle, { mode: "promiseExit" });
 
-  const resolvedSourceId = slugifyNamespace(identity.namespace) || "google";
-  const resolvedDisplayName = identity.name.trim() || "Google";
-  const resolvedDescription = descriptionDraft ?? "Google APIs";
+  const resolvedSourceId =
+    slugifyNamespace(identity.namespace) || (isGooglePhotosPreset ? "google_photos" : "google");
+  const resolvedDisplayName =
+    identity.name.trim() || (isGooglePhotosPreset ? "Google Photos" : "Google");
+  const resolvedDescription =
+    descriptionDraft ??
+    (isGooglePhotosPreset
+      ? "Google Photos albums, uploads, app-created media, and selected picker media."
+      : "Google APIs");
   const slugAlreadyExists = useSlugAlreadyExists(resolvedSourceId);
   const canAdd = bundleDiscoveryUrls.length > 0 && !slugAlreadyExists;
 

--- a/packages/plugins/google/src/react/source-plugin.ts
+++ b/packages/plugins/google/src/react/source-plugin.ts
@@ -1,6 +1,6 @@
 import { lazy } from "react";
 import type { IntegrationPlugin } from "@executor-js/sdk/client";
-import { googleOpenApiBundlePreset } from "../sdk/presets";
+import { googleOpenApiBundlePreset, googlePhotosOpenApiBundlePreset } from "../sdk/presets";
 
 const importAdd = () => import("./AddGoogleSource");
 const importAccounts = () => import("./GoogleAccountsPanel");
@@ -10,7 +10,7 @@ export const googleIntegrationPlugin: IntegrationPlugin = {
   label: "Google",
   add: lazy(importAdd),
   accounts: lazy(importAccounts),
-  presets: [googleOpenApiBundlePreset],
+  presets: [googleOpenApiBundlePreset, googlePhotosOpenApiBundlePreset],
   preload: () => {
     void importAdd();
     void importAccounts();

--- a/packages/plugins/google/src/sdk/__snapshots__/presets.test.ts.snap
+++ b/packages/plugins/google/src/sdk/__snapshots__/presets.test.ts.snap
@@ -39,6 +39,14 @@ exports[`classifies every Google service for bundle OAuth UX 1`] = `
     "oauthAudience": "standard-user",
   },
   {
+    "id": "google-photos-library",
+    "oauthAudience": "advanced-user",
+  },
+  {
+    "id": "google-photos-picker",
+    "oauthAudience": "advanced-user",
+  },
+  {
     "id": "google-chat",
     "oauthAudience": "workspace-admin",
   },

--- a/packages/plugins/google/src/sdk/discovery.ts
+++ b/packages/plugins/google/src/sdk/discovery.ts
@@ -677,9 +677,13 @@ const buildDiscoveryOperation = (input: {
 
 const GOOGLE_OAUTH_SECURITY_SCHEME = "googleOAuth2";
 const GOOGLE_PHOTOS_LIBRARY_SERVICE = "photoslibrary";
+const GOOGLE_PHOTOS_PICKER_SERVICE = "photospicker";
 const GOOGLE_PHOTOS_APPENDONLY_SCOPE = "https://www.googleapis.com/auth/photoslibrary.appendonly";
 const GOOGLE_PHOTOS_UPLOAD_TOOL_PATH = "photoslibrary.mediaItems.upload";
 const GOOGLE_PHOTOS_UPLOAD_PATH = "/uploads";
+
+const isGooglePhotosService = (service: string): boolean =>
+  service === GOOGLE_PHOTOS_LIBRARY_SERVICE || service === GOOGLE_PHOTOS_PICKER_SERVICE;
 
 /** The v2 oauth auth template for a Google-discovery integration. The spec
  *  itself carries the matching `securitySchemes.googleOAuth2` entry; this is the
@@ -919,8 +923,11 @@ export const convertGoogleDiscoveryBundleToOpenApi = Effect.fn(
   for (const info of infos) {
     const schemaPrefix = schemaComponentPart(`${info.service}_${info.version}`);
     const schemaNameForRef = (name: string) => `${schemaPrefix}_${schemaComponentPart(name)}`;
+    const scopeDescriptions = discoveryScopes(info.document);
+    const filterPhotosScopes = consentScopeSet !== null && isGooglePhotosService(info.service);
 
-    for (const [scope, description] of Object.entries(discoveryScopes(info.document))) {
+    for (const [scope, description] of Object.entries(scopeDescriptions)) {
+      if (filterPhotosScopes && !consentScopeSet.has(scope)) continue;
       rawScopes[scope] ??= description;
     }
 
@@ -933,10 +940,10 @@ export const convertGoogleDiscoveryBundleToOpenApi = Effect.fn(
       const rawPathTemplate = Option.getOrUndefined(method.path);
       if (!methodId || !rawPathTemplate || !method.httpMethod) continue;
       const methodScopes = method.scopes ?? [];
-      const oauthScopes = consentScopeSet
+      const oauthScopes = filterPhotosScopes
         ? methodScopes.filter((scope) => consentScopeSet.has(scope))
         : methodScopes;
-      if (consentScopeSet && methodScopes.length > 0 && oauthScopes.length === 0) continue;
+      if (filterPhotosScopes && methodScopes.length > 0 && oauthScopes.length === 0) continue;
 
       const toolPath = methodId;
       const wirePath = rawPathTemplate.startsWith("/") ? rawPathTemplate : `/${rawPathTemplate}`;
@@ -972,9 +979,7 @@ export const convertGoogleDiscoveryBundleToOpenApi = Effect.fn(
     }
   }
 
-  const scopes = input.consentScopes
-    ? Object.fromEntries(input.consentScopes.map((scope) => [scope, rawScopes[scope] ?? ""]))
-    : compactDiscoveryScopeMap(rawScopes);
+  const scopes = compactDiscoveryScopeMap(rawScopes);
   const authenticationTemplate = googleOauthTemplate(scopes);
   const spec: OpenApiDocument = {
     openapi: "3.1.0",

--- a/packages/plugins/google/src/sdk/discovery.ts
+++ b/packages/plugins/google/src/sdk/discovery.ts
@@ -66,12 +66,13 @@ type OpenApiOperationObject = {
   readonly servers?: readonly { readonly url: string }[];
   readonly parameters: readonly OpenApiParameterObject[];
   readonly requestBody?: {
-    readonly required: false;
-    readonly content: {
-      readonly "application/json": {
+    readonly required: boolean;
+    readonly content: Record<
+      string,
+      {
         readonly schema: OpenApiSchemaObject;
-      };
-    };
+      }
+    >;
   };
   readonly responses: {
     readonly "200": {
@@ -605,6 +606,7 @@ const buildDiscoveryOperation = (input: {
   readonly method: DiscoveryMethod;
   readonly toolPath: string;
   readonly pathTemplate: string;
+  readonly oauthScopes?: readonly string[];
   readonly schemaNameForRef?: (name: string) => string;
   readonly serverUrl?: string;
   readonly tags?: readonly string[];
@@ -619,7 +621,7 @@ const buildDiscoveryOperation = (input: {
     if (parameter.location) mergedParameters.set(name, parameter);
   }
 
-  const methodScopes = input.method.scopes ?? [];
+  const methodScopes = input.oauthScopes ?? input.method.scopes ?? [];
   const methodDescription = Option.getOrUndefined(input.method.description);
   const schemaNameForRef = input.schemaNameForRef ?? identitySchemaName;
 
@@ -674,6 +676,10 @@ const buildDiscoveryOperation = (input: {
 };
 
 const GOOGLE_OAUTH_SECURITY_SCHEME = "googleOAuth2";
+const GOOGLE_PHOTOS_LIBRARY_SERVICE = "photoslibrary";
+const GOOGLE_PHOTOS_APPENDONLY_SCOPE = "https://www.googleapis.com/auth/photoslibrary.appendonly";
+const GOOGLE_PHOTOS_UPLOAD_TOOL_PATH = "photoslibrary.mediaItems.upload";
+const GOOGLE_PHOTOS_UPLOAD_PATH = "/uploads";
 
 /** The v2 oauth auth template for a Google-discovery integration. The spec
  *  itself carries the matching `securitySchemes.googleOAuth2` entry; this is the
@@ -694,6 +700,72 @@ const googleOauthTemplate = (scopes: Record<string, string>): readonly Authentic
       scopes: Object.keys(scopes),
     },
   ];
+
+const googlePhotosUploadOperation = (input: {
+  readonly toolPath: string;
+  readonly oauthScopes: readonly string[];
+  readonly serverUrl: string;
+  readonly tags?: readonly string[];
+}): OpenApiOperationObject => ({
+  operationId: input.toolPath,
+  "x-executor-toolPath": input.toolPath,
+  "x-executor-pathTemplate": GOOGLE_PHOTOS_UPLOAD_PATH,
+  ...(input.tags && input.tags.length > 0 ? { tags: input.tags } : {}),
+  description:
+    "Uploads raw photo or video bytes to Google Photos and returns a plain-text upload token. Call mediaItems.batchCreate with the returned token to create the media item.",
+  servers: [{ url: input.serverUrl }],
+  parameters: [
+    {
+      name: "X-Goog-Upload-File-Name",
+      in: "header",
+      required: true,
+      description: "File name Google Photos should associate with the uploaded bytes.",
+      schema: { type: "string" },
+    },
+    {
+      name: "X-Goog-Upload-Protocol",
+      in: "header",
+      required: true,
+      description: "Google Photos raw upload protocol. Set to raw.",
+      schema: { type: "string", enum: ["raw"], default: "raw" },
+    },
+    {
+      name: "X-Goog-Upload-Content-Type",
+      in: "header",
+      required: false,
+      description: "MIME type of the uploaded media, for example image/jpeg or video/mp4.",
+      schema: { type: "string" },
+    },
+  ],
+  requestBody: {
+    required: true,
+    content: {
+      "application/octet-stream": {
+        schema: { type: "string", format: "binary" },
+      },
+    },
+  },
+  responses: {
+    "200": {
+      description: "Successful response",
+      content: {
+        "text/plain": {
+          schema: { type: "string" },
+        },
+      },
+    },
+  },
+  ...(input.oauthScopes.length > 0 ? { security: [{ googleOAuth2: input.oauthScopes }] } : {}),
+  "x-google-scopes": input.oauthScopes,
+});
+
+const hasOperation = (
+  paths: Record<string, Record<string, OpenApiOperationObject>>,
+  operationId: string,
+): boolean =>
+  Object.values(paths).some((pathItem) =>
+    Object.values(pathItem).some((operation) => operation.operationId === operationId),
+  );
 
 export const convertGoogleDiscoveryToOpenApi = Effect.fn("OpenApi.convertGoogleDiscovery")(
   function* (input: { readonly discoveryUrl: string; readonly documentText: string }) {
@@ -735,6 +807,18 @@ export const convertGoogleDiscoveryToOpenApi = Effect.fn("OpenApi.convertGoogleD
         method,
         toolPath,
         pathTemplate: pathTemplate.startsWith("/") ? pathTemplate : `/${pathTemplate}`,
+      });
+    }
+
+    if (
+      service === GOOGLE_PHOTOS_LIBRARY_SERVICE &&
+      !hasOperation(paths, GOOGLE_PHOTOS_UPLOAD_TOOL_PATH)
+    ) {
+      paths[GOOGLE_PHOTOS_UPLOAD_PATH] ??= {};
+      paths[GOOGLE_PHOTOS_UPLOAD_PATH]!.post = googlePhotosUploadOperation({
+        toolPath: GOOGLE_PHOTOS_UPLOAD_TOOL_PATH,
+        oauthScopes: [GOOGLE_PHOTOS_APPENDONLY_SCOPE],
+        serverUrl: baseUrl,
       });
     }
 
@@ -798,6 +882,7 @@ export const convertGoogleDiscoveryBundleToOpenApi = Effect.fn(
   "OpenApi.convertGoogleDiscoveryBundle",
 )(function* (input: {
   readonly documents: readonly { readonly discoveryUrl: string; readonly documentText: string }[];
+  readonly consentScopes?: readonly string[];
 }) {
   if (input.documents.length === 0) {
     return yield* new OpenApiParseError({
@@ -829,6 +914,7 @@ export const convertGoogleDiscoveryBundleToOpenApi = Effect.fn(
   const paths: Record<string, Record<string, OpenApiOperationObject>> = {};
   const schemas: Record<string, OpenApiSchemaObject> = {};
   const rawScopes: Record<string, string> = {};
+  const consentScopeSet = input.consentScopes ? new Set(input.consentScopes) : null;
 
   for (const info of infos) {
     const schemaPrefix = schemaComponentPart(`${info.service}_${info.version}`);
@@ -846,6 +932,11 @@ export const convertGoogleDiscoveryBundleToOpenApi = Effect.fn(
       const methodId = Option.getOrUndefined(method.id);
       const rawPathTemplate = Option.getOrUndefined(method.path);
       if (!methodId || !rawPathTemplate || !method.httpMethod) continue;
+      const methodScopes = method.scopes ?? [];
+      const oauthScopes = consentScopeSet
+        ? methodScopes.filter((scope) => consentScopeSet.has(scope))
+        : methodScopes;
+      if (consentScopeSet && methodScopes.length > 0 && oauthScopes.length === 0) continue;
 
       const toolPath = methodId;
       const wirePath = rawPathTemplate.startsWith("/") ? rawPathTemplate : `/${rawPathTemplate}`;
@@ -859,14 +950,31 @@ export const convertGoogleDiscoveryBundleToOpenApi = Effect.fn(
         method,
         toolPath,
         pathTemplate: wirePath,
+        oauthScopes,
         schemaNameForRef,
+        serverUrl: info.baseUrl,
+        tags: [info.title],
+      });
+    }
+
+    if (
+      info.service === GOOGLE_PHOTOS_LIBRARY_SERVICE &&
+      (!consentScopeSet || consentScopeSet.has(GOOGLE_PHOTOS_APPENDONLY_SCOPE)) &&
+      !hasOperation(paths, GOOGLE_PHOTOS_UPLOAD_TOOL_PATH)
+    ) {
+      paths[GOOGLE_PHOTOS_UPLOAD_PATH] ??= {};
+      paths[GOOGLE_PHOTOS_UPLOAD_PATH]!.post = googlePhotosUploadOperation({
+        toolPath: GOOGLE_PHOTOS_UPLOAD_TOOL_PATH,
+        oauthScopes: [GOOGLE_PHOTOS_APPENDONLY_SCOPE],
         serverUrl: info.baseUrl,
         tags: [info.title],
       });
     }
   }
 
-  const scopes = compactDiscoveryScopeMap(rawScopes);
+  const scopes = input.consentScopes
+    ? Object.fromEntries(input.consentScopes.map((scope) => [scope, rawScopes[scope] ?? ""]))
+    : compactDiscoveryScopeMap(rawScopes);
   const authenticationTemplate = googleOauthTemplate(scopes);
   const spec: OpenApiDocument = {
     openapi: "3.1.0",

--- a/packages/plugins/google/src/sdk/index.ts
+++ b/packages/plugins/google/src/sdk/index.ts
@@ -8,6 +8,11 @@ export {
 export {
   googleOpenApiBundlePreset,
   googleOpenApiPresets,
+  googlePhotosOpenApiBundlePreset,
+  googlePhotosOpenApiPresets,
+  googlePhotosPresetIds,
+  GOOGLE_PHOTOS_ICON,
+  GOOGLE_PHOTOS_PRESET_ID,
   googleStandardUserOAuthPresets,
   googleOAuthConsentScopes,
   googleOAuthConsentScopesForPreset,

--- a/packages/plugins/google/src/sdk/plugin.test.ts
+++ b/packages/plugins/google/src/sdk/plugin.test.ts
@@ -440,4 +440,43 @@ describe("Google bundle add flow", () => {
       }),
     ),
   );
+
+  it.effect("addBundle scopes a partial Google Photos bundle when mixed with another API", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const executor = yield* createExecutor(makeTestConfig({ plugins: bundlePlugins() }));
+
+        yield* executor.google.addBundle({
+          urls: [CALENDAR_URL, PHOTOS_LIBRARY_URL],
+          slug: "google_photos_library_calendar",
+          name: "Google Photos Library and Calendar",
+        });
+
+        const config = yield* executor.google.getConfig("google_photos_library_calendar");
+        const oauth = config?.authenticationTemplate?.find((entry) => entry.kind === "oauth2");
+        expect(oauth?.kind === "oauth2" ? [...oauth.scopes].sort() : undefined).toEqual(
+          [
+            "https://www.googleapis.com/auth/calendar",
+            "https://www.googleapis.com/auth/photoslibrary.appendonly",
+            "https://www.googleapis.com/auth/photoslibrary.readonly.appcreateddata",
+          ].sort(),
+        );
+
+        yield* executor.connections.create({
+          owner: "org",
+          name: ConnectionName.make("main"),
+          integration: IntegrationSlug.make("google_photos_library_calendar"),
+          template: AuthTemplateSlug.make("googleOAuth2"),
+          value: "token-xyz",
+        });
+
+        const toolNames = (yield* executor.tools.list()).map((tool) => String(tool.name));
+        expect(toolNames).toContain("calendar.events.list");
+        expect(toolNames).toContain("photoslibrary.mediaItems.upload");
+        expect(toolNames).toContain("photoslibrary.mediaItems.search");
+        expect(toolNames).not.toContain("photospicker.mediaItems.list");
+        expect(toolNames).not.toContain("photoslibrary.albums.list");
+      }),
+    ),
+  );
 });

--- a/packages/plugins/google/src/sdk/plugin.test.ts
+++ b/packages/plugins/google/src/sdk/plugin.test.ts
@@ -257,6 +257,16 @@ const bundlePlugins = () =>
   [googlePlugin({ httpClientLayer: discoveryHttpClientLayer }), memoryCredentialsPlugin()] as const;
 
 describe("Google bundle add flow", () => {
+  it("SDK catalog includes the Google Photos focused preset", () => {
+    const presetIds =
+      googlePlugin({ httpClientLayer: discoveryHttpClientLayer }).integrationPresets?.map(
+        (preset) => preset.id,
+      ) ?? [];
+
+    expect(presetIds).toContain("google");
+    expect(presetIds).toContain("google-photos");
+  });
+
   it.effect("rejects lookalike Discovery hosts before fetching bundle documents", () =>
     Effect.scoped(
       Effect.gen(function* () {
@@ -383,6 +393,46 @@ describe("Google bundle add flow", () => {
         });
 
         const toolNames = (yield* executor.tools.list()).map((tool) => String(tool.name));
+        expect(toolNames).toContain("photoslibrary.mediaItems.upload");
+        expect(toolNames).toContain("photoslibrary.mediaItems.search");
+        expect(toolNames).toContain("photospicker.mediaItems.list");
+        expect(toolNames).not.toContain("photoslibrary.albums.list");
+      }),
+    ),
+  );
+
+  it.effect("addBundle keeps Google Photos scoped when combined with another API", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const executor = yield* createExecutor(makeTestConfig({ plugins: bundlePlugins() }));
+
+        yield* executor.google.addBundle({
+          urls: [CALENDAR_URL, PHOTOS_LIBRARY_URL, PHOTOS_PICKER_URL],
+          slug: "google_photos_calendar",
+          name: "Google Photos and Calendar",
+        });
+
+        const config = yield* executor.google.getConfig("google_photos_calendar");
+        const oauth = config?.authenticationTemplate?.find((entry) => entry.kind === "oauth2");
+        expect(oauth?.kind === "oauth2" ? [...oauth.scopes].sort() : undefined).toEqual(
+          [
+            "https://www.googleapis.com/auth/calendar",
+            "https://www.googleapis.com/auth/photoslibrary.appendonly",
+            "https://www.googleapis.com/auth/photoslibrary.readonly.appcreateddata",
+            "https://www.googleapis.com/auth/photospicker.mediaitems.readonly",
+          ].sort(),
+        );
+
+        yield* executor.connections.create({
+          owner: "org",
+          name: ConnectionName.make("main"),
+          integration: IntegrationSlug.make("google_photos_calendar"),
+          template: AuthTemplateSlug.make("googleOAuth2"),
+          value: "token-xyz",
+        });
+
+        const toolNames = (yield* executor.tools.list()).map((tool) => String(tool.name));
+        expect(toolNames).toContain("calendar.events.list");
         expect(toolNames).toContain("photoslibrary.mediaItems.upload");
         expect(toolNames).toContain("photoslibrary.mediaItems.search");
         expect(toolNames).toContain("photospicker.mediaItems.list");

--- a/packages/plugins/google/src/sdk/plugin.test.ts
+++ b/packages/plugins/google/src/sdk/plugin.test.ts
@@ -34,6 +34,8 @@ import { googlePlugin } from "./plugin";
 const CALENDAR_URL = "https://www.googleapis.com/discovery/v1/apis/calendar/v3/rest";
 const GMAIL_URL = "https://www.googleapis.com/discovery/v1/apis/gmail/v1/rest";
 const DRIVE_URL = "https://www.googleapis.com/discovery/v1/apis/drive/v3/rest";
+const PHOTOS_LIBRARY_URL = "https://www.googleapis.com/discovery/v1/apis/photoslibrary/v1/rest";
+const PHOTOS_PICKER_URL = "https://www.googleapis.com/discovery/v1/apis/photospicker/v1/rest";
 
 const calendarDoc = {
   name: "calendar",
@@ -141,12 +143,93 @@ const driveDoc = {
   },
 };
 
+const photosLibraryDoc = {
+  name: "photoslibrary",
+  version: "v1",
+  title: "Google Photos Library API",
+  rootUrl: "https://photoslibrary.googleapis.com/",
+  servicePath: "v1/",
+  auth: {
+    oauth2: {
+      scopes: {
+        "https://www.googleapis.com/auth/photoslibrary": {
+          description: "Manage the full Google Photos library",
+        },
+        "https://www.googleapis.com/auth/photoslibrary.appendonly": {
+          description: "Upload to Google Photos",
+        },
+        "https://www.googleapis.com/auth/photoslibrary.readonly.appcreateddata": {
+          description: "Read app-created Google Photos media",
+        },
+      },
+    },
+  },
+  resources: {
+    albums: {
+      methods: {
+        list: {
+          id: "photoslibrary.albums.list",
+          httpMethod: "GET",
+          path: "albums",
+          scopes: ["https://www.googleapis.com/auth/photoslibrary"],
+          parameters: {},
+        },
+      },
+    },
+    mediaItems: {
+      methods: {
+        search: {
+          id: "photoslibrary.mediaItems.search",
+          httpMethod: "POST",
+          path: "mediaItems:search",
+          scopes: ["https://www.googleapis.com/auth/photoslibrary.readonly.appcreateddata"],
+          parameters: {},
+        },
+      },
+    },
+  },
+  schemas: {},
+};
+
+const photosPickerDoc = {
+  name: "photospicker",
+  version: "v1",
+  title: "Google Photos Picker API",
+  rootUrl: "https://photospicker.googleapis.com/",
+  servicePath: "v1/",
+  auth: {
+    oauth2: {
+      scopes: {
+        "https://www.googleapis.com/auth/photospicker.mediaitems.readonly": {
+          description: "Read selected Google Photos media",
+        },
+      },
+    },
+  },
+  resources: {
+    mediaItems: {
+      methods: {
+        list: {
+          id: "photospicker.mediaItems.list",
+          httpMethod: "GET",
+          path: "mediaItems",
+          scopes: ["https://www.googleapis.com/auth/photospicker.mediaitems.readonly"],
+          parameters: {},
+        },
+      },
+    },
+  },
+  schemas: {},
+};
+
 const toJson = (value: unknown): string => JSON.stringify(value);
 
 const DISCOVERY_BODIES: Readonly<Record<string, string>> = {
   [CALENDAR_URL]: toJson(calendarDoc),
   [GMAIL_URL]: toJson(gmailDoc),
   [DRIVE_URL]: toJson(driveDoc),
+  [PHOTOS_LIBRARY_URL]: toJson(photosLibraryDoc),
+  [PHOTOS_PICKER_URL]: toJson(photosPickerDoc),
 };
 
 // A stub HTTP client that serves the canned Discovery document for whichever
@@ -265,5 +348,46 @@ describe("Google bundle add flow", () => {
           expect(googleTools.length).toBe(3);
         }),
       ),
+  );
+
+  it.effect("addBundle constrains Google Photos to the preset scopes and upload tool", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const executor = yield* createExecutor(makeTestConfig({ plugins: bundlePlugins() }));
+
+        yield* executor.google.addBundle({
+          urls: [
+            PHOTOS_LIBRARY_URL,
+            "https://photospicker.googleapis.com/$discovery/rest?version=v1",
+          ],
+          slug: "google_photos",
+          name: "Google Photos",
+        });
+
+        const config = yield* executor.google.getConfig("google_photos");
+        const oauth = config?.authenticationTemplate?.find((entry) => entry.kind === "oauth2");
+        expect(oauth?.kind === "oauth2" ? [...oauth.scopes].sort() : undefined).toEqual(
+          [
+            "https://www.googleapis.com/auth/photoslibrary.appendonly",
+            "https://www.googleapis.com/auth/photoslibrary.readonly.appcreateddata",
+            "https://www.googleapis.com/auth/photospicker.mediaitems.readonly",
+          ].sort(),
+        );
+
+        yield* executor.connections.create({
+          owner: "org",
+          name: ConnectionName.make("main"),
+          integration: IntegrationSlug.make("google_photos"),
+          template: AuthTemplateSlug.make("googleOAuth2"),
+          value: "token-xyz",
+        });
+
+        const toolNames = (yield* executor.tools.list()).map((tool) => String(tool.name));
+        expect(toolNames).toContain("photoslibrary.mediaItems.upload");
+        expect(toolNames).toContain("photoslibrary.mediaItems.search");
+        expect(toolNames).toContain("photospicker.mediaItems.list");
+        expect(toolNames).not.toContain("photoslibrary.albums.list");
+      }),
+    ),
   );
 });

--- a/packages/plugins/google/src/sdk/plugin.ts
+++ b/packages/plugins/google/src/sdk/plugin.ts
@@ -36,7 +36,12 @@ import {
   normalizeGoogleDiscoveryUrl,
 } from "./discovery";
 import { decodeGoogleIntegrationConfig, type GoogleIntegrationConfig } from "./config";
-import { googleOpenApiBundlePreset } from "./presets";
+import {
+  googleOAuthConsentScopesForPreset,
+  googleOpenApiBundlePreset,
+  googlePhotosOpenApiPresets,
+  googlePhotosPresetIds,
+} from "./presets";
 
 export interface GoogleBundleConfig {
   readonly urls: readonly string[];
@@ -68,6 +73,23 @@ export interface GooglePluginOptions {
 
 const DEFAULT_GOOGLE_SLUG = "google";
 
+const googlePhotosBundleUrls = new Set(
+  googlePhotosOpenApiPresets.flatMap((preset) =>
+    preset.url ? [normalizeGoogleDiscoveryUrl(preset.url) ?? preset.url] : [],
+  ),
+);
+
+const googlePhotosBundleConsentScopes = (
+  urls: readonly string[],
+): readonly string[] | undefined => {
+  const normalized = new Set(urls);
+  if (normalized.size !== googlePhotosBundleUrls.size) return undefined;
+  for (const url of googlePhotosBundleUrls) {
+    if (!normalized.has(url)) return undefined;
+  }
+  return googlePhotosPresetIds.flatMap((presetId) => googleOAuthConsentScopesForPreset(presetId));
+};
+
 const fetchGoogleBundleConversion = (
   urls: readonly string[],
   httpClientLayer: Layer.Layer<HttpClient.HttpClient, never, never>,
@@ -80,7 +102,15 @@ const fetchGoogleBundleConversion = (
         Effect.map((documentText) => ({ discoveryUrl: url, documentText })),
       ),
     { concurrency: 4 },
-  ).pipe(Effect.flatMap((documents) => convertGoogleDiscoveryBundleToOpenApi({ documents })));
+  ).pipe(
+    Effect.flatMap((documents) => {
+      const consentScopes = googlePhotosBundleConsentScopes(urls);
+      return convertGoogleDiscoveryBundleToOpenApi({
+        documents,
+        ...(consentScopes ? { consentScopes } : {}),
+      });
+    }),
+  );
 
 const uniqueUrls = (urls: readonly string[]): readonly string[] => [
   ...new Set(urls.flatMap((url) => normalizeGoogleDiscoveryUrl(url) ?? [])),

--- a/packages/plugins/google/src/sdk/plugin.ts
+++ b/packages/plugins/google/src/sdk/plugin.ts
@@ -41,7 +41,6 @@ import {
   googleOpenApiBundlePreset,
   googlePhotosOpenApiBundlePreset,
   googlePhotosOpenApiPresets,
-  googlePhotosPresetIds,
 } from "./presets";
 
 export interface GoogleBundleConfig {
@@ -74,9 +73,9 @@ export interface GooglePluginOptions {
 
 const DEFAULT_GOOGLE_SLUG = "google";
 
-const googlePhotosBundleUrls = new Set(
+const googlePhotosBundlePresetIdByUrl = new Map(
   googlePhotosOpenApiPresets.flatMap((preset) =>
-    preset.url ? [normalizeGoogleDiscoveryUrl(preset.url) ?? preset.url] : [],
+    preset.url ? [[normalizeGoogleDiscoveryUrl(preset.url) ?? preset.url, preset.id] as const] : [],
   ),
 );
 
@@ -84,10 +83,12 @@ const googlePhotosBundleConsentScopes = (
   urls: readonly string[],
 ): readonly string[] | undefined => {
   const normalized = new Set(urls);
-  for (const url of googlePhotosBundleUrls) {
-    if (!normalized.has(url)) return undefined;
-  }
-  return googlePhotosPresetIds.flatMap((presetId) => googleOAuthConsentScopesForPreset(presetId));
+  const presetIds = [...googlePhotosBundlePresetIdByUrl.entries()].flatMap(([url, presetId]) =>
+    normalized.has(url) ? [presetId] : [],
+  );
+  return presetIds.length > 0
+    ? presetIds.flatMap((presetId) => googleOAuthConsentScopesForPreset(presetId))
+    : undefined;
 };
 
 const fetchGoogleBundleConversion = (

--- a/packages/plugins/google/src/sdk/plugin.ts
+++ b/packages/plugins/google/src/sdk/plugin.ts
@@ -39,6 +39,7 @@ import { decodeGoogleIntegrationConfig, type GoogleIntegrationConfig } from "./c
 import {
   googleOAuthConsentScopesForPreset,
   googleOpenApiBundlePreset,
+  googlePhotosOpenApiBundlePreset,
   googlePhotosOpenApiPresets,
   googlePhotosPresetIds,
 } from "./presets";
@@ -83,7 +84,6 @@ const googlePhotosBundleConsentScopes = (
   urls: readonly string[],
 ): readonly string[] | undefined => {
   const normalized = new Set(urls);
-  if (normalized.size !== googlePhotosBundleUrls.size) return undefined;
   for (const url of googlePhotosBundleUrls) {
     if (!normalized.has(url)) return undefined;
   }
@@ -322,7 +322,7 @@ export type GooglePluginExtension = ReturnType<typeof makeGooglePluginExtension>
 export const googlePlugin = definePlugin((options?: GooglePluginOptions) => ({
   id: "google" as const,
   packageName: "@executor-js/plugin-google",
-  integrationPresets: [googleOpenApiBundlePreset],
+  integrationPresets: [googleOpenApiBundlePreset, googlePhotosOpenApiBundlePreset],
   storage: (deps): OpenapiStore => makeDefaultOpenapiStore(deps),
 
   extension: (ctx: PluginCtx<OpenapiStore>) => makeGooglePluginExtension(options, ctx),

--- a/packages/plugins/google/src/sdk/presets.ts
+++ b/packages/plugins/google/src/sdk/presets.ts
@@ -24,12 +24,23 @@ const gd = (service: string, version: string) =>
 
 const GOOGLE_G = "https://fonts.gstatic.com/s/i/productlogos/googleg/v6/192px.svg";
 export const GOOGLE_BUNDLE_PRESET_ID = "google";
+export const GOOGLE_PHOTOS_PRESET_ID = "google-photos";
+export const GOOGLE_PHOTOS_ICON =
+  "https://www.gstatic.com/images/branding/product/2x/photos_96dp.png";
 
 export const googleOpenApiBundlePreset: GooglePreset = {
   id: GOOGLE_BUNDLE_PRESET_ID,
   name: "Google",
   summary: "Bundle Gmail, Calendar, Drive, Docs, and other Google APIs into one source.",
   icon: GOOGLE_G,
+  featured: true,
+};
+
+export const googlePhotosOpenApiBundlePreset: GooglePreset = {
+  id: GOOGLE_PHOTOS_PRESET_ID,
+  name: "Google Photos",
+  summary: "Albums, uploads, app-created media, and user-selected picker media.",
+  icon: GOOGLE_PHOTOS_ICON,
   featured: true,
 };
 
@@ -110,6 +121,22 @@ export const googleOpenApiPresets: readonly GoogleOpenApiPreset[] = [
     url: gd("people", "v1"),
     icon: "https://fonts.gstatic.com/s/i/productlogos/contacts_2022/v2/192px.svg",
     oauthAudience: "standard-user",
+  },
+  {
+    id: "google-photos-library",
+    name: "Google Photos Library",
+    summary: "Albums, uploads, and app-created media through Google Photos.",
+    url: gd("photoslibrary", "v1"),
+    icon: GOOGLE_PHOTOS_ICON,
+    oauthAudience: "advanced-user",
+  },
+  {
+    id: "google-photos-picker",
+    name: "Google Photos Picker",
+    summary: "Picker sessions and user-selected Google Photos media items.",
+    url: "https://photospicker.googleapis.com/$discovery/rest?version=v1",
+    icon: GOOGLE_PHOTOS_ICON,
+    oauthAudience: "advanced-user",
   },
   {
     id: "google-chat",
@@ -197,6 +224,14 @@ export const googleStandardUserOAuthPresets = googleOpenApiPresets.filter(
   (preset) => preset.oauthAudience === "standard-user",
 );
 
+export const googlePhotosPresetIds: readonly string[] = [
+  "google-photos-library",
+  "google-photos-picker",
+];
+
+export const googlePhotosOpenApiPresets: readonly GoogleOpenApiPreset[] =
+  googleOpenApiPresets.filter((preset) => googlePhotosPresetIds.includes(preset.id));
+
 // ---------------------------------------------------------------------------
 // Representative consent scopes per preset.
 //
@@ -221,6 +256,11 @@ export const googleOAuthConsentScopes: Readonly<Record<string, readonly string[]
   "google-forms": ["https://www.googleapis.com/auth/forms.body"],
   "google-tasks": ["https://www.googleapis.com/auth/tasks"],
   "google-people": ["https://www.googleapis.com/auth/contacts"],
+  "google-photos-library": [
+    "https://www.googleapis.com/auth/photoslibrary.appendonly",
+    "https://www.googleapis.com/auth/photoslibrary.readonly.appcreateddata",
+  ],
+  "google-photos-picker": ["https://www.googleapis.com/auth/photospicker.mediaitems.readonly"],
   "google-chat": ["https://www.googleapis.com/auth/chat.spaces"],
   "google-keep": ["https://www.googleapis.com/auth/keep"],
   "google-youtube-data": ["https://www.googleapis.com/auth/youtube"],

--- a/packages/plugins/openapi/src/sdk/extract.ts
+++ b/packages/plugins/openapi/src/sdk/extract.ts
@@ -355,6 +355,7 @@ export const buildInputSchema = (
       properties.bodyBase64 = {
         type: "string",
         contentEncoding: "base64",
+        contentMediaType: "application/octet-stream",
         description:
           "Base64-encoded bytes for application/octet-stream request bodies. When contentType is omitted, this selects application/octet-stream.",
       };

--- a/packages/plugins/openapi/src/sdk/extract.ts
+++ b/packages/plugins/openapi/src/sdk/extract.ts
@@ -328,13 +328,27 @@ export const buildInputSchema = (
 
   if (requestBody) {
     properties.body = Option.getOrElse(requestBody.schema, () => ({ type: "object" }));
-    if (requestBody.required) required.push("body");
 
     // When the spec declares multiple media types for this requestBody,
     // expose `contentType` so the model can pick. Default = first declared.
     // `body` schema tracks the default; the model is responsible for
     // supplying a body shape that matches whichever contentType it picks.
     const contents = Option.getOrUndefined(requestBody.contents);
+    const acceptsOctetStream =
+      requestBody.contentType.split(";")[0]?.trim().toLowerCase() === "application/octet-stream" ||
+      contents?.some(
+        (content) =>
+          content.contentType.split(";")[0]?.trim().toLowerCase() === "application/octet-stream",
+      ) === true;
+    if (acceptsOctetStream) {
+      properties.bodyBase64 = {
+        type: "string",
+        contentEncoding: "base64",
+        description:
+          "Base64-encoded bytes for application/octet-stream request bodies. When contentType is omitted, this selects application/octet-stream.",
+      };
+    }
+    if (requestBody.required && !acceptsOctetStream) required.push("body");
     if (contents && contents.length > 1) {
       properties.contentType = {
         type: "string",

--- a/packages/plugins/openapi/src/sdk/extract.ts
+++ b/packages/plugins/openapi/src/sdk/extract.ts
@@ -328,12 +328,11 @@ export const buildInputSchema = (
   if (serverProperty && !("server" in properties)) properties.server = serverProperty;
 
   if (requestBody) {
-    properties.body = Option.getOrElse(requestBody.schema, () => ({ type: "object" }));
-
     // When the spec declares multiple media types for this requestBody,
     // expose `contentType` so the model can pick. Default = first declared.
-    // `body` schema tracks the default; the model is responsible for
-    // supplying a body shape that matches whichever contentType it picks.
+    // For mixed bodies, `body` schema tracks the default; the model is
+    // responsible for supplying a body shape that matches whichever
+    // contentType it picks. Octet-only operations use `bodyBase64` instead.
     const contents = Option.getOrUndefined(requestBody.contents);
     const defaultIsOctetStream =
       requestBody.contentType.split(";")[0]?.trim().toLowerCase() === "application/octet-stream";
@@ -349,6 +348,9 @@ export const buildInputSchema = (
         (content) =>
           content.contentType.split(";")[0]?.trim().toLowerCase() !== "application/octet-stream",
       ) === true;
+    if (acceptsBody) {
+      properties.body = Option.getOrElse(requestBody.schema, () => ({ type: "object" }));
+    }
     if (acceptsOctetStream) {
       properties.bodyBase64 = {
         type: "string",

--- a/packages/plugins/openapi/src/sdk/extract.ts
+++ b/packages/plugins/openapi/src/sdk/extract.ts
@@ -316,6 +316,7 @@ export const buildInputSchema = (
 ): Record<string, unknown> | undefined => {
   const properties: Record<string, unknown> = {};
   const required: string[] = [];
+  let requiredBodyAlternatives: readonly { readonly required: readonly string[] }[] | undefined;
 
   for (const param of parameters) {
     properties[param.name] = Option.getOrElse(param.schema, () => ({ type: "string" }));
@@ -334,11 +335,19 @@ export const buildInputSchema = (
     // `body` schema tracks the default; the model is responsible for
     // supplying a body shape that matches whichever contentType it picks.
     const contents = Option.getOrUndefined(requestBody.contents);
+    const defaultIsOctetStream =
+      requestBody.contentType.split(";")[0]?.trim().toLowerCase() === "application/octet-stream";
     const acceptsOctetStream =
-      requestBody.contentType.split(";")[0]?.trim().toLowerCase() === "application/octet-stream" ||
+      defaultIsOctetStream ||
       contents?.some(
         (content) =>
           content.contentType.split(";")[0]?.trim().toLowerCase() === "application/octet-stream",
+      ) === true;
+    const acceptsBody =
+      !defaultIsOctetStream ||
+      contents?.some(
+        (content) =>
+          content.contentType.split(";")[0]?.trim().toLowerCase() !== "application/octet-stream",
       ) === true;
     if (acceptsOctetStream) {
       properties.bodyBase64 = {
@@ -348,7 +357,13 @@ export const buildInputSchema = (
           "Base64-encoded bytes for application/octet-stream request bodies. When contentType is omitted, this selects application/octet-stream.",
       };
     }
-    if (requestBody.required && !acceptsOctetStream) required.push("body");
+    if (requestBody.required) {
+      if (acceptsOctetStream && acceptsBody) {
+        requiredBodyAlternatives = [{ required: ["body"] }, { required: ["bodyBase64"] }];
+      } else {
+        required.push(acceptsOctetStream ? "bodyBase64" : "body");
+      }
+    }
     if (contents && contents.length > 1) {
       properties.contentType = {
         type: "string",
@@ -366,6 +381,7 @@ export const buildInputSchema = (
     type: "object",
     properties,
     ...(required.length > 0 ? { required } : {}),
+    ...(requiredBodyAlternatives ? { anyOf: requiredBodyAlternatives } : {}),
     additionalProperties: false,
   };
 };

--- a/packages/plugins/openapi/src/sdk/invoke.ts
+++ b/packages/plugins/openapi/src/sdk/invoke.ts
@@ -782,11 +782,7 @@ export const invoke = Effect.fn("OpenApi.invoke")(function* (
         binaryBody?.ok === true && !octetStreamContent && isOctetStream(rb.contentType)
           ? rb.contentType
           : (selected?.contentType ?? rb.contentType);
-      if (
-        isOctetStream(chosenCt) &&
-        typeof bodyValue !== "string" &&
-        toUint8Array(bodyValue) === null
-      ) {
+      if (isOctetStream(chosenCt) && toUint8Array(bodyValue) === null) {
         return yield* new OpenApiInvocationError({
           message: "application/octet-stream request body must be bytes; provide `bodyBase64`",
           statusCode: Option.none(),

--- a/packages/plugins/openapi/src/sdk/invoke.ts
+++ b/packages/plugins/openapi/src/sdk/invoke.ts
@@ -782,6 +782,16 @@ export const invoke = Effect.fn("OpenApi.invoke")(function* (
         binaryBody?.ok === true && !octetStreamContent && isOctetStream(rb.contentType)
           ? rb.contentType
           : (selected?.contentType ?? rb.contentType);
+      if (
+        isOctetStream(chosenCt) &&
+        typeof bodyValue !== "string" &&
+        toUint8Array(bodyValue) === null
+      ) {
+        return yield* new OpenApiInvocationError({
+          message: "application/octet-stream request body must be bytes; provide `bodyBase64`",
+          statusCode: Option.none(),
+        });
+      }
       const chosenEncoding = selected
         ? Option.getOrUndefined(selected.encoding)
         : contentsOpt && contentsOpt[0]

--- a/packages/plugins/openapi/src/sdk/invoke.ts
+++ b/packages/plugins/openapi/src/sdk/invoke.ts
@@ -304,12 +304,16 @@ const toUint8Array = (value: unknown): Uint8Array | null => {
   if (Array.isArray(value) && value.every((v) => typeof v === "number")) {
     return new Uint8Array(value as readonly number[]);
   }
-  if (typeof value === "object" && value !== null && !Array.isArray(value)) {
-    const encoded = (value as Record<string, unknown>).bodyBase64;
-    if (typeof encoded === "string") return base64ToUint8Array(encoded);
-  }
   return null;
 };
+
+const readNestedBodyBase64 = (value: unknown): unknown =>
+  typeof value === "object" &&
+  value !== null &&
+  !Array.isArray(value) &&
+  Object.prototype.hasOwnProperty.call(value, "bodyBase64")
+    ? (value as Record<string, unknown>).bodyBase64
+    : undefined;
 
 const readHintString = (option: OperationFileHint["dataField"], fallback: string): string =>
   Option.getOrElse(option, () => fallback);
@@ -723,7 +727,39 @@ export const invoke = Effect.fn("OpenApi.invoke")(function* (
       });
     }
 
-    const bodyValue = bodyBase64?.ok === true ? bodyBase64.bytes : (args.body ?? args.input);
+    const rawBodyValue = args.body ?? args.input;
+    const nestedBodyBase64Raw = readNestedBodyBase64(rawBodyValue);
+    const hasNestedBodyBase64 = nestedBodyBase64Raw !== undefined;
+    const nestedBodyBase64 =
+      typeof nestedBodyBase64Raw === "string" ? decodeBase64Body(nestedBodyBase64Raw) : undefined;
+
+    if (hasNestedBodyBase64 && typeof nestedBodyBase64Raw !== "string") {
+      return yield* new OpenApiInvocationError({
+        message: "`body.bodyBase64` must be a base64 string",
+        statusCode: Option.none(),
+      });
+    }
+    if (nestedBodyBase64?.ok === false) {
+      return yield* new OpenApiInvocationError({
+        message: "`body.bodyBase64` is not valid base64",
+        statusCode: Option.none(),
+      });
+    }
+    if (nestedBodyBase64?.ok === true && !bodyAcceptsOctetStream) {
+      return yield* new OpenApiInvocationError({
+        message: "`body.bodyBase64` requires an application/octet-stream request body",
+        statusCode: Option.none(),
+      });
+    }
+    if (nestedBodyBase64?.ok === true && requestedCt && !isOctetStream(requestedCt)) {
+      return yield* new OpenApiInvocationError({
+        message: "`body.bodyBase64` requires an application/octet-stream contentType",
+        statusCode: Option.none(),
+      });
+    }
+
+    const binaryBody = bodyBase64?.ok === true ? bodyBase64 : nestedBodyBase64;
+    const bodyValue = binaryBody?.ok === true ? binaryBody.bytes : rawBodyValue;
     if (rb.required && bodyValue === undefined) {
       return yield* new OpenApiInvocationError({
         message: bodyAcceptsOctetStream
@@ -737,13 +773,13 @@ export const invoke = Effect.fn("OpenApi.invoke")(function* (
       // multiple, the caller can override via `args.contentType`; otherwise
       // we use the first-declared (spec author's preferred ordering).
       const selected: MediaBinding | undefined =
-        bodyBase64?.ok === true && octetStreamContent
+        binaryBody?.ok === true && octetStreamContent
           ? octetStreamContent
           : contentsOpt && requestedCt
             ? contentsOpt.find((c) => c.contentType === requestedCt)
             : undefined;
       const chosenCt =
-        bodyBase64?.ok === true && !octetStreamContent && isOctetStream(rb.contentType)
+        binaryBody?.ok === true && !octetStreamContent && isOctetStream(rb.contentType)
           ? rb.contentType
           : (selected?.contentType ?? rb.contentType);
       const chosenEncoding = selected

--- a/packages/plugins/openapi/src/sdk/invoke.ts
+++ b/packages/plugins/openapi/src/sdk/invoke.ts
@@ -272,6 +272,21 @@ const bytesFromBase64Prefix = (base64: string): Uint8Array => {
 const sniffMimeTypeFromBase64 = (base64: string): string | null =>
   sniffMimeType(bytesFromBase64Prefix(base64));
 
+const base64ToUint8Array = (value: string): Uint8Array | null => {
+  let binary = "";
+  // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: atob throws for invalid base64; invalid shapes are treated as non-byte input
+  try {
+    binary = atob(normalizeBase64(value, "base64"));
+  } catch {
+    return null;
+  }
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes;
+};
+
 const toUint8Array = (value: unknown): Uint8Array | null => {
   if (value instanceof Uint8Array) return value;
   if (value instanceof ArrayBuffer) return new Uint8Array(value);
@@ -281,6 +296,10 @@ const toUint8Array = (value: unknown): Uint8Array | null => {
   }
   if (Array.isArray(value) && value.every((v) => typeof v === "number")) {
     return new Uint8Array(value as readonly number[]);
+  }
+  if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+    const encoded = (value as Record<string, unknown>).bodyBase64;
+    if (typeof encoded === "string") return base64ToUint8Array(encoded);
   }
   return null;
 };
@@ -663,17 +682,22 @@ export const invoke = Effect.fn("OpenApi.invoke")(function* (
 
   if (Option.isSome(operation.requestBody)) {
     const rb = operation.requestBody.value;
-    const bodyValue = args.body ?? args.input;
+    const bodyBase64 =
+      typeof args.bodyBase64 === "string" ? base64ToUint8Array(args.bodyBase64) : null;
+    const bodyValue = bodyBase64 ?? args.body ?? args.input;
     if (bodyValue !== undefined) {
       // Resolve which declared media type to use. When the spec declares
       // multiple, the caller can override via `args.contentType`; otherwise
       // we use the first-declared (spec author's preferred ordering).
       const contentsOpt = Option.getOrUndefined(rb.contents);
       const requestedCt = typeof args.contentType === "string" ? args.contentType : undefined;
+      const octetStreamContent = contentsOpt?.find((c) => isOctetStream(c.contentType));
       const selected: MediaBinding | undefined =
         contentsOpt && requestedCt
           ? contentsOpt.find((c) => c.contentType === requestedCt)
-          : undefined;
+          : bodyBase64 && octetStreamContent
+            ? octetStreamContent
+            : undefined;
       const chosenCt = selected?.contentType ?? rb.contentType;
       const chosenEncoding = selected
         ? Option.getOrUndefined(selected.encoding)

--- a/packages/plugins/openapi/src/sdk/invoke.ts
+++ b/packages/plugins/openapi/src/sdk/invoke.ts
@@ -272,6 +272,8 @@ const bytesFromBase64Prefix = (base64: string): Uint8Array => {
 const sniffMimeTypeFromBase64 = (base64: string): string | null =>
   sniffMimeType(bytesFromBase64Prefix(base64));
 
+type DecodedBase64Body = { readonly ok: true; readonly bytes: Uint8Array } | { readonly ok: false };
+
 const base64ToUint8Array = (value: string): Uint8Array | null => {
   let binary = "";
   // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: atob throws for invalid base64; invalid shapes are treated as non-byte input
@@ -285,6 +287,11 @@ const base64ToUint8Array = (value: string): Uint8Array | null => {
     bytes[index] = binary.charCodeAt(index);
   }
   return bytes;
+};
+
+const decodeBase64Body = (value: string): DecodedBase64Body => {
+  const bytes = base64ToUint8Array(value);
+  return bytes ? { ok: true, bytes } : { ok: false };
 };
 
 const toUint8Array = (value: unknown): Uint8Array | null => {
@@ -682,23 +689,63 @@ export const invoke = Effect.fn("OpenApi.invoke")(function* (
 
   if (Option.isSome(operation.requestBody)) {
     const rb = operation.requestBody.value;
+    const contentsOpt = Option.getOrUndefined(rb.contents);
+    const requestedCt = typeof args.contentType === "string" ? args.contentType : undefined;
+    const octetStreamContent = contentsOpt?.find((c) => isOctetStream(c.contentType));
+    const bodyAcceptsOctetStream = Boolean(octetStreamContent) || isOctetStream(rb.contentType);
+    const hasBodyBase64 = Object.prototype.hasOwnProperty.call(args, "bodyBase64");
+    const bodyBase64Raw = args.bodyBase64;
     const bodyBase64 =
-      typeof args.bodyBase64 === "string" ? base64ToUint8Array(args.bodyBase64) : null;
-    const bodyValue = bodyBase64 ?? args.body ?? args.input;
+      typeof bodyBase64Raw === "string" ? decodeBase64Body(bodyBase64Raw) : undefined;
+
+    if (hasBodyBase64 && typeof bodyBase64Raw !== "string") {
+      return yield* new OpenApiInvocationError({
+        message: "`bodyBase64` must be a base64 string",
+        statusCode: Option.none(),
+      });
+    }
+    if (bodyBase64?.ok === false) {
+      return yield* new OpenApiInvocationError({
+        message: "`bodyBase64` is not valid base64",
+        statusCode: Option.none(),
+      });
+    }
+    if (bodyBase64?.ok === true && !bodyAcceptsOctetStream) {
+      return yield* new OpenApiInvocationError({
+        message: "`bodyBase64` requires an application/octet-stream request body",
+        statusCode: Option.none(),
+      });
+    }
+    if (bodyBase64?.ok === true && requestedCt && !isOctetStream(requestedCt)) {
+      return yield* new OpenApiInvocationError({
+        message: "`bodyBase64` requires an application/octet-stream contentType",
+        statusCode: Option.none(),
+      });
+    }
+
+    const bodyValue = bodyBase64?.ok === true ? bodyBase64.bytes : (args.body ?? args.input);
+    if (rb.required && bodyValue === undefined) {
+      return yield* new OpenApiInvocationError({
+        message: bodyAcceptsOctetStream
+          ? "Missing required request body: provide `bodyBase64`"
+          : "Missing required request body",
+        statusCode: Option.none(),
+      });
+    }
     if (bodyValue !== undefined) {
       // Resolve which declared media type to use. When the spec declares
       // multiple, the caller can override via `args.contentType`; otherwise
       // we use the first-declared (spec author's preferred ordering).
-      const contentsOpt = Option.getOrUndefined(rb.contents);
-      const requestedCt = typeof args.contentType === "string" ? args.contentType : undefined;
-      const octetStreamContent = contentsOpt?.find((c) => isOctetStream(c.contentType));
       const selected: MediaBinding | undefined =
-        contentsOpt && requestedCt
-          ? contentsOpt.find((c) => c.contentType === requestedCt)
-          : bodyBase64 && octetStreamContent
-            ? octetStreamContent
+        bodyBase64?.ok === true && octetStreamContent
+          ? octetStreamContent
+          : contentsOpt && requestedCt
+            ? contentsOpt.find((c) => c.contentType === requestedCt)
             : undefined;
-      const chosenCt = selected?.contentType ?? rb.contentType;
+      const chosenCt =
+        bodyBase64?.ok === true && !octetStreamContent && isOctetStream(rb.contentType)
+          ? rb.contentType
+          : (selected?.contentType ?? rb.contentType);
       const chosenEncoding = selected
         ? Option.getOrUndefined(selected.encoding)
         : contentsOpt && contentsOpt[0]

--- a/packages/plugins/openapi/src/sdk/non-json-body.test.ts
+++ b/packages/plugins/openapi/src/sdk/non-json-body.test.ts
@@ -259,6 +259,25 @@ describe("OpenAPI non-JSON request body dispatch", () => {
     }),
   );
 
+  it.effect("application/octet-stream: bodyBase64 passes through as bytes", () =>
+    Effect.gen(function* () {
+      const { server, captured } = yield* startEchoServer({
+        payload: Schema.Uint8Array.pipe(HttpApiSchema.asUint8Array()),
+      });
+
+      const executor = yield* createExecutor(makeTestConfig({ plugins: testPlugins() }));
+
+      const conn = yield* addOpenApiTestConnection(executor, server, { slug: "bin_b64" });
+
+      yield* executor.execute(conn.address("body.submit"), {
+        bodyBase64: "3q2+7w==",
+      });
+
+      expect(captured.contentType).toBe("application/octet-stream");
+      expect(Array.from(captured.body)).toEqual([0xde, 0xad, 0xbe, 0xef]);
+    }),
+  );
+
   it.effect(
     "format: byte response: Gmail-style image attachment data is exposed as a file artifact",
     () =>
@@ -754,6 +773,33 @@ describe("OpenAPI non-JSON request body dispatch", () => {
     }),
   );
 
+  it.effect("multi-content: bodyBase64 selects octet-stream without explicit contentType", () =>
+    Effect.gen(function* () {
+      const { server, captured } = yield* startEchoServer({
+        payload: multiContentPayload,
+        transformSpec: replaceRequestBodyContent("/submit", "post", {
+          "application/json": {
+            schema: { type: "object" },
+          },
+          "application/octet-stream": {
+            schema: { type: "string", format: "binary" },
+          },
+        }),
+      });
+
+      const executor = yield* createExecutor(makeTestConfig({ plugins: testPlugins() }));
+
+      const conn = yield* addOpenApiTestConnection(executor, server, { slug: "mc_b64" });
+
+      yield* executor.execute(conn.address("body.submit"), {
+        bodyBase64: "3q2+7w==",
+      });
+
+      expect(captured.contentType).toBe("application/octet-stream");
+      expect(Array.from(captured.body)).toEqual([0xde, 0xad, 0xbe, 0xef]);
+    }),
+  );
+
   it.effect("multi-content: tool input schema exposes contentType enum", () =>
     Effect.gen(function* () {
       const { server } = yield* startEchoServer({
@@ -780,6 +826,26 @@ describe("OpenAPI non-JSON request body dispatch", () => {
         "application/json",
       ]);
       expect(schema.properties?.contentType?.default).toBe("multipart/form-data");
+    }),
+  );
+
+  it.effect("octet-stream: tool input schema exposes bodyBase64", () =>
+    Effect.gen(function* () {
+      const { server } = yield* startEchoServer({
+        payload: Schema.Uint8Array.pipe(HttpApiSchema.asUint8Array()),
+      });
+      const executor = yield* createExecutor(makeTestConfig({ plugins: testPlugins() }));
+
+      const conn = yield* addOpenApiTestConnection(executor, server, { slug: "bin_schema" });
+
+      const view = yield* executor.tools.schema(conn.address("body.submit"));
+      expect(view).not.toBeNull();
+      const schema = view!.inputSchema as {
+        properties?: {
+          bodyBase64?: { contentEncoding?: string };
+        };
+      };
+      expect(schema.properties?.bodyBase64?.contentEncoding).toBe("base64");
     }),
   );
 

--- a/packages/plugins/openapi/src/sdk/non-json-body.test.ts
+++ b/packages/plugins/openapi/src/sdk/non-json-body.test.ts
@@ -994,11 +994,13 @@ describe("OpenAPI non-JSON request body dispatch", () => {
       const schema = view!.inputSchema as {
         required?: string[];
         properties?: {
+          body?: unknown;
           bodyBase64?: { contentEncoding?: string };
         };
       };
       expect(schema.required).toContain("bodyBase64");
       expect(schema.required).not.toContain("body");
+      expect(schema.properties?.body).toBeUndefined();
       expect(schema.properties?.bodyBase64?.contentEncoding).toBe("base64");
     }),
   );

--- a/packages/plugins/openapi/src/sdk/non-json-body.test.ts
+++ b/packages/plugins/openapi/src/sdk/non-json-body.test.ts
@@ -967,11 +967,12 @@ describe("OpenAPI non-JSON request body dispatch", () => {
       const schema = view!.inputSchema as {
         anyOf?: readonly { readonly required?: readonly string[] }[];
         properties?: {
-          bodyBase64?: { contentEncoding?: string };
+          bodyBase64?: { contentEncoding?: string; contentMediaType?: string };
         };
       };
       expect(schema.anyOf).toEqual([{ required: ["body"] }, { required: ["bodyBase64"] }]);
       expect(schema.properties?.bodyBase64?.contentEncoding).toBe("base64");
+      expect(schema.properties?.bodyBase64?.contentMediaType).toBe("application/octet-stream");
     }),
   );
 
@@ -1019,13 +1020,14 @@ describe("OpenAPI non-JSON request body dispatch", () => {
         required?: string[];
         properties?: {
           body?: unknown;
-          bodyBase64?: { contentEncoding?: string };
+          bodyBase64?: { contentEncoding?: string; contentMediaType?: string };
         };
       };
       expect(schema.required).toContain("bodyBase64");
       expect(schema.required).not.toContain("body");
       expect(schema.properties?.body).toBeUndefined();
       expect(schema.properties?.bodyBase64?.contentEncoding).toBe("base64");
+      expect(schema.properties?.bodyBase64?.contentMediaType).toBe("application/octet-stream");
     }),
   );
 

--- a/packages/plugins/openapi/src/sdk/non-json-body.test.ts
+++ b/packages/plugins/openapi/src/sdk/non-json-body.test.ts
@@ -344,6 +344,30 @@ describe("OpenAPI non-JSON request body dispatch", () => {
     }),
   );
 
+  it.effect("application/octet-stream: object body fails before dispatch", () =>
+    Effect.gen(function* () {
+      const { server, captured } = yield* startEchoServer({
+        payload: Schema.Uint8Array.pipe(HttpApiSchema.asUint8Array()),
+      });
+
+      const executor = yield* createExecutor(makeTestConfig({ plugins: testPlugins() }));
+
+      const conn = yield* addOpenApiTestConnection(executor, server, {
+        slug: "bin_object_body",
+      });
+
+      const exit = yield* executor
+        .execute(conn.address("body.submit"), {
+          body: { name: "photo.png" },
+        })
+        .pipe(Effect.exit);
+
+      expect(Exit.isFailure(exit)).toBe(true);
+      expect(captured.contentType).toBe("");
+      expect(captured.body.length).toBe(0);
+    }),
+  );
+
   it.effect(
     "format: byte response: Gmail-style image attachment data is exposed as a file artifact",
     () =>

--- a/packages/plugins/openapi/src/sdk/non-json-body.test.ts
+++ b/packages/plugins/openapi/src/sdk/non-json-body.test.ts
@@ -14,7 +14,7 @@
 // ---------------------------------------------------------------------------
 
 import { describe, expect, it } from "@effect/vitest";
-import { Effect, Schema } from "effect";
+import { Effect, Exit, Schema } from "effect";
 import { FetchHttpClient, HttpServerRequest, HttpServerResponse } from "effect/unstable/http";
 import {
   HttpApi,
@@ -275,6 +275,48 @@ describe("OpenAPI non-JSON request body dispatch", () => {
 
       expect(captured.contentType).toBe("application/octet-stream");
       expect(Array.from(captured.body)).toEqual([0xde, 0xad, 0xbe, 0xef]);
+    }),
+  );
+
+  it.effect("application/octet-stream: invalid bodyBase64 fails before dispatch", () =>
+    Effect.gen(function* () {
+      const { server, captured } = yield* startEchoServer({
+        payload: Schema.Uint8Array.pipe(HttpApiSchema.asUint8Array()),
+      });
+
+      const executor = yield* createExecutor(makeTestConfig({ plugins: testPlugins() }));
+
+      const conn = yield* addOpenApiTestConnection(executor, server, { slug: "bin_b64_bad" });
+
+      const exit = yield* executor
+        .execute(conn.address("body.submit"), {
+          bodyBase64: "@@",
+        })
+        .pipe(Effect.exit);
+
+      expect(Exit.isFailure(exit)).toBe(true);
+      expect(captured.contentType).toBe("");
+      expect(captured.body.length).toBe(0);
+    }),
+  );
+
+  it.effect("application/octet-stream: required body fails before dispatch when missing", () =>
+    Effect.gen(function* () {
+      const { server, captured } = yield* startEchoServer({
+        payload: Schema.Uint8Array.pipe(HttpApiSchema.asUint8Array()),
+      });
+
+      const executor = yield* createExecutor(makeTestConfig({ plugins: testPlugins() }));
+
+      const conn = yield* addOpenApiTestConnection(executor, server, {
+        slug: "bin_b64_missing",
+      });
+
+      const exit = yield* executor.execute(conn.address("body.submit"), {}).pipe(Effect.exit);
+
+      expect(Exit.isFailure(exit)).toBe(true);
+      expect(captured.contentType).toBe("");
+      expect(captured.body.length).toBe(0);
     }),
   );
 
@@ -800,6 +842,67 @@ describe("OpenAPI non-JSON request body dispatch", () => {
     }),
   );
 
+  it.effect("multi-content: bodyBase64 rejects a non-octet contentType", () =>
+    Effect.gen(function* () {
+      const { server, captured } = yield* startEchoServer({
+        payload: multiContentPayload,
+        transformSpec: replaceRequestBodyContent("/submit", "post", {
+          "application/json": {
+            schema: { type: "object" },
+          },
+          "application/octet-stream": {
+            schema: { type: "string", format: "binary" },
+          },
+        }),
+      });
+
+      const executor = yield* createExecutor(makeTestConfig({ plugins: testPlugins() }));
+
+      const conn = yield* addOpenApiTestConnection(executor, server, { slug: "mc_b64_bad_ct" });
+
+      const exit = yield* executor
+        .execute(conn.address("body.submit"), {
+          contentType: "application/json",
+          bodyBase64: "3q2+7w==",
+        })
+        .pipe(Effect.exit);
+
+      expect(Exit.isFailure(exit)).toBe(true);
+      expect(captured.contentType).toBe("");
+      expect(captured.body.length).toBe(0);
+    }),
+  );
+
+  it.effect("multi-content: required schema accepts body or bodyBase64", () =>
+    Effect.gen(function* () {
+      const { server } = yield* startEchoServer({
+        payload: multiContentPayload,
+        transformSpec: replaceRequestBodyContent("/submit", "post", {
+          "application/json": {
+            schema: { type: "object" },
+          },
+          "application/octet-stream": {
+            schema: { type: "string", format: "binary" },
+          },
+        }),
+      });
+      const executor = yield* createExecutor(makeTestConfig({ plugins: testPlugins() }));
+
+      const conn = yield* addOpenApiTestConnection(executor, server, { slug: "mc_b64_schema" });
+
+      const view = yield* executor.tools.schema(conn.address("body.submit"));
+      expect(view).not.toBeNull();
+      const schema = view!.inputSchema as {
+        anyOf?: readonly { readonly required?: readonly string[] }[];
+        properties?: {
+          bodyBase64?: { contentEncoding?: string };
+        };
+      };
+      expect(schema.anyOf).toEqual([{ required: ["body"] }, { required: ["bodyBase64"] }]);
+      expect(schema.properties?.bodyBase64?.contentEncoding).toBe("base64");
+    }),
+  );
+
   it.effect("multi-content: tool input schema exposes contentType enum", () =>
     Effect.gen(function* () {
       const { server } = yield* startEchoServer({
@@ -841,10 +944,13 @@ describe("OpenAPI non-JSON request body dispatch", () => {
       const view = yield* executor.tools.schema(conn.address("body.submit"));
       expect(view).not.toBeNull();
       const schema = view!.inputSchema as {
+        required?: string[];
         properties?: {
           bodyBase64?: { contentEncoding?: string };
         };
       };
+      expect(schema.required).toContain("bodyBase64");
+      expect(schema.required).not.toContain("body");
       expect(schema.properties?.bodyBase64?.contentEncoding).toBe("base64");
     }),
   );

--- a/packages/plugins/openapi/src/sdk/non-json-body.test.ts
+++ b/packages/plugins/openapi/src/sdk/non-json-body.test.ts
@@ -368,6 +368,30 @@ describe("OpenAPI non-JSON request body dispatch", () => {
     }),
   );
 
+  it.effect("application/octet-stream: string body fails before dispatch", () =>
+    Effect.gen(function* () {
+      const { server, captured } = yield* startEchoServer({
+        payload: Schema.Uint8Array.pipe(HttpApiSchema.asUint8Array()),
+      });
+
+      const executor = yield* createExecutor(makeTestConfig({ plugins: testPlugins() }));
+
+      const conn = yield* addOpenApiTestConnection(executor, server, {
+        slug: "bin_string_body",
+      });
+
+      const exit = yield* executor
+        .execute(conn.address("body.submit"), {
+          body: "3q2+7w==",
+        })
+        .pipe(Effect.exit);
+
+      expect(Exit.isFailure(exit)).toBe(true);
+      expect(captured.contentType).toBe("");
+      expect(captured.body.length).toBe(0);
+    }),
+  );
+
   it.effect(
     "format: byte response: Gmail-style image attachment data is exposed as a file artifact",
     () =>

--- a/packages/plugins/openapi/src/sdk/non-json-body.test.ts
+++ b/packages/plugins/openapi/src/sdk/non-json-body.test.ts
@@ -300,6 +300,30 @@ describe("OpenAPI non-JSON request body dispatch", () => {
     }),
   );
 
+  it.effect("application/octet-stream: invalid nested bodyBase64 fails before dispatch", () =>
+    Effect.gen(function* () {
+      const { server, captured } = yield* startEchoServer({
+        payload: Schema.Uint8Array.pipe(HttpApiSchema.asUint8Array()),
+      });
+
+      const executor = yield* createExecutor(makeTestConfig({ plugins: testPlugins() }));
+
+      const conn = yield* addOpenApiTestConnection(executor, server, {
+        slug: "bin_nested_b64_bad",
+      });
+
+      const exit = yield* executor
+        .execute(conn.address("body.submit"), {
+          body: { bodyBase64: "@@" },
+        })
+        .pipe(Effect.exit);
+
+      expect(Exit.isFailure(exit)).toBe(true);
+      expect(captured.contentType).toBe("");
+      expect(captured.body.length).toBe(0);
+    }),
+  );
+
   it.effect("application/octet-stream: required body fails before dispatch when missing", () =>
     Effect.gen(function* () {
       const { server, captured } = yield* startEchoServer({


### PR DESCRIPTION
## Summary

Google Photos uploads need a raw byte upload step before `mediaItems.batchCreate`, but Google Discovery does not publish that `/uploads` endpoint as an operation. Executor also receives tool arguments as JSON, so binary media cannot be safely sent through a plain `body` string.

This adds a focused Google Photos preset and a binary-safe `bodyBase64` path for raw upload requests.

## Changes

- Add a `Google Photos` preset for Photos Library + Photos Picker.
- Synthesize `photoslibrary.mediaItems.upload` for the raw `/uploads` token step missing from Google Discovery.
- Add `bodyBase64` support for `application/octet-stream` OpenAPI request bodies.
- Keep the Photos preset scoped to upload, app-created media reads, and picker-selected media reads.

Related: #1096 handled binary Google media downloads. This PR handles binary upload requests.

## Evidence

- `bun run test src/sdk/non-json-body.test.ts` in `packages/plugins/openapi`
- `bun run test src/sdk/plugin.test.ts` in `packages/plugins/google`
- `E2E_CLOUD_URL=http://localhost:43300 bun run test:cloud -- scenarios/google-photos-preset-ui.test.ts` in `e2e`
- `bun run --cwd packages/plugins/openapi typecheck`
- `bun run --cwd packages/plugins/google typecheck`
- `bun run format:check`
- `bun run lint`
- `git diff --check`

![Google Photos: the focused preset opens a Photos-scoped add flow](https://raw.githubusercontent.com/zrm625/executor/e2e-media/google-photos-the-focused-preset-opens-a-photos-scoped-add-flow-f9b030b0.gif)

## Dogfood

Running at https://executor.home.zakstak.com/. Verified on June 25, 2026: hosted catalog exposes `google_photos`, `photoslibrary.mediaItems.upload` exposes `bodyBase64`, and a tiny PNG upload-token smoke returned `ok: true` without calling `mediaItems.batchCreate`.

Hermes dogfooded this as an MCP call and uploaded more than 4,000 photos and videos through this flow.

