### PR TITLE
Warn when `executor web --scope` is used without --foreground (part of #1120)

### DIFF
--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -2352,6 +2352,19 @@ const webCommand = Command.make(
   ({ foreground, port, scope, hostname, allowedHost, authToken }) =>
     Effect.gen(function* () {
       if (!foreground) {
+        // `--scope` can ONLY be honored by a foreground server we boot here.
+        // Without `--foreground` we just open whatever background service is
+        // already running, which uses the scope IT was started with — so a
+        // `--scope` here would be silently ignored and the user could land on a
+        // different workspace ("where did my config go?"). Say so loudly and
+        // point at the flag that actually applies it.
+        if (Option.isSome(scope)) {
+          console.warn(
+            `Ignoring --scope ${scope.value}: it only applies with --foreground. ` +
+              `The running web app uses the scope it was started with. ` +
+              `Run \`executor web --foreground --scope ${scope.value}\` to serve that workspace.`,
+          );
+        }
         yield* openRunningLocalWebApp();
         return;
       }

--- a/e2e/local/cli-web-transition.test.ts
+++ b/e2e/local/cli-web-transition.test.ts
@@ -55,3 +55,35 @@ scenario(
     }
   }),
 );
+
+scenario(
+  "CLI web · --scope without --foreground warns instead of silently ignoring it",
+  { timeout: 120_000 },
+  Effect.promise(async () => {
+    // Regression guard for "Had to setup my config again": `executor web --scope X`
+    // without `--foreground` cannot honor the scope (it opens the running service,
+    // which keeps its own scope). That used to be a SILENT no-op — the user lands
+    // on a different workspace and thinks their config vanished. It must warn.
+    const root = mkdtempSync(join(tmpdir(), "executor-web-scope-"));
+    const dataDir = join(root, "data");
+    const scopeDir = join(root, "workspace");
+    try {
+      const { stdout, stderr } = await execFileAsync(
+        "bun",
+        ["run", "dev:cli", "web", "--scope", scopeDir],
+        { cwd: repoRoot, env: { ...process.env, EXECUTOR_DATA_DIR: dataDir } },
+      );
+      const output = `${stdout}\n${stderr}`;
+
+      expect(output, "the dropped --scope is called out, not silently ignored").toContain(
+        "Ignoring --scope",
+      );
+      expect(output, "the warning names the scope it dropped").toContain(scopeDir);
+      expect(output, "the warning points at the flag that actually applies scope").toContain(
+        "--foreground",
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  }),
+);


### PR DESCRIPTION
Part of #1120 (3 of 4). Independent of the other three.

## Problem

Without `--foreground`, `executor web` just opens whatever background service is already running, which keeps the scope it was started with. A `--scope` passed here was silently ignored, so the user could land on a different workspace and wonder where their config went.

## Fix

Warn loudly when `--scope` is passed without `--foreground`, and name the flag that actually applies it (`executor web --foreground --scope <dir>`).

## Tests

Adds an e2e scenario in `cli-web-transition` asserting the warning names the scope dir and the `--foreground` flag instead of silently dropping it (lint 0/0, typecheck 41/41).
