### PR TITLE
Preserve URL org scope in cloud auth flows

### DIFF
--- a/apps/cloud/src/api.request-scope.node.test.ts
+++ b/apps/cloud/src/api.request-scope.node.test.ts
@@ -188,8 +188,8 @@ describe("makeApiLive (prod handler factory) request scoping", () => {
     // has built the per-request layer. We don't care about the response —
     // only that the layer was built once per request. `/integrations` is a
     // v2 protected route (the old `/scope` group was removed).
-    await handler(new Request("http://test.local/integrations"));
-    await handler(new Request("http://test.local/integrations"));
+    await handler(new Request("http://test.local/integrations"), Context.empty());
+    await handler(new Request("http://test.local/integrations"), Context.empty());
 
     expect(counts.acquires).toBe(2);
     expect(counts.releases).toBe(2);

--- a/apps/cloud/src/api/layers.ts
+++ b/apps/cloud/src/api/layers.ts
@@ -4,7 +4,7 @@ import { Layer } from "effect";
 
 import { makeProtectedApiLayer, requestScopedMiddleware } from "@executor-js/api/server";
 
-import { OrgAuthLive, SessionAuthLive } from "../auth/middleware-live";
+import { SessionAuthLive } from "../auth/middleware-live";
 import { UserStoreService } from "../auth/context";
 import {
   CloudAuthPublicHandlers,
@@ -14,6 +14,7 @@ import {
 import { DbService } from "../db/db";
 import { WorkerTelemetryLive } from "../observability/telemetry";
 import { OrgHttpApi } from "../org/api";
+import { orgAuthMiddleware } from "../org/auth-middleware";
 import { OrgHandlers } from "../org/handlers";
 import { ErrorCaptureLive } from "../observability";
 
@@ -61,23 +62,24 @@ export const makeNonProtectedApiLive = (rsLive: Layer.Layer<DbService | UserStor
     Layer.provideMerge(AutumnService.Default),
   );
 
-// Cloud-only WorkOS domain-verification routes. Auth is enforced by `OrgAuth`
-// middleware declared on `OrgHttpApi`. The domain handlers read the boot
-// `WorkOSClient` plus the `AuthContext` from `OrgAuthLive`; the
-// `getDomainVerificationLink` handler also gates on billing, so
-// `AutumnService.Default` is provided HERE (not on the neutral boot core).
-// Unlike the member endpoints that used to live here, they need no per-request
-// DB scoping (and `OrgAuthLive` stays session-scoped — see its note).
-export const OrgApiLive = HttpApiBuilder.layer(OrgHttpApi).pipe(
-  Layer.provide(OrgHandlers),
-  Layer.provideMerge(OrgAuthLive),
-  Layer.provideMerge(AutumnService.Default),
-);
+// Cloud-only WorkOS domain-verification routes. Auth is enforced by a router
+// middleware that resolves the URL org selector header before falling back to
+// the session org, so slug lookup uses the same per-request UserStoreService as
+// the account and protected APIs. The `getDomainVerificationLink` handler also
+// gates on billing, so `AutumnService.Default` is provided here, not on the
+// neutral boot core.
+export const makeOrgApiLive = (rsLive: Layer.Layer<DbService | UserStoreService>) =>
+  HttpApiBuilder.layer(OrgHttpApi).pipe(
+    Layer.provide(OrgHandlers),
+    Layer.provide(orgAuthMiddleware(rsLive)),
+    Layer.provideMerge(AutumnService.Default),
+  );
 
 // Default export uses the production per-request layer. Existing callers that
 // import `NonProtectedApiLive` continue to work; the `make*` factory exists for
 // tests that need to swap in a fake.
 export const NonProtectedApiLive = makeNonProtectedApiLive(RequestScopedServicesLive);
+export const OrgApiLive = makeOrgApiLive(RequestScopedServicesLive);
 
 // ---------------------------------------------------------------------------
 // Protected API

--- a/apps/cloud/src/api/router.ts
+++ b/apps/cloud/src/api/router.ts
@@ -12,8 +12,8 @@ import { CloudDocsLive } from "../extensions/docs";
 import { ApiErrorLoggingLive } from "../observability/error-logging";
 import {
   BootSharedServices,
-  OrgApiLive,
   RequestScopedServicesLive,
+  makeOrgApiLive,
   makeNonProtectedApiLive,
 } from "./layers";
 import { makeProtectedApiLive } from "./protected";
@@ -35,7 +35,7 @@ export const makeApiLive = (requestScopedLive: Layer.Layer<DbService | UserStore
   );
   return Layer.mergeAll(
     makeNonProtectedApiLive(requestScopedLive),
-    OrgApiLive,
+    makeOrgApiLive(requestScopedLive),
     makeAccountApiLive(requestScopedLive),
     CloudDocsLive,
     makeProtectedApiLive(requestScopedLive),

--- a/apps/cloud/src/auth/handlers.ts
+++ b/apps/cloud/src/auth/handlers.ts
@@ -1,6 +1,7 @@
 import { HttpApi, HttpApiBuilder } from "effect/unstable/httpapi";
-import { HttpServerResponse } from "effect/unstable/http";
+import { HttpServerRequest, HttpServerResponse } from "effect/unstable/http";
 import { Duration, Effect, Predicate } from "effect";
+import { isValidOrgSlug } from "@executor-js/api";
 
 import {
   AUTH_PATHS,
@@ -25,7 +26,12 @@ import {
   isOverFreeOrganizationLimit,
   shouldApplyFreeOrganizationLimit,
 } from "../extensions/billing/plans";
-import { authorizeOrganization, resolveOrganization } from "./organization";
+import {
+  ORG_SELECTOR_HEADER,
+  authorizeOrganization,
+  authorizeOrganizationSelector,
+  resolveOrganization,
+} from "./organization";
 import type {
   McpSessionApprovalResult,
   McpSessionResumeApprovalResult,
@@ -82,14 +88,37 @@ const timingSafeEqual = (a: string, b: string): boolean => {
   return diff === 0;
 };
 
-const requireSessionOrganizationId = Effect.gen(function* () {
+const requestHeaders = Effect.map(HttpServerRequest.HttpServerRequest.asEffect(), (req) => ({
+  ...req.headers,
+}));
+
+const firstPathSegment = (path: string): string | null => {
+  const pathname = path.split(/[?#]/, 1)[0] ?? "";
+  const segment = pathname.split("/")[1];
+  return segment && isValidOrgSlug(segment) ? segment : null;
+};
+
+const requestedOrgSelectorFromReturnTo = (returnTo: string): string | null =>
+  firstPathSegment(returnTo);
+
+const requireSelectedOrganization = Effect.gen(function* () {
   const session = yield* SessionContext;
-  if (!session.organizationId) {
+  const headers = yield* requestHeaders;
+  const selector = headers[ORG_SELECTOR_HEADER] ?? session.organizationId;
+  if (!selector) {
     return yield* new NoOrganization();
   }
+
+  const org = yield* authorizeOrganizationSelector(session.accountId, selector).pipe(
+    Effect.catch(() => Effect.fail(new NoOrganization())),
+  );
+  if (!org) {
+    return yield* new NoOrganization();
+  }
+
   return {
     ...session,
-    organizationId: session.organizationId,
+    organizationId: org.id,
   };
 });
 
@@ -194,37 +223,46 @@ export const CloudAuthPublicHandlers = HttpApiBuilder.group(
 
           let sealedSession = result.sealedSession;
 
-          // If the auth response didn't surface an org but the user is already
-          // an *active* member of one, rehydrate the session with it. Pending
-          // memberships (which represent unaccepted invitations on WorkOS's
-          // side) are skipped — refreshing into one 400s, and silently
-          // attaching an unaccepted org would also bypass invite consent.
-          // If they have no active memberships, leave the session org-less —
-          // AuthGate's onboarding flow surfaces pending invites and the
-          // create-org form. We never auto-create organizations on login.
-          if (!result.organizationId && sealedSession) {
+          // Resume where the SSR gate interrupted them. The state passed the
+          // CSRF check above whenever it's present, but it's still a
+          // round-tripped value, so the returnTo inside it is re-validated like
+          // any other untrusted path.
+          const returnTo = safeReturnTo(decodeLoginState(query.state)?.returnTo) ?? "/";
+          const requestedOrgSelector = requestedOrgSelectorFromReturnTo(returnTo);
+          const requestedOrg = requestedOrgSelector
+            ? yield* authorizeOrganizationSelector(result.user.id, requestedOrgSelector).pipe(
+                Effect.orElseSucceed(() => null),
+              )
+            : null;
+
+          // Prefer the org in the URL that sent the user to login. If the URL
+          // is bare, or not an org route, fall back to WorkOS's org and then to
+          // the first active membership for org-less sessions. Pending
+          // memberships are skipped because refreshing into one 400s and would
+          // bypass invite consent.
+          let targetOrganizationId = requestedOrg?.id ?? result.organizationId ?? null;
+          if (!targetOrganizationId && !requestedOrgSelector) {
             const memberships = yield* workos.listUserMemberships(result.user.id);
             const existingActive = memberships.data.find((m) => m.status === "active");
-            if (existingActive) {
-              // Best-effort refresh — if WorkOS rejects (e.g. the membership
-              // was just revoked), fall through to an org-less session rather
-              // than 500ing the entire callback.
-              const refreshed = yield* workos
-                .refreshSession(sealedSession, existingActive.organizationId)
-                .pipe(Effect.orElseSucceed(() => null));
-              if (refreshed) sealedSession = refreshed;
-            }
+            targetOrganizationId = existingActive?.organizationId ?? null;
+          }
+
+          if (
+            targetOrganizationId &&
+            targetOrganizationId !== result.organizationId &&
+            sealedSession
+          ) {
+            // Best-effort refresh: if WorkOS rejects, fall through with the
+            // original session instead of 500ing the entire callback.
+            const refreshed = yield* workos
+              .refreshSession(sealedSession, targetOrganizationId)
+              .pipe(Effect.orElseSucceed(() => null));
+            if (refreshed) sealedSession = refreshed;
           }
 
           if (!sealedSession) {
             return HttpServerResponse.text("Failed to create session", { status: 500 });
           }
-
-          // Resume where the SSR gate interrupted them. The state passed the
-          // CSRF check above whenever it's present, but it's still a
-          // round-tripped value — so the returnTo inside it is re-validated
-          // like any other untrusted path.
-          const returnTo = safeReturnTo(decodeLoginState(query.state)?.returnTo) ?? "/";
 
           return deleteResponseCookie(
             setResponseCookie(
@@ -489,7 +527,7 @@ export const CloudSessionAuthHandlers = HttpApiBuilder.group(
       )
       .handle("getMcpPaused", ({ params }) =>
         Effect.gen(function* () {
-          const owner = yield* requireSessionOrganizationId;
+          const owner = yield* requireSelectedOrganization;
           const stub = yield* requireMcpSessionStub(params.mcpSessionId, params.executionId);
           const result = yield* Effect.promise(
             () =>
@@ -511,7 +549,7 @@ export const CloudSessionAuthHandlers = HttpApiBuilder.group(
       )
       .handle("resumeMcpExecution", ({ params, payload }) =>
         Effect.gen(function* () {
-          const owner = yield* requireSessionOrganizationId;
+          const owner = yield* requireSelectedOrganization;
           const stub = yield* requireMcpSessionStub(params.mcpSessionId, params.executionId);
           const result = yield* Effect.promise(
             () =>

--- a/apps/cloud/src/auth/middleware-live.ts
+++ b/apps/cloud/src/auth/middleware-live.ts
@@ -85,13 +85,6 @@ export const OrgAuthLive = Layer.effect(
             return yield* Effect.fail(new NoOrganization());
           }
 
-          // NOTE: the domains plane stays scoped to the SESSION org, not the URL
-          // org. Unlike the data + account planes (which resolve the selector
-          // header), this `HttpApiMiddleware` security handler may carry no
-          // residual requirement, so it can't reach the per-request
-          // `UserStoreService` a slug→id resolution needs. The domains surface
-          // (org-settings → domain verification) is niche; URL-scoping it would
-          // mean converting this to an HttpRouter middleware — deferred.
           const session = sessionFromSealed(result, Redacted.value(credential));
           const auth = {
             accountId: session.accountId,

--- a/apps/cloud/src/extensions/routes.ts
+++ b/apps/cloud/src/extensions/routes.ts
@@ -33,8 +33,9 @@ import {
   NonProtectedApi,
 } from "../auth/handlers";
 import { CloudAuthApi, CloudAuthPublicApi } from "../auth/api";
-import { OrgAuthLive, SessionAuthLive } from "../auth/middleware-live";
+import { SessionAuthLive } from "../auth/middleware-live";
 import { OrgApi, OrgHttpApi } from "../org/api";
+import { orgAuthMiddleware } from "../org/auth-middleware";
 import { OrgHandlers } from "../org/handlers";
 import { AutumnService } from "../extensions/billing/service";
 import { DbService } from "../db/db";
@@ -79,11 +80,13 @@ export const makeCloudExtensionRoutes = (rsLive: Layer.Layer<DbService | UserSto
     Layer.provide(apiPrefixedRouter),
   );
 
-  // Cloud-only WorkOS domain-verification routes; `OrgAuth` enforces an
-  // authenticated org session. No per-request DB scoping needed.
+  // Cloud-only WorkOS domain-verification routes; the auth middleware resolves
+  // the URL org selector header before falling back to the session org, so slug
+  // lookup needs the same request-scoped UserStoreService as other org-scoped
+  // APIs.
   const OrgRoutes = HttpApiBuilder.layer(OrgHttpApi).pipe(
     Layer.provide(OrgHandlers),
-    Layer.provideMerge(OrgAuthLive),
+    Layer.provide(orgAuthMiddleware(rsLive)),
     Layer.provideMerge(AutumnService.Default),
     Layer.provide(apiPrefixedRouter),
   );

--- a/apps/cloud/src/mcp/session-durable-object.ts
+++ b/apps/cloud/src/mcp/session-durable-object.ts
@@ -217,6 +217,7 @@ export class McpSessionDO extends McpSessionDOBase<CloudSessionDbHandle> {
                     origin: env.VITE_PUBLIC_SITE_URL ?? "https://executor.sh",
                     executionId,
                     sessionId: self.sessionId,
+                    organizationSlug: sessionMeta.organizationSlug,
                   }),
               }
             : { mode: sessionElicitationMode },

--- a/apps/cloud/src/org/api.ts
+++ b/apps/cloud/src/org/api.ts
@@ -1,7 +1,6 @@
 import { HttpApi, HttpApiEndpoint, HttpApiGroup } from "effect/unstable/httpapi";
 import { Schema } from "effect";
 import { WorkOSError } from "../auth/errors";
-import { OrgAuth } from "../auth/middleware";
 
 // ---------------------------------------------------------------------------
 // Cloud-local org API — the WorkOS domain-verification surface only. Members /
@@ -59,5 +58,5 @@ export class OrgApi extends HttpApiGroup.make("org")
     }),
   ) {}
 
-/** Org API with org-level auth — requires authenticated session with an org. */
-export const OrgHttpApi = HttpApi.make("org").add(OrgApi).middleware(OrgAuth);
+/** Org API with org-level auth supplied by the router middleware in auth-middleware.ts. */
+export const OrgHttpApi = HttpApi.make("org").add(OrgApi);

--- a/apps/cloud/src/org/auth-middleware.ts
+++ b/apps/cloud/src/org/auth-middleware.ts
@@ -1,0 +1,67 @@
+import { Effect, Layer } from "effect";
+import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http";
+
+import { AuthContext, requestScopedMiddleware } from "@executor-js/api/server";
+
+import { UserStoreService } from "../auth/context";
+import { sessionFromSealed } from "../auth/middleware";
+import { ORG_SELECTOR_HEADER, authorizeOrganizationSelector } from "../auth/organization";
+import { WorkOSClient } from "../auth/workos";
+import { DbService } from "../db/db";
+
+const unauthorized = () =>
+  HttpServerResponse.jsonUnsafe(
+    {
+      error: "Invalid or expired session",
+      code: "invalid_session",
+    },
+    { status: 401 },
+  );
+
+const noOrganization = () =>
+  HttpServerResponse.jsonUnsafe(
+    {
+      error: "No organization in session",
+      code: "no_organization",
+    },
+    { status: 403 },
+  );
+
+const OrgAuthMiddleware = HttpRouter.middleware<{ provides: AuthContext }>()(
+  Effect.gen(function* () {
+    const captured = yield* Effect.context<WorkOSClient>();
+    const workos = yield* WorkOSClient;
+    return (httpEffect) =>
+      Effect.gen(function* () {
+        const request = yield* HttpServerRequest.HttpServerRequest;
+        const cookieValue = request.cookies["wos-session"] ?? "";
+        const result = yield* workos
+          .authenticateSealedSession(cookieValue)
+          .pipe(Effect.orElseSucceed(() => null));
+        if (!result) return unauthorized();
+
+        const selector = request.headers[ORG_SELECTOR_HEADER] ?? result.organizationId;
+        if (!selector) return noOrganization();
+
+        const org = yield* authorizeOrganizationSelector(result.userId, selector).pipe(
+          Effect.orElseSucceed(() => null),
+        );
+        if (!org) return noOrganization();
+
+        const session = sessionFromSealed(result, cookieValue);
+        const auth = AuthContext.of({
+          accountId: session.accountId,
+          organizationId: org.id,
+          email: session.email,
+          name: session.name,
+          avatarUrl: session.avatarUrl,
+          roles: [],
+        });
+
+        return yield* Effect.provideService(httpEffect, AuthContext, auth);
+      }).pipe(Effect.provideContext(captured));
+  }),
+);
+
+export const orgAuthMiddleware = (rsLive: Layer.Layer<DbService | UserStoreService>) =>
+  OrgAuthMiddleware.combine(requestScopedMiddleware(rsLive)).layer;

--- a/apps/cloud/src/org/handlers.ts
+++ b/apps/cloud/src/org/handlers.ts
@@ -5,6 +5,7 @@ import { AuthContext } from "@executor-js/api/server";
 import { env } from "cloudflare:workers";
 import { WorkOSClient } from "../auth/workos";
 import { AutumnService } from "../extensions/billing/service";
+import { resolveOrganization } from "../auth/organization";
 import { Forbidden, OrgHttpApi } from "./api";
 
 // ---------------------------------------------------------------------------
@@ -89,13 +90,16 @@ export const OrgHandlers = HttpApiBuilder.group(OrgHttpApi, "org", (handlers) =>
           return yield* new Forbidden();
         }
 
+        const org = yield* resolveOrganization(auth.organizationId).pipe(
+          Effect.catchCause(() => Effect.succeed(null)),
+        );
+        const returnPath = org?.slug ? `/${org.slug}/org` : "/org";
         const workos = yield* WorkOSClient;
-        // WorkOS requires an ABSOLUTE returnUrl — fall back to the pinned origin
-        // (matching every other VITE_PUBLIC_SITE_URL site in this host), not a
-        // bare relative path that WorkOS would reject.
+        // WorkOS requires an absolute returnUrl. Keep the URL org slug in that
+        // return path so the browser comes back to the same selected org.
         const { link } = yield* workos.generateDomainVerificationPortalLink(
           auth.organizationId,
-          `${env.VITE_PUBLIC_SITE_URL ?? "https://executor.sh"}/org`,
+          `${env.VITE_PUBLIC_SITE_URL ?? "https://executor.sh"}${returnPath}`,
         );
         return { link };
       }),

--- a/apps/cloud/src/web/client.tsx
+++ b/apps/cloud/src/web/client.tsx
@@ -1,7 +1,8 @@
 import * as AtomHttpApi from "effect/unstable/reactivity/AtomHttpApi";
-import { FetchHttpClient } from "effect/unstable/http";
+import { FetchHttpClient, HttpClient, HttpClientRequest } from "effect/unstable/http";
 import { addGroup } from "@executor-js/api";
 import { getBaseUrl } from "@executor-js/react/api/base-url";
+import { EXECUTOR_ORG_HEADER, getActiveOrgSlug } from "@executor-js/react/api/server-connection";
 import { CloudAuthApi } from "../auth/api";
 import { OrgApi } from "../org/api";
 
@@ -14,6 +15,10 @@ const CloudApiClient = AtomHttpApi.Service<"CloudApiClient">()("CloudApiClient",
   api: CloudApi,
   httpClient: FetchHttpClient.layer,
   baseUrl: getBaseUrl(),
+  transformClient: HttpClient.mapRequest((request) => {
+    const orgSlug = getActiveOrgSlug();
+    return orgSlug ? HttpClientRequest.setHeader(request, EXECUTOR_ORG_HEADER, orgSlug) : request;
+  }),
 });
 
 export { CloudApiClient };

--- a/apps/host-cloudflare/src/mcp/session-durable-object.ts
+++ b/apps/host-cloudflare/src/mcp/session-durable-object.ts
@@ -108,6 +108,7 @@ export class McpSessionDO extends McpSessionDOBase<CfSessionDbHandle> {
                     origin: origin ?? "https://unconfigured-origin.invalid",
                     executionId,
                     sessionId: self.sessionId,
+                    organizationSlug: sessionMeta.organizationSlug,
                   });
                 },
               }

--- a/e2e/cloud/mcp-browser-approval-org-scope.test.ts
+++ b/e2e/cloud/mcp-browser-approval-org-scope.test.ts
@@ -1,0 +1,206 @@
+// Cloud-only: MCP browser approval URLs must preserve the session's org scope.
+//
+// The MCP session is created in org A, then the browser cookie is moved to org B
+// before the human opens the approval link. The returned approval URL itself
+// must carry org A's slug so the rendered approval page scopes both GET and
+// resume POST requests to org A, not the cookie-pinned org B.
+import { randomBytes } from "node:crypto";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import type { Page, Request } from "playwright";
+import { composePluginApi } from "@executor-js/api/server";
+
+import { scenario } from "../src/scenario";
+import { Api, Browser, Mcp, Target } from "../src/services";
+import { type McpBrowserApproval, parseBrowserApproval } from "../src/surfaces/mcp";
+
+const coreApi = composePluginApi([] as const);
+
+const GATE_TOOL = "executor.coreTools.policies.list";
+
+const GATED_CODE = `
+const result = await tools.executor.coreTools.policies.list({});
+return JSON.stringify(result);
+`;
+
+const cookiePair = (response: Response, name: string): string | undefined => {
+  for (const header of response.headers.getSetCookie?.() ?? []) {
+    if (header.startsWith(`${name}=`)) return header.split(";")[0];
+  }
+  return undefined;
+};
+
+const cookieValue = (pair: string): string => {
+  const [, value] = pair.split(/=(.*)/s);
+  if (!value) throw new Error("cookie pair has no value");
+  return value;
+};
+
+const cookieOf = (identity: { readonly headers?: Record<string, string> }): string =>
+  identity.headers?.cookie ?? "";
+
+const originHeaders = (baseUrl: string) => ({ origin: new URL(baseUrl).origin });
+
+const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+const setWorkosSessionCookie = async (page: Page, baseUrl: string, cookie: string) => {
+  await page.context().addCookies([
+    {
+      name: "wos-session",
+      value: cookieValue(cookie),
+      url: baseUrl,
+    },
+  ]);
+};
+
+const expectOrgShell = async (
+  page: Page,
+  org: { readonly name: string; readonly slug: string },
+) => {
+  await page.waitForURL(
+    (url) => url.pathname === `/${org.slug}` || url.pathname === `/${org.slug}/`,
+    {
+      timeout: 30_000,
+    },
+  );
+  await page.getByRole("button", { name: new RegExp(escapeRegExp(org.name)) }).waitFor();
+  await page.getByRole("heading", { name: "Integrations" }).waitFor();
+};
+
+const activeOrg = (baseUrl: string, cookie: string) =>
+  Effect.promise(async () => {
+    const response = await fetch(new URL("/api/auth/me", baseUrl), {
+      headers: { cookie },
+    });
+    if (!response.ok) throw new Error(`/api/auth/me failed (${response.status})`);
+    const body = (await response.json()) as {
+      organization: { id: string; name: string; slug: string } | null;
+    };
+    if (!body.organization) throw new Error("identity has no active organization");
+    return body.organization;
+  });
+
+const createOrganization = (baseUrl: string, cookie: string, name: string) =>
+  Effect.promise(async () => {
+    const response = await fetch(new URL("/api/auth/create-organization", baseUrl), {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        cookie,
+        ...originHeaders(baseUrl),
+      },
+      body: JSON.stringify({ name }),
+    });
+    if (!response.ok) {
+      throw new Error(`/api/auth/create-organization failed (${response.status})`);
+    }
+    const session = cookiePair(response, "wos-session");
+    if (!session) throw new Error("create organization did not refresh the session");
+    const org = (await response.json()) as { id: string; name: string; slug: string };
+    return { org, session };
+  });
+
+const approvalApiRequest =
+  (approval: McpBrowserApproval, method: "GET" | "POST") =>
+  (request: Request): boolean => {
+    const url = request.url();
+    const executionPath = `/executions/${encodeURIComponent(approval.executionId)}`;
+    return (
+      request.method() === method &&
+      url.includes("/api/mcp-sessions/") &&
+      url.includes(executionPath) &&
+      (method === "POST" ? url.endsWith(`${executionPath}/resume`) : !url.endsWith("/resume"))
+    );
+  };
+
+scenario(
+  "MCP approval · URL-scoped org survives approval while the session cookie points elsewhere",
+  { timeout: 180_000 },
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const api = yield* Api;
+    const browser = yield* Browser;
+    const mcp = yield* Mcp;
+
+    const identity = yield* target.newIdentity();
+    const sessionA = cookieOf(identity);
+    const orgA = yield* activeOrg(target.baseUrl, sessionA);
+    const client = yield* api.client(coreApi, identity);
+
+    const policy = yield* client.policies.create({
+      payload: { owner: "org", pattern: GATE_TOOL, action: "require_approval" },
+    });
+
+    yield* Effect.gen(function* () {
+      const mcpSession = mcp.session(identity, { elicitationMode: "browser" });
+      yield* mcpSession.listTools();
+
+      const paused = yield* mcpSession.call("execute", { code: GATED_CODE });
+      const approval = parseBrowserApproval(paused);
+      const approvalUrl = new URL(approval.approvalUrl);
+      expect(approvalUrl.pathname, "the real MCP approval URL is pinned to the session org").toBe(
+        `/${orgA.slug}/resume/${approval.executionId}`,
+      );
+
+      const { org: orgB, session: sessionB } = yield* createOrganization(
+        target.baseUrl,
+        sessionA,
+        `MCP Approval Org B ${randomBytes(3).toString("hex")}`,
+      );
+      expect(orgB.slug, "the browser can be pinned to a different org").not.toBe(orgA.slug);
+
+      const [resumed] = yield* Effect.all(
+        [
+          mcpSession.awaitResume(approval.executionId),
+          browser.session(identity, async ({ page, step }) => {
+            await step("Land in the original organization", async () => {
+              await page.goto(`/${orgA.slug}`, { waitUntil: "networkidle" });
+              await expectOrgShell(page, orgA);
+            });
+
+            await step("The browser session is switched to another organization", async () => {
+              await setWorkosSessionCookie(page, target.baseUrl, sessionB);
+              await page.goto(`/${orgB.slug}`, { waitUntil: "networkidle" });
+              await expectOrgShell(page, orgB);
+            });
+
+            await step("Open the original organization's approval URL and approve", async () => {
+              const loadRequest = page.waitForRequest(approvalApiRequest(approval, "GET"), {
+                timeout: 30_000,
+              });
+              await page.goto(approval.approvalUrl, { waitUntil: "networkidle" });
+              expect(
+                (await loadRequest).headers()["x-executor-organization"],
+                "loading the approval page scopes the paused execution lookup to org A",
+              ).toBe(orgA.slug);
+
+              await page.getByRole("button", { name: "Approve" }).waitFor();
+              const resumeRequest = page.waitForRequest(approvalApiRequest(approval, "POST"), {
+                timeout: 30_000,
+              });
+              await page.getByRole("button", { name: "Approve" }).click();
+              expect(
+                (await resumeRequest).headers()["x-executor-organization"],
+                "approving the paused execution scopes the resume POST to org A",
+              ).toBe(orgA.slug);
+              await page.getByText("Approve sent").waitFor();
+            });
+          }),
+        ],
+        { concurrency: "unbounded" },
+      );
+
+      expect(resumed.ok, "the approved execution completed without error").toBe(true);
+      expect(resumed.text, "the gated tool ran in org A and returned its policy").toContain(
+        policy.id,
+      );
+    }).pipe(
+      Effect.ensuring(
+        client.policies
+          .remove({ params: { policyId: policy.id }, payload: { owner: "org" } })
+          .pipe(Effect.ignore),
+      ),
+    );
+  }),
+);

--- a/packages/hosts/mcp/src/browser-approval.ts
+++ b/packages/hosts/mcp/src/browser-approval.ts
@@ -53,6 +53,8 @@ export const readElicitationMode = (request: Request): McpElicitationMode => {
 
 /**
  * Build the console approval URL for a paused execution:
+ * `<origin>/<organizationSlug>/resume/<executionId>?mcp_session_id=<sessionId>`
+ * when the host knows the org slug, otherwise
  * `<origin>/resume/<executionId>?mcp_session_id=<sessionId>`. The
  * `mcp_session_id` query routes the console's resume page back to the host's
  * approval endpoint for that session.
@@ -61,8 +63,10 @@ export const buildResumeApprovalUrl = (input: {
   readonly origin: string | URL;
   readonly executionId: string;
   readonly sessionId?: string | null;
+  readonly organizationSlug?: string | null;
 }): string => {
-  const url = new URL(`/resume/${encodeURIComponent(input.executionId)}`, input.origin);
+  const orgPath = input.organizationSlug ? `/${encodeURIComponent(input.organizationSlug)}` : "";
+  const url = new URL(`${orgPath}/resume/${encodeURIComponent(input.executionId)}`, input.origin);
   if (input.sessionId) url.searchParams.set("mcp_session_id", input.sessionId);
   return url.toString();
 };


### PR DESCRIPTION
## Summary

- Follow-up to #1134 for sibling URL-org-scope bugs found after the OAuth callback fix.
- Rehydrate WorkOS login callbacks into the org from the validated `returnTo` URL when present.
- Stamp `x-executor-organization` on cloud app API calls from the current URL, including MCP approval lookups and resumes.
- Generate MCP browser approval URLs with the session org slug so approval links stay scoped even when the browser cookie points at another org.
- Move cloud domain-verification auth to a request-scoped router middleware so URL org slugs resolve through the same per-request org selector path.
- Add cloud e2e coverage for the MCP browser approval org-switch flow.

## Watch It

![MCP approval · URL-scoped org survives approval while the session cookie points elsewhere (cloud)](https://raw.githubusercontent.com/RhysSullivan/executor/e2e-media/mcp-approval-url-scoped-org-survives-approval-while-the-session-cookie-points-el-2e39b5bf.gif)

## Verification

- `vitest run src/api.request-scope.node.test.ts src/auth/org-selector-auth.node.test.ts src/org/handlers.test.ts` in `apps/cloud`
- `vitest run src/envelope.test.ts` in `packages/hosts/mcp`
- `tsgo --noEmit` in `apps/cloud`, `apps/host-cloudflare`, and `packages/hosts/mcp`
- `tsc --noEmit` in `e2e`
- targeted `oxlint`
- `E2E_CLOUD_URL=http://localhost:45900 vitest run --project cloud cloud/mcp-browser-approval-org-scope.test.ts` in `e2e`
