### PR TITLE
Fix Executor sidebar icon in cloud/self-host and match local sidebar to cloud

### DIFF
--- a/packages/app/src/web/shell.tsx
+++ b/packages/app/src/web/shell.tsx
@@ -321,9 +321,6 @@ function IntegrationList(props: { pathname: string; onNavigate?: () => void }) {
                   size="sm"
                 />
                 <span className="flex-1 truncate">{name}</span>
-                <span className="rounded bg-secondary/50 px-1 py-px text-xs font-medium text-muted-foreground">
-                  {integration.kind}
-                </span>
               </Link>
             );
           })}

--- a/packages/react/src/components/integration-favicon.test.tsx
+++ b/packages/react/src/components/integration-favicon.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "@effect/vitest";
 
 import {
+  integrationFaviconSrc,
   integrationFaviconUrl,
   integrationInferredUrl,
   integrationLocalIconUrl,
@@ -28,6 +29,28 @@ describe("IntegrationFavicon", () => {
   it("uses the Executor favicon for the built-in executor source", () => {
     expect(integrationLocalIconUrl("executor")).toBe("/favicon-32.png");
     expect(integrationLocalIconUrl("openapi")).toBeNull();
+  });
+
+  it("resolves the Executor sidebar icon only when the source id is threaded (cloud/self-host repro)", () => {
+    // Reconstruct the props the multiplayer shell derives for the built-in
+    // executor source (EXECUTOR_SOURCE: kind "built-in", name "Executor", no
+    // displayUrl). The sidebar's IntegrationList builds icon/url exactly this way.
+    const slug = "executor";
+    const name = "Executor";
+    const icon = integrationPresetIconUrl({ id: slug, kind: "built-in", name, url: undefined }, []);
+    const url = integrationInferredUrl({ id: slug, name }) ?? undefined;
+
+    // The built-in source matches no preset and has no inferable host, so the
+    // sourceId branch is the only thing that can resolve its icon.
+    expect(icon).toBeNull();
+    expect(url).toBeUndefined();
+
+    // Bug: cloud/self-host dropped sourceId, so the cascade fell through to null
+    // and rendered the neutral BoxIcon placeholder.
+    expect(integrationFaviconSrc({ icon, url, size: 16 })).toBeNull();
+
+    // Fix: threading sourceId resolves the bundled Executor favicon.
+    expect(integrationFaviconSrc({ icon, sourceId: slug, url, size: 16 })).toBe("/favicon-32.png");
   });
 
   it("finds preset icons from a source URL", () => {

--- a/packages/react/src/components/integration-favicon.tsx
+++ b/packages/react/src/components/integration-favicon.tsx
@@ -160,6 +160,28 @@ export function integrationPresetIconUrl(
   return preset?.icon ?? null;
 }
 
+// Resolution cascade for the rendered favicon: first non-null, non-failed of an
+// explicit preset icon, the bundled local icon for a known source id, then a
+// favicon-service URL derived from the source URL. The built-in executor source
+// has no preset icon and no URL, so it resolves ONLY through the sourceId branch:
+// callers that drop sourceId fall through to the neutral BoxIcon placeholder.
+export function integrationFaviconSrc(args: {
+  icon?: string | null;
+  sourceId?: string;
+  url?: string;
+  size: number;
+  failedSrcs?: readonly string[];
+}): string | null {
+  const failedSrcs = args.failedSrcs ?? [];
+  return (
+    [
+      args.icon ?? null,
+      integrationLocalIconUrl(args.sourceId),
+      integrationFaviconUrl(args.url, args.size),
+    ].find((candidate) => candidate !== null && !failedSrcs.includes(candidate)) ?? null
+  );
+}
+
 export function IntegrationFavicon({
   icon,
   sourceId,
@@ -172,10 +194,7 @@ export function IntegrationFavicon({
   size?: number;
 }) {
   const [failedSrcs, setFailedSrcs] = useState<readonly string[]>([]);
-  const src =
-    [icon ?? null, integrationLocalIconUrl(sourceId), integrationFaviconUrl(url, size)].find(
-      (candidate) => candidate !== null && !failedSrcs.includes(candidate),
-    ) ?? null;
+  const src = integrationFaviconSrc({ icon, sourceId, url, size, failedSrcs });
 
   if (!src) {
     return (

--- a/packages/react/src/multiplayer/shell.tsx
+++ b/packages/react/src/multiplayer/shell.tsx
@@ -198,6 +198,7 @@ function IntegrationList(props: { pathname: string; onNavigate?: () => void }) {
                     { id: slug, kind: integration.kind, name, url: integration.displayUrl },
                     integrationPlugins,
                   )}
+                  sourceId={slug}
                   url={
                     integration.displayUrl ??
                     integrationInferredUrl({ id: slug, name }) ??


### PR DESCRIPTION
## Summary

Two sidebar consistency fixes for the integrations list.

### 1. Built-in Executor icon now resolves in cloud and self-host

Cloud and self-host render the sidebar through the multiplayer shell, which called `IntegrationFavicon` without `sourceId`. For the built-in `executor` source (kind `built-in`, no preset icon, no `displayUrl`), every branch of the favicon resolution cascade was empty, so the row fell through to the neutral box placeholder. The local/desktop shell already passes `sourceId`, which is why the bug only showed in cloud and self-host.

Fix: thread `sourceId={slug}` so the cascade resolves the bundled `/favicon-32.png`.

The resolution cascade is extracted into a pure `integrationFaviconSrc` helper (behavior preserving) so it can be unit tested. A repro test reconstructs the exact props the multiplayer shell derives for the executor source and pins the divergence: null (placeholder) without `sourceId`, the favicon with it.

### 2. Local sidebar type badge removed to match cloud

The local/desktop sidebar rendered an `integration.kind` pill after each integration name; the cloud and self-host sidebar does not. Removed it so the two surfaces match.

## Testing

- `vitest run packages/react/src/components/integration-favicon.test.tsx`: 12 passing, including the new repro.
- `oxlint --deny-warnings` and `oxfmt --check` clean on changed files.
- `tsgo --noEmit` clean for the `react` and `app` packages.

## Coverage gap

The repro guards the resolution cascade logic. Neither package has a DOM render harness, so the JSX prop wiring itself and the badge removal are not covered by a render test. A follow-up e2e or visual scenario asserting the sidebar Executor row renders an image rather than the placeholder would close that gap.
