### PR TITLE
[codex] Move OAuth org selector into state

### DIFF
--- a/apps/cloud/src/start.ts
+++ b/apps/cloud/src/start.ts
@@ -1,5 +1,5 @@
 import { createMiddleware, createStart } from "@tanstack/react-start";
-import { OAUTH_CALLBACK_ORG_QUERY_PARAM } from "@executor-js/sdk/shared";
+import { decodeOAuthCallbackState } from "@executor-js/sdk/shared";
 
 import { cloudApiHandler } from "./app";
 import { isAppOwnedPath } from "./app-paths";
@@ -42,11 +42,14 @@ const SESSION_COOKIE = "wos-session";
 const OAUTH_CALLBACK_PATH = "/api/oauth/callback";
 
 const oauthCallbackOrgScopedRequest = (request: Request): Request => {
-  const orgSelector = new URL(request.url).searchParams.get(OAUTH_CALLBACK_ORG_QUERY_PARAM);
-  if (!orgSelector) return request;
-  const headers = new Headers(request.headers);
-  headers.set(ORG_SELECTOR_HEADER, orgSelector);
-  return new Request(request, { headers });
+  const url = new URL(request.url);
+  const callbackState = decodeOAuthCallbackState(url.searchParams.get("state"));
+  if (callbackState === null) return request;
+  url.searchParams.set("state", callbackState.state);
+  const rewritten = new Request(url, request);
+  const headers = new Headers(rewritten.headers);
+  headers.set(ORG_SELECTOR_HEADER, callbackState.orgSlug);
+  return new Request(rewritten, { headers });
 };
 
 const oauthCallbackSignInMiddleware = createMiddleware({ type: "request" }).server(

--- a/e2e/cloud/oauth-callback-org-scope.test.ts
+++ b/e2e/cloud/oauth-callback-org-scope.test.ts
@@ -2,8 +2,8 @@
 //
 // A browser session cookie can be pinned to org B while a tab is operating in
 // org A via the URL org selector. OAuth redirects leave the console route and
-// land on /api/oauth/callback, so the callback URL itself must carry the same
-// org selector that was present when oauth.start created the session.
+// land on /api/oauth/callback, so the provider state must carry the org selector
+// without adding provider-facing query params to redirect_uri.
 import { randomBytes } from "node:crypto";
 
 import { expect } from "@effect/vitest";
@@ -11,11 +11,7 @@ import { Effect } from "effect";
 import type { Page } from "playwright";
 import { composePluginApi } from "@executor-js/api/server";
 import { openApiHttpPlugin } from "@executor-js/plugin-openapi/api";
-import {
-  IntegrationSlug,
-  OAUTH_CALLBACK_ORG_QUERY_PARAM,
-  OAuthClientSlug,
-} from "@executor-js/sdk/shared";
+import { IntegrationSlug, OAuthClientSlug } from "@executor-js/sdk/shared";
 import { serveOAuthTestServer } from "@executor-js/sdk/testing";
 
 import { scenario } from "../src/scenario";
@@ -171,7 +167,7 @@ const oauthIntegrationSpec = (oauth: {
   }) as const;
 
 scenario(
-  "OAuth callback · URL-scoped org survives a callback while the session cookie points elsewhere",
+  "OAuth callback · state-scoped org survives a callback while the session cookie points elsewhere",
   {},
   Effect.gen(function* () {
     const target = yield* Target;
@@ -211,6 +207,7 @@ scenario(
     });
 
     let callback = new URL("http://invalid.example");
+    let providerAuthorizeUrl = new URL("http://invalid.example");
     yield* browser.session(identity, async ({ page, step }) => {
       await installSameWindowOAuthPopup(page);
 
@@ -232,11 +229,28 @@ scenario(
         await page.getByRole("heading", { name: /Add connection/ }).waitFor({
           timeout: 30_000,
         });
+        const authorizeRequest = page.waitForRequest(
+          (request) => {
+            const url = new URL(request.url());
+            return url.origin === new URL(oauth.issuerUrl).origin && url.pathname === "/authorize";
+          },
+          { timeout: 30_000 },
+        );
         await page.getByRole("button", { name: "Connect with OAuth" }).click();
+        providerAuthorizeUrl = new URL((await authorizeRequest).url());
         await page.waitForURL(
           (url) => url.origin === new URL(oauth.issuerUrl).origin && url.pathname === "/login",
           { timeout: 30_000 },
         );
+        const redirectUri = new URL(providerAuthorizeUrl.searchParams.get("redirect_uri") ?? "");
+        expect(redirectUri.pathname, "the provider redirects to the OAuth callback").toBe(
+          "/api/oauth/callback",
+        );
+        expect(redirectUri.search, "the provider-facing redirect_uri has no org query").toBe("");
+        expect(
+          providerAuthorizeUrl.searchParams.get("state"),
+          "OAuth state is present",
+        ).toBeTruthy();
         await page.getByText("OAuth test login").waitFor();
       });
 
@@ -258,8 +272,12 @@ scenario(
     });
 
     expect(
-      callback.searchParams.get(OAUTH_CALLBACK_ORG_QUERY_PARAM),
-      "the provider callback URL carries the original org selector",
-    ).toBe(orgA.slug);
+      new URL(providerAuthorizeUrl.searchParams.get("redirect_uri") ?? "").search,
+      "the provider-facing redirect_uri remains static",
+    ).toBe("");
+    expect(
+      callback.searchParams.has("executor_org"),
+      "the provider callback has no org query",
+    ).toBe(false);
   }).pipe(Effect.scoped),
 );

--- a/packages/core/api/src/server/oauth-origin.test.ts
+++ b/packages/core/api/src/server/oauth-origin.test.ts
@@ -49,13 +49,12 @@ describe("OAuth web origin resolution", () => {
     ).toBe("https://executor.sh/api/oauth/callback");
   });
 
-  it("carries the URL org selector in OAuth redirect URLs", () => {
-    expect(
-      buildOAuthRedirectUri({
-        webBaseUrl: "https://executor.sh",
-        oauthCallbackPath: "/api/oauth/callback",
-        orgSlug: "acme",
-      }),
-    ).toBe("https://executor.sh/api/oauth/callback?executor_org=acme");
+  it("does not put org routing in OAuth redirect URLs", () => {
+    const redirectUri = buildOAuthRedirectUri({
+      webBaseUrl: "https://executor.sh",
+      oauthCallbackPath: "/api/oauth/callback",
+    });
+
+    expect(new URL(redirectUri ?? "").search).toBe("");
   });
 });

--- a/packages/core/api/src/server/scoped-executor.ts
+++ b/packages/core/api/src/server/scoped-executor.ts
@@ -35,7 +35,6 @@ import { Context, Effect, Option } from "effect";
 
 import {
   createExecutor,
-  OAUTH_CALLBACK_ORG_QUERY_PARAM,
   Subject,
   Tenant,
   type AnyPlugin,
@@ -152,13 +151,9 @@ export const resolveScopedWebBaseUrl = (input: {
 export const buildOAuthRedirectUri = (input: {
   readonly webBaseUrl: string | undefined;
   readonly oauthCallbackPath: string;
-  readonly orgSlug?: string | null;
 }): string | undefined => {
   if (!input.webBaseUrl) return undefined;
-  const url = new URL(input.oauthCallbackPath, input.webBaseUrl);
-  const slug = input.orgSlug?.trim();
-  if (slug) url.searchParams.set(OAUTH_CALLBACK_ORG_QUERY_PARAM, slug);
-  return url.toString();
+  return new URL(input.oauthCallbackPath, input.webBaseUrl).toString();
 };
 
 // ---------------------------------------------------------------------------
@@ -245,7 +240,6 @@ export const makeScopedExecutor = <
     const redirectUri = buildOAuthRedirectUri({
       webBaseUrl,
       oauthCallbackPath: config.oauthCallbackPath,
-      orgSlug,
     });
 
     const plugins = pluginsFactory();
@@ -268,6 +262,7 @@ export const makeScopedExecutor = <
       fetch: hostedFetch,
       onElicitation: "accept-all",
       redirectUri,
+      oauthCallbackStateOrgSlug: orgSlug,
       coreTools: {
         webBaseUrl,
         orgSlug,

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -370,6 +370,8 @@ export interface ExecutorConfig<TPlugins extends readonly AnyPlugin[] = readonly
    * Hosts serving OAuth derive this from the request origin / web base URL.
    */
   readonly redirectUri?: string;
+  /** Optional URL selected organization slug to carry inside OAuth `state`. */
+  readonly oauthCallbackStateOrgSlug?: string;
   readonly oauthEndpointUrlPolicy?: OAuthEndpointUrlPolicy;
   /**
    * Enable the built-in `core-tools` plugin which contributes agent-facing
@@ -3094,6 +3096,7 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
       // instead of silently using `http://127.0.0.1/callback`. Hosts that serve
       // OAuth (cloud, self-host) derive a real `${webBaseUrl}/oauth/callback`.
       redirectUri: config.redirectUri ?? null,
+      callbackStateOrgSlug: config.oauthCallbackStateOrgSlug ?? null,
     });
 
     // ------------------------------------------------------------------

--- a/packages/core/sdk/src/index.ts
+++ b/packages/core/sdk/src/index.ts
@@ -217,7 +217,9 @@ export {
 export {
   OAUTH2_PROVIDER_KEY,
   OAUTH2_SESSION_TTL_MS,
-  OAUTH_CALLBACK_ORG_QUERY_PARAM,
+  decodeOAuthCallbackState,
+  encodeOAuthCallbackState,
+  type OAuthCallbackState,
 } from "./oauth";
 export {
   OAuthStartError,

--- a/packages/core/sdk/src/oauth-callback-state.test.ts
+++ b/packages/core/sdk/src/oauth-callback-state.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import { decodeOAuthCallbackState, encodeOAuthCallbackState } from "./oauth";
+
+describe("OAuth callback state", () => {
+  it("keeps state raw when no URL org slug is present", () => {
+    expect(encodeOAuthCallbackState({ state: "state_123", orgSlug: null })).toBe("state_123");
+    expect(decodeOAuthCallbackState("state_123")).toBeNull();
+  });
+
+  it("round-trips the raw session state and URL org slug", () => {
+    const encoded = encodeOAuthCallbackState({ state: "state_123", orgSlug: " acme " });
+
+    expect(encoded).not.toBe("state_123");
+    expect(decodeOAuthCallbackState(encoded)).toEqual({
+      state: "state_123",
+      orgSlug: "acme",
+    });
+  });
+
+  it("rejects foreign state values", () => {
+    expect(decodeOAuthCallbackState("not-base64url!!")).toBeNull();
+    expect(decodeOAuthCallbackState("aGVsbG8")).toBeNull();
+  });
+});

--- a/packages/core/sdk/src/oauth-flow.test.ts
+++ b/packages/core/sdk/src/oauth-flow.test.ts
@@ -10,6 +10,7 @@ import {
   ToolAddress,
   ToolName,
 } from "./ids";
+import { decodeOAuthCallbackState } from "./oauth";
 import { OAuthStartError } from "./oauth-client";
 import { definePlugin } from "./plugin";
 import { makeTestWorkspaceHarness, memoryCredentialsPlugin } from "./test-config";
@@ -184,6 +185,64 @@ describe("oauth.start / oauth.complete", () => {
           expect(yield* server.acceptsAccessToken(out.token)).toBe(true);
         }),
       ),
+  );
+
+  it.effect("carries the URL org selector in provider state without changing redirect_uri", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const server = yield* serveOAuthTestServer({ scopes: ["read"] });
+        const { executor } = yield* makeTestWorkspaceHarness({
+          plugins,
+          oauthCallbackStateOrgSlug: "acme",
+        });
+        yield* executor.acme.seed();
+
+        yield* executor.oauth.createClient({
+          owner: "org",
+          slug: CLIENT,
+          authorizationUrl: server.authorizationEndpoint,
+          tokenUrl: server.tokenEndpoint,
+          grant: "authorization_code",
+          clientId: "test-client",
+          clientSecret: "test-secret",
+        });
+
+        const started = yield* executor.oauth.start({
+          owner: "org",
+          client: CLIENT,
+          clientOwner: "org",
+          name: ConnectionName.make("main-account"),
+          integration: INTEG,
+          template: TEMPLATE,
+        });
+        expect(started.status).toBe("redirect");
+        if (started.status !== "redirect") return;
+
+        const authorizationUrl = new URL(started.authorizationUrl);
+        const redirectUri = new URL(authorizationUrl.searchParams.get("redirect_uri") ?? "");
+        const providerState = authorizationUrl.searchParams.get("state") ?? "";
+
+        expect(redirectUri.toString()).toBe("http://localhost/oauth/callback");
+        expect(providerState).not.toBe(String(started.state));
+        expect(decodeOAuthCallbackState(providerState)).toEqual({
+          state: String(started.state),
+          orgSlug: "acme",
+        });
+
+        const callback = yield* server.completeAuthorizationCodeFlow({
+          authorizationUrl: started.authorizationUrl,
+        });
+        const callbackState = decodeOAuthCallbackState(callback.state);
+        expect(callbackState).not.toBeNull();
+        if (callbackState === null) return;
+
+        const connection = yield* executor.oauth.complete({
+          state: OAuthState.make(callbackState.state),
+          code: callback.code,
+        });
+        expect(String(connection.address)).toBe("tools.acme.org.mainAccount");
+      }),
+    ),
   );
 
   it.effect("records offline_access when a refresh token proves it was granted", () =>

--- a/packages/core/sdk/src/oauth-service.ts
+++ b/packages/core/sdk/src/oauth-service.ts
@@ -67,7 +67,7 @@ import {
   type OAuth2TokenResponse,
   type OAuthEndpointUrlPolicy,
 } from "./oauth-helpers";
-import { OAUTH2_SESSION_TTL_MS } from "./oauth";
+import { OAUTH2_SESSION_TTL_MS, encodeOAuthCallbackState } from "./oauth";
 
 /** Connection-minting input for the OAuth flow — extends a connection create
  *  with the OAuth lifecycle fields (client slug, refresh material, expiry,
@@ -148,6 +148,8 @@ export interface OAuthServiceDeps {
    * that serve OAuth MUST derive this from the request origin / web base URL.
    */
   readonly redirectUri: string | null;
+  /** URL selected organization slug to round-trip through OAuth `state`. */
+  readonly callbackStateOrgSlug?: string | null;
 }
 
 type LooseDb = {
@@ -724,6 +726,10 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
       const verifier = createPkceCodeVerifier();
       const challenge = yield* Effect.promise(() => createPkceCodeChallenge(verifier));
       const state = OAuthState.make(createOAuthState());
+      const providerState = encodeOAuthCallbackState({
+        state: String(state),
+        orgSlug: deps.callbackStateOrgSlug,
+      });
 
       const now = new Date();
       const expiresAt = Date.now() + OAUTH2_SESSION_TTL_MS;
@@ -757,7 +763,7 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
             clientId: client.clientId,
             redirectUrl: flowRedirectUri,
             scopes: requestedScopes,
-            state: String(state),
+            state: providerState,
             codeChallenge: challenge,
             resource: client.resource ?? undefined,
             // Provider quirks (Google: access_type=offline + prompt=consent) —

--- a/packages/core/sdk/src/oauth.ts
+++ b/packages/core/sdk/src/oauth.ts
@@ -12,6 +12,8 @@
 // row and core owns the flow (D14).
 // ---------------------------------------------------------------------------
 
+import { Encoding, Option, Result, Schema } from "effect";
+
 export {
   type OAuthGrant,
   type OAuthAuthentication,
@@ -36,5 +38,46 @@ export const OAUTH2_PROVIDER_KEY = "oauth2" as const;
 /** How long a pending authorization stays redeemable. */
 export const OAUTH2_SESSION_TTL_MS = 15 * 60 * 1000;
 
-/** Query parameter used to carry the URL-selected org through OAuth callbacks. */
-export const OAUTH_CALLBACK_ORG_QUERY_PARAM = "executor_org" as const;
+const OAuthCallbackStateSchema = Schema.Struct({
+  state: Schema.String,
+  orgSlug: Schema.String,
+});
+
+export type OAuthCallbackState = typeof OAuthCallbackStateSchema.Type;
+
+const OAuthCallbackStateFromJson = Schema.fromJsonString(OAuthCallbackStateSchema);
+const decodeOAuthCallbackStateJson = Schema.decodeUnknownOption(OAuthCallbackStateFromJson);
+const encodeOAuthCallbackStateJson = Schema.encodeSync(OAuthCallbackStateFromJson);
+
+/** Encode URL selected callback routing data into OAuth `state`.
+ *
+ * The persisted OAuth session still uses the raw random state. Only the value
+ * sent to the authorization server is wrapped, so providers can keep a static
+ * redirect_uri while echoing enough state for the callback edge to pick the
+ * correct organization before completing the flow.
+ */
+export const encodeOAuthCallbackState = (input: {
+  readonly state: string;
+  readonly orgSlug?: string | null;
+}): string => {
+  const orgSlug = input.orgSlug?.trim();
+  if (!orgSlug) return input.state;
+  return Encoding.encodeBase64Url(encodeOAuthCallbackStateJson({ state: input.state, orgSlug }));
+};
+
+/** Decode a callback state value minted by `encodeOAuthCallbackState`.
+ *
+ * Returns null for raw or foreign state values, which lets non-org hosts use
+ * the raw OAuth state unchanged.
+ */
+export const decodeOAuthCallbackState = (
+  value: string | null | undefined,
+): OAuthCallbackState | null => {
+  if (!value) return null;
+  const json = Result.getOrNull(Encoding.decodeBase64UrlString(value));
+  if (json === null) return null;
+  const decoded = Option.getOrNull(decodeOAuthCallbackStateJson(json));
+  if (decoded === null) return null;
+  const orgSlug = decoded.orgSlug.trim();
+  return orgSlug ? { state: decoded.state, orgSlug } : null;
+};

--- a/packages/core/sdk/src/shared.ts
+++ b/packages/core/sdk/src/shared.ts
@@ -99,7 +99,11 @@ export type { ToolPolicyAction } from "./core-schema";
 // Schema-side views + onboarding autodetect.
 export { ToolSchemaView, IntegrationDetectionResult } from "./types";
 
-export { OAUTH_CALLBACK_ORG_QUERY_PARAM } from "./oauth";
+export {
+  decodeOAuthCallbackState,
+  encodeOAuthCallbackState,
+  type OAuthCallbackState,
+} from "./oauth";
 
 // OAuth wire contracts (data + tagged errors; the flow impl is server-only).
 export {

--- a/packages/core/sdk/src/test-config.ts
+++ b/packages/core/sdk/src/test-config.ts
@@ -121,6 +121,7 @@ export type TestConfigOptions<TPlugins extends readonly AnyPlugin[] = readonly [
   /** Override the OAuth callback URL. Pass `null` to construct an executor with
    *  no OAuth callback (exercises the fail-loud redirect path). */
   readonly redirectUri?: string | null;
+  readonly oauthCallbackStateOrgSlug?: string;
 };
 
 export const makeTestConfig = <const TPlugins extends readonly AnyPlugin[] = readonly []>(
@@ -159,6 +160,7 @@ export const makeTestConfig = <const TPlugins extends readonly AnyPlugin[] = rea
     // Tests default to auto-accepting elicitation prompts.
     onElicitation: "accept-all",
     ...(redirectUri != null ? { redirectUri } : {}),
+    oauthCallbackStateOrgSlug: options?.oauthCallbackStateOrgSlug,
   };
 };
 

--- a/packages/react/src/plugins/oauth-sign-in.test.ts
+++ b/packages/react/src/plugins/oauth-sign-in.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, describe, expect, it } from "@effect/vitest";
-import { OAUTH_CALLBACK_ORG_QUERY_PARAM } from "@executor-js/sdk/shared";
 
 import { oauthCallbackUrl } from "./oauth-sign-in";
 
@@ -29,13 +28,13 @@ describe("oauthCallbackUrl", () => {
     expect(oauthCallbackUrl()).toBe("/api/oauth/callback");
   });
 
-  it("carries the active org slug from the console URL", () => {
+  it("keeps the callback URL static from an org console URL", () => {
     setLocation("https://executor.sh/acme/integrations/posthog");
 
     const url = new URL(oauthCallbackUrl());
 
-    expect(url.toString()).toBe("https://executor.sh/api/oauth/callback?executor_org=acme");
-    expect(url.searchParams.get(OAUTH_CALLBACK_ORG_QUERY_PARAM)).toBe("acme");
+    expect(url.toString()).toBe("https://executor.sh/api/oauth/callback");
+    expect(url.search).toBe("");
   });
 
   it("does not add an org selector on bare app routes", () => {

--- a/packages/react/src/plugins/oauth-sign-in.tsx
+++ b/packages/react/src/plugins/oauth-sign-in.tsx
@@ -14,7 +14,6 @@ import {
   type OAuthPopupResult,
 } from "../api/oauth-popup";
 import { connectionWriteKeys } from "../api/reactivity-keys";
-import { getActiveOrgSlug } from "../api/server-connection";
 
 type DesktopBridge = {
   readonly openExternal: (url: string) => Promise<void>;
@@ -31,7 +30,6 @@ const getDesktopBridge = (): DesktopBridge | null => {
 import { Button } from "../components/button";
 import {
   OAUTH_POPUP_MESSAGE_TYPE,
-  OAUTH_CALLBACK_ORG_QUERY_PARAM,
   OAuthState,
   type AuthTemplateSlug,
   type ConnectionName,
@@ -99,10 +97,7 @@ export type StartOAuthAuthorizationInput<TPayload extends OAuthCompletionPayload
 
 export function oauthCallbackUrl(path = "/api/oauth/callback"): string {
   if (typeof window === "undefined") return path;
-  const url = new URL(path, window.location.origin);
-  const orgSlug = getActiveOrgSlug();
-  if (orgSlug) url.searchParams.set(OAUTH_CALLBACK_ORG_QUERY_PARAM, orgSlug);
-  return url.toString();
+  return new URL(path, window.location.origin).toString();
 }
 
 export function useOAuthPopupFlow<


### PR DESCRIPTION
## Summary

Moves URL-selected organization routing for OAuth callbacks out of the provider-facing `redirect_uri` query string and into OAuth `state`.

The callback URL registered with providers and sent on authorization requests is now static. When a cloud request is scoped by URL org, the SDK wraps the raw OAuth session state with the org slug for the authorization server to echo. Cloud callback middleware decodes that state, sets the internal org selector header, and rewrites the callback request back to the raw session state before completion.

## Root Cause

The previous fix preserved org scope by appending `executor_org` to `/api/oauth/callback`. That works with tolerant providers, but it changes the callback URI shape and conflicts with providers or app registrations that reject query strings or require exact redirect URI registration.

## Watch It

![OAuth callback · state-scoped org survives a callback while the session cookie points elsewhere (cloud)](https://raw.githubusercontent.com/RhysSullivan/executor/e2e-media/oauth-callback-state-scoped-org-survives-a-callback-while-the-session-cookie-poi-b737c360.gif)

In the recording, the browser lands in one org, switches the session cookie to another org, starts OAuth from the original org URL, and completes successfully. The scenario asserts the provider-facing `redirect_uri` has no query string and the callback has no `executor_org` query param.

## Validation

- `bun run --cwd packages/core/sdk test src/oauth-callback-state.test.ts src/oauth-flow.test.ts`
- `bun run --cwd packages/core/api test src/server/oauth-origin.test.ts`
- `bun run --cwd packages/react test src/plugins/oauth-sign-in.test.ts`
- `bunx oxlint -c .oxlintrc.jsonc --deny-warnings <touched files>`
- `bun run --cwd packages/core/sdk typecheck`
- `bun run --cwd packages/core/api typecheck`
- `bun run --cwd packages/react typecheck`
- `bun run --cwd apps/cloud typecheck`
- `bun run --cwd e2e typecheck`
- `E2E_CLOUD_URL=http://localhost:43870 bun run --cwd e2e test:cloud cloud/oauth-callback-org-scope.test.ts`