### PR TITLE
[codex] add CIMD client metadata document registry

### DIFF
--- a/apps/cloud/src/app-paths.test.ts
+++ b/apps/cloud/src/app-paths.test.ts
@@ -13,6 +13,7 @@ describe("isAppOwnedPath", () => {
     "/api/executions",
     "/api/auth/me",
     "/api/openapi.json",
+    "/api/oauth/client-id-metadata/default.json",
     "/api/billing/customer", // AutumnProvider pathPrefix — the billing UI
     "/api/billing/attach",
     "/api/docs", // Swagger UI

--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -54,6 +54,9 @@ export default defineConfig({
         process.env.npm_package_version ?? "0.0.0",
       ),
       "import.meta.env.VITE_GITHUB_URL": JSON.stringify("https://github.com/RhysSullivan/executor"),
+      "import.meta.env.VITE_EXECUTOR_CIMD_CLIENT_ID_METADATA_BASE_URL": JSON.stringify(
+        process.env.EXECUTOR_CIMD_CLIENT_ID_METADATA_BASE_URL ?? "https://executor.sh",
+      ),
     },
     resolve: {
       alias: {

--- a/apps/local/src/serve-shared.test.ts
+++ b/apps/local/src/serve-shared.test.ts
@@ -4,7 +4,9 @@ import {
   DEFAULT_ALLOWED_HOSTS,
   hasBearerToken,
   isAllowedOrigin,
+  isUnauthenticatedOAuthClientMetadataPath,
   isUnauthenticatedOAuthCallbackPath,
+  isUnauthenticatedOAuthPath,
   makeIsAuthorized,
 } from "./serve-shared";
 
@@ -47,5 +49,26 @@ describe("isUnauthenticatedOAuthCallbackPath", () => {
     expect(isUnauthenticatedOAuthCallbackPath("/api/oauth/callback/x")).toBe(true);
     expect(isUnauthenticatedOAuthCallbackPath("/api/oauth/await/session-1")).toBe(false);
     expect(isUnauthenticatedOAuthCallbackPath("/api/scope")).toBe(false);
+  });
+});
+
+describe("isUnauthenticatedOAuthClientMetadataPath", () => {
+  it("exempts the CIMD documents the OAuth provider fetches", () => {
+    expect(isUnauthenticatedOAuthClientMetadataPath("/api/oauth/client-id-metadata.json")).toBe(
+      true,
+    );
+    expect(
+      isUnauthenticatedOAuthClientMetadataPath("/api/oauth/client-id-metadata/default.json"),
+    ).toBe(true);
+    expect(
+      isUnauthenticatedOAuthClientMetadataPath("/api/oauth/client-id-metadata/local.json"),
+    ).toBe(true);
+  });
+
+  it("does not exempt OAuth result polling or arbitrary API paths", () => {
+    expect(isUnauthenticatedOAuthPath("/api/oauth/client-id-metadata/local.json")).toBe(true);
+    expect(isUnauthenticatedOAuthPath("/api/oauth/callback")).toBe(true);
+    expect(isUnauthenticatedOAuthPath("/api/oauth/await/session-1")).toBe(false);
+    expect(isUnauthenticatedOAuthPath("/api/connections")).toBe(false);
   });
 });

--- a/apps/local/src/serve-shared.ts
+++ b/apps/local/src/serve-shared.ts
@@ -86,3 +86,11 @@ export const hasFileExtension = (pathname: string): boolean => {
  */
 export const isUnauthenticatedOAuthCallbackPath = (pathname: string): boolean =>
   /^\/api\/oauth\/callback(\/|$)/.test(pathname);
+
+export const isUnauthenticatedOAuthClientMetadataPath = (pathname: string): boolean =>
+  pathname === "/api/oauth/client-id-metadata.json" ||
+  /^\/api\/oauth\/client-id-metadata\/[^/]+\.json$/.test(pathname);
+
+export const isUnauthenticatedOAuthPath = (pathname: string): boolean =>
+  isUnauthenticatedOAuthCallbackPath(pathname) ||
+  isUnauthenticatedOAuthClientMetadataPath(pathname);

--- a/apps/local/src/serve.test.ts
+++ b/apps/local/src/serve.test.ts
@@ -134,6 +134,25 @@ describe("startServer bearer auth", () => {
     expect(response.status).toBe(200);
   });
 
+  it("serves the CIMD client metadata document without a bearer", async () => {
+    const baseUrl = await startTestServer();
+    const documentUrl = `${baseUrl}/api/oauth/client-id-metadata/local.json`;
+    const response = await fetch(documentUrl);
+    expect(response.status).toBe(200);
+    const metadata = (await response.json()) as {
+      readonly client_id: string;
+      readonly redirect_uris: readonly string[];
+      readonly application_type: string;
+    };
+    expect(metadata.client_id).toBe(documentUrl);
+    expect(metadata.redirect_uris).toEqual([
+      "http://127.0.0.1/api/oauth/callback",
+      "http://localhost/api/oauth/callback",
+      "http://[::1]/api/oauth/callback",
+    ]);
+    expect(metadata.application_type).toBe("native");
+  });
+
   it("requires the bearer token on the OAuth await poll", async () => {
     const baseUrl = await startTestServer();
     const response = await fetch(`${baseUrl}/api/oauth/await/session-1`);

--- a/apps/local/src/serve.ts
+++ b/apps/local/src/serve.ts
@@ -11,6 +11,7 @@ import { resolve, join } from "node:path";
 import { readdirSync } from "node:fs";
 import type { Subprocess } from "bun";
 import { setOAuthCompletionListener } from "@executor-js/api";
+import { oauthClientIdMetadataDocumentFromRequest } from "@executor-js/api/server";
 import { loadOrMintLocalAuthToken } from "./auth";
 import { consumeOAuthResult, publishOAuthResult } from "./oauth-result-store";
 import { startIntegrationsRefresh } from "./integrations";
@@ -19,7 +20,8 @@ import {
   DEFAULT_ALLOWED_HOSTS,
   hasFileExtension,
   isAllowedOrigin,
-  isUnauthenticatedOAuthCallbackPath,
+  isUnauthenticatedOAuthClientMetadataPath,
+  isUnauthenticatedOAuthPath,
   makeIsAuthorized,
   normalizeCredential,
 } from "./serve-shared";
@@ -34,6 +36,23 @@ const htmlResponse = (file: Bun.BunFile): Response =>
   new Response(file, {
     headers: { "content-type": "text/html", "cache-control": "no-store" },
   });
+
+const oauthClientMetadataResponse = (requestUrl: string, webRequest: Request): Response =>
+  new Response(
+    JSON.stringify(
+      oauthClientIdMetadataDocumentFromRequest({
+        requestUrl,
+        webRequest,
+        mountPrefix: "/api",
+      }),
+    ),
+    {
+      headers: {
+        "content-type": "application/json",
+        "cache-control": "public, max-age=300",
+      },
+    },
+  );
 
 function collectStaticRoutes(dir: string, prefix = ""): Record<string, StaticHandler> {
   const routes: Record<string, StaticHandler> = {};
@@ -339,11 +358,10 @@ export async function startServer(opts: StartServerOptions = {}): Promise<Server
         return withCors(new Response("ok", { headers: { "content-type": "text/plain" } }));
       }
 
-      // OAuth provider callbacks are hit by the user's external browser and
-      // can't carry our bearer. The OAuth `state` parameter is the security
-      // gate — see isUnauthenticatedOAuthCallbackPath. Everything else under
+      // OAuth callbacks and CIMD documents are reached by the external
+      // provider, which cannot carry our local bearer. Everything else under
       // /api and /mcp requires the bearer.
-      const skipAuth = isUnauthenticatedOAuthCallbackPath(url.pathname);
+      const skipAuth = isUnauthenticatedOAuthPath(url.pathname);
       const isGatedSurface = url.pathname.startsWith("/api") || url.pathname.startsWith("/mcp");
 
       if (isGatedSurface && !skipAuth && !isAuthorized(req)) {
@@ -353,6 +371,10 @@ export async function startServer(opts: StartServerOptions = {}): Promise<Server
             headers: { "www-authenticate": 'Bearer realm="executor"' },
           }),
         );
+      }
+
+      if (isUnauthenticatedOAuthClientMetadataPath(url.pathname) && req.method === "GET") {
+        return withCors(oauthClientMetadataResponse(`${url.pathname}${url.search}`, req));
       }
 
       if (url.pathname.startsWith("/mcp")) {

--- a/apps/local/vite.config.ts
+++ b/apps/local/vite.config.ts
@@ -4,9 +4,14 @@ import { Readable } from "node:stream";
 import { fileURLToPath } from "node:url";
 import { defineConfig, type Plugin } from "vite";
 import appPlugin from "@executor-js/app/vite";
+import { oauthClientIdMetadataDocumentFromRequest } from "@executor-js/api/server";
 import { loadOrMintLocalAuthToken } from "./src/auth";
 import { consumeOAuthResult } from "./src/oauth-result-store";
-import { isUnauthenticatedOAuthCallbackPath, makeIsAuthorized } from "./src/serve-shared";
+import {
+  isUnauthenticatedOAuthClientMetadataPath,
+  isUnauthenticatedOAuthPath,
+  makeIsAuthorized,
+} from "./src/serve-shared";
 
 // oxlint-disable-next-line executor/no-json-parse -- boundary: Vite config reads package metadata from package.json
 const rootPackage = JSON.parse(
@@ -32,6 +37,23 @@ const EXECUTOR_GITHUB_URL = (
 
 const REPO_ROOT = fileURLToPath(new URL("../..", import.meta.url));
 const APP_ROOT = fileURLToPath(new URL("../../packages/app/", import.meta.url));
+
+const oauthClientMetadataResponse = (requestUrl: string, webRequest: Request): Response =>
+  new Response(
+    JSON.stringify(
+      oauthClientIdMetadataDocumentFromRequest({
+        requestUrl,
+        webRequest,
+        mountPrefix: "/api",
+      }),
+    ),
+    {
+      headers: {
+        "content-type": "application/json",
+        "cache-control": "public, max-age=300",
+      },
+    },
+  );
 
 /**
  * Vite plugin that forwards /api and /mcp requests to the Effect handlers
@@ -85,8 +107,7 @@ function executorApiPlugin(): Plugin {
         // bootstrap, so the UI is unaffected; external MCP clients use the
         // daemon port.
         const pathOnly = rawUrl.split("?")[0] ?? "/";
-        const authExempt =
-          pathOnly === "/api/health" || isUnauthenticatedOAuthCallbackPath(pathOnly);
+        const authExempt = pathOnly === "/api/health" || isUnauthenticatedOAuthPath(pathOnly);
         if (!authExempt) {
           const presented = req.headers.authorization;
           const authValue = Array.isArray(presented) ? presented[0] : presented;
@@ -125,7 +146,9 @@ function executorApiPlugin(): Plugin {
             } as RequestInit);
 
           let response: Response;
-          if (isMcp) {
+          if (isUnauthenticatedOAuthClientMetadataPath(pathOnly) && req.method === "GET") {
+            response = oauthClientMetadataResponse(rawUrl, webRequest(rawUrl));
+          } else if (isMcp) {
             response = await handlers.mcp.handleRequest(webRequest(rawUrl));
           } else if (pathOnly === "/api/health" && req.method === "GET") {
             response = new Response("ok", { headers: { "content-type": "text/plain" } });
@@ -182,6 +205,9 @@ export default defineConfig({
     "import.meta.env.VITE_APP_VERSION": JSON.stringify(EXECUTOR_VERSION),
     "import.meta.env.VITE_GITHUB_URL": JSON.stringify(EXECUTOR_GITHUB_URL),
     "import.meta.env.VITE_EXECUTOR_DEV_CLI_CWD": JSON.stringify(REPO_ROOT),
+    "import.meta.env.VITE_EXECUTOR_CIMD_CLIENT_ID_METADATA_BASE_URL": JSON.stringify(
+      process.env.EXECUTOR_CIMD_CLIENT_ID_METADATA_BASE_URL ?? "https://executor.sh",
+    ),
     "process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV ?? "development"),
   },
   resolve: {

--- a/packages/core/api/src/server.ts
+++ b/packages/core/api/src/server.ts
@@ -95,6 +95,18 @@ export {
   type MakeAccountApiLayerOptions,
   type ApiHandler,
 } from "./server/host-foundation";
+export {
+  makeOAuthClientIdMetadataRoute,
+  oauthClientIdMetadataDocumentFromRequest,
+  oauthClientIdMetadataDocumentPath,
+  oauthClientIdMetadataDocumentTargetPath,
+  oauthClientIdMetadataDocumentUrlFromRequest,
+  OAUTH_CLIENT_ID_METADATA_DOCUMENT_BASE_PATH,
+  OAUTH_CLIENT_ID_METADATA_DOCUMENT_DEFAULT_TARGET,
+  OAUTH_CLIENT_ID_METADATA_DOCUMENT_LOCAL_TARGET,
+  OAUTH_CLIENT_ID_METADATA_DOCUMENT_PATH,
+  OAUTH_CLIENT_ID_METADATA_DOCUMENT_TARGET_PATH_PREFIX,
+} from "./server/oauth-client-metadata";
 export * as ExecutorApp from "./server/executor-app";
 export type {
   ExecutorAppOptions,

--- a/packages/core/api/src/server/executor-app.ts
+++ b/packages/core/api/src/server/executor-app.ts
@@ -74,6 +74,7 @@ import {
   toApiHandler,
   type ApiHandler,
 } from "./host-foundation";
+import { makeOAuthClientIdMetadataRoute } from "./oauth-client-metadata";
 
 // A fully-resolved route/app Layer with its channels erased. Used at the
 // assembly boundaries (mirrors `toApiHandler`'s loose typing): each host's
@@ -562,7 +563,10 @@ export const make = <
   // `provideMerge(boot)` resolves the seams' residual requirements (the
   // long-lived DB handle, the control-plane services); the runtime contract is
   // the same — every route requirement is provided.
-  const routeLayers: AppRouteLayer[] = [apiLive];
+  const routeLayers: AppRouteLayer[] = [
+    makeOAuthClientIdMetadataRoute(config.mountPrefix) as AppRouteLayer,
+    apiLive,
+  ];
   if (mcpRouteLive) routeLayers.push(mcpRouteLive);
   for (const route of extensionRoutes) routeLayers.push(route);
 

--- a/packages/core/api/src/server/oauth-client-metadata.test.ts
+++ b/packages/core/api/src/server/oauth-client-metadata.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import { oauthClientIdMetadataDocumentFromRequest } from "./oauth-client-metadata";
+
+describe("OAuth client ID metadata document", () => {
+  it("builds an org-scoped hosted document from a target path", () => {
+    const metadata = oauthClientIdMetadataDocumentFromRequest({
+      requestUrl: "/api/oauth/client-id-metadata/acme.json",
+      webRequest: new Request("http://127.0.0.1:42384/api/oauth/client-id-metadata/acme.json", {
+        headers: { Host: "100.81.219.45:42384" },
+      }),
+      mountPrefix: "/api",
+    });
+
+    expect(metadata.client_id).toBe(
+      "http://100.81.219.45:42384/api/oauth/client-id-metadata/acme.json",
+    );
+    expect(metadata.redirect_uris).toEqual([
+      "http://100.81.219.45:42384/api/oauth/callback?executor_org=acme",
+    ]);
+    expect(metadata.token_endpoint_auth_method).toBe("none");
+    expect(metadata.application_type).toBe("web");
+  });
+
+  it("uses forwarded host and protocol for proxy-facing hosted documents", () => {
+    const metadata = oauthClientIdMetadataDocumentFromRequest({
+      requestUrl: "/api/oauth/client-id-metadata/default.json",
+      webRequest: new Request("http://127.0.0.1:3000/api/oauth/client-id-metadata/default.json", {
+        headers: {
+          "x-forwarded-host": "wsl-dev.tail5665af.ts.net",
+          "x-forwarded-proto": "https",
+          Host: "127.0.0.1:3000",
+        },
+      }),
+      mountPrefix: "/api",
+    });
+
+    expect(metadata.client_id).toBe(
+      "https://wsl-dev.tail5665af.ts.net/api/oauth/client-id-metadata/default.json",
+    );
+    expect(metadata.redirect_uris).toEqual([
+      "https://wsl-dev.tail5665af.ts.net/api/oauth/callback",
+    ]);
+  });
+
+  it("serves a hosted local document with portless loopback callbacks", () => {
+    const metadata = oauthClientIdMetadataDocumentFromRequest({
+      requestUrl: "/api/oauth/client-id-metadata/local.json",
+      webRequest: new Request("http://127.0.0.1:3000/api/oauth/client-id-metadata/local.json", {
+        headers: {
+          "x-forwarded-host": "executor.sh",
+          "x-forwarded-proto": "https",
+          Host: "127.0.0.1:3000",
+        },
+      }),
+      mountPrefix: "/api",
+    });
+
+    expect(metadata.client_id).toBe("https://executor.sh/api/oauth/client-id-metadata/local.json");
+    expect(metadata.redirect_uris).toEqual([
+      "http://127.0.0.1/api/oauth/callback",
+      "http://localhost/api/oauth/callback",
+      "http://[::1]/api/oauth/callback",
+    ]);
+    expect(metadata.application_type).toBe("native");
+  });
+
+  it("still reads the org selector from the legacy query form", () => {
+    const metadata = oauthClientIdMetadataDocumentFromRequest({
+      requestUrl: "/api/oauth/client-id-metadata.json?executor_org=acme",
+      webRequest: new Request("http://127.0.0.1:42384/api/oauth/client-id-metadata.json", {
+        headers: { Host: "100.81.219.45:42384" },
+      }),
+      mountPrefix: "/api",
+    });
+
+    expect(metadata.client_id).toBe(
+      "http://100.81.219.45:42384/api/oauth/client-id-metadata.json?executor_org=acme",
+    );
+    expect(metadata.redirect_uris).toEqual([
+      "http://100.81.219.45:42384/api/oauth/callback?executor_org=acme",
+    ]);
+  });
+});

--- a/packages/core/api/src/server/oauth-client-metadata.ts
+++ b/packages/core/api/src/server/oauth-client-metadata.ts
@@ -1,0 +1,193 @@
+import { Effect, Layer, Option } from "effect";
+import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http";
+
+export const OAUTH_CLIENT_ID_METADATA_DOCUMENT_BASE_PATH = "/oauth/client-id-metadata" as const;
+export const OAUTH_CLIENT_ID_METADATA_DOCUMENT_PATH =
+  `${OAUTH_CLIENT_ID_METADATA_DOCUMENT_BASE_PATH}.json` as const;
+export const OAUTH_CLIENT_ID_METADATA_DOCUMENT_TARGET_PATH_PREFIX =
+  `${OAUTH_CLIENT_ID_METADATA_DOCUMENT_BASE_PATH}/` as const;
+export const OAUTH_CLIENT_ID_METADATA_DOCUMENT_DEFAULT_TARGET = "default" as const;
+export const OAUTH_CLIENT_ID_METADATA_DOCUMENT_LOCAL_TARGET = "local" as const;
+const OAUTH_CALLBACK_ORG_QUERY_PARAM = "executor_org" as const;
+
+type MetadataTarget =
+  | typeof OAUTH_CLIENT_ID_METADATA_DOCUMENT_DEFAULT_TARGET
+  | typeof OAUTH_CLIENT_ID_METADATA_DOCUMENT_LOCAL_TARGET
+  | string;
+
+interface OAuthClientIdMetadataDocument {
+  readonly client_id: string;
+  readonly client_name: string;
+  readonly client_uri: string;
+  readonly redirect_uris: readonly string[];
+  readonly grant_types: readonly ["authorization_code"];
+  readonly response_types: readonly ["code"];
+  readonly token_endpoint_auth_method: "none";
+  readonly application_type: "web" | "native";
+}
+
+const pathWithMountPrefix = (mountPrefix?: string): `/${string}` =>
+  `${mountPrefix ?? ""}${OAUTH_CLIENT_ID_METADATA_DOCUMENT_PATH}` as `/${string}`;
+
+const targetPathWithMountPrefix = (mountPrefix?: string): `/${string}` =>
+  `${mountPrefix ?? ""}${OAUTH_CLIENT_ID_METADATA_DOCUMENT_TARGET_PATH_PREFIX}*` as `/${string}`;
+
+const callbackPathWithMountPrefix = (mountPrefix?: string): `/${string}` =>
+  `${mountPrefix ?? ""}/oauth/callback` as `/${string}`;
+
+export const oauthClientIdMetadataDocumentPath = (mountPrefix?: string): `/${string}` =>
+  pathWithMountPrefix(mountPrefix);
+
+export const oauthClientIdMetadataDocumentTargetPath = (
+  target: MetadataTarget,
+  mountPrefix?: string,
+): `/${string}` =>
+  `${mountPrefix ?? ""}${OAUTH_CLIENT_ID_METADATA_DOCUMENT_TARGET_PATH_PREFIX}${encodeURIComponent(
+    target,
+  )}.json` as `/${string}`;
+
+const firstForwardedHeaderValue = (headers: Headers, name: string): string | undefined => {
+  const value = headers.get(name)?.split(",")[0]?.trim();
+  return value ? value : undefined;
+};
+
+const parseAbsoluteUrl = (value: string): URL | undefined => {
+  if (!/^[a-z][a-z\d+.-]*:\/\//i.test(value)) return undefined;
+  return new URL(value);
+};
+const decodeUriComponentOption = Option.liftThrowable(decodeURIComponent);
+
+const pathSearchAndHash = (value: string, fallbackPath: `/${string}`): string => {
+  const parsed = parseAbsoluteUrl(value);
+  if (parsed) return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+  return value.startsWith("/") ? value : fallbackPath;
+};
+
+const metadataTargetFromPath = ({
+  pathname,
+  mountPrefix,
+}: {
+  readonly pathname: string;
+  readonly mountPrefix?: string;
+}): MetadataTarget | undefined => {
+  const prefix = `${mountPrefix ?? ""}${OAUTH_CLIENT_ID_METADATA_DOCUMENT_TARGET_PATH_PREFIX}`;
+  if (!pathname.startsWith(prefix) || !pathname.endsWith(".json")) return undefined;
+  const encoded = pathname.slice(prefix.length, -".json".length);
+  if (!encoded || encoded.includes("/")) return undefined;
+  const target = Option.getOrUndefined(
+    Option.map(decodeUriComponentOption(encoded), (value) => value.trim()),
+  );
+  return target ? target : undefined;
+};
+
+const orgSlugFromMetadataTarget = (target: MetadataTarget | undefined): string | undefined => {
+  if (!target) return undefined;
+  if (
+    target === OAUTH_CLIENT_ID_METADATA_DOCUMENT_DEFAULT_TARGET ||
+    target === OAUTH_CLIENT_ID_METADATA_DOCUMENT_LOCAL_TARGET
+  ) {
+    return undefined;
+  }
+  return target;
+};
+
+export const oauthClientIdMetadataDocumentUrlFromRequest = ({
+  requestUrl,
+  webRequest,
+  mountPrefix,
+}: {
+  readonly requestUrl: string;
+  readonly webRequest: Request;
+  readonly mountPrefix?: string;
+}): URL => {
+  const requestAbsoluteUrl = parseAbsoluteUrl(requestUrl) ?? parseAbsoluteUrl(webRequest.url);
+  const proto =
+    firstForwardedHeaderValue(webRequest.headers, "x-forwarded-proto") ??
+    requestAbsoluteUrl?.protocol.replace(/:$/, "") ??
+    "http";
+  const host =
+    firstForwardedHeaderValue(webRequest.headers, "x-forwarded-host") ??
+    firstForwardedHeaderValue(webRequest.headers, "host") ??
+    requestAbsoluteUrl?.host ??
+    "localhost";
+  const origin = `${proto}://${host}`;
+  return new URL(pathSearchAndHash(requestUrl, pathWithMountPrefix(mountPrefix)), origin);
+};
+
+const localLoopbackRedirectUris = (mountPrefix?: string): readonly string[] => {
+  const callbackPath = callbackPathWithMountPrefix(mountPrefix);
+  return [
+    new URL(callbackPath, "http://127.0.0.1").toString(),
+    new URL(callbackPath, "http://localhost").toString(),
+    new URL(callbackPath, "http://[::1]").toString(),
+  ];
+};
+
+export const oauthClientIdMetadataDocumentFromRequest = ({
+  requestUrl,
+  webRequest,
+  mountPrefix,
+}: {
+  readonly requestUrl: string;
+  readonly webRequest: Request;
+  readonly mountPrefix?: string;
+}): OAuthClientIdMetadataDocument => {
+  const url = oauthClientIdMetadataDocumentUrlFromRequest({ requestUrl, webRequest, mountPrefix });
+  const target = metadataTargetFromPath({ pathname: url.pathname, mountPrefix });
+
+  if (target === OAUTH_CLIENT_ID_METADATA_DOCUMENT_LOCAL_TARGET) {
+    return {
+      client_id: url.toString(),
+      client_name: "Executor Local",
+      client_uri: url.origin,
+      redirect_uris: localLoopbackRedirectUris(mountPrefix),
+      grant_types: ["authorization_code"],
+      response_types: ["code"],
+      token_endpoint_auth_method: "none",
+      application_type: "native",
+    };
+  }
+
+  const redirectUri = new URL(callbackPathWithMountPrefix(mountPrefix), url.origin);
+  const orgSlug =
+    orgSlugFromMetadataTarget(target) ??
+    url.searchParams.get(OAUTH_CALLBACK_ORG_QUERY_PARAM)?.trim();
+  if (orgSlug) redirectUri.searchParams.set(OAUTH_CALLBACK_ORG_QUERY_PARAM, orgSlug);
+
+  return {
+    client_id: url.toString(),
+    client_name: "Executor",
+    client_uri: url.origin,
+    redirect_uris: [redirectUri.toString()],
+    grant_types: ["authorization_code"],
+    response_types: ["code"],
+    token_endpoint_auth_method: "none",
+    application_type: "web",
+  };
+};
+
+export const makeOAuthClientIdMetadataRoute = (
+  mountPrefix?: string,
+): Layer.Layer<never, never, HttpRouter.HttpRouter> => {
+  const handler = Effect.gen(function* () {
+    const request = yield* HttpServerRequest.HttpServerRequest;
+    // oxlint-disable-next-line executor/no-effect-escape-hatch -- boundary: HTTP router request conversion failure is an edge defect, not recoverable route input
+    const webRequest = yield* HttpServerRequest.toWeb(request).pipe(Effect.orDie);
+    const metadata = oauthClientIdMetadataDocumentFromRequest({
+      requestUrl: request.url,
+      webRequest,
+      mountPrefix,
+    });
+
+    return HttpServerResponse.jsonUnsafe(metadata, {
+      headers: {
+        "cache-control": "public, max-age=300",
+      },
+    });
+  });
+
+  return Layer.mergeAll(
+    HttpRouter.add("GET", pathWithMountPrefix(mountPrefix), handler),
+    HttpRouter.add("GET", targetPathWithMountPrefix(mountPrefix), handler),
+  );
+};

--- a/packages/react/src/plugins/oauth-sign-in.test.ts
+++ b/packages/react/src/plugins/oauth-sign-in.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from "@effect/vitest";
 
-import { oauthCallbackUrl } from "./oauth-sign-in";
+import { oauthCallbackUrl, oauthClientIdMetadataDocumentUrl } from "./oauth-sign-in";
 
 const originalWindow = globalThis.window;
 
@@ -20,6 +20,32 @@ afterEach(() => {
     return;
   }
   Reflect.deleteProperty(globalThis, "window");
+});
+
+describe("oauthClientIdMetadataDocumentUrl", () => {
+  it("returns a relative default metadata path outside the browser", () => {
+    Reflect.deleteProperty(globalThis, "window");
+    expect(oauthClientIdMetadataDocumentUrl()).toBe("/api/oauth/client-id-metadata/default.json");
+  });
+
+  it("carries the active org slug from the console URL", () => {
+    setLocation("https://executor.sh/acme/integrations/posthog");
+
+    const url = new URL(oauthClientIdMetadataDocumentUrl());
+
+    expect(url.toString()).toBe("https://executor.sh/api/oauth/client-id-metadata/acme.json");
+    expect(url.search).toBe("");
+  });
+
+  it("uses the hosted local document when configured", () => {
+    setLocation("http://localhost:4788/integrations/posthog");
+
+    expect(
+      oauthClientIdMetadataDocumentUrl({
+        hostedBaseUrl: "https://executor.sh",
+      }),
+    ).toBe("https://executor.sh/api/oauth/client-id-metadata/local.json");
+  });
 });
 
 describe("oauthCallbackUrl", () => {

--- a/packages/react/src/plugins/oauth-sign-in.tsx
+++ b/packages/react/src/plugins/oauth-sign-in.tsx
@@ -14,6 +14,7 @@ import {
   type OAuthPopupResult,
 } from "../api/oauth-popup";
 import { connectionWriteKeys } from "../api/reactivity-keys";
+import { getActiveOrgSlug } from "../api/server-connection";
 
 type DesktopBridge = {
   readonly openExternal: (url: string) => Promise<void>;
@@ -98,6 +99,39 @@ export type StartOAuthAuthorizationInput<TPayload extends OAuthCompletionPayload
 export function oauthCallbackUrl(path = "/api/oauth/callback"): string {
   if (typeof window === "undefined") return path;
   return new URL(path, window.location.origin).toString();
+}
+
+export const OAUTH_CLIENT_ID_METADATA_DOCUMENT_PATH = "/api/oauth/client-id-metadata/default.json";
+export const OAUTH_CLIENT_ID_METADATA_DOCUMENT_LOCAL_PATH =
+  "/api/oauth/client-id-metadata/local.json";
+
+const configuredClientIdMetadataBaseUrl = (): string | undefined => {
+  const env = (
+    import.meta as ImportMeta & {
+      readonly env?: Record<string, string | undefined>;
+    }
+  ).env;
+  const value = env?.VITE_EXECUTOR_CIMD_CLIENT_ID_METADATA_BASE_URL?.trim();
+  return value ? value : undefined;
+};
+
+export function oauthClientIdMetadataDocumentUrl(options?: {
+  readonly hostedBaseUrl?: string | null;
+  readonly path?: string;
+}): string {
+  const hostedBaseUrl = options?.hostedBaseUrl ?? configuredClientIdMetadataBaseUrl();
+  if (hostedBaseUrl) {
+    return new URL(OAUTH_CLIENT_ID_METADATA_DOCUMENT_LOCAL_PATH, hostedBaseUrl).toString();
+  }
+
+  const defaultPath = options?.path ?? OAUTH_CLIENT_ID_METADATA_DOCUMENT_PATH;
+  if (typeof window === "undefined") return defaultPath;
+  const orgSlug = getActiveOrgSlug();
+  const metadataPath = orgSlug
+    ? `/api/oauth/client-id-metadata/${encodeURIComponent(orgSlug)}.json`
+    : defaultPath;
+  const url = new URL(metadataPath, window.location.origin);
+  return url.toString();
 }
 
 export function useOAuthPopupFlow<


### PR DESCRIPTION
## What changed

- Added unauthenticated CIMD client metadata documents under `/api/oauth/client-id-metadata/*.json`, including hosted/default org docs and a local native-client document.
- Mounted the metadata document route through the core API server and local serving path so cloud/self-host/local targets can serve the documents without auth.
- Added local/desktop config defaults plus a small React URL helper so local/desktop clients can use the hosted `local.json` metadata document without pinning a local callback port.
- Added focused route, serving, dispatch, and URL-helper coverage.

## Why

Some OAuth providers accept a Client ID Metadata Document URL as `client_id`. Executor needs stable, queryless metadata document URLs for hosted deployments, while local and desktop need to reference a stable hosted local-client document without fixing the user’s local callback port.

## Validation

- `bun run test src/server/oauth-client-metadata.test.ts src/oauth-popup.test.ts` in `packages/core/api`
- `bun run test src/plugins/oauth-sign-in.test.ts` in `packages/react`
- `bun run test src/serve.test.ts src/serve-shared.test.ts` in `apps/local`
- `bun run test src/app-paths.test.ts` in `apps/cloud`
- `bun run lint`
- `bun run typecheck` in `packages/core/api`, `packages/react`, `apps/local`, and `apps/desktop`
- `git diff --check --cached`