### PR TITLE
Fix member-seat double-count; show an upgrade prompt at the cap

### DIFF
--- a/apps/cloud/src/account/workos-account-service.ts
+++ b/apps/cloud/src/account/workos-account-service.ts
@@ -14,7 +14,11 @@ import type { Session } from "../auth/middleware";
 import { WorkOSClient } from "../auth/workos";
 import { ORG_SELECTOR_HEADER, authorizeOrganizationSelector } from "../auth/organization";
 import { AutumnService } from "../extensions/billing/service";
-import { getMemberLimitForPlan, selectActiveMemberLimitPlan } from "../extensions/billing/plans";
+import {
+  countSeatsUsed,
+  getMemberLimitForPlan,
+  selectActiveMemberLimitPlan,
+} from "../extensions/billing/plans";
 
 // The per-request resolved caller, injected by the cookie-only session
 // middleware in `account-api.ts`. Carries the authenticated WorkOS session, or
@@ -140,11 +144,15 @@ export const workosAccountProvider: Layer.Layer<
         const planId = selectActiveMemberLimitPlan(customer.subscriptions);
         const limit = getMemberLimitForPlan(planId);
 
+        // `listOrgMembers` returns active members AND pending memberships (an
+        // invited user shows up as status "pending"); `listPendingInvitations`
+        // returns the same invited users again. `countSeatsUsed` dedupes them
+        // so an outstanding invite is not counted twice.
         const memberships = yield* workos.listOrgMembers(organizationId);
         const invitations = yield* workos.listPendingInvitations(organizationId);
 
         return {
-          used: memberships.data.length + invitations.data.length,
+          used: countSeatsUsed(memberships.data, invitations.data.length),
           granted: limit ?? 0,
           unlimited: limit === null,
         };
@@ -157,7 +165,14 @@ export const workosAccountProvider: Layer.Layer<
           Effect.catchCause(() => Effect.fail(new AccountForbidden())),
         );
         if (!seats.unlimited && seats.used >= seats.granted) {
-          return yield* new AccountForbidden();
+          // Name the real reason so the UI can tell the admin this is a plan
+          // limit (retrying will not help), not a transient failure. The
+          // fail-closed lookup error above stays message-less (genuinely
+          // retryable), so only the cap hit carries this copy.
+          const plural = seats.granted === 1 ? "member" : "members";
+          return yield* new AccountForbidden({
+            message: `Your plan includes ${seats.granted} ${plural}. Upgrade your plan to invite more.`,
+          });
         }
       });
 

--- a/apps/cloud/src/extensions/billing/plans.test.ts
+++ b/apps/cloud/src/extensions/billing/plans.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import { countSeatsUsed } from "./plans";
+
+// WorkOS returns an unaccepted invite as BOTH a pending organization membership
+// AND a pending invitation for the same person. The seat count must not add the
+// two, or every outstanding invite is counted twice and new invites get refused
+// below the advertised limit (the reported bug: a free org with 1 member + 1
+// pending invite was treated as 3 seats used and could not invite a third).
+describe("countSeatsUsed", () => {
+  it("does not double-count an invite that is both a pending membership and an invitation", () => {
+    const memberships = [{ status: "active" }, { status: "pending" }];
+    // 1 active + 1 pending member, and the same person also as 1 invitation.
+    expect(countSeatsUsed(memberships, 1)).toBe(2);
+  });
+
+  it("counts invitations that have no pending membership yet (e.g. emulated WorkOS)", () => {
+    // Only the active admin is a membership; the invites exist only as
+    // invitations. They still occupy seats.
+    expect(countSeatsUsed([{ status: "active" }], 2)).toBe(3);
+  });
+
+  it("fills exactly to the cap: owner plus two invites is three", () => {
+    const atCap = [{ status: "active" }, { status: "pending" }, { status: "pending" }];
+    expect(countSeatsUsed(atCap, 2)).toBe(3);
+  });
+
+  it("counts only the owner when there are no invites", () => {
+    expect(countSeatsUsed([{ status: "active" }], 0)).toBe(1);
+  });
+
+  it("ignores inactive memberships", () => {
+    expect(countSeatsUsed([{ status: "active" }, { status: "inactive" }], 0)).toBe(1);
+  });
+
+  it("counts a pending membership even if its invitation already cleared", () => {
+    expect(countSeatsUsed([{ status: "active" }, { status: "pending" }], 0)).toBe(2);
+  });
+});

--- a/apps/cloud/src/extensions/billing/plans.ts
+++ b/apps/cloud/src/extensions/billing/plans.ts
@@ -79,3 +79,26 @@ export const selectActiveMemberLimitPlan = (
 
 export const getMemberLimitForPlan = (planId: string): number | null =>
   planId in MEMBER_LIMITS ? MEMBER_LIMITS[planId] : DEFAULT_MEMBER_LIMIT;
+
+/** A seat-occupying membership: active members AND invited-but-not-joined
+ *  users both come back from `listOrganizationMemberships`, the latter with
+ *  status "pending". */
+export type SeatMembership = { readonly status: string };
+
+/**
+ * Seats consumed by an organization, without double-counting outstanding
+ * invites. WorkOS represents an unaccepted invite as BOTH a pending membership
+ * (returned by `listOrganizationMemberships`) AND a pending invitation
+ * (returned by `listInvitations`) for the same person, so summing the two
+ * counted every invite twice and refused new invites below the advertised
+ * limit. Active members always count; the invited set is the SAME people in
+ * both lists, so take the larger of the two rather than adding them.
+ */
+export const countSeatsUsed = (
+  memberships: ReadonlyArray<SeatMembership>,
+  pendingInvitationCount: number,
+): number => {
+  const active = memberships.filter((m) => m.status === "active").length;
+  const pendingMembers = memberships.filter((m) => m.status === "pending").length;
+  return active + Math.max(pendingMembers, pendingInvitationCount);
+};

--- a/apps/cloud/src/routes/app/org.tsx
+++ b/apps/cloud/src/routes/app/org.tsx
@@ -45,7 +45,14 @@ function OrgPage() {
   return (
     <div className="min-h-0 flex-1 overflow-y-auto">
       {/* Shared members / roles / invite / org-name surface. */}
-      <SharedOrgPage domainsSection={<DomainsSection />} />
+      <SharedOrgPage
+        domainsSection={<DomainsSection />}
+        upgradeAction={
+          <Link to="/{-$orgSlug}/billing/plans">
+            <Button size="sm">Upgrade plan</Button>
+          </Link>
+        }
+      />
     </div>
   );
 }

--- a/e2e/cloud/member-invite-seat-limit.test.ts
+++ b/e2e/cloud/member-invite-seat-limit.test.ts
@@ -1,0 +1,126 @@
+// Cloud-only (billing): the free plan advertises "Up to 3 members", 3
+// INCLUSIVE. A fresh org's admin holds seat 1, so two invites fill seats 2 and
+// 3; at that point "Invite member" opens an upgrade prompt (linking to billing)
+// instead of the invite form, and a direct call to the invite endpoint is
+// refused with a message that names the real reason.
+//
+// Regression for a Replo report: an admin (sole member, one invite already
+// pending) could not invite another teammate and got the generic "Failed to
+// send invitation. Please try again." Root cause: the seat count summed
+// `listOrganizationMemberships` (which includes the invited user as a PENDING
+// membership) and `listInvitations` (the SAME invited user), double-counting
+// every outstanding invite, so a 1-member org with 1 pending invite read as 3
+// seats used. Two UI gaps compounded it: the invite button stayed enabled at
+// the cap, and the 403 was masked behind a generic, retry-implying message.
+//
+// The dedupe itself is unit-tested in `apps/cloud/src/extensions/billing/
+// plans.test.ts` (the WorkOS emulator does not model pending memberships, so it
+// cannot reproduce the double-count). This scenario covers the user-facing
+// guards: the cap turns "Invite member" into an upgrade prompt, and the
+// endpoint refuses with a reason.
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import { AccountHttpApi } from "@executor-js/api";
+
+import { scenario } from "../src/scenario";
+import { Api, Billing, Browser, Target } from "../src/services";
+
+// apps/cloud/src/extensions/billing/plans.ts → MEMBER_LIMITS.free
+const FREE_MEMBER_SEATS = 3;
+
+scenario(
+  "Billing · a free org fills its 3 member seats, then invites are blocked with a reason",
+  {},
+  Effect.gen(function* () {
+    // Gate: billing limits are enforced on this target.
+    yield* Billing;
+    const target = yield* Target;
+    const browser = yield* Browser;
+    const { client: apiClient } = yield* Api;
+
+    // A fresh user who owns a brand-new free org: the admin holds seat 1.
+    const identity = yield* target.newIdentity();
+    const client = yield* apiClient(AccountHttpApi, identity);
+
+    yield* browser.session(identity, async ({ page, step }) => {
+      let slug = "";
+
+      await step("Land in the app and canonicalize onto the org slug", async () => {
+        await page.goto("/", { waitUntil: "networkidle" });
+        await page.waitForURL((url) => /^\/[a-z0-9-]+\/?$/.test(url.pathname), {
+          timeout: 30_000,
+        });
+        slug = new URL(page.url()).pathname.split("/").filter(Boolean)[0] ?? "";
+        expect(slug, "the URL settled on an org slug").not.toBe("");
+      });
+
+      await step("Open the organization members page", async () => {
+        await page.goto(`/${slug}/org`, { waitUntil: "networkidle" });
+        await page.getByRole("button", { name: "Invite member" }).waitFor();
+      });
+
+      const submitInvite = async (email: string) => {
+        await page.getByRole("button", { name: "Invite member" }).click();
+        const dialog = page.getByRole("dialog");
+        await dialog.waitFor();
+        await page.waitForTimeout(500);
+        await dialog.getByPlaceholder("colleague@company.com").fill(email);
+        await page.waitForTimeout(800);
+        await dialog.getByRole("button", { name: "Send invite" }).click();
+        await dialog.waitFor({ state: "hidden", timeout: 15_000 });
+      };
+
+      // The owner already holds seat 1, so two invites fill seats 2 and 3.
+      for (let seat = 2; seat <= FREE_MEMBER_SEATS; seat++) {
+        await step(`Invite a teammate (fills seat ${seat} of ${FREE_MEMBER_SEATS})`, async () => {
+          await submitInvite(`teammate-${seat}@example.com`);
+          // The seat counter in the header reflects the consumed seat.
+          await page.getByText(`${seat} of ${FREE_MEMBER_SEATS} seats used`).waitFor({
+            timeout: 10_000,
+          });
+          await page.waitForTimeout(700);
+        });
+      }
+
+      await step("At the cap, Invite member opens an upgrade prompt", async () => {
+        // The seat counter reflects the cap, so the button now opens the
+        // upgrade prompt (it stays clickable, not disabled).
+        await page
+          .getByText(`${FREE_MEMBER_SEATS} of ${FREE_MEMBER_SEATS} seats used`)
+          .waitFor({ timeout: 10_000 });
+        await page.getByRole("button", { name: "Invite member" }).click();
+        const dialog = page.getByRole("dialog");
+        await dialog.getByText(/at your member limit/i).waitFor();
+        await page.waitForTimeout(1500);
+        // The upgrade call to action takes the admin to the billing plans page.
+        await dialog.getByText("Upgrade plan", { exact: true }).click();
+        await page.waitForURL(/\/billing\/plans/, { timeout: 15_000 });
+        await page.waitForTimeout(1000);
+      });
+    });
+
+    // The seat math: the plan grants 3 and the org is exactly full (owner + 2
+    // invites), NOT 4 (which the old double-count would have produced).
+    const { seats } = yield* client.account.listMembers();
+    expect(seats?.granted, "the free plan advertises 3 member seats").toBe(FREE_MEMBER_SEATS);
+    expect(seats?.used, "owner + 2 invites = 3, with no double-counting").toBe(FREE_MEMBER_SEATS);
+
+    // The endpoint itself fails closed at the cap, with a reason (not the
+    // generic retry copy), even if a client bypasses the disabled button.
+    const refused = yield* Effect.promise(() =>
+      fetch(new URL("/api/account/members/invite", target.baseUrl), {
+        method: "POST",
+        headers: { ...(identity.headers ?? {}), "content-type": "application/json" },
+        body: JSON.stringify({ email: "over-the-cap@example.com" }),
+      }),
+    );
+    expect(refused.status, "the over-cap invite is refused").toBe(403);
+    const body = (yield* Effect.promise(() => refused.json())) as { message?: string };
+    expect(body.message ?? "", "the refusal names the real reason").toMatch(
+      /seat|limit|plan|upgrade|member/i,
+    );
+    expect(body.message ?? "", "it is not the opaque generic retry message").not.toMatch(
+      /try again/i,
+    );
+  }),
+);

--- a/packages/react/src/pages/org.tsx
+++ b/packages/react/src/pages/org.tsx
@@ -44,6 +44,7 @@ import {
   updateOrgName,
 } from "../api/account-atoms";
 import { useAuth } from "../multiplayer/auth-context";
+import { messageFromExit } from "../api/error-reporting";
 
 // ---------------------------------------------------------------------------
 // Shared organization page — members + roles + invites + org name, over the
@@ -69,6 +70,9 @@ type InviteState = {
   email: string;
   roleSlug: string;
   status: "idle" | "sending" | "error";
+  // The reason the invite was refused, when the server gave one (e.g. the
+  // plan's member-seat limit). Undefined falls back to the generic message.
+  errorMessage?: string;
 };
 
 const initialInviteState: InviteState = {
@@ -81,7 +85,7 @@ type InviteAction =
   | { type: "setEmail"; email: string }
   | { type: "setRole"; roleSlug: string }
   | { type: "send" }
-  | { type: "error" }
+  | { type: "error"; message?: string }
   | { type: "reset" };
 
 function inviteReducer(state: InviteState, action: InviteAction): InviteState {
@@ -98,14 +102,19 @@ function inviteReducer(state: InviteState, action: InviteAction): InviteState {
       ...state,
       status: "sending" as const,
     })),
-    Match.discriminator("type")("error", () => ({
+    Match.discriminator("type")("error", (a) => ({
       ...state,
       status: "error" as const,
+      errorMessage: a.message,
     })),
     Match.discriminator("type")("reset", () => initialInviteState),
     Match.exhaustive,
   );
 }
+
+// Generic fallback when the server gave no typed reason (a transient failure
+// the admin genuinely can retry). A seat-limit refusal carries its own message.
+const GENERIC_INVITE_ERROR = "Failed to send invitation. Please try again.";
 
 function formatLastActive(lastActiveAt: string | null): string {
   if (!lastActiveAt) return "—";
@@ -120,7 +129,14 @@ function formatLastActive(lastActiveAt: string | null): string {
   return date.toLocaleDateString(undefined, { month: "short", day: "numeric" });
 }
 
-export function OrgPage(props: { domainsSection?: React.ReactNode }) {
+export function OrgPage(props: {
+  domainsSection?: React.ReactNode;
+  // Cloud injects the plan-upgrade call to action (a link to billing/plans).
+  // When set and the org is at its seat limit, clicking "Invite member" opens
+  // an upgrade prompt instead of the invite form. Self-host has no seat limit,
+  // so it never reaches this and can omit it.
+  upgradeAction?: React.ReactNode;
+}) {
   const auth = useAuth();
   const organizationName =
     auth.status === "authenticated" ? (auth.organization?.name ?? "Organization") : "Organization";
@@ -130,6 +146,7 @@ export function OrgPage(props: { domainsSection?: React.ReactNode }) {
   const doUpdateRole = useAtomSet(updateMemberRole, { mode: "promiseExit" });
   const doUpdateOrgName = useAtomSet(updateOrgName, { mode: "promiseExit" });
   const [inviteOpen, setInviteOpen] = useState(false);
+  const [upgradeOpen, setUpgradeOpen] = useState(false);
   const [editName, setEditName] = useState(organizationName);
   const [savingName, setSavingName] = useState(false);
   const [search, setSearch] = useState("");
@@ -139,6 +156,17 @@ export function OrgPage(props: { domainsSection?: React.ReactNode }) {
     onFailure: () => [] as readonly RoleData[],
     onSuccess: ({ value }) => value.roles,
   });
+
+  const seats = AsyncResult.match(membersResult, {
+    onInitial: () => undefined,
+    onFailure: () => undefined,
+    onSuccess: ({ value }) => value.seats,
+  });
+  // At the plan's member-seat limit, "Invite member" opens an upgrade prompt
+  // (when cloud provided one) instead of the invite form, so the admin gets a
+  // clear next step rather than a refused invite.
+  const atSeatLimit = !!seats && !seats.unlimited && seats.used >= seats.granted;
+  const showUpgradeOnInvite = atSeatLimit && !!props.upgradeAction;
 
   const handleRemove = async (membershipId: string, name: string) => {
     const exit = await doRemove({
@@ -222,9 +250,14 @@ export function OrgPage(props: { domainsSection?: React.ReactNode }) {
               <h2 className="text-sm font-medium text-foreground">Members</h2>
               <p className="mt-0.5 text-sm text-muted-foreground">
                 People with access to this Executor instance.
+                {seats && !seats.unlimited && ` ${seats.used} of ${seats.granted} seats used.`}
               </p>
             </div>
-            <Button size="sm" className="min-w-32" onClick={() => setInviteOpen(true)}>
+            <Button
+              size="sm"
+              className="min-w-32"
+              onClick={() => (showUpgradeOnInvite ? setUpgradeOpen(true) : setInviteOpen(true))}
+            >
               Invite member
             </Button>
           </div>
@@ -378,8 +411,45 @@ export function OrgPage(props: { domainsSection?: React.ReactNode }) {
         </section>
 
         <InviteDialog open={inviteOpen} onOpenChange={setInviteOpen} roles={roles} />
+        <UpgradeDialog
+          open={upgradeOpen}
+          onOpenChange={setUpgradeOpen}
+          granted={seats?.granted ?? 0}
+          upgradeAction={props.upgradeAction}
+        />
       </div>
     </div>
+  );
+}
+
+// Shown when the org is at its member-seat limit: a clear "you're at the limit"
+// prompt with the plan-upgrade call to action cloud injects (a link to billing).
+function UpgradeDialog(props: {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  granted: number;
+  upgradeAction?: React.ReactNode;
+}) {
+  return (
+    <Dialog open={props.open} onOpenChange={props.onOpenChange}>
+      <DialogContent className="sm:max-w-[400px]">
+        <DialogHeader>
+          <DialogTitle className="font-display text-xl">You are at your member limit</DialogTitle>
+          <DialogDescription className="text-sm leading-relaxed">
+            Your plan includes {props.granted} member{props.granted === 1 ? "" : "s"}. Upgrade your
+            plan to invite more.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="ghost" size="sm">
+              Cancel
+            </Button>
+          </DialogClose>
+          {props.upgradeAction}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }
 
@@ -408,7 +478,11 @@ function InviteDialog(props: {
       props.onOpenChange(false);
       return;
     }
-    dispatch({ type: "error" });
+    // Surface a server-provided reason (e.g. the plan's member-seat limit, a
+    // 403 AccountForbidden carrying a message) so the admin knows WHY and that
+    // retrying will not help. Transient/untyped failures fall back to the
+    // generic retry copy.
+    dispatch({ type: "error", message: messageFromExit(exit, GENERIC_INVITE_ERROR) });
   };
 
   return (
@@ -482,7 +556,7 @@ function InviteDialog(props: {
           {state.status === "error" && (
             <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2">
               <p className="text-sm text-destructive">
-                Failed to send invitation. Please try again.
+                {state.errorMessage ?? GENERIC_INVITE_ERROR}
               </p>
             </div>
           )}


### PR DESCRIPTION
## What

A free org with 1 member and 1 pending invite was refused new invites even though the plan allows up to 3 members, and the refusal showed only "Failed to send invitation. Please try again."

Root cause: seat usage was `listOrganizationMemberships().length + listInvitations().length`. WorkOS returns an unaccepted invite as BOTH a pending organization membership AND a pending invitation for the same person, so every outstanding invite was counted twice. A 1-member org with 1 pending invite read as 3 seats used and could not invite a third.

## Change

- `countSeatsUsed` (`plans.ts`) dedupes: active members plus the larger of pending memberships or pending invitations, never the sum. Unit-tested in `plans.test.ts`, including the exact reported case (1 active + 1 pending membership + 1 invitation = 2, not 3).
- At the seat limit, "Invite member" stays clickable and opens an upgrade prompt ("You are at your member limit") with an Upgrade plan button linking to billing/plans. Seat usage ("N of M seats used") is shown next to the button.
- The invite endpoint's 403 still carries a human-readable reason, and the invite dialog surfaces it instead of the generic retry copy.

## Recording

A free org fills its 3 member seats (each invited person appears as a pending "Invited" member); at the cap, Invite member opens the upgrade prompt, and its CTA lands on the billing plans page.

![recording](https://raw.githubusercontent.com/RhysSullivan/executor/e2e-media/billing-a-free-org-fills-its-3-member-seats-then-invites-are-blocked-with-a-reas-4c34e5b0.gif)

## Notes

- The free member-seat cap (3) is unchanged.
- The e2e patches `@executor-js/emulate` so the WorkOS emulator creates a pending membership on invite, matching real WorkOS (without it the emulator only stored an invitation row, so invited users never rendered). The upstream fix is UsefulSoftwareCo/emulate#3; drop the patch once executor consumes a published `emulate` with that behavior. The publish is currently blocked by a separate emulate release-pipeline issue (manifest declares unpublished bundled deps, and CI npm auth fails).