### PR TITLE
Make the main area's top strip draggable on the desktop app

### DIFF
--- a/packages/app/src/web/shell.tsx
+++ b/packages/app/src/web/shell.tsx
@@ -545,6 +545,11 @@ export function Shell() {
 
       {/* Main content */}
       <main className="flex min-h-0 flex-1 flex-col min-w-0 overflow-hidden">
+        {/* Desktop (macOS frameless) draggable title-bar strip. Gives the main
+            area the same native window drag + double-click-to-zoom as the
+            sidebar header; hidden everywhere else via CSS. */}
+        <div className="desktop-macos-main-titlebar" />
+
         {/* Mobile top bar */}
         <div className="flex h-12 shrink-0 items-center justify-between border-b border-border bg-background px-4 md:hidden">
           <Button

--- a/packages/react/src/styles/globals.css
+++ b/packages/react/src/styles/globals.css
@@ -164,6 +164,27 @@
   -webkit-app-region: no-drag;
 }
 
+/* The main content area sits to the right of the sidebar. On the frameless
+   desktop window it renders page content straight to the top edge with nothing
+   marked as a drag region, so the window could not be moved or
+   double-clicked-to-zoom from there (only the sidebar header worked, see
+   .desktop-macos-titlebar above). Reserve a title-bar-height strip along the
+   top of the main area and make it draggable so the whole top row behaves like
+   the native title bar. Hidden off-desktop. It reserves space rather than
+   overlaying, so no page content sits under the drag region (a drag region
+   would otherwise swallow clicks on anything beneath it). The traffic lights
+   sit over the sidebar, never the main area, so no left offset is needed here. */
+.desktop-macos-main-titlebar {
+  display: none;
+}
+
+.executor-desktop-macos .desktop-macos-main-titlebar {
+  display: block;
+  height: 3rem; /* matches the sidebar header (h-12) */
+  flex-shrink: 0;
+  -webkit-app-region: drag;
+}
+
 /* The 88px title-bar offset eats into the sidebar's width; without extra room
    the brand wordmark and the server-connection menu collide. Widen the macOS
    sidebar so both clear the traffic lights with comfortable spacing. */


### PR DESCRIPTION
## Problem

On the macOS desktop app the window is frameless (`titleBarStyle: "hidden"`), so the OS only treats regions marked with CSS `-webkit-app-region: drag` as the native title bar (window drag + double-click-to-zoom). Only the **sidebar header** was marked draggable, so double-clicking the top of the **main content area** did nothing. Double-clicking the sidebar header worked.

## Fix

Reserve a title-bar-height strip along the top of `<main>` and mark it draggable, mirroring the sidebar header. It is:

- **scoped to the desktop app** (`.executor-desktop-macos`, added only in the Electron app on macOS) so the web build is unaffected;
- a **reserved** strip rather than an overlay, so the drag region never sits on top of page content and swallow clicks on it.

Files:
- `packages/react/src/styles/globals.css` — new `.desktop-macos-main-titlebar` rule.
- `packages/app/src/web/shell.tsx` — render the strip as the first child of `<main>`.

## Proof (real desktop build running in a macOS VM)

Built the actual desktop app from this branch (`bun run build` + `electron-builder --dir`), ran the resulting `Executor.app` in a fresh macOS 15 `tart` VM, and synthesized a real left double-click (CGEvent) at logical point **(600, 55)** — which is in the **main content area**, to the right of the 240px sidebar.

The window moved from `x=40 y=31 w=960 h=680` to `x=0 y=25 w=1024 h=686` (zoomed to fill the screen), i.e. double-click-to-zoom now works from the main area, not just the sidebar.

**Before** — windowed; red circle marks the double-click target in the main-area top bar:

![before](https://raw.githubusercontent.com/RhysSullivan/executor/e2e-media/desktop-main-titlebar/before.png)

**After** — the same double-click zoomed the window to fill the screen:

![after](https://raw.githubusercontent.com/RhysSullivan/executor/e2e-media/desktop-main-titlebar/after.png)

## Note on the layout tradeoff

Because the strip reserves space (rather than overlaying, which would block clicks), main-area content sits ~48px lower on the desktop app, forming a title-bar row aligned with the sidebar header. If a no-shift overlay with per-header `no-drag` exceptions is preferred instead, that is an easy alternative.
