### PR TITLE
fix: align Toolkits header (scan all plugin src for Tailwind)

### DIFF
--- a/packages/react/src/styles/globals.css
+++ b/packages/react/src/styles/globals.css
@@ -5,7 +5,7 @@
 @source "../**/*.{ts,tsx}";
 @source "../../../../apps/local/src/**/*.{ts,tsx}";
 @source "../../../../apps/cloud/src/**/*.{ts,tsx}";
-@source "../../../plugins/*/src/react/**/*.{ts,tsx}";
+@source "../../../plugins/*/src/**/*.{ts,tsx}";
 
 @theme inline {
   --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif;


### PR DESCRIPTION
## Problem

The Toolkits content header sits ~12px higher than the sidebar header, so their bottom borders don't line up:

| Before | After |
|---|---|
| header collapsed to ~36px | both headers aligned at 48px |

## Root cause

The Tailwind v4 `@source` globs only scanned plugin UI under `plugins/*/src/react/**`. The toolkits plugin keeps its UI directly in `src/` (`page.tsx`, `client.tsx`), so Tailwind never scanned those files and any utility class used **only** there was silently dropped from the generated CSS.

The content header at `packages/plugins/toolkits/src/page.tsx` uses `min-h-12`, which is used nowhere else in the codebase. It was never generated, so the header lost its 48px floor and collapsed to ~36px (`py-2` + one line) while the sidebar's `h-12` stayed 48px.

Confirmed from the built CSS: `min-h-12`, `min-h-36`, and `space-y-7` were all absent, each used only in the toolkits plugin. (`min-h-36` was masked in the running app by an inline `minHeight: 9rem` fallback on the card; the header had no such fallback.)

## Fix

Widen the glob to `plugins/*/src/**` so all plugin UI is scanned regardless of whether it lives under `src/react`. This also covers the `desktop-settings` and `example` plugins, which have the same `src/`-not-`src/react/` layout.

## Verification

Rebuilt `apps/local` and confirmed `min-h-12`, `min-h-36`, and `space-y-7` now generate. Visual before/after (real compiled CSS around the real header markup) shows both header borders landing on the 48px baseline.