### PR TITLE
Meter MCP executions to Autumn

### DIFF
--- a/apps/cloud/src/api/protected.ts
+++ b/apps/cloud/src/api/protected.ts
@@ -50,9 +50,11 @@ export {
 //   - `cloudIdentityFailureStrategy` -> renders the shared identity errors as
 //                                     cloud's exact `{ error, code }` JSON at
 //                                     status 401/403/503 (byte-identical).
-//   - `cloudPlugins` + `CloudMeteredExecutionStackLayer` — the executor plane is
-//                                     the ONLY path that meters, so billing lives
-//                                     here (not in the neutral stack the DO shares).
+//   - `cloudPlugins` + `CloudMeteredExecutionStackLayer` — the HTTP executor
+//                                     plane meters here; the MCP session DO uses
+//                                     the same metered stack (with its own
+//                                     `AutumnService.Default`), so both planes
+//                                     bill executions.
 //
 // Only `AutumnService` is captured at boot; `IdentityProvider` + `DbService` +
 // `UserStoreService` stay residual and are supplied per request by the combined

--- a/apps/cloud/src/engine/execution-stack-metered.ts
+++ b/apps/cloud/src/engine/execution-stack-metered.ts
@@ -1,15 +1,17 @@
 // ---------------------------------------------------------------------------
-// Metered execution stack — the HTTP executor plane's billing overlay.
+// Metered execution stack: cloud's billing overlay over the execution seams.
 //
-// Cloud is the only host that meters executions, and only the HTTP `/api/*`
-// executor plane does so (the MCP session DO never bills). This module is where
-// the billing decorator binds to the neutral `CloudExecutionStackLayer`: it
-// overrides the base stack's no-op `EngineDecorator` with one that calls
-// `AutumnService.trackExecution` after each execution.
+// Cloud is the only host that meters executions, and BOTH of its execution
+// planes do so: the HTTP `/api/*` executor plane (api/protected.ts) and the MCP
+// session Durable Object (mcp/session-durable-object.ts). This module composes
+// the four billing-free `CloudExecutionSeamsLayer` seams with an `EngineDecorator`
+// that calls `AutumnService.trackExecution` after each execution.
 //
 // Keeping this in the cloud APP layer (not the neutral `engine/execution-stack.ts`)
-// is the billing-boundary line: the neutral stack the DO shares names no billing
-// service; the metered overlay — provided ONLY here — does.
+// is the billing-boundary line: the seams module names no billing service; the
+// metered overlay, provided ONLY here, does. Both planes import THIS layer and
+// supply `AutumnService` from their own context (boot for the HTTP plane,
+// `AutumnService.Default` locally for the DO).
 // ---------------------------------------------------------------------------
 
 import { Effect, Layer } from "effect";
@@ -42,10 +44,10 @@ export const CloudMeteringEngineDecorator: Layer.Layer<EngineDecorator, never, A
   );
 
 /**
- * The execution-stack seams for the metered HTTP executor plane: the four
- * billing-free `CloudExecutionSeamsLayer` seams plus the billing decorator.
- * Requires `DbService` (per-request Hyperdrive db) and `AutumnService` (usage
- * metering) from the surrounding context.
+ * The metered execution stack used by BOTH cloud planes (HTTP executor plane and
+ * MCP session DO): the four billing-free `CloudExecutionSeamsLayer` seams plus
+ * the billing decorator. Requires `DbService` (per-request Hyperdrive db) and
+ * `AutumnService` (usage metering) from the surrounding context.
  */
 export const CloudMeteredExecutionStackLayer: Layer.Layer<
   DbProvider | PluginsProvider | HostConfig | CodeExecutorProvider | EngineDecorator,

--- a/apps/cloud/src/engine/execution-stack.ts
+++ b/apps/cloud/src/engine/execution-stack.ts
@@ -22,12 +22,14 @@
 //                            a test flag. `webBaseUrl` is `VITE_PUBLIC_SITE_URL ??
 //                            executor.sh`.
 //   - CodeExecutorProvider -> `makeDynamicWorkerExecutor({ loader: env.LOADER })`.
-//   - EngineDecorator      -> the BASE stack uses the no-op decorator (the MCP
-//                            session DO never meters); the METERED stack (HTTP
-//                            executor plane only) overrides it with the billing
-//                            decorator (`CloudMeteredExecutionStackLayer`,
-//                            ../engine/execution-stack-metered.ts). Billing lives in
-//                            the cloud app, not this neutral stack.
+//   - EngineDecorator      -> the billing decorator that meters each execution
+//                            to Autumn. BOTH cloud execution planes (the HTTP
+//                            `/api/*` executor plane AND the MCP session DO) use
+//                            the metered stack (`CloudMeteredExecutionStackLayer`,
+//                            ../engine/execution-stack-metered.ts), since the MCP
+//                            server is the primary execution surface. Billing
+//                            still lives in the cloud app, not this neutral
+//                            seams module; the decorator is composed on top.
 // ---------------------------------------------------------------------------
 
 import { env } from "cloudflare:workers";
@@ -36,8 +38,6 @@ import { Layer } from "effect";
 import {
   CodeExecutorProvider,
   DbProvider,
-  EngineDecorator,
-  EngineDecoratorNoop,
   HostConfig,
   PluginsProvider,
   collectTables,
@@ -98,11 +98,11 @@ export const CloudCodeExecutorProvider: Layer.Layer<CodeExecutorProvider> = Laye
 
 /**
  * The four billing-free execution-stack seams (db / plugins / host-config /
- * code-executor) — everything `makeExecutionStack` reads EXCEPT the
- * `EngineDecorator`. The metered HTTP plane composes this with the billing
- * decorator (../engine/execution-stack-metered.ts); the neutral stack below adds
- * the no-op decorator. Exported so the metered overlay builds over the SAME four
- * seams rather than relying on a layer override.
+ * code-executor): everything `makeExecutionStack` reads EXCEPT the
+ * `EngineDecorator`. Both cloud planes compose this with the billing decorator
+ * via `CloudMeteredExecutionStackLayer` (../engine/execution-stack-metered.ts);
+ * exported so that overlay builds over the SAME four seams. There is no neutral
+ * no-op-decorator variant anymore: every cloud execution meters.
  */
 export const CloudExecutionSeamsLayer: Layer.Layer<
   DbProvider | PluginsProvider | HostConfig | CodeExecutorProvider,
@@ -114,20 +114,3 @@ export const CloudExecutionSeamsLayer: Layer.Layer<
   CloudHostConfig,
   CloudCodeExecutorProvider,
 );
-
-/**
- * The five execution-stack seams the shared `makeExecutionStack` reads from,
- * with the NO-OP engine decorator. This is the neutral stack: it requires only
- * `DbService` (per-request Hyperdrive db) and carries NO billing dependency, so
- * the MCP session DO — which never meters — can build an engine without dragging
- * in any billing service.
- *
- * The HTTP executor plane (the only path that meters) uses
- * `CloudMeteredExecutionStackLayer` (../engine/execution-stack-metered.ts), which
- * swaps the no-op decorator for the billing one.
- */
-export const CloudExecutionStackLayer: Layer.Layer<
-  DbProvider | PluginsProvider | HostConfig | CodeExecutorProvider | EngineDecorator,
-  never,
-  DbService
-> = Layer.merge(CloudExecutionSeamsLayer, EngineDecoratorNoop);

--- a/apps/cloud/src/mcp/session-durable-object.ts
+++ b/apps/cloud/src/mcp/session-durable-object.ts
@@ -32,14 +32,17 @@ import {
 } from "@executor-js/cloudflare/mcp/durable-object";
 import { buildExecuteDescription } from "@executor-js/execution";
 
-// The DO only needs the neutral boot-scoped service (WorkOSClient). It never
-// bills, so it does NOT depend on any billing service — `CloudExecutionStackLayer`
-// here is the no-op-decorator (Autumn-free) stack. It imports the focused
-// `CoreSharedServices` root (beside `WorkOSClient`), NOT `../api/layers`, so the
-// DO bundle stays small and free of the whole HTTP API assembly. (This used to
-// require a dedicated `core-shared-services.ts` leaf to keep `auth/handlers.ts` →
-// `@tanstack/react-start` out of the DO bundle; that coupling is gone now that
-// `handlers.ts` queues cookies through `SessionAuthLive` instead.)
+// The DO meters executions just like the HTTP `/api/*` plane: it builds its
+// engine with `CloudMeteredExecutionStackLayer`, so every MCP execution is
+// tracked to Autumn (the MCP server is the primary execution surface, so leaving
+// it unmetered silently dropped the bulk of real usage). The billing service
+// (`AutumnService.Default`) is provided LOCALLY to the metered stack below, so
+// the DO still imports the focused `CoreSharedServices` root (beside
+// `WorkOSClient`), NOT `../api/layers`, and its bundle stays free of the whole
+// HTTP API assembly. (This used to require a dedicated `core-shared-services.ts`
+// leaf to keep `auth/handlers.ts` -> `@tanstack/react-start` out of the DO
+// bundle; that coupling is gone now that `handlers.ts` queues cookies through
+// `SessionAuthLive` instead.)
 import { CoreSharedServices } from "../auth/workos";
 import { UserStoreService } from "../auth/context";
 import { resolveOrganization } from "../auth/organization";
@@ -50,7 +53,9 @@ import {
   type DrizzleDb,
   type DbServiceShape,
 } from "../db/db";
-import { CloudExecutionStackLayer, makeExecutionStack } from "../engine/execution-stack";
+import { makeExecutionStack } from "../engine/execution-stack";
+import { CloudMeteredExecutionStackLayer } from "../engine/execution-stack-metered";
+import { AutumnService } from "../extensions/billing/service";
 import { DoTelemetryLive, flushTracerProvider } from "../observability/telemetry";
 import { captureCause as reportCause } from "../observability";
 
@@ -196,7 +201,15 @@ export class McpSessionDO extends McpSessionDOBase<CloudSessionDbHandle> {
         sessionMeta.organizationName,
         { mcpResource: sessionMeta.resource },
       ).pipe(
-        Effect.provide(CloudExecutionStackLayer),
+        // The metered stack tracks each execution to Autumn. It requires
+        // `AutumnService | DbService`; `AutumnService.Default` is provided here
+        // (it only reads `env`, no further deps), and `DbService` flows from the
+        // outer `makeSessionServices`. When `AUTUMN_SECRET_KEY` is unset the
+        // billing service degrades to a no-op tracker, so this stays inert in
+        // cloud dev/preview environments that run without a billing backend.
+        Effect.provide(
+          CloudMeteredExecutionStackLayer.pipe(Layer.provide(AutumnService.Default)),
+        ),
         Effect.withSpan("McpSessionDO.makeExecutionStack"),
       );
       // Build the description here so `executor.connections.list()` stays under

--- a/apps/cloud/src/mcp/session-durable-object.ts
+++ b/apps/cloud/src/mcp/session-durable-object.ts
@@ -207,9 +207,7 @@ export class McpSessionDO extends McpSessionDOBase<CloudSessionDbHandle> {
         // outer `makeSessionServices`. When `AUTUMN_SECRET_KEY` is unset the
         // billing service degrades to a no-op tracker, so this stays inert in
         // cloud dev/preview environments that run without a billing backend.
-        Effect.provide(
-          CloudMeteredExecutionStackLayer.pipe(Layer.provide(AutumnService.Default)),
-        ),
+        Effect.provide(CloudMeteredExecutionStackLayer.pipe(Layer.provide(AutumnService.Default))),
         Effect.withSpan("McpSessionDO.makeExecutionStack"),
       );
       // Build the description here so `executor.connections.list()` stays under

--- a/e2e/cloud/mcp-execution-metering.test.ts
+++ b/e2e/cloud/mcp-execution-metering.test.ts
@@ -1,0 +1,102 @@
+// Cloud-only (billing): every code execution run through the MCP session
+// Durable Object is metered to Autumn, exactly like the HTTP executor plane.
+// The MCP server is the PRIMARY execution surface (Claude/Cursor run code here,
+// not over /api), so if the DO doesn't bill, the bulk of real usage silently
+// never reaches the meter — the regression this pins.
+//
+// Black-box and end-to-end: drive a real @modelcontextprotocol/sdk client over
+// StreamableHTTP (the exact transport an MCP client uses) against the production
+// workerd + McpSessionDO topology, then read the usage the server ACTUALLY
+// tracked from the Autumn ledger. The execution's own response can't prove it
+// was billed — metering is fire-and-forget, decoupled from the user-facing
+// result — so only the meter is the source of truth.
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+import { scenario } from "../src/scenario";
+import { Autumn, Billing, Mcp, Target } from "../src/services";
+import type { Identity } from "../src/target";
+
+const emailOf = (identity: Identity): string => identity.credentials?.email ?? identity.label;
+
+/** The org the bearer is scoped to — the Autumn customer id `trackExecution`
+ *  meters against — read from the JWT's public claims. */
+const orgIdOf = (bearer: string): string => {
+  const claims = JSON.parse(Buffer.from(bearer.split(".")[1] ?? "", "base64url").toString()) as {
+    readonly org_id?: string;
+  };
+  if (!claims.org_id) throw new Error("orgIdOf: bearer carries no org_id claim");
+  return claims.org_id;
+};
+
+const textOf = (result: { content?: unknown; toolResult?: unknown }): string =>
+  ((result.content ?? []) as Array<{ type: string; text?: string }>)
+    .filter((part) => part.type === "text")
+    .map((part) => part.text)
+    .join("\n");
+
+const RUNS = 3;
+
+scenario(
+  "Billing · every MCP execution is metered to Autumn, one unit per run",
+  { timeout: 180_000 },
+  Effect.gen(function* () {
+    // Gates: billing is enforced here AND the Autumn ledger is observable
+    // (the suite booted the emulator). Yield before any work so a target
+    // missing either capability skips cleanly.
+    yield* Billing;
+    const autumn = yield* Autumn;
+    const target = yield* Target;
+    const mcp = yield* Mcp;
+
+    const identity = yield* target.newIdentity();
+    const bearer = yield* mcp.mintBearer(emailOf(identity));
+    const customerId = orgIdOf(bearer);
+
+    // A fresh org has metered nothing yet — the baseline the run is measured
+    // against, and a guard that we're reading this customer's ledger in
+    // isolation from every other scenario's executions.
+    const before = yield* autumn.usageEvents({ customerId, featureId: "executions" });
+    expect(before.length, "a brand-new org starts with zero metered executions").toBe(0);
+
+    // A real MCP client over StreamableHTTP — the production code path.
+    const client = new Client(
+      { name: "executor-e2e-metering", version: "0.0.1" },
+      { capabilities: {} },
+    );
+    const transport = new StreamableHTTPClientTransport(new URL(target.mcpUrl), {
+      requestInit: { headers: { authorization: `Bearer ${bearer}` } },
+    });
+    const connected = yield* Effect.promise(() => client.connect(transport).then(() => client));
+
+    yield* Effect.gen(function* () {
+      // Run a handful of executions; each is one billable unit.
+      for (let i = 1; i <= RUNS; i++) {
+        const result = yield* Effect.promise(() =>
+          connected.callTool({ name: "execute", arguments: { code: `return ${i} * 2;` } }),
+        );
+        expect(result.isError, `execution ${i} succeeds`).not.toBe(true);
+        expect(textOf(result), `execution ${i} returns its value`).toContain(String(i * 2));
+      }
+
+      // The meter is the source of truth. Tracking is fire-and-forget, so poll
+      // the ledger until all runs have landed.
+      const after = yield* autumn.expectUsage({
+        customerId,
+        featureId: "executions",
+        count: RUNS,
+      });
+
+      expect(
+        after.length,
+        "exactly one 'executions' usage event per run — no over- or under-counting",
+      ).toBe(RUNS);
+      expect(
+        after.every((event) => event.value === 1),
+        "each run meters a single unit",
+      ).toBe(true);
+    }).pipe(Effect.ensuring(Effect.promise(() => connected.close().catch(() => undefined))));
+  }),
+);

--- a/e2e/setup/cloud.globalsetup.ts
+++ b/e2e/setup/cloud.globalsetup.ts
@@ -50,6 +50,11 @@ export default async function setup(): Promise<(() => Promise<void>) | void> {
       // slow" gets a span waterfall, not a guess.
       extraEnv: motelExporterEnv(motel, publicUrl),
     });
+    // Publish the Autumn emulator URL to the test workers (they inherit this
+    // process's env): scenarios that assert on tracked usage yield the Autumn
+    // service, which exists only when this is set. No emulator → those scenarios
+    // skip, never fail. (Cloud-only; selfhost never boots Autumn.)
+    process.env.E2E_AUTUMN_URL = booted.autumnUrl;
   } catch (error) {
     await motel?.teardown();
     await release();

--- a/e2e/src/scenario.ts
+++ b/e2e/src/scenario.ts
@@ -21,6 +21,7 @@ import { FetchHttpClient, type HttpClient } from "effect/unstable/http";
 import type { Target as TargetShape } from "./target";
 import { resolveTarget } from "../targets/registry";
 import { makeApiSurface } from "./surfaces/api";
+import { makeAutumnSurface } from "./surfaces/autumn";
 import { makeBrowserSurface } from "./surfaces/browser";
 import { makeCliSurface } from "./surfaces/cli";
 import { makeMcpSurface } from "./surfaces/mcp";
@@ -28,6 +29,7 @@ import { makeTelemetrySurface } from "./surfaces/telemetry";
 import { completeOAuthConsent, hasOpenCode, makeOpenCodeHome, warmUp } from "./clients/opencode";
 import {
   Api,
+  Autumn,
   Billing,
   Browser,
   Cli,
@@ -62,6 +64,7 @@ type AllServices =
   | Browser
   | Mcp
   | Billing
+  | Autumn
   | OpenCode
   | TtlControl
   | Restart
@@ -99,6 +102,9 @@ const contextFor = (target: TargetShape, dir: string): Context.Context<AllServic
   }
   if (process.env.E2E_MOTEL_URL) {
     context = Context.add(context, Telemetry, makeTelemetrySurface(process.env.E2E_MOTEL_URL));
+  }
+  if (process.env.E2E_AUTUMN_URL) {
+    context = Context.add(context, Autumn, makeAutumnSurface(process.env.E2E_AUTUMN_URL));
   }
   return context;
 };

--- a/e2e/src/services.ts
+++ b/e2e/src/services.ts
@@ -8,6 +8,7 @@ import { Context, type Effect } from "effect";
 
 import type { Target as TargetShape } from "./target";
 import type { ApiSurface } from "./surfaces/api";
+import type { AutumnSurface } from "./surfaces/autumn";
 import type { BrowserSurface } from "./surfaces/browser";
 import type { CliSurface } from "./surfaces/cli";
 import type { McpSurface } from "./surfaces/mcp";
@@ -34,6 +35,10 @@ export class Mcp extends Context.Service<Mcp, McpSurface>()("e2e/mcp-oauth") {}
 
 /** Marker: billing limits are enforced on this target. */
 export class Billing extends Context.Service<Billing, true>()("e2e/billing") {}
+
+/** Read the usage events the target tracked to its billing backend (present
+ *  when the suite booted the Autumn emulator — E2E_AUTUMN_URL; cloud-only). */
+export class Autumn extends Context.Service<Autumn, AutumnSurface>()("e2e/autumn") {}
 
 /** Query the suite's OTLP trace store for spans the target actually exported
  *  (present when the suite booted motel — E2E_MOTEL_URL). */

--- a/e2e/src/surfaces/autumn.ts
+++ b/e2e/src/surfaces/autumn.ts
@@ -61,7 +61,9 @@ export const makeAutumnSurface = (autumnUrl: string): AutumnSurface => {
         }>;
       };
       return (body.list ?? [])
-        .filter((event) => event.customer_id === query.customerId && event.feature_id === query.featureId)
+        .filter(
+          (event) => event.customer_id === query.customerId && event.feature_id === query.featureId,
+        )
         .map((event) => ({
           customerId: event.customer_id,
           featureId: event.feature_id,

--- a/e2e/src/surfaces/autumn.ts
+++ b/e2e/src/surfaces/autumn.ts
@@ -1,0 +1,86 @@
+// Autumn surface: read the usage events the target ACTUALLY tracked to its
+// billing backend. Metering is fire-and-forget (the engine decorator forks the
+// `autumn.track` call so billing can't stall a user-facing execution), so "this
+// execution was billed" is an eventually-consistent fact that lives in Autumn's
+// ledger, not in the execution's own response. This surface reads that ledger
+// from the suite's Autumn emulator: the layer where a "we silently stopped
+// metering" regression (the unmetered MCP plane these scenarios pin) is actually
+// observable. A missing track looks identical to health from the product side,
+// so the contract has to be pinned where the usage is read.
+import { Effect, Schedule } from "effect";
+
+/** One usage event Autumn recorded: a `track` of `value` units of `featureId`
+ *  for `customerId` (the organization the execution ran under). */
+export interface UsageEvent {
+  readonly customerId: string;
+  readonly featureId: string;
+  readonly value: number;
+}
+
+export interface UsageQuery {
+  /** The Autumn customer — the organization id the metered work ran under. */
+  readonly customerId: string;
+  /** The metered feature, e.g. "executions". */
+  readonly featureId: string;
+}
+
+export interface AutumnSurface {
+  /** One-shot read of the matching usage events from the ledger. */
+  readonly usageEvents: (query: UsageQuery) => Effect.Effect<readonly UsageEvent[], unknown>;
+  /** Poll until at least `count` matching events have landed. The track is
+   *  forked and the worker drains it on `waitUntil` shortly after the execution
+   *  returns, so arrival is eventually-consistent — polling IS the contract:
+   *  "the execution reaches the meter, soon". */
+  readonly expectUsage: (
+    query: UsageQuery & { readonly count: number },
+  ) => Effect.Effect<readonly UsageEvent[], unknown>;
+}
+
+export const makeAutumnSurface = (autumnUrl: string): AutumnSurface => {
+  const usageEvents = (query: UsageQuery) =>
+    Effect.gen(function* () {
+      // The emulator's ledger endpoint returns every recorded track event;
+      // filter to this customer + feature. (autumn-js drives /v1/* RPC-style.)
+      const response = yield* Effect.promise(() =>
+        fetch(`${autumnUrl}/v1/events.list`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: "{}",
+        }),
+      );
+      if (!response.ok) {
+        return yield* Effect.fail(
+          `autumn events.list responded ${response.status}: ${yield* Effect.promise(() => response.text())}`,
+        );
+      }
+      const body = (yield* Effect.promise(() => response.json())) as {
+        readonly list?: ReadonlyArray<{
+          readonly customer_id: string;
+          readonly feature_id: string;
+          readonly value: number;
+        }>;
+      };
+      return (body.list ?? [])
+        .filter((event) => event.customer_id === query.customerId && event.feature_id === query.featureId)
+        .map((event) => ({
+          customerId: event.customer_id,
+          featureId: event.feature_id,
+          value: event.value,
+        }));
+    });
+
+  return {
+    usageEvents,
+    expectUsage: (query) =>
+      usageEvents(query).pipe(
+        Effect.filterOrFail(
+          (events) => events.length >= query.count,
+          (events) =>
+            `only ${events.length}/${query.count} '${query.featureId}' usage events for ${query.customerId}`,
+        ),
+        // ~20s ceiling (40 x 500ms): the forked track drains on the worker's
+        // waitUntil shortly after the execution returns; slower is a real bug.
+        Effect.retry(Schedule.both(Schedule.spaced("500 millis"), Schedule.recurs(40))),
+      ),
+  };
+};

--- a/packages/core/api/src/server/execution-stack-middleware.ts
+++ b/packages/core/api/src/server/execution-stack-middleware.ts
@@ -24,7 +24,7 @@
 //                          identical; only the rendering differs.
 //   - `plugins`          — the host's plugin tuple (typed extension Services).
 //   - `stackLayer`       — the host's `makeExecutionStack` seam Layer (cloud:
-//                          `CloudExecutionStackLayer`; self-host:
+//                          `CloudMeteredExecutionStackLayer`; self-host:
 //                          `SelfHostExecutionStackLayer`).
 //
 // `LongLived` is the boot-scoped context captured at layer-build time (the


### PR DESCRIPTION
## Problem

Only the HTTP `/api/*` executor plane reported executions to Autumn. The MCP session Durable Object built its execution engine with the no-op decorator (`CloudExecutionStackLayer`), so executions run through the MCP server — the **primary** execution surface that MCP clients use to run code — were never metered. The result: the usage dashboard counted only the small fraction of executions that went through the REST API, undercounting real usage by a wide margin.

## Fix

The DO now builds its engine with `CloudMeteredExecutionStackLayer`, the same metered stack the HTTP plane uses, so every MCP execution calls `autumn.track({ featureId: "executions" })`.

- `AutumnService.Default` is provided **locally** to the metered stack in the DO, so the DO bundle stays free of the whole HTTP API assembly. It only reads `env`; `DbService` flows from the existing per-session services.
- When `AUTUMN_SECRET_KEY` is unset (cloud dev/preview without a billing backend), the service degrades to a no-op tracker, so this stays inert there.
- Both cloud planes now meter, so the now-unused neutral `CloudExecutionStackLayer` (and its no-op decorator import) is removed, and the "the DO never bills" comments across the execution-stack modules are corrected.

Metering remains cloud-only: self-host and host-cloudflare execution stacks are untouched and still use the no-op decorator.

## Test

New cloud e2e scenario `e2e/cloud/mcp-execution-metering.test.ts`: drives a real `@modelcontextprotocol/sdk` client over StreamableHTTP against the production workerd + `McpSessionDO` topology, runs 3 executions, then asserts the Autumn ledger recorded exactly 3 `executions` events for that org (one unit each), with a fresh-org zero baseline as an isolation guard. It's a true regression guard: on the old code the DO emitted zero tracks, so the poll would time out and fail.

Supporting harness: a new `Autumn` surface reads the emulator's usage ledger (mirrors the existing `Telemetry`/motel pattern — provided only when the Autumn emulator booted, so non-cloud targets skip rather than fail).

## Verification

- `bun run typecheck` — pass (42/42)
- `bun run lint` — pass (0 warnings, 0 errors)
- `vitest --project cloud mcp-execution-metering` — **1 passed** against a freshly-booted cloud stack (scenario 5.3s)