### PR TITLE
Fix cramped spacing in MCP install card header

### DIFF
--- a/packages/react/src/components/mcp-install-card.tsx
+++ b/packages/react/src/components/mcp-install-card.tsx
@@ -240,7 +240,7 @@ export function McpInstallCard(props: { className?: string }) {
 
   const header = (
     <CardStackHeader
-      className="items-start pt-4 pb-1"
+      className="items-start py-4"
       rightSlot={
         showStdio ? (
           <TabsList>
@@ -259,7 +259,7 @@ export function McpInstallCard(props: { className?: string }) {
 
   const body = (
     <CardStackContent>
-      <div className="px-4 pt-1 pb-3">
+      <div className="px-4 pt-3 pb-3">
         <CodeBlock
           code={command}
           lang="bash"


### PR DESCRIPTION
The "Connect an agent" card (`McpInstallCard`) crowded its divider border and code block against the surrounding content.

Two spacing issues in the header/body:

- The header used `pt-4 pb-1`, so the subtitle sat only ~4px above the divider border, while the title had ~17px above it. Unbalanced.
- The body used `pt-1`, leaving the code block jammed ~4px below that divider.

Fix (two one-class edits in `mcp-install-card.tsx`):

- Header `pt-4 pb-1` -> `py-4`: equal ~16px above the title and below the subtitle.
- Body `pt-1` -> `pt-3`: the code block now sits ~13px below the divider instead of ~4px.

The shared `CodeBlock` component is intentionally untouched; this is purely the card layout.

### Before
![before](https://raw.githubusercontent.com/RhysSullivan/executor/e2e-media/mcp-card-spacing/before.png)

### After
![after](https://raw.githubusercontent.com/RhysSullivan/executor/e2e-media/mcp-card-spacing/after.png)