### PR TITLE
Fix desktop sidecar failing to start when the auth token begins with a dash

### DIFF
--- a/.changeset/desktop-sidecar-auth-token-dash.md
+++ b/.changeset/desktop-sidecar-auth-token-dash.md
@@ -1,0 +1,5 @@
+---
+"executor": patch
+---
+
+Fix the desktop app failing to start its local server when the generated auth token begins with a dash. The token is `randomBytes(32).toString("base64url")`, which can start with "-", and the packaged app passed it to the bundled CLI as a separate argument (`--auth-token`, then the token). The CLI then read the leading-dash token as an unknown flag, printed its help, and exited, so the desktop showed a fatal "local Executor server crashed during startup" dialog. This was persistent (the token is saved) and cross-platform, affecting roughly 1 in 64 fresh installs. The token is now passed in the combined `--auth-token=<value>` form so a leading dash is treated as the value.

--- a/apps/desktop/src/main/sidecar.ts
+++ b/apps/desktop/src/main/sidecar.ts
@@ -237,8 +237,12 @@ const resolveSidecarCommand = (input: {
         String(input.port),
         "--hostname",
         input.hostname,
-        "--auth-token",
-        input.authToken,
+        // Combined `--flag=value` form: the auth token is base64url and can
+        // start with "-", which the space-separated form makes the CLI parser
+        // read as an unknown flag, so the daemon prints help and exits and the
+        // desktop reports a fatal "server crashed during startup". Persistent
+        // until the token rotates, and cross-platform (~1 in 64 fresh installs).
+        `--auth-token=${input.authToken}`,
       ],
       cwd: process.resourcesPath,
       cliManagedManifest: true,


### PR DESCRIPTION
## Problem

The desktop app's local server auth token is `randomBytes(32).toString("base64url")`, which can begin with `-`. In packaged builds the app spawns the bundled CLI with the token as a separate argument:

```
["daemon", "run", "--foreground", "--port", ..., "--hostname", ..., "--auth-token", token]
```

When `token` starts with `-`, the CLI reads it as an unknown flag rather than the value of `--auth-token`, so the daemon prints its help text and exits. The desktop surfaces this as a fatal "local Executor server crashed during startup" dialog and never reaches its UI.

This is:
- **persistent**: the token is saved to disk, so an affected install fails on every launch until the token is rotated
- **cross-platform**: it is argument parsing, not OS specific
- roughly **1 in 64 fresh installs** (any token whose base64url encoding starts with `-`)

## Fix

Pass the token in the combined `--auth-token=<value>` form, so a leading dash is treated as part of the value instead of a new flag.

## Verification

Confirmed against the bundled CLI directly with a real leading-dash token:
- `daemon run --foreground ... --auth-token -<token>` prints help and exits
- `daemon run --foreground ... --auth-token=-<token>` starts the daemon ("Daemon ready on http://localhost:...")
