### PR TITLE
Add a test seam to skip the background-service consent dialog under automation

### DIFF
--- a/.changeset/desktop-background-service-consent-seam.md
+++ b/.changeset/desktop-background-service-consent-seam.md
@@ -1,0 +1,5 @@
+---
+"executor": patch
+---
+
+Add a test seam to skip the first-run "keep Executor running in the background?" consent dialog under automation, matching the existing `confirmResetState` seam. Set `EXECUTOR_TEST_AUTO_CONFIRM_BACKGROUND_SERVICE=1` to keep the background service or any other value to decline. When the variable is unset the dialog is shown exactly as before. Native dialogs cannot be answered from CDP or Playwright, so a packaged first-run boot under automation previously blocked at this prompt with no way to proceed.

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -190,6 +190,13 @@ const waitForSupervisedAttach = async (
 };
 
 const confirmEnableBackgroundService = async (): Promise<boolean> => {
+  // EXECUTOR_TEST_AUTO_CONFIRM_BACKGROUND_SERVICE skips the modal, the same seam
+  // as confirmResetState. Native dialogs are unreachable from CDP/Playwright, so
+  // a first-run boot under automation otherwise blocks here forever with no way
+  // to answer. "1" keeps the background service; any other value declines and
+  // falls back to the managed sidecar.
+  const autoConfirm = process.env.EXECUTOR_TEST_AUTO_CONFIRM_BACKGROUND_SERVICE;
+  if (autoConfirm !== undefined) return autoConfirm === "1";
   const { response } = await dialog.showMessageBox({
     type: "question",
     title: "Keep Executor running in the background?",


### PR DESCRIPTION
## Problem

The first-run consent dialog in `confirmEnableBackgroundService` ("Keep Executor running in the background?") is a native `dialog.showMessageBox`, which cannot be clicked from CDP or Playwright. A packaged first-run boot under automation blocks at this prompt with no way to answer it. On macOS the modal additionally runs a nested run loop that starves the app's main thread, so the remote-debugging server stops responding while it is up.

## Fix

Add an `EXECUTOR_TEST_AUTO_CONFIRM_BACKGROUND_SERVICE` env seam, mirroring the existing `EXECUTOR_TEST_AUTO_CONFIRM_RESET` used by `confirmResetState`:

- `1` keeps the background service (same as clicking "Keep running in the background")
- any other value declines (falls back to the managed sidecar)
- unset: the dialog is shown exactly as before

This is test-only behavior, production launches are unchanged.
