### PR TITLE
Make the E2E (stdio MCP) job robust to two harness flakes

### DIFF
--- a/e2e/local/local-server.ts
+++ b/e2e/local/local-server.ts
@@ -59,12 +59,29 @@ export const withLocalServer = (
           async (term) => {
             markRecordingStart(runDir, "terminal");
             markFocus(runDir, "terminal");
-            const snapshot = await term.screen.waitUntil(
-              (current) => TOKEN_URL.test(current.text),
-              // A cold `executor web` runs vite's optimizeDeps before it prints
-              // the URL; give CI runners headroom over the warm ~3s boot.
-              { timeoutMs: 180_000 },
-            );
+            // Capture the latest rendered screen on every poll so a boot that
+            // never prints the URL is still diagnosable: `waitUntil` rejects
+            // with a tail-less "timed out" on its deadline, so without this the
+            // failure tells us nothing about how far boot actually got.
+            let lastText = "";
+            const snapshot = await term.screen
+              .waitUntil(
+                (current) => {
+                  lastText = current.text;
+                  return TOKEN_URL.test(current.text);
+                },
+                // A cold `executor web` runs vite's optimizeDeps before it prints
+                // the URL; 180s is generous headroom over the warm ~3s boot. Kept
+                // BELOW each scenario's test timeout (240s) so that on a slow or
+                // wedged boot THIS error surfaces, with the terminal tail, rather
+                // than racing vitest's generic timeout at the same deadline.
+                { timeoutMs: 180_000 },
+              )
+              .catch((cause: unknown) => {
+                throw new Error(
+                  `executor web --foreground printed no ?_token URL within 180s (${String(cause)}):\n${lastText.slice(-600)}`,
+                );
+              });
             const url = TOKEN_URL.exec(snapshot.text)?.[0];
             if (!url) {
               throw new Error(

--- a/e2e/local/stdio-mcp.test.ts
+++ b/e2e/local/stdio-mcp.test.ts
@@ -39,7 +39,14 @@ const SECRET = "s3cr3t-from-the-vault";
 
 scenario(
   "Local · a stdio MCP server's tools are detected on a fresh install, with env stored as a secret",
-  { timeout: 180_000 },
+  // Must stay STRICTLY greater than the boot-URL wait in `withLocalServer`
+  // (currently 180s). When this CI job runs `stdio-mcp.test.ts` alone it always
+  // pays a cold `vite optimizeDeps` boot (no prior file to warm the cache), the
+  // one variable step. If this test timeout equals the boot wait, both deadlines
+  // fire together and vitest's generic "Test timed out" wins, swallowing the
+  // harness's "printed no ?_token URL\n<terminal tail>" error that tells us what
+  // boot actually got stuck on. Keep the gap so the boot diagnostic surfaces.
+  { timeout: 240_000 },
   Effect.gen(function* () {
     const cli = yield* Cli;
     const runDir = yield* RunDir;

--- a/e2e/src/surfaces/cli.ts
+++ b/e2e/src/surfaces/cli.ts
@@ -24,22 +24,32 @@ export interface CliSurface {
   ) => Effect.Effect<T>;
 }
 
+interface AsciicastEvent {
+  type: string;
+  cols?: number;
+  rows?: number;
+  at_ms?: number;
+  bytes?: number[];
+}
+
 /** terminal-control's JSONL recording → asciicast v2 (what asciinema plays). */
 const toAsciicast = (recording: Uint8Array): string => {
   const events = new TextDecoder()
     .decode(recording)
     .split("\n")
     .filter(Boolean)
-    .map(
-      (line) =>
-        JSON.parse(line) as {
-          type: string;
-          cols?: number;
-          rows?: number;
-          at_ms?: number;
-          bytes?: number[];
-        },
-    );
+    .flatMap((line): AsciicastEvent[] => {
+      // The PTY can be killed mid-write on teardown (e.g. a vitest timeout
+      // interrupts the fiber), leaving a truncated final JSONL line. A line
+      // that doesn't parse is one dropped frame, never a failed test: skip it
+      // instead of throwing.
+      // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: lenient parse of a best-effort recording artifact
+      try {
+        return [JSON.parse(line) as AsciicastEvent];
+      } catch {
+        return [];
+      }
+    });
   const header = events.find((event) => event.type === "header");
   const lines = [
     JSON.stringify({ version: 2, width: header?.cols ?? 80, height: header?.rows ?? 24 }),
@@ -89,7 +99,15 @@ export const makeCliSurface = (): CliSurface => ({
         Effect.promise(async () => {
           if (options?.record) {
             const recording = await session.recording().catch(() => undefined);
-            if (recording) writeFileSync(options.record, toAsciicast(recording));
+            // Writing the cast is a best-effort film artifact (symmetric with the
+            // fetch above): a serialization or IO hiccup in teardown must never
+            // fail an otherwise-passing test.
+            // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: best-effort artifact write
+            try {
+              if (recording) writeFileSync(options.record, toAsciicast(recording));
+            } catch {
+              // drop the cast; the test result stands
+            }
           }
           await session.stop().catch(() => {});
           await tc[Symbol.asyncDispose]();


### PR DESCRIPTION
## Why

The `E2E (stdio MCP)` job runs `stdio-mcp.test.ts` on its own, so it always pays a cold `vite optimizeDeps` boot, the one high-variance step. Running it repeatedly produces three outcomes from identical code: pass (~3s), a 180s hang, and a fast crash. The recent red on `main` was on a changeset-only version bump (no product change), so this is harness flakiness, not a regression. Two distinct issues let the job go red:

1. **Blind boot timeout.** The scenario's test timeout (`180_000`) was set equal to the boot-URL wait inside `withLocalServer` (`180_000`). When boot is slow, both deadlines fire together and vitest's generic `Test timed out in 180000ms` wins, so the failure carries no clue about what boot got stuck on.
2. **Teardown crash on a truncated recording.** `toAsciicast` `JSON.parse`d every recording line. A PTY killed mid-write leaves a truncated final JSONL line, throwing `Unexpected end of JSON input` and failing an otherwise-passing test over a best-effort film artifact.

## What

- `e2e/local/stdio-mcp.test.ts`: raise the scenario timeout to `240_000` so the boot wait trips first.
- `e2e/local/local-server.ts`: capture the last rendered screen on each poll and, on boot-wait rejection, throw with the terminal tail (`waitUntil` otherwise throws a tail-less "timed out"). A slow or wedged boot now reports how far it got.
- `e2e/src/surfaces/cli.ts`: skip unparseable recording lines (a dropped frame, not a failure) and make the cast write best-effort, matching the `session.recording().catch(...)` posture beside it.

This does not eliminate the rare boot hang itself (most likely environmental contention, the same shape as a loaded CI runner). It converts the next occurrence from a mystery timeout into a diagnosable failure with the terminal tail.

## Verification

- `format:check`, `lint` (0 warnings), and e2e `typecheck` pass.
- Targeted test passes repeatedly (3 consecutive clean runs, 3-7s, no JSON crash).
- Forcing the boot wait to trip yields `printed no ?_token URL within 180s (...): <terminal tail>` instead of a bare timeout.

No changeset: `@executor-js/e2e` is private.