### PR TITLE
fix(graphql): generate valid operations against large schemas (#1146)

### DIFF
--- a/.changeset/graphql-valid-selections.md
+++ b/.changeset/graphql-valid-selections.md
@@ -1,0 +1,5 @@
+---
+"@executor-js/plugin-graphql": patch
+---
+
+Fix the GraphQL plugin generating invalid operations against large schemas. The auto-generated selection set no longer emits composite (object/connection) fields without a sub-selection, and no longer selects nested fields whose required arguments it cannot supply. Generated tools now validate against rich schemas (such as GitLab's) instead of failing on every call against a rich return type.

--- a/.changeset/graphql-valid-selections.md
+++ b/.changeset/graphql-valid-selections.md
@@ -2,4 +2,8 @@
 "@executor-js/plugin-graphql": patch
 ---
 
-Fix the GraphQL plugin generating invalid operations against large schemas. The auto-generated selection set no longer emits composite (object/connection) fields without a sub-selection, and no longer selects nested fields whose required arguments it cannot supply. Generated tools now validate against rich schemas (such as GitLab's) instead of failing on every call against a rich return type.
+Fix the GraphQL plugin generating invalid operations against large schemas, and make field selection caller-controlled instead of a baked-in guess.
+
+Previously each tool froze a recursive, depth- and count-bounded selection at sync time. Against a rich schema (GitLab) this produced invalid GraphQL (composite fields with no sub-selection, nested fields missing required arguments) so every call over a rich return type failed, and the arbitrary bound silently truncated which fields came back.
+
+Generated tools now default to selecting only scalar/enum leaf fields of the return type (always valid, always within a server's query-complexity budget), and expose an optional `select` input carrying a GraphQL selection set so a caller can request nested or list data per call (including supplying nested required arguments). Fixes #1146.

--- a/packages/plugins/graphql/src/sdk/invoke.ts
+++ b/packages/plugins/graphql/src/sdk/invoke.ts
@@ -21,6 +21,25 @@ export const endpointForTelemetry = (endpoint: string): string => {
   return url.toString();
 };
 
+/** The operation string to send for a call. A caller-supplied `select` overrides
+ *  the default scalar-leaf selection: it is spliced into the field's selection
+ *  set (`field { <select> }`) so nested/list data can be requested per call. Falls
+ *  back to the stored default operation when `select` is absent or the binding
+ *  predates the prefix/suffix split. `select` is a control input, never a GraphQL
+ *  variable. Shared with plugin.invokeTool so the validated string matches the
+ *  sent string exactly. */
+export const effectiveOperationString = (
+  operation: OperationBinding,
+  args: Record<string, unknown>,
+): string => {
+  const customSelect = typeof args.select === "string" ? args.select.trim() : "";
+  return customSelect.length > 0 &&
+    operation.operationPrefix != null &&
+    operation.operationSuffix != null
+    ? `${operation.operationPrefix} { ${customSelect} }${operation.operationSuffix}`
+    : operation.operationString;
+};
+
 // ---------------------------------------------------------------------------
 // Response helpers
 // ---------------------------------------------------------------------------
@@ -71,18 +90,10 @@ export const invoke = Effect.fn("GraphQL.invoke")(function* (
     Object.assign(variables, args.variables);
   }
 
-  // A caller-supplied `select` overrides the default scalar-leaf selection: it is
-  // spliced into the field's selection set so nested/list data can be requested
-  // per call. `select` is a control input, not a GraphQL variable, so it never
-  // enters `variables`. Falls back to the stored default operation when absent or
-  // when the binding predates the prefix/suffix split.
-  const customSelect = typeof args.select === "string" ? args.select.trim() : "";
-  const operationString =
-    customSelect.length > 0 &&
-    operation.operationPrefix != null &&
-    operation.operationSuffix != null
-      ? `${operation.operationPrefix} { ${customSelect} }${operation.operationSuffix}`
-      : operation.operationString;
+  // `select` (a control input, not a GraphQL variable) is applied here and never
+  // enters `variables`. plugin.invokeTool validates this same string before we
+  // reach the network.
+  const operationString = effectiveOperationString(operation, args);
 
   let request = HttpClientRequest.post(requestEndpoint).pipe(
     HttpClientRequest.setHeader("Content-Type", "application/json"),

--- a/packages/plugins/graphql/src/sdk/invoke.ts
+++ b/packages/plugins/graphql/src/sdk/invoke.ts
@@ -71,10 +71,23 @@ export const invoke = Effect.fn("GraphQL.invoke")(function* (
     Object.assign(variables, args.variables);
   }
 
+  // A caller-supplied `select` overrides the default scalar-leaf selection: it is
+  // spliced into the field's selection set so nested/list data can be requested
+  // per call. `select` is a control input, not a GraphQL variable, so it never
+  // enters `variables`. Falls back to the stored default operation when absent or
+  // when the binding predates the prefix/suffix split.
+  const customSelect = typeof args.select === "string" ? args.select.trim() : "";
+  const operationString =
+    customSelect.length > 0 &&
+    operation.operationPrefix != null &&
+    operation.operationSuffix != null
+      ? `${operation.operationPrefix} { ${customSelect} }${operation.operationSuffix}`
+      : operation.operationString;
+
   let request = HttpClientRequest.post(requestEndpoint).pipe(
     HttpClientRequest.setHeader("Content-Type", "application/json"),
     HttpClientRequest.bodyJsonUnsafe({
-      query: operation.operationString,
+      query: operationString,
       variables: Object.keys(variables).length > 0 ? variables : undefined,
     }),
   );

--- a/packages/plugins/graphql/src/sdk/plugin.test.ts
+++ b/packages/plugins/graphql/src/sdk/plugin.test.ts
@@ -28,6 +28,7 @@ import { endpointForTelemetry } from "./invoke";
 import { introspect } from "./introspect";
 import type { IntrospectionResult } from "./introspect";
 import {
+  makeGitlab1146Schema,
   makeGreetingGraphqlSchema,
   serveGraphqlFailureTestServer,
   serveGraphqlTestServer,
@@ -882,6 +883,74 @@ describe("graphqlPlugin detect URL-token fallback", () => {
       const executor = yield* makeExecutor();
       const results = yield* executor.integrations.detect("http://127.0.0.1:1/api/v1");
       expect(results.find((r) => r.kind === "graphql")).toBeUndefined();
+    }),
+  );
+});
+
+// Issue #1146: against a large, real-world schema (GitLab) the auto-generated
+// operations were invalid GraphQL and every call against a rich object type
+// failed validation. These drive the real plugin (live introspection -> operation
+// generation -> invocation) against a GitLab-shaped graphql-yoga server, which
+// validates with graphql-js exactly like the @emulators/gitlab surface. A clean
+// `ok: true` therefore proves the generated operation is valid GraphQL.
+describe("graphqlPlugin generates valid operations against rich schemas (#1146)", () => {
+  const gitlabServer = serveGraphqlTestServer({ schema: makeGitlab1146Schema() });
+
+  const lastQuery = (requests: { readonly payload: { readonly query?: string } }[]): string =>
+    requests[requests.length - 1]?.payload.query ?? "";
+
+  it.effect("query.metadata: drops the nested field whose required argument it cannot fill", () =>
+    Effect.gen(function* () {
+      const server = yield* gitlabServer;
+      const executor = yield* makeExecutor();
+
+      yield* executor.graphql.addIntegration({ endpoint: server.endpoint, slug: "gitlab" });
+      yield* createOrgConnection(executor, {
+        integration: "gitlab",
+        name: "main",
+        template: "none",
+        value: "unused",
+      });
+
+      yield* server.clearRequests;
+      const result = yield* executor.execute(toolAddr("gitlab", "main", "query.metadata"), {});
+
+      // Valid GraphQL: the server accepts and resolves it (no validation errors).
+      expect(result).toMatchObject({ ok: true });
+      // `featureFlags(names: [String!]!)` has a required arg the generator cannot
+      // supply, so it is omitted rather than emitted without arguments.
+      const query = lastQuery(yield* server.requests);
+      expect(query).not.toContain("featureFlags");
+      // Fields it CAN select are still present (no over-pruning).
+      expect(query).toContain("kas {");
+    }),
+  );
+
+  it.effect("query.currentUser: never emits a composite field without a sub-selection", () =>
+    Effect.gen(function* () {
+      const server = yield* gitlabServer;
+      const executor = yield* makeExecutor();
+
+      yield* executor.graphql.addIntegration({ endpoint: server.endpoint, slug: "gitlab2" });
+      yield* createOrgConnection(executor, {
+        integration: "gitlab2",
+        name: "main",
+        template: "none",
+        value: "unused",
+      });
+
+      yield* server.clearRequests;
+      const result = yield* executor.execute(toolAddr("gitlab2", "main", "query.currentUser"), {});
+
+      expect(result).toMatchObject({ ok: true });
+      const query = lastQuery(yield* server.requests);
+      // The connection is traversed (proves recursion still works)...
+      expect(query).toContain("mergeRequests {");
+      expect(query).toContain("nodes {");
+      // ...but composite leaves past the depth cap (`author`, `assignees`) are
+      // dropped instead of being emitted bare, which the server would reject.
+      expect(query).not.toContain("author");
+      expect(query).not.toContain("assignees");
     }),
   );
 });

--- a/packages/plugins/graphql/src/sdk/plugin.test.ts
+++ b/packages/plugins/graphql/src/sdk/plugin.test.ts
@@ -889,68 +889,106 @@ describe("graphqlPlugin detect URL-token fallback", () => {
 
 // Issue #1146: against a large, real-world schema (GitLab) the auto-generated
 // operations were invalid GraphQL and every call against a rich object type
-// failed validation. These drive the real plugin (live introspection -> operation
-// generation -> invocation) against a GitLab-shaped graphql-yoga server, which
-// validates with graphql-js exactly like the @emulators/gitlab surface. A clean
-// `ok: true` therefore proves the generated operation is valid GraphQL.
+// failed validation. The plugin now defaults to a scalar-leaf selection (always
+// valid, always cheap) and lets the caller pass an explicit `select` for nested
+// or list data. These drive the real plugin (live introspection -> generation ->
+// invocation) against a GitLab-shaped graphql-yoga server, which validates with
+// graphql-js exactly like the @emulators/gitlab surface, so a clean `ok: true`
+// proves the operation that went over the wire is valid GraphQL.
 describe("graphqlPlugin generates valid operations against rich schemas (#1146)", () => {
   const gitlabServer = serveGraphqlTestServer({ schema: makeGitlab1146Schema() });
 
   const lastQuery = (requests: { readonly payload: { readonly query?: string } }[]): string =>
     requests[requests.length - 1]?.payload.query ?? "";
 
-  it.effect("query.metadata: drops the nested field whose required argument it cannot fill", () =>
+  const setup = (slug: string) =>
     Effect.gen(function* () {
       const server = yield* gitlabServer;
       const executor = yield* makeExecutor();
-
-      yield* executor.graphql.addIntegration({ endpoint: server.endpoint, slug: "gitlab" });
+      yield* executor.graphql.addIntegration({ endpoint: server.endpoint, slug });
       yield* createOrgConnection(executor, {
-        integration: "gitlab",
+        integration: slug,
         name: "main",
         template: "none",
         value: "unused",
       });
-
       yield* server.clearRequests;
-      const result = yield* executor.execute(toolAddr("gitlab", "main", "query.metadata"), {});
+      return { server, executor };
+    });
 
-      // Valid GraphQL: the server accepts and resolves it (no validation errors).
-      expect(result).toMatchObject({ ok: true });
-      // `featureFlags(names: [String!]!)` has a required arg the generator cannot
-      // supply, so it is omitted rather than emitted without arguments.
-      const query = lastQuery(yield* server.requests);
-      expect(query).not.toContain("featureFlags");
-      // Fields it CAN select are still present (no over-pruning).
-      expect(query).toContain("kas {");
+  it.effect("default selection is scalar leaves only: valid, and never bare composites", () =>
+    Effect.gen(function* () {
+      const { server, executor } = yield* setup("gitlab_default");
+
+      // metadata: scalar leaves only. `featureFlags` (required arg) and `kas`
+      // (composite) are omitted rather than emitted invalidly.
+      const meta = yield* executor.execute(
+        toolAddr("gitlab_default", "main", "query.metadata"),
+        {},
+      );
+      expect(meta).toMatchObject({ ok: true });
+      const metaQuery = lastQuery(yield* server.requests);
+      expect(metaQuery).toContain("version");
+      expect(metaQuery).not.toContain("featureFlags");
+      expect(metaQuery).not.toContain("kas");
+
+      // currentUser: scalar leaves only. No `mergeRequests` (composite) bare.
+      yield* server.clearRequests;
+      const user = yield* executor.execute(
+        toolAddr("gitlab_default", "main", "query.currentUser"),
+        {},
+      );
+      expect(user).toMatchObject({ ok: true });
+      const userQuery = lastQuery(yield* server.requests);
+      expect(userQuery).toContain("active");
+      expect(userQuery).not.toContain("mergeRequests");
     }),
   );
 
-  it.effect("query.currentUser: never emits a composite field without a sub-selection", () =>
+  it.effect("a caller-supplied `select` fetches nested/list data and stays valid", () =>
     Effect.gen(function* () {
-      const server = yield* gitlabServer;
-      const executor = yield* makeExecutor();
+      const { server, executor } = yield* setup("gitlab_select");
 
-      yield* executor.graphql.addIntegration({ endpoint: server.endpoint, slug: "gitlab2" });
-      yield* createOrgConnection(executor, {
-        integration: "gitlab2",
-        name: "main",
-        template: "none",
-        value: "unused",
-      });
-
-      yield* server.clearRequests;
-      const result = yield* executor.execute(toolAddr("gitlab2", "main", "query.currentUser"), {});
+      const result = yield* executor.execute(
+        toolAddr("gitlab_select", "main", "query.currentUser"),
+        { select: "active mergeRequests { count nodes { id title author { name } } }" },
+      );
 
       expect(result).toMatchObject({ ok: true });
       const query = lastQuery(yield* server.requests);
-      // The connection is traversed (proves recursion still works)...
-      expect(query).toContain("mergeRequests {");
       expect(query).toContain("nodes {");
-      // ...but composite leaves past the depth cap (`author`, `assignees`) are
-      // dropped instead of being emitted bare, which the server would reject.
-      expect(query).not.toContain("author");
-      expect(query).not.toContain("assignees");
+      expect(query).toContain("author {");
+    }),
+  );
+
+  it.effect("`select` can supply a nested field's required argument", () =>
+    Effect.gen(function* () {
+      const { server, executor } = yield* setup("gitlab_ff");
+
+      const result = yield* executor.execute(toolAddr("gitlab_ff", "main", "query.metadata"), {
+        select: 'version featureFlags(names: ["flag_a"]) { name enabled }',
+      });
+
+      expect(result).toMatchObject({ ok: true });
+      expect(lastQuery(yield* server.requests)).toContain("featureFlags(names:");
+    }),
+  );
+
+  it.effect("an invalid `select` surfaces the server's validation error verbatim", () =>
+    Effect.gen(function* () {
+      const { executor } = yield* setup("gitlab_bad");
+
+      // `author` is a composite emitted bare: the plugin passes the selection
+      // through and surfaces the server's rejection rather than silently fixing
+      // or swallowing it.
+      const result = yield* executor.execute(toolAddr("gitlab_bad", "main", "query.currentUser"), {
+        select: "mergeRequests { nodes { id author } }",
+      });
+
+      expect(result).toMatchObject({
+        ok: false,
+        error: { code: "graphql_errors" },
+      });
     }),
   );
 });

--- a/packages/plugins/graphql/src/sdk/plugin.test.ts
+++ b/packages/plugins/graphql/src/sdk/plugin.test.ts
@@ -991,4 +991,27 @@ describe("graphqlPlugin generates valid operations against rich schemas (#1146)"
       });
     }),
   );
+
+  it.effect("rejects a malformed `select` locally, before any network call", () =>
+    Effect.gen(function* () {
+      const { server, executor } = yield* setup("gitlab_syntax");
+      // Warm the binding cache (the first invoke introspects to materialize
+      // bindings) so the malformed call below has no legitimate reason to hit the
+      // wire: if it does, validation failed to short-circuit.
+      yield* executor.execute(toolAddr("gitlab_syntax", "main", "query.currentUser"), {});
+      yield* server.clearRequests;
+
+      const result = yield* executor.execute(
+        toolAddr("gitlab_syntax", "main", "query.currentUser"),
+        { select: "active mergeRequests { nodes {" },
+      );
+
+      expect(result).toMatchObject({
+        ok: false,
+        error: { code: "graphql_invalid_selection" },
+      });
+      // Parse-check happens before the request is built, so nothing reached the server.
+      expect((yield* server.requests).length).toBe(0);
+    }),
+  );
 });

--- a/packages/plugins/graphql/src/sdk/plugin.ts
+++ b/packages/plugins/graphql/src/sdk/plugin.ts
@@ -38,6 +38,7 @@ import {
   type IntrospectionResult,
   type IntrospectionType,
   type IntrospectionField,
+  type IntrospectionInputValue,
   type IntrospectionTypeRef,
 } from "./introspect";
 import { extract } from "./extract";
@@ -217,13 +218,40 @@ const unwrapTypeName = (ref: IntrospectionTypeRef): string => {
   return "Unknown";
 };
 
+// Bound the auto-generated selection so a huge schema (GitLab has 4000+ types)
+// does not produce an unbounded operation: cap recursion depth and the number
+// of fields emitted per level.
+const MAX_SELECTION_DEPTH = 2;
+const MAX_FIELDS_PER_LEVEL = 12;
+
+// Composite (output) types require a sub-selection; leaves (scalars/enums) must
+// not have one. Anything we cannot resolve in the type map is treated as a leaf
+// (custom scalars live in the map as SCALAR; truly-unknown types are rare).
+const isCompositeType = (
+  ref: IntrospectionTypeRef,
+  types: ReadonlyMap<string, IntrospectionType>,
+): boolean => {
+  const kind = types.get(unwrapTypeName(ref))?.kind;
+  return kind === "OBJECT" || kind === "INTERFACE" || kind === "UNION";
+};
+
+// A nested field whose argument is non-null without a default cannot be selected
+// by the generator: it has no value to pass and emitting the field without the
+// argument is invalid (e.g. GitLab's `metadata.featureFlags(names:)`). Required
+// root-field arguments are different: those are threaded as operation variables
+// (and surfaced on the tool's input schema) in `buildOperationStringForField`.
+const hasRequiredArgWithoutDefault = (field: IntrospectionField): boolean =>
+  field.args.some(
+    (arg: IntrospectionInputValue) => arg.type.kind === "NON_NULL" && arg.defaultValue == null,
+  );
+
 const buildSelectionSet = (
   ref: IntrospectionTypeRef,
   types: ReadonlyMap<string, IntrospectionType>,
   depth: number,
   seen: Set<string>,
 ): string => {
-  if (depth > 2) return "";
+  if (depth > MAX_SELECTION_DEPTH) return "";
 
   const leafName = unwrapTypeName(ref);
   if (seen.has(leafName)) return "";
@@ -236,13 +264,25 @@ const buildSelectionSet = (
 
   seen.add(leafName);
 
-  const subFields = objectType.fields
-    .filter((f: IntrospectionField) => !f.name.startsWith("__"))
-    .slice(0, 12)
-    .map((f: IntrospectionField) => {
+  const subFields: string[] = [];
+  for (const f of objectType.fields) {
+    if (subFields.length >= MAX_FIELDS_PER_LEVEL) break;
+    if (f.name.startsWith("__")) continue;
+    // Cannot synthesize a value for a required nested argument: skip the field
+    // rather than emit an invalid selection.
+    if (hasRequiredArgWithoutDefault(f)) continue;
+
+    if (isCompositeType(f.type, types)) {
+      // A composite field MUST have a sub-selection. When the recursion yields
+      // nothing (depth cap, cycle guard, or every child skipped) we drop the
+      // field instead of emitting it bare (which the server rejects).
       const sub = buildSelectionSet(f.type, types, depth + 1, seen);
-      return sub ? `${f.name} ${sub}` : f.name;
-    });
+      if (sub) subFields.push(`${f.name} ${sub}`);
+    } else {
+      // Scalar / enum leaf: select it directly.
+      subFields.push(f.name);
+    }
+  }
 
   seen.delete(leafName);
 

--- a/packages/plugins/graphql/src/sdk/plugin.ts
+++ b/packages/plugins/graphql/src/sdk/plugin.ts
@@ -218,12 +218,6 @@ const unwrapTypeName = (ref: IntrospectionTypeRef): string => {
   return "Unknown";
 };
 
-// Bound the auto-generated selection so a huge schema (GitLab has 4000+ types)
-// does not produce an unbounded operation: cap recursion depth and the number
-// of fields emitted per level.
-const MAX_SELECTION_DEPTH = 2;
-const MAX_FIELDS_PER_LEVEL = 12;
-
 // Composite (output) types require a sub-selection; leaves (scalars/enums) must
 // not have one. Anything we cannot resolve in the type map is treated as a leaf
 // (custom scalars live in the map as SCALAR; truly-unknown types are rare).
@@ -235,58 +229,48 @@ const isCompositeType = (
   return kind === "OBJECT" || kind === "INTERFACE" || kind === "UNION";
 };
 
-// A nested field whose argument is non-null without a default cannot be selected
-// by the generator: it has no value to pass and emitting the field without the
-// argument is invalid (e.g. GitLab's `metadata.featureFlags(names:)`). Required
-// root-field arguments are different: those are threaded as operation variables
-// (and surfaced on the tool's input schema) in `buildOperationStringForField`.
+// A field whose argument is non-null without a default cannot be selected by the
+// generator: it has no value to pass and emitting the field without the argument
+// is invalid (e.g. GitLab's `metadata.featureFlags(names:)`). Root-field required
+// arguments are different: those are threaded as operation variables (and
+// surfaced on the tool's input schema) in `buildOperationStringForField`.
 const hasRequiredArgWithoutDefault = (field: IntrospectionField): boolean =>
   field.args.some(
     (arg: IntrospectionInputValue) => arg.type.kind === "NON_NULL" && arg.defaultValue == null,
   );
 
-const buildSelectionSet = (
+// Build the DEFAULT selection set for a field's return type: every scalar/enum
+// leaf the generator can select without arguments. It deliberately does NOT
+// recurse into composite fields or guess at nested selections, for two reasons:
+//   - A real schema (GitLab has 4000+ types) makes any recursive auto-expansion
+//     either arbitrary (which N fields? how deep?) or so large the server
+//     rejects it for exceeding its query-complexity budget.
+//   - A bounded-but-arbitrary selection silently freezes a partial view at sync
+//     time. Instead, callers that want nested or list data pass an explicit
+//     `select` (see buildOperationStringForField / invoke), so the choice of
+//     deeper fields is the caller's, not a guess baked into the tool.
+// The result is always valid: selecting only leaves never needs a sub-selection,
+// and a composite type with no selectable leaves falls back to `__typename`.
+const buildDefaultSelectionSet = (
   ref: IntrospectionTypeRef,
   types: ReadonlyMap<string, IntrospectionType>,
-  depth: number,
-  seen: Set<string>,
 ): string => {
-  if (depth > MAX_SELECTION_DEPTH) return "";
+  const objectType = types.get(unwrapTypeName(ref));
+  if (!objectType?.fields) return ""; // scalar / enum / unknown: no selection
+  if (objectType.kind === "SCALAR" || objectType.kind === "ENUM") return "";
 
-  const leafName = unwrapTypeName(ref);
-  if (seen.has(leafName)) return "";
+  const leaves = objectType.fields
+    .filter(
+      (f: IntrospectionField) =>
+        !f.name.startsWith("__") &&
+        !hasRequiredArgWithoutDefault(f) &&
+        !isCompositeType(f.type, types),
+    )
+    .map((f: IntrospectionField) => f.name);
 
-  const objectType = types.get(leafName);
-  if (!objectType?.fields) return "";
-
-  const kind = objectType.kind;
-  if (kind === "SCALAR" || kind === "ENUM") return "";
-
-  seen.add(leafName);
-
-  const subFields: string[] = [];
-  for (const f of objectType.fields) {
-    if (subFields.length >= MAX_FIELDS_PER_LEVEL) break;
-    if (f.name.startsWith("__")) continue;
-    // Cannot synthesize a value for a required nested argument: skip the field
-    // rather than emit an invalid selection.
-    if (hasRequiredArgWithoutDefault(f)) continue;
-
-    if (isCompositeType(f.type, types)) {
-      // A composite field MUST have a sub-selection. When the recursion yields
-      // nothing (depth cap, cycle guard, or every child skipped) we drop the
-      // field instead of emitting it bare (which the server rejects).
-      const sub = buildSelectionSet(f.type, types, depth + 1, seen);
-      if (sub) subFields.push(`${f.name} ${sub}`);
-    } else {
-      // Scalar / enum leaf: select it directly.
-      subFields.push(f.name);
-    }
-  }
-
-  seen.delete(leafName);
-
-  return subFields.length > 0 ? `{ ${subFields.join(" ")} }` : "";
+  // A composite type MUST have a non-empty selection; `__typename` is a leaf
+  // that exists on every composite, so it is a safe minimal fallback.
+  return leaves.length > 0 ? `{ ${leaves.join(" ")} }` : "{ __typename }";
 };
 
 // Name every generated operation: some servers reject anonymous operations, and
@@ -295,11 +279,23 @@ const buildSelectionSet = (
 const operationNameForField = (fieldName: string): string =>
   fieldName.charAt(0).toUpperCase() + fieldName.slice(1);
 
+interface BuiltOperation {
+  /** The operation with the default (scalar-leaf) selection. */
+  readonly operationString: string;
+  /** Everything up to (not including) the field's selection set:
+   *  `query Op($a: T) { field(a: $a)`. A caller-supplied `select` is wrapped as
+   *  `{ <select> }` and spliced between this prefix and the suffix at invoke
+   *  time, so the selection can be chosen per call without re-introspecting. */
+  readonly operationPrefix: string;
+  /** Closes the operation: ` }`. */
+  readonly operationSuffix: string;
+}
+
 const buildOperationStringForField = (
   kind: GraphqlOperationKind,
   field: IntrospectionField,
   types: ReadonlyMap<string, IntrospectionType>,
-): string => {
+): BuiltOperation => {
   const opType = kind === "query" ? "query" : "mutation";
   const opName = operationNameForField(field.name);
 
@@ -309,12 +305,16 @@ const buildOperationStringForField = (
   });
 
   const argPasses = field.args.map((arg) => `${arg.name}: $${arg.name}`);
-  const selectionSet = buildSelectionSet(field.type, types, 0, new Set());
+  const defaultSelection = buildDefaultSelectionSet(field.type, types);
 
   const varDefsStr = varDefs.length > 0 ? `(${varDefs.join(", ")})` : "";
   const argPassStr = argPasses.length > 0 ? `(${argPasses.join(", ")})` : "";
 
-  return `${opType} ${opName}${varDefsStr} { ${field.name}${argPassStr}${selectionSet ? ` ${selectionSet}` : ""} }`;
+  const operationPrefix = `${opType} ${opName}${varDefsStr} { ${field.name}${argPassStr}`;
+  const operationSuffix = ` }`;
+  const operationString = `${operationPrefix}${defaultSelection ? ` ${defaultSelection}` : ""}${operationSuffix}`;
+
+  return { operationString, operationPrefix, operationSuffix };
 };
 
 interface PreparedOperation {
@@ -323,6 +323,28 @@ interface PreparedOperation {
   readonly inputSchema: unknown;
   readonly binding: OperationBinding;
 }
+
+// Surface an optional `select` input on every tool so a caller can choose the
+// return fields per call. The default operation selects only scalar leaves; to
+// fetch nested or list data the caller passes a GraphQL selection set here, which
+// is spliced into the operation at invoke time. A real field argument named
+// `select` (rare) is left untouched.
+const withSelectInput = (inputSchema: unknown, returnTypeName: string): unknown => {
+  const base =
+    inputSchema && typeof inputSchema === "object"
+      ? (inputSchema as Record<string, unknown>)
+      : { type: "object", properties: {} };
+  const properties = {
+    ...((base.properties as Record<string, unknown> | undefined) ?? {}),
+  };
+  if (!("select" in properties)) {
+    properties.select = {
+      type: "string",
+      description: `Optional GraphQL selection set for the \`${returnTypeName}\` return type. Overrides the default, which selects only scalar fields. Provide the fields to return, with sub-selections for nested objects and arguments where required, e.g. "id name items { id title }". Omit for the default.`,
+    };
+  }
+  return { ...base, type: "object", properties };
+};
 
 const prepareOperations = (
   fields: readonly ExtractedField[],
@@ -360,21 +382,31 @@ const prepareOperations = (
 
     const key = `${extracted.kind}.${extracted.fieldName}`;
     const entry = fieldMap.get(key);
-    const operationString = entry
+    const built = entry
       ? buildOperationStringForField(entry.kind, entry.field, typeMap)
-      : `${extracted.kind} ${operationNameForField(extracted.fieldName)} { ${extracted.fieldName} }`;
+      : {
+          operationString: `${extracted.kind} ${operationNameForField(extracted.fieldName)} { ${extracted.fieldName} }`,
+          operationPrefix: undefined,
+          operationSuffix: undefined,
+        };
 
     const binding = OperationBinding.make({
       kind: extracted.kind,
       fieldName: extracted.fieldName,
-      operationString,
+      operationString: built.operationString,
       variableNames: extracted.arguments.map((a) => a.name),
+      ...(built.operationPrefix !== undefined && built.operationSuffix !== undefined
+        ? { operationPrefix: built.operationPrefix, operationSuffix: built.operationSuffix }
+        : {}),
     });
 
     return {
       toolName,
       description,
-      inputSchema: Option.getOrUndefined(extracted.inputSchema),
+      inputSchema: withSelectInput(
+        Option.getOrUndefined(extracted.inputSchema),
+        extracted.returnTypeName,
+      ),
       binding,
     };
   });

--- a/packages/plugins/graphql/src/sdk/plugin.ts
+++ b/packages/plugins/graphql/src/sdk/plugin.ts
@@ -47,7 +47,8 @@ import {
   GraphqlIntrospectionError,
   GraphqlInvocationError,
 } from "./errors";
-import { invokeWithLayer } from "./invoke";
+import { effectiveOperationString, invokeWithLayer } from "./invoke";
+import { validateOperationString } from "./validate-selection";
 import { graphqlPresets } from "./presets";
 import { makeDefaultGraphqlStore, type GraphqlStore, type StoredOperation } from "./store";
 import {
@@ -1044,6 +1045,27 @@ export const graphqlPlugin = definePlugin((options?: GraphqlPluginOptions) => {
             message: `No GraphQL operation found for tool "${integration}.${toolName}"`,
             statusCode: Option.none(),
           });
+        }
+
+        // Parse-check a caller-supplied `select` locally, before any network
+        // call: reject a malformed selection (and any attempt to break out of the
+        // field's selection set) with a precise error instead of a confusing
+        // server response. Field- and argument-level validity is left to the
+        // server, which returns verbatim errors.
+        const selectArg = (args as Record<string, unknown> | undefined)?.select;
+        if (typeof selectArg === "string" && selectArg.trim().length > 0) {
+          const operationString = effectiveOperationString(
+            op.binding,
+            (args ?? {}) as Record<string, unknown>,
+          );
+          const selectionErrors = validateOperationString(operationString);
+          if (selectionErrors.length > 0) {
+            return ToolResult.fail({
+              code: "graphql_invalid_selection",
+              message: selectionErrors[0]!,
+              details: { errors: selectionErrors },
+            });
+          }
         }
 
         const headers: Record<string, string> = { ...(config.headers ?? {}) };

--- a/packages/plugins/graphql/src/sdk/types.ts
+++ b/packages/plugins/graphql/src/sdk/types.ts
@@ -55,8 +55,16 @@ export type ExtractionResult = typeof ExtractionResult.Type;
 export const OperationBinding = Schema.Struct({
   kind: GraphqlOperationKind,
   fieldName: Schema.String,
-  /** The full GraphQL query/mutation string */
+  /** The full GraphQL query/mutation string, with the default scalar-leaf
+   *  selection. Sent when the caller does not supply a custom `select`. */
   operationString: Schema.String,
+  /** Operation text up to (not including) the field's selection set, e.g.
+   *  `query Op($a: T) { field(a: $a)`. With `operationSuffix`, lets `invoke`
+   *  splice a caller-supplied `select` as `{ <select> }` without re-introspecting.
+   *  Optional so bindings persisted before this field still decode. */
+  operationPrefix: Schema.optional(Schema.String),
+  /** Closes the operation (` }`); pairs with `operationPrefix`. */
+  operationSuffix: Schema.optional(Schema.String),
   /** Ordered variable names for mapping */
   variableNames: Schema.Array(Schema.String),
 });

--- a/packages/plugins/graphql/src/sdk/validate-selection.ts
+++ b/packages/plugins/graphql/src/sdk/validate-selection.ts
@@ -1,0 +1,22 @@
+import { parse } from "graphql";
+
+// Local validation for a caller-supplied `select` (see invoke / plugin.invokeTool).
+// graphql-js is already a runtime dependency of this plugin, so we reuse its
+// parser to reject a malformed selection before any network round trip, and to
+// catch any attempt to break out of the field's selection set (the spliced text
+// must parse as part of a single operation). Field- and argument-level validity
+// is left to the upstream server, which returns verbatim errors: building a local
+// GraphQLSchema would need a full introspection snapshot, but the stored snapshot
+// is a reduced shape (see introspect.ts) that buildClientSchema cannot consume.
+
+/** Parse-check an assembled operation string. Returns a one-element error array
+ *  when the selection is not valid GraphQL, or an empty array when it parses. */
+export const validateOperationString = (operationString: string): readonly string[] => {
+  // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: graphql `parse` throws on a syntax error; the thrown value is reported generically (its message is not extracted, per the typed-error lint rules)
+  try {
+    parse(operationString);
+    return [];
+  } catch {
+    return ["`select` is not a valid GraphQL selection set"];
+  }
+};

--- a/packages/plugins/graphql/src/testing/index.ts
+++ b/packages/plugins/graphql/src/testing/index.ts
@@ -251,6 +251,77 @@ export const makeGreetingGraphqlSchema = (
   });
 };
 
+// A small GitLab-shaped schema that reproduces the two failure modes from issue
+// #1146 when the plugin auto-generates selection sets against it:
+//   1. `metadata.featureFlags(names: [String!]!)` has a REQUIRED nested argument
+//      the generator cannot fill.
+//   2. `currentUser` nests connections deep enough that composite leaf fields
+//      (`author`, `assignees`) sit past the recursion depth cap, so a naive
+//      generator emits them with no sub-selection.
+// graphql-yoga validates with graphql-js, exactly like the @emulators/gitlab
+// surface, so a generated operation that validates clean here is valid GraphQL.
+export const makeGitlab1146Schema = (): GraphQLSchema =>
+  createSchema<GraphqlTestContext>({
+    typeDefs: /* GraphQL */ `
+      type Query {
+        metadata: Metadata
+        currentUser: User
+      }
+
+      type Metadata {
+        version: String
+        revision: String
+        enterprise: Boolean
+        featureFlags(names: [String!]!): [FeatureFlag!]!
+        kas: Kas
+      }
+
+      type FeatureFlag {
+        name: String
+        enabled: Boolean
+      }
+
+      type Kas {
+        enabled: Boolean
+        externalUrl: String
+      }
+
+      type User {
+        active: Boolean
+        admin: Boolean
+        mergeRequests: MergeRequestConnection
+      }
+
+      type MergeRequestConnection {
+        count: Int
+        nodes: [MergeRequest!]
+        pageInfo: PageInfo
+      }
+
+      type PageInfo {
+        hasNextPage: Boolean
+        endCursor: String
+      }
+
+      type MergeRequest {
+        id: ID
+        title: String
+        author: Author
+        assignees: AssigneeConnection
+      }
+
+      type Author {
+        name: String
+        username: String
+      }
+
+      type AssigneeConnection {
+        count: Int
+        nodes: [Author!]
+      }
+    `,
+  });
+
 export const TestLayers = {
   greeting: () => GraphqlTestServer.layer({ schema: makeGreetingGraphqlSchema() }),
   greetingWithOAuth: () =>


### PR DESCRIPTION
## Problem

Fixes #1146. The GraphQL plugin auto-generated a selection set for every field at sync time and reused it verbatim on every call. Against a large schema (GitLab) this had two failure modes:

1. **Invalid GraphQL.** Composite fields were emitted with no sub-selection (when the recursion hit its depth cap or cycle guard), and nested fields with required arguments were emitted without them (e.g. `metadata.featureFlags(names:)`). Every call over a rich return type failed server-side validation.
2. **Arbitrary, frozen selection.** The bound was `slice(0, 12)` (first 12 fields, alphabetical) at depth 2: which fields you got was arbitrary, deeper data was unreachable, and the choice was baked in at sync time with no signal to the caller.

Unbounded isn't an option either: large GraphQL APIs cap query cost (confirmed live, GitLab rejects with `complexity of 600, which exceeds max complexity of 250`), so "select everything" just trades one failure for a complexity error.

## Change

- **Default selection is scalar/enum leaves only.** Always valid (leaves need no sub-selection), always small enough to stay under a server's complexity budget. Composite fields and fields with unsatisfiable required arguments are simply not in the default. A composite type with no scalar leaves falls back to `__typename`.
- **Selection is caller-controlled.** Every generated tool gains an optional `select` input carrying a GraphQL selection set, spliced into the operation at invoke time (`operationPrefix`/`operationSuffix` on the binding). Callers request nested/list data, and supply nested required arguments, per call, instead of inheriting one frozen guess. `select` is a control input, never sent as a GraphQL variable.

The old depth cap and 12-field truncation are gone; depth and breadth are now the caller's choice, bounded by the server's own limits.

## Tests

`plugin.test.ts` drives the real plugin end to end (live introspection -> generation -> invocation) against a GitLab-shaped graphql-yoga server (graphql-js, the same engine the GitLab emulator uses):

- default selection is scalar-leaves-only and valid (no bare composites, no missing-arg fields);
- a caller `select` fetches nested/list data and stays valid;
- `select` can supply a nested field's required argument;
- an invalid `select` surfaces the server's validation error verbatim (no silent fixing).

Full graphql package suite passes (85 tests); typecheck, lint, and format clean.