### PR TITLE
fix(desktop): bind Cmd+W to close the window

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -846,9 +846,18 @@ const installApplicationMenu = () => {
       { role: "quit" },
     ],
   };
+  // The close-window accelerator (Cmd+W on macOS, Ctrl+W elsewhere) lives on
+  // the `close` role, which the File menu carries. The Window menu's role only
+  // provides Minimize/Zoom/Front, so without an explicit File menu nothing
+  // binds Cmd+W and the window can't be closed from the keyboard.
+  const fileMenu: MenuItemConstructorOptions = {
+    label: "File",
+    submenu: [{ role: "close" }],
+  };
   Menu.setApplicationMenu(
     Menu.buildFromTemplate([
       appMenu,
+      fileMenu,
       { role: "editMenu" },
       { role: "viewMenu" },
       { role: "windowMenu" },


### PR DESCRIPTION
## Problem

`Cmd+W` (and `Ctrl+W` on Windows/Linux) did nothing in the desktop app, so the window could not be closed from the keyboard. Only `Cmd+Q` (full quit) worked.

## Cause

The application menu template had no **File** menu. On macOS the close-window accelerator is provided by the `close` role, which lives in the File menu. The `windowMenu` role only contributes Minimize, Zoom, and Bring All to Front, so nothing was binding the close accelerator.

## Fix

Add a File menu with `{ role: "close" }`. That role auto-binds `CmdOrCtrl+W`:

- macOS: `Cmd+W` closes the window (app stays in the dock, as expected; `Cmd+Q` still fully quits).
- Windows/Linux: `Ctrl+W` works too.

## Verification

`typecheck`, `oxfmt --check`, and `oxlint` pass on the changed file. Verified manually by booting the desktop app and confirming `Cmd+W` closes the window.

Note: this is a native macOS menu accelerator, which the web/Playwright e2e harness cannot drive, so it is not covered by an automated scenario.