### PR TITLE
Guide users to manual OAuth registration when automatic (DCR) is rejected

### DIFF
--- a/packages/react/src/components/add-account-modal.tsx
+++ b/packages/react/src/components/add-account-modal.tsx
@@ -751,6 +751,10 @@ function AddAccountModalView(props: AddAccountModalProps) {
   const [dcrBusy, setDcrBusy] = useState(false);
   const [dcrFailed, setDcrFailed] = useState(false);
   const [oauthFallbackProbe, setOAuthFallbackProbe] = useState<DcrProbeResult | null>(null);
+  // When transparent DCR is rejected with an actionable reason (e.g. the server
+  // refuses our redirect URI), surface it as an inline error card on the
+  // bring-your-own-app recovery view instead of a transient toast.
+  const [dcrFallbackMessage, setDcrFallbackMessage] = useState<string | null>(null);
   // FIX 3 escape hatch: when no registered app matched the integration's
   // endpoints, the unmatched apps are collapsed behind an opt-in expander.
   const [showOtherApps, setShowOtherApps] = useState(false);
@@ -817,6 +821,7 @@ function AddAccountModalView(props: AddAccountModalProps) {
     setPickedApp(null);
     setOAuthFallbackProbe(null);
     setDcrFailed(false);
+    setDcrFallbackMessage(null);
   }, [initialState, allMethods, defaultOwner, ownerOptions]);
 
   useEffect(() => {
@@ -1004,6 +1009,7 @@ function AddAccountModalView(props: AddAccountModalProps) {
     setOnePasswordItemId("");
     setDcrFailed(false);
     setOAuthFallbackProbe(null);
+    setDcrFallbackMessage(null);
   };
 
   // A just-created custom method joins the in-session list and is auto-selected
@@ -1267,10 +1273,10 @@ function AddAccountModalView(props: AddAccountModalProps) {
     if (outcome.kind === "fallback") {
       setOAuthFallbackProbe("probe" in outcome ? outcome.probe : null);
       setDcrFailed(true);
-      toast.error(
-        ("message" in outcome ? outcome.message : undefined) ??
-          "Automatic setup unavailable. Register an app instead.",
-      );
+      // Surface the server's actionable rejection reason on the recovery view as
+      // an inline error card. Generic fallbacks (no message) fall through to the
+      // "register an app" empty state, which already guides the user.
+      setDcrFallbackMessage("message" in outcome ? (outcome.message ?? null) : null);
     }
   };
 
@@ -1511,6 +1517,22 @@ function AddAccountModalView(props: AddAccountModalProps) {
                               <p className="text-xs text-muted-foreground">Loading OAuth apps…</p>
                             ) : (
                               <div className="space-y-3">
+                                {dcrFallbackMessage ? (
+                                  <div
+                                    role="alert"
+                                    className="space-y-1 rounded-lg border border-destructive/40 bg-destructive/5 px-3 py-3"
+                                  >
+                                    <p className="text-sm font-medium text-destructive">
+                                      Couldn&apos;t set up {integrationName} automatically
+                                    </p>
+                                    <p className="text-xs text-muted-foreground">
+                                      {dcrFallbackMessage}
+                                    </p>
+                                    <p className="text-xs text-muted-foreground">
+                                      Register an app below to connect.
+                                    </p>
+                                  </div>
+                                ) : null}
                                 {/* No registered app matched the integration's endpoint:
                         empty state + a prominent register CTA, and an opt-in
                         collapsed "use a different registered app" escape hatch. */}

--- a/packages/react/src/components/add-account-modal.tsx
+++ b/packages/react/src/components/add-account-modal.tsx
@@ -1348,6 +1348,7 @@ function AddAccountModalView(props: AddAccountModalProps) {
                 existingSlugs={[...oauthApps, ...oauthOtherApps].map((app: OAuthClientOption) =>
                   String(app.slug),
                 )}
+                autoRegisterRejectedReason={dcrFallbackMessage}
                 prefill={{
                   authorizationUrl:
                     oauthHandoffPrefill?.authorizationUrl ??

--- a/packages/react/src/components/add-account-modal.tsx
+++ b/packages/react/src/components/add-account-modal.tsx
@@ -1552,7 +1552,9 @@ function AddAccountModalView(props: AddAccountModalProps) {
                                         size="sm"
                                         onClick={() => setRegisteringOAuthClient(true)}
                                       >
-                                        Register app
+                                        {dcrFallbackMessage
+                                          ? "Manually register an app"
+                                          : "Register app"}
                                       </Button>
                                       {oauthOtherApps.length > 0 && !showOtherApps ? (
                                         <Button

--- a/packages/react/src/components/oauth-client-form.tsx
+++ b/packages/react/src/components/oauth-client-form.tsx
@@ -88,6 +88,11 @@ export function OAuthClientForm(props: {
   readonly onCreated: (result: { readonly owner: Owner; readonly slug: OAuthClientSlug }) => void;
   readonly onCancel?: () => void;
   readonly surface?: "card" | "plain";
+  /** When set, the server's automatic (DCR) registration is known to be rejected
+   *  for this host (e.g. it refused our redirect URI). The form then suppresses
+   *  the "Register automatically" path and leads with manual client entry; the
+   *  string is the actionable reason shown to the user. */
+  readonly autoRegisterRejectedReason?: string | null;
 }) {
   const {
     integrationName,
@@ -98,6 +103,7 @@ export function OAuthClientForm(props: {
     onCreated,
     onCancel,
     surface = "card",
+    autoRegisterRejectedReason = null,
   } = props;
   // Non-org hosts (local/desktop) have one local workspace. Offer only Local,
   // so the owner dropdown (which hides on a single option) disappears.
@@ -177,6 +183,11 @@ export function OAuthClientForm(props: {
     authorizationUrl.trim().length > 0 &&
     tokenUrl.trim().length > 0 &&
     grant === "authorization_code";
+
+  // When the server already rejected automatic registration for this host (e.g.
+  // it refused our non-loopback redirect URI), don't lead the user back into the
+  // path that just failed: suppress the auto CTA and lead with manual entry.
+  const showAutoRegister = canRegisterDynamic && autoRegisterRejectedReason === null;
 
   const handleDiscover = async () => {
     const url = issuerUrl.trim();
@@ -283,11 +294,18 @@ export function OAuthClientForm(props: {
       <div className="space-y-1">
         <p className="text-sm font-medium">Register an OAuth app</p>
         <p className="text-xs text-muted-foreground">
-          {canRegisterDynamic
+          {showAutoRegister
             ? "Register automatically below, or enter a client id/secret manually."
             : "Paste a client id/secret. We only ask for endpoints when they aren't already known."}
         </p>
       </div>
+
+      {autoRegisterRejectedReason ? (
+        <div className="space-y-1 rounded-lg border border-destructive/40 bg-destructive/5 p-3">
+          <p className="text-sm font-medium text-destructive">Automatic registration unavailable</p>
+          <p className="text-xs text-muted-foreground">{autoRegisterRejectedReason}</p>
+        </div>
+      ) : null}
 
       {/* app name */}
       <div className="space-y-1.5">
@@ -305,7 +323,7 @@ export function OAuthClientForm(props: {
 
       {/* register automatically (RFC 7591 DCR) — the primary path when the
           server advertises a registration endpoint: no client id/secret needed */}
-      {canRegisterDynamic ? (
+      {showAutoRegister ? (
         <div className="space-y-2 rounded-lg border border-ring/40 bg-accent/30 p-3">
           <p className="text-sm font-medium">No client ID needed</p>
           <p className="text-xs text-muted-foreground">
@@ -365,7 +383,7 @@ export function OAuthClientForm(props: {
       </div>
 
       {/* divider before the manual (secondary) path when DCR is available */}
-      {canRegisterDynamic ? (
+      {showAutoRegister ? (
         <div className="flex items-center gap-2 text-xs text-muted-foreground">
           <span className="h-px flex-1 bg-border/60" />
           or enter a client ID manually


### PR DESCRIPTION
## Summary

When transparent Dynamic Client Registration (DCR) is rejected by a server (for example one that only approves loopback redirect URIs), the add-connection flow now guides the user toward the path that works instead of bouncing them back into the one that just failed.

## Changes

- Surface the server's actionable rejection reason as an inline error card on the bring-your-own-app recovery view, instead of a transient toast that disappears.
- When automatic registration was rejected, the "Register an OAuth app" form suppresses the "Register automatically" path (it cannot succeed for that server), restates why, and leads with manual client id/secret entry plus the callback URL to allow-list.
- Relabel the recovery CTA to "Manually register an app" in that case.

Generic fallbacks with no actionable reason are unchanged: they still land on the existing "register an app" empty state, and servers that support automatic registration still lead with it.

## Tests

- packages/react `oauth-client-form` and `add-account-modal` unit tests pass.
- typecheck, oxfmt, and oxlint clean.