### PR TITLE
Support CIMD OAuth for API sources

### DIFF
--- a/packages/core/api/src/integrations/api.ts
+++ b/packages/core/api/src/integrations/api.ts
@@ -47,9 +47,11 @@ const OAuthDescriptor = Schema.Struct({
   discoveryUrl: Schema.optional(Schema.String),
   authorizationUrl: Schema.optional(Schema.String),
   tokenUrl: Schema.optional(Schema.String),
+  resource: Schema.optional(Schema.NullOr(Schema.String)),
   scopes: Schema.optional(Schema.Array(Schema.String)),
   registrationEndpoint: Schema.optional(Schema.String),
   supportsDynamicRegistration: Schema.optional(Schema.Boolean),
+  supportsClientIdMetadataDocument: Schema.optional(Schema.Boolean),
 });
 
 /** A single declared auth method — mirrors the SDK's `AuthMethodDescriptor`. */

--- a/packages/core/api/src/oauth-popup.test.ts
+++ b/packages/core/api/src/oauth-popup.test.ts
@@ -235,44 +235,33 @@ describe("runOAuthCallback", () => {
     expect(received[1]!.callbackDomain).toBeNull();
   });
 
-  it("prefers `error` over `error_description` but falls back when absent", async () => {
-    const received: Array<{
-      state: string;
-      code: string | null;
-      error: string | null;
-      callbackDomain: string | null;
-    }> = [];
-    const complete = (params: {
-      state: string;
-      code: string | null;
-      error: string | null;
-      callbackDomain: string | null;
-    }) => {
-      received.push(params);
+  it("renders provider OAuth errors without invoking completeOAuth", async () => {
+    let completeCalls = 0;
+    const complete = () => {
+      completeCalls += 1;
       return Effect.succeed({
         kind: "oauth2" as const,
         accessTokenSecretId: "s",
         refreshTokenSecretId: null,
       });
     };
-    await Effect.runPromise(
+    const html = await Effect.runPromise(
       runOAuthCallback<GoogleAuth, never, never>({
         complete,
-        urlParams: { state: "s1", error: "access_denied" },
+        urlParams: {
+          state: "s1",
+          error: "invalid_scope",
+          error_description: "unknown scope wizard_session:write",
+        },
         toErrorMessage: () => ({ short: "" }),
         channelName: "c",
       }),
     );
-    await Effect.runPromise(
-      runOAuthCallback<GoogleAuth, never, never>({
-        complete,
-        urlParams: { state: "s2", error_description: "user cancelled" },
-        toErrorMessage: () => ({ short: "" }),
-        channelName: "c",
-      }),
-    );
-    expect(received[0]!.error).toBe("access_denied");
-    expect(received[1]!.error).toBe("user cancelled");
+    expect(completeCalls).toBe(0);
+    expect(html).toContain("<title>Connection failed</title>");
+    expect(html).toContain("OAuth provider rejected authorization");
+    expect(html).toContain("invalid_scope");
+    expect(html).toContain("unknown scope wizard_session:write");
   });
 
   it("renders a failure popup when completeOAuth fails and uses toErrorMessage", async () => {

--- a/packages/core/api/src/oauth-popup.ts
+++ b/packages/core/api/src/oauth-popup.ts
@@ -155,6 +155,17 @@ export type RunOAuthCallbackInput<TAuth, E, R> = {
   readonly channelName: string;
 };
 
+const providerErrorMessage = (params: OAuthCallbackUrlParams): PopupErrorMessage | null => {
+  const error = params.error ?? null;
+  const description = params.error_description ?? null;
+  const value = error ?? description;
+  if (!value) return null;
+  return {
+    short: "OAuth provider rejected authorization",
+    details: error && description && description !== error ? `${error}: ${description}` : value,
+  };
+};
+
 /**
  * Run a plugin's `completeOAuth` against URL params from the OAuth redirect,
  * wrap the success / failure in an `OAuthPopupResult`, and return the HTML
@@ -165,35 +176,49 @@ export type RunOAuthCallbackInput<TAuth, E, R> = {
  */
 export const runOAuthCallback = <TAuth, E, R>(
   input: RunOAuthCallbackInput<TAuth, E, R>,
-): Effect.Effect<string, never, R> =>
-  input
-    .complete({
-      state: input.urlParams.state,
-      code: input.urlParams.code ?? null,
-      error: input.urlParams.error ?? input.urlParams.error_description ?? null,
-      callbackDomain: input.urlParams.domain ?? input.urlParams.site ?? null,
-    })
-    .pipe(
-      Effect.map(
-        (auth): OAuthPopupResult<TAuth> => ({
-          type: OAUTH_POPUP_MESSAGE_TYPE,
-          ok: true,
-          sessionId: input.urlParams.state,
-          ...auth,
-        }),
-      ),
-      Effect.catchCause((cause) => {
-        const { short, details } = input.toErrorMessage(Cause.squash(cause));
-        return Effect.succeed<OAuthPopupResult<TAuth>>({
+): Effect.Effect<string, never, R> => {
+  const providerError = providerErrorMessage(input.urlParams);
+  const result =
+    providerError == null
+      ? input
+          .complete({
+            state: input.urlParams.state,
+            code: input.urlParams.code ?? null,
+            error: null,
+            callbackDomain: input.urlParams.domain ?? input.urlParams.site ?? null,
+          })
+          .pipe(
+            Effect.map(
+              (auth): OAuthPopupResult<TAuth> => ({
+                type: OAUTH_POPUP_MESSAGE_TYPE,
+                ok: true,
+                sessionId: input.urlParams.state,
+                ...auth,
+              }),
+            ),
+          )
+      : Effect.succeed<OAuthPopupResult<TAuth>>({
           type: OAUTH_POPUP_MESSAGE_TYPE,
           ok: false,
           sessionId: input.urlParams.state ?? null,
-          error: short,
-          ...(details && details !== short ? { errorDetails: details } : {}),
+          error: providerError.short,
+          ...(providerError.details ? { errorDetails: providerError.details } : {}),
         });
-      }),
-      Effect.tap((result) =>
-        Effect.sync(() => completionListener?.(result as OAuthPopupResult<unknown>)),
-      ),
-      Effect.map((result) => popupDocument(result, input.channelName)),
-    );
+
+  return result.pipe(
+    Effect.catchCause((cause) => {
+      const { short, details } = input.toErrorMessage(Cause.squash(cause));
+      return Effect.succeed<OAuthPopupResult<TAuth>>({
+        type: OAUTH_POPUP_MESSAGE_TYPE,
+        ok: false,
+        sessionId: input.urlParams.state ?? null,
+        error: short,
+        ...(details && details !== short ? { errorDetails: details } : {}),
+      });
+    }),
+    Effect.tap((result) =>
+      Effect.sync(() => completionListener?.(result as OAuthPopupResult<unknown>)),
+    ),
+    Effect.map((result) => popupDocument(result, input.channelName)),
+  );
+};

--- a/packages/core/api/src/oauth/api.ts
+++ b/packages/core/api/src/oauth/api.ts
@@ -209,6 +209,7 @@ const ProbeResponse = Schema.Struct({
   scopesSupported: Schema.optional(Schema.Array(Schema.String)),
   registrationEndpoint: Schema.optional(Schema.NullOr(Schema.String)),
   tokenEndpointAuthMethodsSupported: Schema.optional(Schema.Array(Schema.String)),
+  clientIdMetadataDocumentSupported: Schema.optional(Schema.Boolean),
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/core/sdk/src/core-tools.ts
+++ b/packages/core/sdk/src/core-tools.ts
@@ -293,6 +293,7 @@ const OAuthProbeOutput = Schema.Struct({
   scopesSupported: Schema.optional(Schema.Array(Schema.String)),
   registrationEndpoint: Schema.optional(Schema.NullOr(Schema.String)),
   tokenEndpointAuthMethodsSupported: Schema.optional(Schema.Array(Schema.String)),
+  clientIdMetadataDocumentSupported: Schema.optional(Schema.Boolean),
 });
 const OAuthStartInput = Schema.Struct({
   client: Schema.String,
@@ -794,6 +795,7 @@ export const coreToolsPlugin = definePlugin((options: CoreToolsPluginOptions = {
               scopesSupported: result.scopesSupported,
               registrationEndpoint: result.registrationEndpoint ?? null,
               tokenEndpointAuthMethodsSupported: result.tokenEndpointAuthMethodsSupported,
+              clientIdMetadataDocumentSupported: result.clientIdMetadataDocumentSupported,
             })),
         }),
         tool({

--- a/packages/core/sdk/src/integration.ts
+++ b/packages/core/sdk/src/integration.ts
@@ -52,11 +52,16 @@ export interface AuthMethodOAuthDescriptor {
   readonly discoveryUrl?: string;
   readonly authorizationUrl?: string;
   readonly tokenUrl?: string;
+  readonly resource?: string | null;
   readonly scopes?: readonly string[];
   readonly registrationEndpoint?: string;
   /** True when the integration is known to support RFC 7591 dynamic client
    *  registration (drives the transparent auto-register connect flow). */
   readonly supportsDynamicRegistration?: boolean;
+  /** True when the authorization server supports Client ID Metadata Document
+   *  clients. The UI can create a local public OAuth client using this host's
+   *  metadata-document URL as `client_id`, with no provider app registration. */
+  readonly supportsClientIdMetadataDocument?: boolean;
 }
 
 /** A single declared auth method on an integration's catalog response. */

--- a/packages/core/sdk/src/oauth-client.ts
+++ b/packages/core/sdk/src/oauth-client.ts
@@ -32,7 +32,15 @@ export interface OAuthAuthentication {
   readonly kind: "oauth2";
   readonly authorizationUrl: string;
   readonly tokenUrl: string;
+  /** RFC 8707 Resource Indicator to bind the OAuth flow to this protected
+   *  resource, when discovered from protected-resource metadata. */
+  readonly resource?: string | null;
   readonly scopes: readonly string[];
+  /** True when the authorization server supports OAuth Client ID Metadata
+   *  Document (CIMD). The local OAuth client is then a public PKCE client whose
+   *  `client_id` is this host's metadata-document URL, not a provider-side
+   *  registered app id. */
+  readonly supportsClientIdMetadataDocument?: boolean;
 }
 
 /** A registered OAuth app — pure app identity: clientId/secret + its endpoints.
@@ -138,6 +146,9 @@ export interface OAuthProbeResult {
   /** RFC 8414 `token_endpoint_auth_methods_supported`. Surfaced so DCR can pick
    *  a public ("none") client when the server allows it. */
   readonly tokenEndpointAuthMethodsSupported?: readonly string[];
+  /** Draft OAuth Client ID Metadata Document support, advertised by providers
+   *  such as PostHog as `client_id_metadata_document_supported`. */
+  readonly clientIdMetadataDocumentSupported?: boolean;
 }
 
 /** Mint an OAuth client via RFC 7591 Dynamic Client Registration and persist it.

--- a/packages/core/sdk/src/oauth-discovery.ts
+++ b/packages/core/sdk/src/oauth-discovery.ts
@@ -72,6 +72,7 @@ export const OAuthAuthorizationServerMetadataSchema = Schema.Struct({
   authorization_endpoint: Schema.String,
   token_endpoint: Schema.String,
   registration_endpoint: Schema.optional(Schema.String),
+  client_id_metadata_document_supported: Schema.optional(Schema.Boolean),
   scopes_supported: Schema.optional(StringArray),
   response_types_supported: Schema.optional(StringArray),
   grant_types_supported: Schema.optional(StringArray),

--- a/packages/core/sdk/src/oauth-scope-union.test.ts
+++ b/packages/core/sdk/src/oauth-scope-union.test.ts
@@ -220,6 +220,44 @@ describe("oauth.start integration-driven scopes", () => {
       ),
   );
 
+  it.effect("filters stale declared scopes against authorization-server metadata", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const server = yield* serveOAuthTestServer({ scopes: ["calendar", "drive"] });
+        const plugins = [
+          memoryCredentialsPlugin(),
+          makeScopePlugin({ scopes: ["calendar", "stale_scope", "drive"] }),
+        ] as const;
+        const { executor } = yield* makeTestWorkspaceHarness({ plugins });
+        yield* executor.acme.seed();
+
+        yield* executor.oauth.createClient({
+          owner: "org",
+          slug: CLIENT,
+          authorizationUrl: server.authorizationEndpoint,
+          tokenUrl: server.tokenEndpoint,
+          grant: "authorization_code",
+          clientId: "test-client",
+          clientSecret: "test-secret",
+          resource: server.resourceUrl,
+        });
+
+        const started = yield* executor.oauth.start({
+          owner: "org",
+          client: CLIENT,
+          clientOwner: "org",
+          name: ConnectionName.make("main"),
+          integration: INTEG,
+          template: TEMPLATE,
+        });
+        expect(started.status).toBe("redirect");
+        if (started.status !== "redirect") return;
+
+        expect(scopesFromAuthorizeUrl(started.authorizationUrl)).toEqual(["calendar", "drive"]);
+      }),
+    ),
+  );
+
   it.effect("(b) when the integration declares no oauth scopes, start requests none", () =>
     Effect.scoped(
       Effect.gen(function* () {

--- a/packages/core/sdk/src/oauth-service.ts
+++ b/packages/core/sdk/src/oauth-service.ts
@@ -180,6 +180,15 @@ const refreshItemIdFor = (accessId: string): string => `${accessId}:refresh`;
 /** Order-preserving de-duplication of a scope list. */
 const dedupeScopes = (scopes: readonly string[]): readonly string[] => [...new Set(scopes)];
 
+const intersectScopes = (
+  requested: readonly string[],
+  supported: readonly string[] | undefined,
+): readonly string[] => {
+  if (!supported || supported.length === 0) return requested;
+  const supportedSet = new Set(supported);
+  return requested.filter((scope) => supportedSet.has(scope));
+};
+
 const recordedOAuthScope = (
   token: OAuth2TokenResponse,
   requestedScopes: readonly string[],
@@ -354,6 +363,28 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
   // EXPLICIT — no localhost default. `null` means this executor has no OAuth
   // callback; redirect-requiring flows fail loudly via `requireRedirectUri`.
   const redirectUri = deps.redirectUri;
+  const discoveryOptions = { endpointUrlPolicy: deps.endpointUrlPolicy };
+
+  const filterAuthorizationCodeScopes = (
+    client: LoadedOAuthClient,
+    requestedScopes: readonly string[],
+  ): Effect.Effect<readonly string[], never> =>
+    Effect.gen(function* () {
+      if (requestedScopes.length === 0) return requestedScopes;
+      const resource = client.resource
+        ? yield* discoverProtectedResourceMetadata(client.resource, discoveryOptions).pipe(
+            Effect.catch(() => Effect.succeed(null)),
+            Effect.provide(httpClientLayer),
+          )
+        : null;
+      const issuer =
+        resource?.metadata.authorization_servers?.[0] ?? new URL(client.authorizationUrl).origin;
+      const as = yield* discoverAuthorizationServerMetadata(issuer, discoveryOptions).pipe(
+        Effect.catch(() => Effect.succeed(null)),
+        Effect.provide(httpClientLayer),
+      );
+      return intersectScopes(requestedScopes, as?.metadata.scopes_supported);
+    }).pipe(Effect.catch(() => Effect.succeed(requestedScopes)));
 
   // Caps on server-controlled discovery input — a hostile or buggy server must
   // not be able to hang `oauth.start` or overflow the authorize URL.
@@ -818,6 +849,14 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
           message: REDIRECT_URI_REQUIRED_MESSAGE,
         });
       }
+      // Prune stale DECLARED scopes against the AS's advertised set, but leave
+      // resource-discovered scopes untouched: an RFC 9728 `scopes_supported`
+      // list is already authoritative (§7.2) and must not be re-narrowed by a
+      // divergent authorization server.
+      const authorizationRequestedScopes =
+        scopePolicy.kind === "discover"
+          ? requestedScopes
+          : yield* filterAuthorizationCodeScopes(client, requestedScopes);
 
       // authorization_code: persist a session + build the authorize URL.
       const verifier = createPkceCodeVerifier();
@@ -843,11 +882,15 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
           redirect_url: flowRedirectUri,
           pkce_verifier: verifier,
           identity_label: input.identityLabel ?? null,
-          // Persist the requested scope set (the integration's declared or
-          // discovered scopes) so `complete`'s recorded-scope fallback reflects
-          // exactly what was requested when the AS omits `scope`, without
-          // re-resolving it at completion.
-          payload: { owner: input.owner, clientOwner: input.clientOwner, requestedScopes },
+          // Persist the requested scope set (declared ∪ client, filtered to the
+          // authorization-code flow) so `complete`'s recorded-scope fallback
+          // reflects exactly what was requested when the AS omits `scope`,
+          // without re-resolving the integration's declared scopes at completion.
+          payload: {
+            owner: input.owner,
+            clientOwner: input.clientOwner,
+            requestedScopes: authorizationRequestedScopes,
+          },
           expires_at: expiresAt,
           created_at: now,
         }),
@@ -859,7 +902,7 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
             authorizationUrl: client.authorizationUrl,
             clientId: client.clientId,
             redirectUrl: flowRedirectUri,
-            scopes: requestedScopes,
+            scopes: authorizationRequestedScopes,
             state: providerState,
             codeChallenge: challenge,
             resource: client.resource ?? undefined,
@@ -1127,6 +1170,8 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
         scopesSupported: resource?.metadata.scopes_supported ?? as.metadata.scopes_supported,
         registrationEndpoint: as.metadata.registration_endpoint ?? null,
         tokenEndpointAuthMethodsSupported: as.metadata.token_endpoint_auth_methods_supported,
+        clientIdMetadataDocumentSupported:
+          as.metadata.client_id_metadata_document_supported === true,
       } satisfies OAuthProbeResult;
     }).pipe(Effect.provide(httpClientLayer));
 

--- a/packages/plugins/openapi/src/api/group.ts
+++ b/packages/plugins/openapi/src/api/group.ts
@@ -55,7 +55,9 @@ const OAuthTemplatePayload = Schema.Struct({
   kind: Schema.Literal("oauth2"),
   authorizationUrl: Schema.String,
   tokenUrl: Schema.String,
+  resource: Schema.optional(Schema.NullOr(Schema.String)),
   scopes: Schema.Array(Schema.String),
+  supportsClientIdMetadataDocument: Schema.optional(Schema.Boolean),
 });
 
 /** Auth INPUTS: oauth templates + the request-shaped apikey dialect. */

--- a/packages/plugins/openapi/src/react/AddOpenApiSource.test.ts
+++ b/packages/plugins/openapi/src/react/AddOpenApiSource.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import { baseUrlFromSpecInput } from "./AddOpenApiSource";
+
+describe("baseUrlFromSpecInput", () => {
+  it("defaults URL-hosted specs to their origin", () => {
+    expect(baseUrlFromSpecInput("https://app.posthog.com/api/schema/")).toBe(
+      "https://app.posthog.com",
+    );
+  });
+
+  it("does not default raw specs", () => {
+    expect(baseUrlFromSpecInput('{"openapi":"3.0.0"}')).toBe("");
+  });
+});

--- a/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
@@ -65,6 +65,14 @@ const specInputForAdd = (input: string) => {
     : { kind: "blob" as const, value };
 };
 
+export const baseUrlFromSpecInput = (input: string): string => {
+  const value = input.trim();
+  if (!URL.canParse(value)) return "";
+  const parsed = new URL(value);
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") return "";
+  return parsed.origin;
+};
+
 // ---------------------------------------------------------------------------
 // Component: single progressive form. Post-redesign: preview -> addSpec
 // (register the integration catalog entry with ALL detected auth methods) →
@@ -220,7 +228,7 @@ export default function AddOpenApiSource(props: {
     }
     const result = exit.value;
     setPreview(result);
-    setBaseUrl("");
+    setBaseUrl(result.servers.length === 0 ? baseUrlFromSpecInput(specUrl) : "");
     setAnalyzing(false);
   };
 

--- a/packages/plugins/openapi/src/react/auth-method-config.test.ts
+++ b/packages/plugins/openapi/src/react/auth-method-config.test.ts
@@ -17,7 +17,9 @@ describe("authMethodsFromConfig", () => {
         kind: "oauth2",
         authorizationUrl: "https://x.example/auth",
         tokenUrl: "https://x.example/token",
+        resource: "https://api.example",
         scopes: ["read"],
+        supportsClientIdMetadataDocument: true,
       },
     ]);
     expect(methods[0]).toMatchObject({
@@ -27,7 +29,9 @@ describe("authMethodsFromConfig", () => {
       oauth: {
         authorizationUrl: "https://x.example/auth",
         tokenUrl: "https://x.example/token",
+        resource: "https://api.example",
         scopes: ["read"],
+        supportsClientIdMetadataDocument: true,
       },
     });
   });
@@ -73,13 +77,17 @@ describe("editor round-trip", () => {
         kind: "oauth2",
         authorizationUrl: "https://x.example/auth",
         tokenUrl: "https://x.example/token",
+        resource: "https://api.example",
         scopes: ["a", "b"],
+        supportsClientIdMetadataDocument: true,
       }),
     ).toEqual({
       kind: "oauth",
       authorizationUrl: "https://x.example/auth",
       tokenUrl: "https://x.example/token",
+      resource: "https://api.example",
       scopes: ["a", "b"],
+      supportsClientIdMetadataDocument: true,
     });
   });
 

--- a/packages/plugins/openapi/src/react/auth-method-config.ts
+++ b/packages/plugins/openapi/src/react/auth-method-config.ts
@@ -41,7 +41,9 @@ const oauthAuthMethod = (template: Extract<Authentication, { kind: "oauth2" }>):
     oauth: {
       authorizationUrl: template.authorizationUrl,
       tokenUrl: template.tokenUrl,
+      resource: template.resource ?? null,
       scopes: template.scopes,
+      supportsClientIdMetadataDocument: template.supportsClientIdMetadataDocument,
     },
   };
 };
@@ -78,7 +80,9 @@ export function editorValueFromAuthentication(template: Authentication): AuthTem
       kind: "oauth",
       authorizationUrl: template.authorizationUrl ?? "",
       tokenUrl: template.tokenUrl ?? "",
+      resource: template.resource ?? null,
       scopes: template.scopes ?? [],
+      supportsClientIdMetadataDocument: template.supportsClientIdMetadataDocument,
     };
   }
   return editorValueFromSharedMethod(template);
@@ -93,7 +97,11 @@ const oauthTemplateFromEditorValue = (
   kind: "oauth2",
   authorizationUrl: value.authorizationUrl,
   tokenUrl: value.tokenUrl,
+  resource: value.resource ?? null,
   scopes: [...value.scopes],
+  ...(value.supportsClientIdMetadataDocument === true
+    ? { supportsClientIdMetadataDocument: true }
+    : {}),
 });
 
 /** Convert one generic editor value back into a stored `Authentication`, or

--- a/packages/plugins/openapi/src/sdk/config.ts
+++ b/packages/plugins/openapi/src/sdk/config.ts
@@ -32,7 +32,9 @@ const OAuthAuthenticationSchema = Schema.Struct({
   kind: Schema.Literal("oauth2"),
   authorizationUrl: Schema.String,
   tokenUrl: Schema.String,
+  resource: Schema.optional(Schema.NullOr(Schema.String)),
   scopes: Schema.Array(Schema.String),
+  supportsClientIdMetadataDocument: Schema.optional(Schema.Boolean),
 });
 
 export const AuthenticationSchema = Schema.Union([OAuthAuthenticationSchema, ApiKeyAuthMethod]);

--- a/packages/plugins/openapi/src/sdk/derive-auth.ts
+++ b/packages/plugins/openapi/src/sdk/derive-auth.ts
@@ -131,7 +131,11 @@ const oauthTemplateFromPreset = (
     baseUrl,
   ),
   tokenUrl: resolveOAuthUrl(preset.tokenUrl, baseUrl),
+  resource: Option.getOrUndefined(preset.resource) ?? null,
   scopes: [...scopes],
+  ...(preset.supportsClientIdMetadataDocument === true
+    ? { supportsClientIdMetadataDocument: true }
+    : {}),
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/plugins/openapi/src/sdk/describe-auth-methods.test.ts
+++ b/packages/plugins/openapi/src/sdk/describe-auth-methods.test.ts
@@ -60,7 +60,9 @@ describe("describeOpenApiAuthMethods", () => {
           kind: "oauth2",
           authorizationUrl: "https://auth.example/authorize",
           tokenUrl: "https://auth.example/token",
+          resource: "https://api.example",
           scopes: ["read", "write"],
+          supportsClientIdMetadataDocument: true,
         },
       ]),
     );
@@ -74,7 +76,9 @@ describe("describeOpenApiAuthMethods", () => {
         oauth: {
           authorizationUrl: "https://auth.example/authorize",
           tokenUrl: "https://auth.example/token",
+          resource: "https://api.example",
           scopes: ["read", "write"],
+          supportsClientIdMetadataDocument: true,
         },
       },
     ]);

--- a/packages/plugins/openapi/src/sdk/plugin.test.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.test.ts
@@ -13,9 +13,9 @@
 // ---------------------------------------------------------------------------
 
 import { describe, expect, it } from "@effect/vitest";
-import { Effect, Predicate, Schema } from "effect";
+import { Effect, Option, Predicate, Schema } from "effect";
 import { HttpApi, HttpApiBuilder, HttpApiEndpoint, HttpApiGroup } from "effect/unstable/httpapi";
-import { FetchHttpClient, HttpServerRequest } from "effect/unstable/http";
+import { FetchHttpClient, HttpServerRequest, HttpServerResponse } from "effect/unstable/http";
 
 import {
   createExecutor,
@@ -33,6 +33,7 @@ import {
   makeTestConfig,
   makeTestWorkspaceHarness,
   memoryCredentialsPlugin,
+  serveTestHttpApp,
   typeCheckOutputTypeScript,
 } from "@executor-js/sdk/testing";
 
@@ -273,6 +274,63 @@ const oauthTemplate: AuthenticationInput = {
   scopes: ["read"],
 };
 
+const serveOAuthDiscoverableOpenApiSpec = () =>
+  Effect.gen(function* () {
+    let baseUrl = "";
+    const server = yield* serveTestHttpApp((request) => {
+      if (request.url.includes("/api/schema")) {
+        return Effect.succeed(
+          HttpServerResponse.jsonUnsafe({
+            openapi: "3.0.0",
+            info: { title: "PostHog-like API", version: "1.0.0" },
+            paths: {
+              "/api/projects/": {
+                get: {
+                  operationId: "projects_list",
+                  security: [{ PersonalAPIKeyAuth: ["project:read", "wizard_session:write"] }],
+                  responses: { "200": { description: "OK" } },
+                },
+              },
+            },
+            components: {
+              securitySchemes: {
+                PersonalAPIKeyAuth: { type: "http", scheme: "bearer" },
+              },
+            },
+          }),
+        );
+      }
+      if (request.url.includes("/.well-known/oauth-protected-resource")) {
+        return Effect.succeed(
+          HttpServerResponse.jsonUnsafe({
+            resource: baseUrl,
+            authorization_servers: [baseUrl],
+            scopes_supported: ["project:read"],
+          }),
+        );
+      }
+      if (request.url.includes("/.well-known/oauth-authorization-server")) {
+        return Effect.succeed(
+          HttpServerResponse.jsonUnsafe({
+            issuer: baseUrl,
+            authorization_endpoint: `${baseUrl}/oauth/authorize/`,
+            token_endpoint: `${baseUrl}/oauth/token/`,
+            registration_endpoint: `${baseUrl}/oauth/register/`,
+            client_id_metadata_document_supported: true,
+            response_types_supported: ["code"],
+            grant_types_supported: ["authorization_code"],
+            code_challenge_methods_supported: ["S256"],
+            token_endpoint_auth_methods_supported: ["none"],
+            scopes_supported: ["project:read"],
+          }),
+        );
+      }
+      return Effect.succeed(HttpServerResponse.text("not found", { status: 404 }));
+    });
+    baseUrl = server.baseUrl;
+    return server;
+  });
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -289,6 +347,57 @@ describe("OpenAPI Plugin", () => {
 
         expect(preview.operationCount).toBeGreaterThanOrEqual(2);
         expect(preview.servers).toBeDefined();
+      }),
+    ),
+  );
+
+  it.effect("previewSpec discovers OAuth metadata from a URL-hosted bearer spec", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const server = yield* serveOAuthDiscoverableOpenApiSpec();
+        const executor = yield* createExecutor(
+          makeTestConfig({ plugins: testPlugins(server.httpClientLayer) }),
+        );
+
+        const preview = yield* executor.openapi.previewSpec(server.url("/api/schema/"));
+
+        expect(preview.headerPresets.map((preset) => preset.label)).toContain("Bearer Token");
+        expect(preview.oauth2Presets).toHaveLength(1);
+        const oauth = preview.oauth2Presets[0]!;
+        expect(oauth.securitySchemeName).toBe("DiscoveredOAuth2");
+        expect(oauth.flow).toBe("authorizationCode");
+        expect(oauth.tokenUrl).toBe(`${server.baseUrl}/oauth/token/`);
+        expect(Option.getOrNull(oauth.resource)).toBe(server.baseUrl);
+        expect(oauth.supportsClientIdMetadataDocument).toBe(true);
+        expect(oauth.scopes).toEqual({ "project:read": "" });
+
+        yield* executor.openapi.addSpec({
+          spec: { kind: "url", url: server.url("/api/schema/") },
+          slug: "posthog_like",
+          baseUrl: server.baseUrl,
+        });
+        const config = yield* executor.openapi.getConfig("posthog_like");
+        expect(
+          (config?.authenticationTemplate ?? []).map((template) => ({
+            slug: String(template.slug),
+            kind: template.kind,
+            ...(template.kind === "oauth2"
+              ? {
+                  resource: template.resource ?? null,
+                  supportsClientIdMetadataDocument:
+                    template.supportsClientIdMetadataDocument === true,
+                }
+              : {}),
+          })),
+        ).toEqual([
+          { slug: "apikey-0", kind: "apikey" },
+          {
+            slug: "oauth-DiscoveredOAuth2",
+            kind: "oauth2",
+            resource: server.baseUrl,
+            supportsClientIdMetadataDocument: true,
+          },
+        ]);
       }),
     ),
   );

--- a/packages/plugins/openapi/src/sdk/plugin.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.ts
@@ -24,7 +24,14 @@ import { decodeOpenApiIntegrationConfig, type OpenApiIntegrationConfig } from ".
 import { OpenApiExtractionError, OpenApiOAuthError, OpenApiParseError } from "./errors";
 import { parse, resolveSpecText } from "./parse";
 import { extract } from "./extract";
-import { previewSpecText, type SpecPreview } from "./preview";
+import {
+  OAuth2AuthorizationCodeFlow,
+  OAuth2Flows,
+  OAuth2Preset,
+  SecurityScheme,
+  previewSpecText,
+  type SpecPreview,
+} from "./preview";
 import { deriveAuthenticationTemplateFromPreview, firstBaseUrlForPreview } from "./derive-auth";
 import { openApiPresets } from "./presets";
 import { makeDefaultOpenapiStore, type OpenapiStore } from "./store";
@@ -38,6 +45,7 @@ import {
   resolveOpenApiBackedAnnotations,
   resolveOpenApiBackedTools,
 } from "./backing";
+import { resolveServerUrl } from "./openapi-utils";
 
 // ---------------------------------------------------------------------------
 // Extension input shapes
@@ -197,6 +205,7 @@ const StaticPreviewOAuth2PresetSchema = Schema.Struct({
   flow: Schema.Literals(["authorizationCode", "clientCredentials"]),
   authorizationUrl: Schema.NullOr(Schema.String),
   tokenUrl: Schema.String,
+  resource: Schema.NullOr(Schema.String),
   refreshUrl: Schema.NullOr(Schema.String),
   scopes: Schema.Record(Schema.String, Schema.String),
   identityScopes: Schema.Union([
@@ -204,6 +213,7 @@ const StaticPreviewOAuth2PresetSchema = Schema.Struct({
     Schema.Literal(false),
     Schema.Array(Schema.String),
   ]),
+  supportsClientIdMetadataDocument: Schema.optional(Schema.Boolean),
 });
 const StaticPreviewSpecOutputSchema = Schema.Struct({
   title: Schema.NullOr(Schema.String),
@@ -235,7 +245,9 @@ const AuthenticationSchema = Schema.Union([
     kind: Schema.Literal("oauth2"),
     authorizationUrl: Schema.String,
     tokenUrl: Schema.String,
+    resource: Schema.optional(Schema.NullOr(Schema.String)),
     scopes: Schema.Array(Schema.String),
+    supportsClientIdMetadataDocument: Schema.optional(Schema.Boolean),
   }),
   // Credential methods are authored request-shaped - the ONE apikey input
   // dialect: `{ type: "apiKey", headers: { Authorization: ["Bearer ",
@@ -336,14 +348,169 @@ const staticPreviewOutput = (preview: SpecPreview): StaticPreviewSpecOutput => (
     flow: preset.flow,
     authorizationUrl: Option.getOrNull(preset.authorizationUrl),
     tokenUrl: preset.tokenUrl,
+    resource: Option.getOrNull(preset.resource),
     refreshUrl: Option.getOrNull(preset.refreshUrl),
     scopes: preset.scopes,
     identityScopes: preset.identityScopes,
+    supportsClientIdMetadataDocument: preset.supportsClientIdMetadataDocument,
   })),
 });
 
 const specInputToSourceUrl = (spec: OpenApiSpecInput): string | undefined =>
   spec.kind === "url" ? spec.url : undefined;
+
+const OAUTH_DISCOVERED_SCHEME_NAME = "DiscoveredOAuth2";
+const OPENAPI_HTTP_METHODS = new Set([
+  "get",
+  "put",
+  "post",
+  "delete",
+  "patch",
+  "head",
+  "options",
+  "trace",
+]);
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const maybeUrl = (value: string): URL | null => {
+  // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: URL parsing accepts user-pasted spec/base URLs
+  try {
+    return new URL(value);
+  } catch {
+    return null;
+  }
+};
+
+const addProbeCandidate = (candidates: string[], value: string | undefined): void => {
+  const trimmed = value?.trim();
+  if (!trimmed) return;
+  const parsed = maybeUrl(trimmed);
+  if (!parsed || (parsed.protocol !== "https:" && parsed.protocol !== "http:")) return;
+  const normalized = parsed.toString();
+  const origin = parsed.origin;
+  if (!candidates.includes(normalized)) candidates.push(normalized);
+  if (!candidates.includes(origin)) candidates.push(origin);
+};
+
+const oauthProbeCandidates = (
+  preview: SpecPreview,
+  sourceUrl: string | undefined,
+  baseUrl: string | undefined,
+): readonly string[] => {
+  const candidates: string[] = [];
+  addProbeCandidate(candidates, baseUrl);
+  for (const server of preview.servers) {
+    addProbeCandidate(
+      candidates,
+      resolveServerUrl(server.url, Option.getOrUndefined(server.variables), {}),
+    );
+  }
+  addProbeCandidate(candidates, sourceUrl);
+  return candidates;
+};
+
+const securityRequirementScopes = (
+  security: unknown,
+  targetSchemes: ReadonlySet<string>,
+): readonly string[] => {
+  if (!Array.isArray(security)) return [];
+  const scopes = new Set<string>();
+  for (const requirement of security) {
+    if (!isRecord(requirement)) continue;
+    for (const [scheme, rawScopes] of Object.entries(requirement)) {
+      if (targetSchemes.size > 0 && !targetSchemes.has(scheme)) continue;
+      if (!Array.isArray(rawScopes)) continue;
+      for (const scope of rawScopes) {
+        if (typeof scope === "string" && scope.trim().length > 0) scopes.add(scope.trim());
+      }
+    }
+  }
+  return [...scopes];
+};
+
+const collectDeclaredSecurityScopes = (doc: unknown, targetSchemes: ReadonlySet<string>) => {
+  const scopes = new Set<string>();
+  if (!isRecord(doc)) return [] as readonly string[];
+
+  for (const scope of securityRequirementScopes(doc.security, targetSchemes)) scopes.add(scope);
+
+  const paths = doc.paths;
+  if (!isRecord(paths)) return [...scopes].sort();
+  for (const pathItem of Object.values(paths)) {
+    if (!isRecord(pathItem)) continue;
+    for (const [method, operation] of Object.entries(pathItem)) {
+      if (!OPENAPI_HTTP_METHODS.has(method.toLowerCase()) || !isRecord(operation)) continue;
+      for (const scope of securityRequirementScopes(operation.security, targetSchemes)) {
+        scopes.add(scope);
+      }
+    }
+  }
+  return [...scopes].sort();
+};
+
+const nonOAuthSecuritySchemeNames = (preview: SpecPreview): ReadonlySet<string> =>
+  new Set(
+    preview.securitySchemes
+      .filter((scheme) => scheme.type === "http" || scheme.type === "apiKey")
+      .map((scheme) => scheme.name),
+  );
+
+const discoveredOAuthPreview = (input: {
+  readonly preview: SpecPreview;
+  readonly authorizationUrl: string;
+  readonly tokenUrl: string;
+  readonly resource?: string | null;
+  readonly scopes: readonly string[];
+  readonly supportsClientIdMetadataDocument?: boolean;
+}): SpecPreview => {
+  const scopes = Object.fromEntries(input.scopes.map((scope) => [scope, ""]));
+  const flow = OAuth2AuthorizationCodeFlow.make({
+    authorizationUrl: input.authorizationUrl,
+    tokenUrl: input.tokenUrl,
+    refreshUrl: Option.none(),
+    scopes,
+  });
+  const flows = OAuth2Flows.make({
+    authorizationCode: Option.some(flow),
+    clientCredentials: Option.none(),
+  });
+  return {
+    ...input.preview,
+    securitySchemes: [
+      ...input.preview.securitySchemes,
+      SecurityScheme.make({
+        name: OAUTH_DISCOVERED_SCHEME_NAME,
+        type: "oauth2",
+        scheme: Option.none(),
+        bearerFormat: Option.none(),
+        in: Option.none(),
+        headerName: Option.none(),
+        description: Option.some("Discovered from OAuth authorization-server metadata"),
+        flows: Option.some(flows),
+        openIdConnectUrl: Option.none(),
+      }),
+    ],
+    oauth2Presets: [
+      ...input.preview.oauth2Presets,
+      OAuth2Preset.make({
+        label: `OAuth2 Authorization Code · ${OAUTH_DISCOVERED_SCHEME_NAME}`,
+        securitySchemeName: OAUTH_DISCOVERED_SCHEME_NAME,
+        flow: "authorizationCode",
+        authorizationUrl: Option.some(input.authorizationUrl),
+        tokenUrl: input.tokenUrl,
+        resource: input.resource ? Option.some(input.resource) : Option.none(),
+        refreshUrl: Option.none(),
+        scopes,
+        identityScopes: "auto",
+        ...(input.supportsClientIdMetadataDocument === true
+          ? { supportsClientIdMetadataDocument: true }
+          : {}),
+      }),
+    ],
+  };
+};
 
 // ---------------------------------------------------------------------------
 // Declared auth methods - project the stored `authenticationTemplate` into the
@@ -369,7 +536,9 @@ export const describeOpenApiAuthMethods = (
           oauth: {
             authorizationUrl: template.authorizationUrl,
             tokenUrl: template.tokenUrl,
+            resource: template.resource ?? null,
             scopes: template.scopes,
+            supportsClientIdMetadataDocument: template.supportsClientIdMetadataDocument,
           },
         };
       }
@@ -427,6 +596,51 @@ export const openApiPlugin = definePlugin((options?: OpenApiPluginOptions) => {
     extension: (ctx: PluginCtx<OpenapiStore>) => {
       const httpClientLayer = options?.httpClientLayer ?? ctx.httpClientLayer;
 
+      const enrichPreviewWithDiscoveredOAuth = (input: {
+        readonly specText: string;
+        readonly preview: SpecPreview;
+        readonly sourceUrl?: string;
+        readonly baseUrl?: string;
+      }): Effect.Effect<SpecPreview, OpenApiParseError | OpenApiExtractionError> =>
+        Effect.gen(function* () {
+          if (input.preview.oauth2Presets.length > 0) return input.preview;
+
+          const candidates = oauthProbeCandidates(input.preview, input.sourceUrl, input.baseUrl);
+          if (candidates.length === 0) return input.preview;
+
+          for (const candidate of candidates) {
+            const oauth = yield* ctx.oauth.probe({ url: candidate }).pipe(
+              Effect.map((result) => ({ ok: true as const, result })),
+              Effect.catch(() => Effect.succeed({ ok: false as const, result: null })),
+            );
+            if (!oauth.ok) continue;
+
+            const doc = yield* parse(input.specText);
+            const declaredScopes = collectDeclaredSecurityScopes(
+              doc,
+              nonOAuthSecuritySchemeNames(input.preview),
+            );
+            const supportedScopes =
+              oauth.result.scopesSupported && oauth.result.scopesSupported.length > 0
+                ? new Set(oauth.result.scopesSupported)
+                : null;
+            const scopes = supportedScopes
+              ? declaredScopes.filter((scope) => supportedScopes.has(scope))
+              : declaredScopes;
+            return discoveredOAuthPreview({
+              preview: input.preview,
+              authorizationUrl: oauth.result.authorizationUrl,
+              tokenUrl: oauth.result.tokenUrl,
+              resource: oauth.result.resource ?? null,
+              scopes,
+              supportsClientIdMetadataDocument:
+                oauth.result.clientIdMetadataDocumentSupported === true,
+            });
+          }
+
+          return input.preview;
+        });
+
       const addSpec = (config: OpenApiSpecConfig) =>
         Effect.gen(function* () {
           // Resolve URL → text and parse BEFORE opening a transaction. Holding
@@ -451,7 +665,16 @@ export const openApiPlugin = definePlugin((options?: OpenApiPluginOptions) => {
           const needsDerivedAuth = config.authenticationTemplate == null;
           const preview =
             needsDerivedBaseUrl || needsDerivedAuth
-              ? yield* previewSpecText(resolved.specText)
+              ? yield* previewSpecText(resolved.specText).pipe(
+                  Effect.flatMap((rawPreview) =>
+                    enrichPreviewWithDiscoveredOAuth({
+                      specText: resolved.specText,
+                      preview: rawPreview,
+                      sourceUrl: specInputToSourceUrl(config.spec),
+                      baseUrl: config.baseUrl,
+                    }),
+                  ),
+                )
               : undefined;
           const derivedBaseUrl =
             needsDerivedBaseUrl && preview ? firstBaseUrlForPreview(preview) : undefined;
@@ -632,7 +855,12 @@ export const openApiPlugin = definePlugin((options?: OpenApiPluginOptions) => {
             const specText = yield* resolveSpecText(previewInput.spec).pipe(
               Effect.provide(httpClientLayer),
             );
-            return yield* previewSpecText(specText);
+            const preview = yield* previewSpecText(specText);
+            return yield* enrichPreviewWithDiscoveredOAuth({
+              specText,
+              preview,
+              sourceUrl: maybeUrl(previewInput.spec.trim()) ? previewInput.spec.trim() : undefined,
+            });
           }),
 
         addSpec,

--- a/packages/plugins/openapi/src/sdk/preview.ts
+++ b/packages/plugins/openapi/src/sdk/preview.ts
@@ -102,6 +102,8 @@ export const OAuth2Preset = Schema.Struct({
   authorizationUrl: Schema.OptionFromOptional(Schema.String),
   /** Token endpoint to exchange the code / refresh. */
   tokenUrl: Schema.String,
+  /** RFC 8707 resource indicator discovered from protected-resource metadata. */
+  resource: Schema.OptionFromOptional(Schema.String),
   /** Optional refresh endpoint if the spec declares one separately. */
   refreshUrl: Schema.OptionFromOptional(Schema.String),
   /** Declared scopes for this flow: `{ scope: description }`. */
@@ -112,6 +114,8 @@ export const OAuth2Preset = Schema.Struct({
     Schema.Literal(false),
     Schema.Array(Schema.String),
   ]),
+  /** Provider metadata advertised Client ID Metadata Document support. */
+  supportsClientIdMetadataDocument: Schema.optional(Schema.Boolean),
 });
 export type OAuth2Preset = typeof OAuth2Preset.Type;
 
@@ -365,6 +369,7 @@ const buildOAuth2Presets = (schemes: readonly SecurityScheme[]): OAuth2Preset[] 
           flow: "authorizationCode",
           authorizationUrl: Option.some(flow.authorizationUrl),
           tokenUrl: flow.tokenUrl,
+          resource: Option.none(),
           refreshUrl: flow.refreshUrl,
           scopes: flow.scopes,
           identityScopes: "auto",
@@ -381,6 +386,7 @@ const buildOAuth2Presets = (schemes: readonly SecurityScheme[]): OAuth2Preset[] 
           flow: "clientCredentials",
           authorizationUrl: Option.none(),
           tokenUrl: flow.tokenUrl,
+          resource: Option.none(),
           refreshUrl: flow.refreshUrl,
           scopes: flow.scopes,
           identityScopes: false,

--- a/packages/react/src/api/analytics.tsx
+++ b/packages/react/src/api/analytics.tsx
@@ -67,7 +67,7 @@ export interface AnalyticsEvents {
   connection_oauth_started: {
     integration_slug: string;
     owner: Owner;
-    flow: "byo" | "dcr";
+    flow: "byo" | "dcr" | "cimd";
     success: boolean;
     dcr_fallback?: boolean;
   };

--- a/packages/react/src/components/accounts-section.tsx
+++ b/packages/react/src/components/accounts-section.tsx
@@ -2,7 +2,11 @@ import { useEffect, useMemo, useState } from "react";
 import { useAtomValue, useAtomSet } from "@effect/atom-react";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 import * as Exit from "effect/Exit";
-import { IntegrationSlug, type Connection, type Owner } from "@executor-js/sdk/shared";
+import {
+  IntegrationSlug,
+  type Connection,
+  type Owner,
+} from "@executor-js/sdk/shared";
 import type { IntegrationAccountHandoff } from "@executor-js/sdk/client";
 import { toast } from "sonner";
 
@@ -22,6 +26,7 @@ import {
   connectionNeedsReconsent,
   oauthReconnectPayload,
   reconnectMode,
+  reconsentRequiredScopes,
 } from "../plugins/oauth-reconnect";
 import { useOAuthPopupFlow } from "../plugins/oauth-sign-in";
 import { AddAccountModal } from "./add-account-modal";
@@ -79,7 +84,10 @@ function AccountRow(props: {
         <CardStackEntryTitle className="flex min-w-0 items-center gap-2">
           <span className="truncate">{displayLabel}</span>
           {needsReconsent ? (
-            <Badge variant="outline" className="shrink-0 border-border text-muted-foreground">
+            <Badge
+              variant="outline"
+              className="shrink-0 border-border text-muted-foreground"
+            >
               Reconnect to grant access
             </Badge>
           ) : null}
@@ -91,7 +99,8 @@ function AccountRow(props: {
         ) : null}
         {needsReconsent ? (
           <CardStackEntryDescription className="mt-1 text-xs text-muted-foreground">
-            This integration now needs access this connection wasn't granted.
+            This connection wasn't granted all the access this integration now
+            needs.
           </CardStackEntryDescription>
         ) : null}
       </CardStackEntryContent>
@@ -120,7 +129,11 @@ function AccountRow(props: {
             <DropdownMenuItem className="text-sm" onClick={props.onReconnect}>
               Reconnect
             </DropdownMenuItem>
-            <DropdownMenuItem variant="destructive" className="text-sm" onClick={props.onRemove}>
+            <DropdownMenuItem
+              variant="destructive"
+              className="text-sm"
+              onClick={props.onRemove}
+            >
               Remove
             </DropdownMenuItem>
           </DropdownMenuContent>
@@ -142,7 +155,9 @@ function OwnerAccounts(props: {
   readonly declaredScopes: readonly string[] | undefined;
 }) {
   const { integration, owner } = props;
-  const connections = useAtomValue(connectionsForIntegrationAtom({ integration, owner }));
+  const connections = useAtomValue(
+    connectionsForIntegrationAtom({ integration, owner }),
+  );
   const doRemove = useAtomSet(removeConnectionOptimistic(owner), {
     mode: "promiseExit",
   });
@@ -159,7 +174,9 @@ function OwnerAccounts(props: {
     startErrorMessage: "Failed to reconnect",
   });
 
-  const rows: readonly Connection[] = AsyncResult.isSuccess(connections) ? connections.value : [];
+  const rows: readonly Connection[] = AsyncResult.isSuccess(connections)
+    ? connections.value
+    : [];
   if (rows.length === 0) return null;
 
   const handleReconnect = async (connection: Connection) => {
@@ -168,7 +185,8 @@ function OwnerAccounts(props: {
     if (reconnectMode(connection) === "oauth") {
       const method = props.methods.find(
         (candidate: AuthMethod) =>
-          candidate.kind === "oauth" && String(candidate.template) === String(connection.template),
+          candidate.kind === "oauth" &&
+          String(candidate.template) === String(connection.template),
       );
       if (
         method?.oauth?.supportsDynamicRegistration === true ||
@@ -275,13 +293,18 @@ function OwnerAccounts(props: {
 
   return (
     <CardStack>
-      {props.showOwnerLabels ? <CardStackHeader>{ownerLabel(owner)}</CardStackHeader> : null}
+      {props.showOwnerLabels ? (
+        <CardStackHeader>{ownerLabel(owner)}</CardStackHeader>
+      ) : null}
       <CardStackContent>
         {rows.map((connection: Connection) => (
           <AccountRow
             key={`${connection.owner}:${connection.integration}:${connection.name}`}
             connection={connection}
-            needsReconsent={connectionNeedsReconsent(connection, props.declaredScopes)}
+            needsReconsent={connectionNeedsReconsent(
+              connection,
+              props.declaredScopes,
+            )}
             showOwnerLabel={props.showOwnerLabels}
             onEdit={() => props.onEdit(connection)}
             onReconnect={() => void handleReconnect(connection)}
@@ -312,10 +335,14 @@ export function AccountsSection(props: {
     removeCustomMethod,
   } = props;
   const [adding, setAdding] = useState(false);
-  const [editingConnection, setEditingConnection] = useState<Connection | null>(null);
-  const [reconnectHandoff, setReconnectHandoff] = useState<IntegrationAccountHandoff | null>(null);
+  const [editingConnection, setEditingConnection] = useState<Connection | null>(
+    null,
+  );
+  const [reconnectHandoff, setReconnectHandoff] =
+    useState<IntegrationAccountHandoff | null>(null);
   const ownerDisplay = useOwnerDisplay();
-  const canAddConnection = methods.length > 0 || createCustomMethod !== undefined;
+  const canAddConnection =
+    methods.length > 0 || createCustomMethod !== undefined;
 
   useEffect(() => {
     if (accountHandoff) {
@@ -326,11 +353,20 @@ export function AccountsSection(props: {
   // The integration's declared oauth scopes — what connections need granted. A
   // connection granted fewer is flagged to reconnect (e.g. after a service was
   // added widened the consent).
-  const declaredScopes = methods.find((m: AuthMethod) => m.kind === "oauth")?.oauth?.scopes;
+  //
+  // Spec-derived oauth scopes are the full per-operation catalog union (e.g. an
+  // OpenAPI source like PostHog declares hundreds of scopes). Those are requested
+  // broadly but not individually required: a provider that narrows the grant to
+  // the user's actual access is healthy, not in need of reconnect. So only treat
+  // CUSTOM (user-configured) scopes as required here; never the spec catalog.
+  const oauthMethod = methods.find((m: AuthMethod) => m.kind === "oauth");
+  const declaredScopes = reconsentRequiredScopes(oauthMethod);
 
   // Read both owners to decide between the grouped view and the empty CTA. The
   // grouped sub-components re-read these (effect-atom dedupes) and self-hide.
-  const orgConnections = useAtomValue(connectionsForIntegrationAtom({ integration, owner: "org" }));
+  const orgConnections = useAtomValue(
+    connectionsForIntegrationAtom({ integration, owner: "org" }),
+  );
   const userConnections = useAtomValue(
     connectionsForIntegrationAtom({ integration, owner: "user" }),
   );
@@ -341,12 +377,18 @@ export function AccountsSection(props: {
   useAtomSet(addConnectionOptimistic("user"));
 
   const totalCount = useMemo(() => {
-    const orgRows = AsyncResult.isSuccess(orgConnections) ? orgConnections.value.length : 0;
-    const userRows = AsyncResult.isSuccess(userConnections) ? userConnections.value.length : 0;
+    const orgRows = AsyncResult.isSuccess(orgConnections)
+      ? orgConnections.value.length
+      : 0;
+    const userRows = AsyncResult.isSuccess(userConnections)
+      ? userConnections.value.length
+      : 0;
     return orgRows + userRows;
   }, [orgConnections, userConnections]);
 
-  const loading = !AsyncResult.isSuccess(orgConnections) && !AsyncResult.isSuccess(userConnections);
+  const loading =
+    !AsyncResult.isSuccess(orgConnections) &&
+    !AsyncResult.isSuccess(userConnections);
 
   const modalState = reconnectHandoff ?? accountHandoff;
   const modal = (
@@ -378,7 +420,9 @@ export function AccountsSection(props: {
           onClick={() => {
             trackEvent("connection_add_opened", {
               integration_slug: String(integration),
-              has_oauth_method: methods.some((m: AuthMethod) => m.kind === "oauth"),
+              has_oauth_method: methods.some(
+                (m: AuthMethod) => m.kind === "oauth",
+              ),
               has_api_key_method: methods.some(
                 (m: AuthMethod) => m.kind !== "oauth" && m.kind !== "none",
               ),
@@ -398,7 +442,9 @@ export function AccountsSection(props: {
         </div>
       ) : totalCount === 0 ? (
         <div className="rounded-lg border border-dashed border-border/60 px-6 py-8 text-center">
-          <p className="text-sm font-medium text-foreground">No connections yet</p>
+          <p className="text-sm font-medium text-foreground">
+            No connections yet
+          </p>
           <p className="mt-1 text-sm text-muted-foreground">
             Add a connection to make this integration's tools available.
           </p>
@@ -409,7 +455,9 @@ export function AccountsSection(props: {
             onClick={() => {
               trackEvent("connection_add_opened", {
                 integration_slug: String(integration),
-                has_oauth_method: methods.some((m: AuthMethod) => m.kind === "oauth"),
+                has_oauth_method: methods.some(
+                  (m: AuthMethod) => m.kind === "oauth",
+                ),
                 has_api_key_method: methods.some(
                   (m: AuthMethod) => m.kind !== "oauth" && m.kind !== "none",
                 ),

--- a/packages/react/src/components/add-account-modal.test.ts
+++ b/packages/react/src/components/add-account-modal.test.ts
@@ -17,6 +17,7 @@ import {
   dcrClientNameForIntegration,
   DEFAULT_CONNECTION_OWNER,
   mergeCustomMethods,
+  runCimdConnect,
   runDcrConnect,
 } from "./add-account-modal";
 
@@ -53,6 +54,19 @@ type RegisterArgs = {
 };
 
 type StartArgs = { readonly client: OAuthClientSlug; readonly owner: Owner };
+
+type CimdCreateArgs = {
+  readonly owner: Owner;
+  readonly slug: OAuthClientSlug;
+  readonly authorizationUrl: string;
+  readonly tokenUrl: string;
+  readonly resource?: string | null;
+  readonly grant: "authorization_code";
+  readonly clientId: string;
+  readonly clientSecret: "";
+};
+
+type CimdStartArgs = { readonly client: OAuthClientSlug; readonly owner: Owner };
 
 const TEST_INTEGRATION = IntegrationSlug.make("linear_mcp");
 
@@ -191,6 +205,90 @@ describe("createCredentialPayloadOrigin", () => {
         singleInput: false,
       }),
     ).toBeNull();
+  });
+});
+
+describe("runCimdConnect", () => {
+  it("creates a public metadata-document OAuth client and starts OAuth", async () => {
+    let createArgs: CimdCreateArgs | null = null;
+    let startArgs: CimdStartArgs | null = null;
+
+    const outcome = await runCimdConnect(
+      {
+        createClient: (args: CimdCreateArgs): Promise<OAuthClientSlug | null> => {
+          createArgs = args;
+          return Promise.resolve(args.slug);
+        },
+        start: (args: CimdStartArgs): void => {
+          startArgs = args;
+        },
+      },
+      {
+        owner: "user",
+        integrationName: "PostHog API",
+        authorizationUrl: "https://us.posthog.com/oauth/authorize/",
+        tokenUrl: "https://us.posthog.com/oauth/token/",
+        resource: "https://us.posthog.com",
+        clientIdMetadataDocumentUrl:
+          "https://executor.example/api/oauth/client-id-metadata/acme.json",
+        existingClients: [],
+      },
+    );
+
+    expect(outcome.kind).toBe("started");
+    expect(createArgs).toMatchObject({
+      owner: "user",
+      authorizationUrl: "https://us.posthog.com/oauth/authorize/",
+      tokenUrl: "https://us.posthog.com/oauth/token/",
+      resource: "https://us.posthog.com",
+      grant: "authorization_code",
+      clientId: "https://executor.example/api/oauth/client-id-metadata/acme.json",
+      clientSecret: "",
+    });
+    expect(String(createArgs!.slug)).toBe("posthog-api-cimd");
+    expect(String(startArgs!.client)).toBe("posthog-api-cimd");
+    expect(startArgs!.owner).toBe("user");
+  });
+
+  it("reuses an existing matching metadata-document client", async () => {
+    const existingSlug = OAuthClientSlug.make("posthog-api-cimd");
+    let created = false;
+    let startArgs: CimdStartArgs | null = null;
+
+    const outcome = await runCimdConnect(
+      {
+        createClient: (): Promise<OAuthClientSlug | null> => {
+          created = true;
+          return Promise.resolve(OAuthClientSlug.make("new-client"));
+        },
+        start: (args: CimdStartArgs): void => {
+          startArgs = args;
+        },
+      },
+      {
+        owner: "user",
+        integrationName: "PostHog API",
+        authorizationUrl: "https://us.posthog.com/oauth/authorize/",
+        tokenUrl: "https://us.posthog.com/oauth/token/",
+        resource: "https://us.posthog.com",
+        clientIdMetadataDocumentUrl: "https://executor.example/api/oauth/client-id-metadata.json",
+        existingClients: [
+          {
+            owner: "user",
+            slug: existingSlug,
+            grant: "authorization_code",
+            authorizationUrl: "https://us.posthog.com/oauth/authorize/",
+            tokenUrl: "https://us.posthog.com/oauth/token/",
+            resource: "https://us.posthog.com",
+            clientId: "https://executor.example/api/oauth/client-id-metadata.json",
+          },
+        ],
+      },
+    );
+
+    expect(outcome).toEqual({ kind: "started", client: existingSlug, reused: true });
+    expect(created).toBe(false);
+    expect(startArgs).toEqual({ client: existingSlug, owner: "user" });
   });
 });
 

--- a/packages/react/src/components/add-account-modal.tsx
+++ b/packages/react/src/components/add-account-modal.tsx
@@ -17,6 +17,7 @@ import { toast } from "sonner";
 import {
   addConnectionOptimistic,
   connectionsAllAtom,
+  createOAuthClientOptimistic,
   oauthClientsOptimisticAtom,
   probeOAuth,
   providerItemsAtom,
@@ -38,7 +39,11 @@ import {
   resolveOAuthConnectionOwnerForHost,
   type ConnectionOwnerOption,
 } from "../plugins/connection-owner";
-import { oauthCallbackUrl, useOAuthPopupFlow } from "../plugins/oauth-sign-in";
+import {
+  oauthCallbackUrl,
+  oauthClientIdMetadataDocumentUrl,
+  useOAuthPopupFlow,
+} from "../plugins/oauth-sign-in";
 import {
   clientDisplayName,
   clientHost,
@@ -459,6 +464,94 @@ export const connectionNameFrom = (
   connectionIdentifier(connectionLabelForHost(label, owner, integrationName, organizationId));
 
 // ---------------------------------------------------------------------------
+// Transparent CIMD connect orchestration.
+//
+// Client ID Metadata Document support is not Dynamic Client Registration:
+// there is no POST to a registration endpoint and no provider-side app to pick.
+// The OAuth client identity is this host's public metadata-document URL, stored
+// locally as a public PKCE client (`clientSecret: ""`) so the existing
+// `oauth.start` flow can run unchanged.
+// ---------------------------------------------------------------------------
+
+type CimdExistingClient = Pick<
+  OAuthClientSummary,
+  "owner" | "slug" | "grant" | "authorizationUrl" | "tokenUrl" | "resource" | "clientId"
+>;
+
+type CimdCreateClientArgs = {
+  readonly owner: Owner;
+  readonly slug: OAuthClientSlug;
+  readonly authorizationUrl: string;
+  readonly tokenUrl: string;
+  readonly resource?: string | null;
+  readonly grant: "authorization_code";
+  readonly clientId: string;
+  readonly clientSecret: "";
+};
+
+type RunCimdConnectDeps = {
+  readonly createClient: (args: CimdCreateClientArgs) => Promise<OAuthClientSlug | null>;
+  readonly start: (args: { readonly client: OAuthClientSlug; readonly owner: Owner }) => void;
+};
+
+type RunCimdConnectInput = {
+  readonly owner: Owner;
+  readonly integrationName: string;
+  readonly authorizationUrl: string;
+  readonly tokenUrl: string;
+  readonly resource?: string | null;
+  readonly clientIdMetadataDocumentUrl: string;
+  readonly existingClients: readonly CimdExistingClient[];
+};
+
+type CimdOutcome =
+  | { readonly kind: "started"; readonly client: OAuthClientSlug; readonly reused: boolean }
+  | { readonly kind: "failed"; readonly reason: "missing-endpoints" | "create-failed" };
+
+export async function runCimdConnect(
+  deps: RunCimdConnectDeps,
+  input: RunCimdConnectInput,
+): Promise<CimdOutcome> {
+  if (input.authorizationUrl.trim().length === 0 || input.tokenUrl.trim().length === 0) {
+    return { kind: "failed", reason: "missing-endpoints" };
+  }
+
+  const resource = input.resource ?? null;
+  const existing = input.existingClients.find(
+    (client) =>
+      client.owner === input.owner &&
+      client.grant === "authorization_code" &&
+      client.authorizationUrl === input.authorizationUrl &&
+      client.tokenUrl === input.tokenUrl &&
+      (client.resource ?? null) === resource &&
+      client.clientId === input.clientIdMetadataDocumentUrl,
+  );
+
+  if (existing) {
+    deps.start({ client: existing.slug, owner: input.owner });
+    return { kind: "started", client: existing.slug, reused: true };
+  }
+
+  const slug = uniqueClientSlug(
+    `${input.integrationName} CIMD`,
+    input.existingClients.map((client) => String(client.slug)),
+  );
+  const created = await deps.createClient({
+    owner: input.owner,
+    slug,
+    authorizationUrl: input.authorizationUrl,
+    tokenUrl: input.tokenUrl,
+    resource,
+    grant: "authorization_code",
+    clientId: input.clientIdMetadataDocumentUrl,
+    clientSecret: "",
+  });
+  if (created === null) return { kind: "failed", reason: "create-failed" };
+  deps.start({ client: created, owner: input.owner });
+  return { kind: "started", client: created, reused: false };
+}
+
+// ---------------------------------------------------------------------------
 // Transparent DCR (RFC 7591) connect orchestration.
 //
 // For DCR-capable methods (MCP OAuth) the user clicks one "Connect" button and
@@ -746,6 +839,7 @@ function AddAccountModalView(props: AddAccountModalProps) {
   const [pickedApp, setPickedApp] = useState<string | null>(null);
   const [registeringOAuthClient, setRegisteringOAuthClient] = useState(false);
   const [ccBusy, setCcBusy] = useState(false);
+  const [cimdBusy, setCimdBusy] = useState(false);
   // Transparent DCR: busy while probing/registering/starting; `dcrFailed` flips
   // the modal to the bring-your-own-app picker if auto setup is unavailable.
   const [dcrBusy, setDcrBusy] = useState(false);
@@ -765,6 +859,7 @@ function AddAccountModalView(props: AddAccountModalProps) {
     mode: "promiseExit",
   });
   const doStartOAuth = useAtomSet(startOAuth, { mode: "promiseExit" });
+  const doCreateOAuthClient = useAtomSet(createOAuthClientOptimistic, { mode: "promiseExit" });
   const doProbe = useAtomSet(probeOAuth, { mode: "promiseExit" });
   const doRegisterDynamic = useAtomSet(registerDynamicOAuthClient, {
     mode: "promiseExit",
@@ -897,13 +992,20 @@ function AddAccountModalView(props: AddAccountModalProps) {
     method != null &&
     method.placements.length > 0 &&
     method.placements.every((p) => p.carrier === "env");
+  // CIMD-capable: the provider accepts a client_id that is a metadata-document
+  // URL, so we can create a public local client and skip provider app
+  // registration entirely.
+  const isCimd = isOAuth && method?.oauth?.supportsClientIdMetadataDocument === true;
+  const cimdActive = isCimd;
   // DCR-capable: the integration advertises dynamic registration (MCP oauth2),
   // OR carries a discovery URL we can probe at connect time. When DCR-capable
   // and not yet fallen back, we skip the app picker entirely (Option A).
   const isDcr =
+    !cimdActive &&
     isOAuth &&
     (method?.oauth?.supportsDynamicRegistration === true || method?.oauth?.discoveryUrl != null);
   const dcrActive = isDcr && !dcrFailed;
+  const automaticOAuthActive = cimdActive || dcrActive;
 
   // OAuth apps usable for this integration (user-owned first). Hooks run
   // unconditionally; in DCR mode the result is ignored until/unless we fall back.
@@ -942,7 +1044,9 @@ function AddAccountModalView(props: AddAccountModalProps) {
   const chosenClient: OAuthClientOption | null =
     oauthApps.find((c: OAuthClientOption) => String(c.slug) === selectedApp) ?? null;
   const oauthBusy = ccBusy || oauthPopup.busy;
+  const cimdConnecting = cimdBusy || oauthPopup.busy;
   const dcrConnecting = dcrBusy || oauthPopup.busy;
+  const automaticOAuthConnecting = cimdConnecting || dcrConnecting;
 
   // "Connection saved to" for a PICKED BYO OAuth app. Cloud: a Workspace (`org`)
   // app can mint Personal or Workspace connections; a Personal (`user`) app can
@@ -960,10 +1064,11 @@ function AddAccountModalView(props: AddAccountModalProps) {
     requestedOwner: owner,
     clientOwner: chosenClient?.owner ?? "user",
   });
-  const savedToOptions = isOAuth && !dcrActive ? oauthConnectionOptions : ownerOptions;
-  const savedToOwner = isOAuth && !dcrActive ? oauthConnectionOwner : owner;
+  const savedToOptions = isOAuth && !automaticOAuthActive ? oauthConnectionOptions : ownerOptions;
+  const savedToOwner = isOAuth && !automaticOAuthActive ? oauthConnectionOwner : owner;
   const showSavedToPicker = !oauthRegistering && savedToOptions.length > 1;
   const callableName = connectionNameFrom(label, savedToOwner, integrationName, organizationId);
+  const authStepLabel = isOAuth ? (cimdActive ? "OAuth setup" : "OAuth app") : "Credential";
 
   // Build the picker row's Edit/Remove menu for an app, but only once its full
   // summary has loaded (the picker option lacks endpoints/resource). Until then
@@ -1173,6 +1278,78 @@ function AddAccountModalView(props: AddAccountModalProps) {
     });
   };
 
+  const handleCimdConnect = async () => {
+    const authorizationUrl = method?.oauth?.authorizationUrl;
+    const tokenUrl = method?.oauth?.tokenUrl;
+    if (!method || !authorizationUrl || !tokenUrl) {
+      toast.error("OAuth metadata is missing endpoints");
+      return;
+    }
+    const cimdOwner = owner;
+    const connectionName = connectionNameFrom(label, cimdOwner, integrationName, organizationId);
+    const identityLabel = connectionLabelForHost(label, cimdOwner, integrationName, organizationId);
+    setCimdBusy(true);
+    const outcome = await runCimdConnect(
+      {
+        createClient: async (args: CimdCreateClientArgs): Promise<OAuthClientSlug | null> => {
+          const exit = await doCreateOAuthClient({
+            payload: {
+              owner: args.owner,
+              slug: args.slug,
+              authorizationUrl: args.authorizationUrl,
+              tokenUrl: args.tokenUrl,
+              resource: args.resource ?? null,
+              grant: args.grant,
+              clientId: args.clientId,
+              clientSecret: args.clientSecret,
+            },
+            reactivityKeys: oauthClientWriteKeys,
+          });
+          if (Exit.isFailure(exit)) return null;
+          return exit.value.client;
+        },
+        start: (args: { readonly client: OAuthClientSlug; readonly owner: Owner }): void => {
+          void oauthPopup.start({
+            payload: {
+              client: args.client,
+              // CIMD creates the public client under the connection owner, so
+              // the app and connection share one owner.
+              clientOwner: args.owner,
+              owner: args.owner,
+              name: connectionName,
+              integration,
+              template: method.template,
+              identityLabel,
+            },
+            onSuccess: () => {
+              toast.success("Connection added");
+              close();
+            },
+          });
+        },
+      },
+      {
+        owner: cimdOwner,
+        integrationName,
+        authorizationUrl,
+        tokenUrl,
+        resource: method.oauth?.resource ?? null,
+        clientIdMetadataDocumentUrl: oauthClientIdMetadataDocumentUrl(),
+        existingClients: clientSummaries,
+      },
+    );
+    setCimdBusy(false);
+    trackEvent("connection_oauth_started", {
+      integration_slug: String(integration),
+      owner: cimdOwner,
+      flow: "cimd",
+      success: outcome.kind === "started",
+    });
+    if (outcome.kind === "failed") {
+      toast.error("Client metadata setup failed");
+    }
+  };
+
   // Transparent DCR connect: probe → register → start, no app picker. On any
   // failure (probe error, no registration endpoint, or registration failure) we
   // flip `dcrFailed` so the bring-your-own-app picker renders as the recovery
@@ -1368,6 +1545,11 @@ function AddAccountModalView(props: AddAccountModalProps) {
                   ...(oauthHandoffPrefill?.clientId
                     ? { clientId: oauthHandoffPrefill.clientId }
                     : {}),
+                  ...(oauthHandoffPrefill?.resource != null
+                    ? { resource: oauthHandoffPrefill.resource }
+                    : method.oauth?.resource != null
+                      ? { resource: method.oauth.resource }
+                      : {}),
                 }}
                 fixedSlug={
                   oauthClientHandoff?.slug != null && oauthClientHandoff.slug.length > 0
@@ -1493,10 +1675,19 @@ function AddAccountModalView(props: AddAccountModalProps) {
 
                       {!isNoAuth && (
                         <div className="space-y-2">
-                          <StepHeader index={2} label={isOAuth ? "OAuth app" : "Credential"} />
+                          <StepHeader index={2} label={authStepLabel} />
 
                           {isOAuth && method ? (
-                            dcrActive ? (
+                            cimdActive ? (
+                              <div className="space-y-2 rounded-lg border border-ring/40 bg-accent/30 px-3 py-3">
+                                <p className="text-sm font-medium">No app registration</p>
+                                <p className="text-xs text-muted-foreground">
+                                  {cimdConnecting
+                                    ? `Connecting to ${integrationName}…`
+                                    : `${integrationName} supports Client ID Metadata Document OAuth. We'll use this Executor host's public client metadata document and sign you in.`}
+                                </p>
+                              </div>
+                            ) : dcrActive ? (
                               // Transparent DCR: no picker. We register an app for you and run
                               // the OAuth flow with a single Connect click.
                               <div className="space-y-2 rounded-lg border border-ring/40 bg-accent/30 px-3 py-3">
@@ -1644,17 +1835,27 @@ function AddAccountModalView(props: AddAccountModalProps) {
                 type="button"
                 variant="ghost"
                 onClick={close}
-                disabled={submitting || oauthBusy || dcrConnecting}
+                disabled={submitting || oauthBusy || automaticOAuthConnecting}
               >
                 {isOAuth ? "Close" : "Cancel"}
               </Button>
               {/* Footer action, in precedence order:
+              - transparent CIMD (no app registration): create/reuse a public
+                metadata-document client and start OAuth;
               - transparent DCR (no picker): a single Connect that runs
                 probe → register → start;
               - registering a BYO app: the form owns its own submit, no footer;
               - picked BYO OAuth app: Connect with OAuth / Connect (client creds);
               - credential/no-auth method: Add connection. */}
-              {dcrActive ? (
+              {cimdActive ? (
+                <Button
+                  type="button"
+                  onClick={() => void handleCimdConnect()}
+                  disabled={cimdConnecting}
+                >
+                  {cimdConnecting ? "Connecting…" : "Connect with OAuth"}
+                </Button>
+              ) : dcrActive ? (
                 <Button
                   type="button"
                   onClick={() => void handleDcrConnect()}

--- a/packages/react/src/components/auth-template-editor.tsx
+++ b/packages/react/src/components/auth-template-editor.tsx
@@ -33,7 +33,9 @@ export type AuthTemplateEditorValue =
       readonly kind: "oauth";
       readonly authorizationUrl: string;
       readonly tokenUrl: string;
+      readonly resource?: string | null;
       readonly scopes: readonly string[];
+      readonly supportsClientIdMetadataDocument?: boolean;
     };
 
 export interface AuthTemplateEditorPreset {

--- a/packages/react/src/components/oauth-client-form.test.ts
+++ b/packages/react/src/components/oauth-client-form.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it } from "@effect/vitest";
 
-import { registrationScopes } from "./oauth-client-form";
+import { canSubmitOAuthClientForm, registrationScopes } from "./oauth-client-form";
+
+const validBase = {
+  submitting: false,
+  name: "PostHog",
+  clientId: "https://example.com/oauth/client-id-metadata.json",
+  clientSecret: "secret",
+  authorizationUrl: "https://us.posthog.com/oauth/authorize",
+  tokenUrl: "https://us.posthog.com/oauth/token",
+} as const;
 
 describe("registrationScopes", () => {
   it("sends declared scopes and ignores discovered when declared scopes exist", () => {
@@ -24,5 +33,38 @@ describe("registrationScopes", () => {
 
   it("returns empty when nothing is declared or discovered", () => {
     expect(registrationScopes([], [])).toEqual([]);
+  });
+});
+
+describe("canSubmitOAuthClientForm", () => {
+  it("allows authorization-code public clients with no client secret", () => {
+    expect(
+      canSubmitOAuthClientForm({
+        ...validBase,
+        grant: "authorization_code",
+        clientSecret: "",
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps client secret required for client-credentials clients", () => {
+    expect(
+      canSubmitOAuthClientForm({
+        ...validBase,
+        grant: "client_credentials",
+        clientSecret: "",
+      }),
+    ).toBe(false);
+  });
+
+  it("requires an authorization URL for authorization-code clients", () => {
+    expect(
+      canSubmitOAuthClientForm({
+        ...validBase,
+        grant: "authorization_code",
+        clientSecret: "",
+        authorizationUrl: "",
+      }),
+    ).toBe(false);
   });
 });

--- a/packages/react/src/components/oauth-client-form.tsx
+++ b/packages/react/src/components/oauth-client-form.tsx
@@ -70,6 +70,22 @@ export const registrationScopes = (
   discoveredScopes: readonly string[],
 ): readonly string[] => (declaredScopes.length > 0 ? declaredScopes : discoveredScopes);
 
+export const canSubmitOAuthClientForm = (input: {
+  readonly submitting: boolean;
+  readonly name: string;
+  readonly grant: OAuthGrant;
+  readonly clientId: string;
+  readonly clientSecret: string;
+  readonly authorizationUrl: string;
+  readonly tokenUrl: string;
+}): boolean =>
+  !input.submitting &&
+  input.name.trim().length > 0 &&
+  input.clientId.trim().length > 0 &&
+  (input.grant === "authorization_code" || input.clientSecret.trim().length > 0) &&
+  input.tokenUrl.trim().length > 0 &&
+  (input.grant === "client_credentials" || input.authorizationUrl.trim().length > 0);
+
 export function OAuthClientForm(props: {
   /** Human label for the integration this app backs (used in toasts + default name). */
   readonly integrationName: string;
@@ -162,13 +178,15 @@ export function OAuthClientForm(props: {
     mode: "promiseExit",
   });
 
-  const canSubmit =
-    !submitting &&
-    name.trim().length > 0 &&
-    clientId.trim().length > 0 &&
-    clientSecret.trim().length > 0 &&
-    tokenUrl.trim().length > 0 &&
-    (grant === "client_credentials" || authorizationUrl.trim().length > 0);
+  const canSubmit = canSubmitOAuthClientForm({
+    submitting,
+    name,
+    grant,
+    clientId,
+    clientSecret,
+    authorizationUrl,
+    tokenUrl,
+  });
 
   // DCR is offered when the server advertises a registration endpoint AND we
   // have the interactive-flow endpoints to persist alongside the minted client.
@@ -285,7 +303,7 @@ export function OAuthClientForm(props: {
         <p className="text-xs text-muted-foreground">
           {canRegisterDynamic
             ? "Register automatically below, or enter a client id/secret manually."
-            : "Paste a client id/secret. We only ask for endpoints when they aren't already known."}
+            : "Paste a client id and optional secret. We only ask for endpoints when they aren't already known."}
         </p>
       </div>
 
@@ -413,12 +431,19 @@ export function OAuthClientForm(props: {
         <div className="space-y-1.5">
           <Label htmlFor="oauth-client-secret" className="text-xs text-muted-foreground">
             Client secret
+            {grant === "authorization_code" ? (
+              <span className="font-normal text-muted-foreground/70">
+                optional for public clients
+              </span>
+            ) : null}
           </Label>
           <Input
             id="oauth-client-secret"
             type="password"
             autoComplete="new-password"
-            placeholder="client secret"
+            placeholder={
+              grant === "authorization_code" ? "optional client secret" : "required client secret"
+            }
             value={clientSecret}
             onChange={(e: React.ChangeEvent<HTMLInputElement>) => setClientSecret(e.target.value)}
             className="font-mono"

--- a/packages/react/src/lib/auth-placements.test.ts
+++ b/packages/react/src/lib/auth-placements.test.ts
@@ -37,8 +37,10 @@ describe("authMethodsFromDescriptors", () => {
         oauth: {
           authorizationUrl: "https://accounts.google.com/o/oauth2/v2/auth",
           tokenUrl: "https://oauth2.googleapis.com/token",
+          resource: "https://api.example",
           scopes: ["read", "write"],
           registrationEndpoint: "https://accounts.google.com/register",
+          supportsClientIdMetadataDocument: true,
         },
       },
     ]);
@@ -47,8 +49,10 @@ describe("authMethodsFromDescriptors", () => {
       "https://accounts.google.com/o/oauth2/v2/auth",
     );
     expect(methods[0]?.oauth?.tokenUrl).toBe("https://oauth2.googleapis.com/token");
+    expect(methods[0]?.oauth?.resource).toBe("https://api.example");
     expect(methods[0]?.oauth?.scopes).toEqual(["read", "write"]);
     expect(methods[0]?.oauth?.registrationEndpoint).toBe("https://accounts.google.com/register");
+    expect(methods[0]?.oauth?.supportsClientIdMetadataDocument).toBe(true);
   });
 
   it("maps an apikey/header descriptor preserving placements", () => {

--- a/packages/react/src/lib/auth-placements.tsx
+++ b/packages/react/src/lib/auth-placements.tsx
@@ -54,6 +54,7 @@ export type AuthMethodKind = "oauth" | "apikey" | "none";
 export interface AuthMethodOAuth {
   readonly authorizationUrl?: string;
   readonly tokenUrl?: string;
+  readonly resource?: string | null;
   readonly scopes?: readonly string[];
   /** RFC 7591 registration endpoint, when the provider advertises Dynamic
    *  Client Registration. Lets the form offer a one-click "Register
@@ -68,6 +69,11 @@ export interface AuthMethodOAuth {
    *  registration. Drives the transparent auto-register connect flow (probe →
    *  register → start, with no app picker). */
   readonly supportsDynamicRegistration?: boolean;
+  /** True when the authorization server supports OAuth Client ID Metadata
+   *  Document. The connect flow can create a public local client whose
+   *  `client_id` is this host's metadata document URL, with no provider-side app
+   *  registration. */
+  readonly supportsClientIdMetadataDocument?: boolean;
 }
 
 export interface AuthMethod {
@@ -158,10 +164,12 @@ function authMethodFromDescriptor(descriptor: AuthMethodDescriptor): AuthMethod 
       oauth: {
         authorizationUrl: oauth?.authorizationUrl,
         tokenUrl: oauth?.tokenUrl,
+        resource: oauth?.resource ?? null,
         scopes: oauth?.scopes,
         registrationEndpoint: oauth?.registrationEndpoint,
         discoveryUrl: oauth?.discoveryUrl,
         supportsDynamicRegistration: oauth?.supportsDynamicRegistration,
+        supportsClientIdMetadataDocument: oauth?.supportsClientIdMetadataDocument,
       },
     };
   }

--- a/packages/react/src/plugins/oauth-reconnect.test.ts
+++ b/packages/react/src/plugins/oauth-reconnect.test.ts
@@ -9,7 +9,12 @@ import {
   type Connection,
 } from "@executor-js/sdk/shared";
 
-import { missingScopes, oauthReconnectPayload, reconnectMode } from "./oauth-reconnect";
+import {
+  missingScopes,
+  oauthReconnectPayload,
+  reconnectMode,
+  reconsentRequiredScopes,
+} from "./oauth-reconnect";
 
 const connection = (overrides: Partial<Connection> = {}): Connection => ({
   owner: "user",
@@ -107,5 +112,31 @@ describe("missingScopes (Part 2 informational subset warning)", () => {
         ],
       ),
     ).toEqual([]);
+  });
+});
+
+describe("reconsentRequiredScopes", () => {
+  it("treats spec-derived oauth scopes as NOT required (opportunistic catalog)", () => {
+    // An OpenAPI source (e.g. PostHog) declares the full per-operation scope
+    // catalog. A narrower grant is healthy and must not nag for reconnect.
+    expect(
+      reconsentRequiredScopes({
+        source: "spec",
+        oauth: { scopes: ["insight:read", "insight:write", "person:read"] },
+      }),
+    ).toBeUndefined();
+  });
+
+  it("keeps custom (user-configured) oauth scopes required", () => {
+    expect(
+      reconsentRequiredScopes({
+        source: "custom",
+        oauth: { scopes: ["read", "write"] },
+      }),
+    ).toEqual(["read", "write"]);
+  });
+
+  it("returns undefined when there is no oauth method", () => {
+    expect(reconsentRequiredScopes(undefined)).toBeUndefined();
   });
 });

--- a/packages/react/src/plugins/oauth-reconnect.ts
+++ b/packages/react/src/plugins/oauth-reconnect.ts
@@ -28,7 +28,9 @@ export function reconnectMode(connection: Connection): ReconnectMode {
  *  connection are exactly the branded types `oauth.start` expects, so the same
  *  connection (owner/integration/name) is re-minted with a fresh refresh token
  *  and the widened scope union. Returns null for a non-OAuth connection. */
-export function oauthReconnectPayload(connection: Connection): OAuthStartPayload | null {
+export function oauthReconnectPayload(
+  connection: Connection,
+): OAuthStartPayload | null {
   if (connection.oauthClient == null) return null;
   return {
     client: connection.oauthClient,
@@ -59,7 +61,8 @@ const OAUTH_SCOPE_ALIASES: Readonly<Record<string, string>> = {
   "https://www.googleapis.com/auth/userinfo.profile": "profile",
 };
 
-const canonicalScope = (scope: string): string => OAUTH_SCOPE_ALIASES[scope] ?? scope;
+const canonicalScope = (scope: string): string =>
+  OAUTH_SCOPE_ALIASES[scope] ?? scope;
 
 /** Normalize a scope list: trim, canonicalize known provider aliases, drop
  *  empties, de-dupe (order-preserving). A scope set is compared as a SET —
@@ -91,8 +94,12 @@ export function missingScopes(
 
 /** The scopes a connection was actually GRANTED, parsed from its space-delimited
  *  `oauthScope` record. Empty for static creds / when the AS omitted scope. */
-export function connectionGrantedScopes(connection: Connection): readonly string[] {
-  return connection.oauthScope ? connection.oauthScope.split(/\s+/).filter(Boolean) : [];
+export function connectionGrantedScopes(
+  connection: Connection,
+): readonly string[] {
+  return connection.oauthScope
+    ? connection.oauthScope.split(/\s+/).filter(Boolean)
+    : [];
 }
 
 /** Whether an OAuth connection must RECONNECT to grant newly-needed access: the
@@ -106,5 +113,29 @@ export function connectionNeedsReconsent(
   declaredScopes: readonly string[] | undefined,
 ): boolean {
   if (connection.oauthClient == null) return false;
-  return missingScopes(declaredScopes, connectionGrantedScopes(connection)).length > 0;
+  return (
+    missingScopes(declaredScopes, connectionGrantedScopes(connection)).length >
+    0
+  );
+}
+
+/** The scopes that count as REQUIRED for a connection to be considered fully
+ *  granted, given the integration's oauth auth method.
+ *
+ *  Spec-derived oauth scopes are the full per-operation catalog union (an OpenAPI
+ *  source like PostHog declares hundreds): requested broadly to unlock as many
+ *  tools as possible, but none individually required. A provider that narrows the
+ *  grant to the user's actual access is healthy, so the spec catalog must NOT
+ *  drive a reconnect prompt. Custom (user-configured) scopes are intentional and
+ *  stay required. Feed the result to `connectionNeedsReconsent`. */
+export function reconsentRequiredScopes(
+  method:
+    | {
+        readonly source: "spec" | "custom";
+        readonly oauth?: { readonly scopes?: readonly string[] };
+      }
+    | undefined,
+): readonly string[] | undefined {
+  if (method == null || method.source === "spec") return undefined;
+  return method.oauth?.scopes;
 }

--- a/packages/react/src/plugins/oauth-sign-in.test.ts
+++ b/packages/react/src/plugins/oauth-sign-in.test.ts
@@ -2,6 +2,10 @@ import { afterEach, describe, expect, it } from "@effect/vitest";
 
 import { oauthCallbackUrl, oauthClientIdMetadataDocumentUrl } from "./oauth-sign-in";
 
+// The legacy query-param org selector the metadata-document URL must NOT use
+// (org is carried in the path instead). Mirrors the server-side constant.
+const OAUTH_CALLBACK_ORG_QUERY_PARAM = "executor_org";
+
 const originalWindow = globalThis.window;
 
 const setLocation = (href: string): void => {
@@ -67,5 +71,21 @@ describe("oauthCallbackUrl", () => {
     setLocation("https://executor.sh/login");
 
     expect(oauthCallbackUrl()).toBe("https://executor.sh/api/oauth/callback");
+  });
+});
+
+describe("oauthClientIdMetadataDocumentUrl", () => {
+  it("returns a relative metadata path outside the browser", () => {
+    Reflect.deleteProperty(globalThis, "window");
+    expect(oauthClientIdMetadataDocumentUrl()).toBe("/api/oauth/client-id-metadata/default.json");
+  });
+
+  it("carries the active org slug from the console URL", () => {
+    setLocation("https://executor.sh/acme/integrations/posthog");
+
+    const url = new URL(oauthClientIdMetadataDocumentUrl());
+
+    expect(url.toString()).toBe("https://executor.sh/api/oauth/client-id-metadata/acme.json");
+    expect(url.searchParams.has(OAUTH_CALLBACK_ORG_QUERY_PARAM)).toBe(false);
   });
 });


### PR DESCRIPTION
## What

Adds OAuth Client ID Metadata Document (CIMD) support so an API source can be
connected without Dynamic Client Registration or a manually registered app.

When an authorization server advertises `client_id_metadata_document_supported`,
the connect flow uses a public PKCE client whose `client_id` is this host's
metadata-document URL. The provider fetches that document to learn the client's
name and redirect URIs, so there is no provider-side app to create. This is what
lets a provider like PostHog be connected directly from its API spec.

## Changes

- **Detection**: parse `client_id_metadata_document_supported` from RFC 8414
  authorization-server metadata; carry `supportsClientIdMetadataDocument` and the
  RFC 8707 resource indicator on the auth method and probe result.
- **Flow**: when CIMD is advertised, skip DCR and use the client-id-as-URL public
  client; the existing metadata-document route serves the client document.
- **OpenAPI plugin**: derive and preview CIMD-capable OAuth from a spec, and wire
  it through the add-source path.
- **UI**: add-account and OAuth client form handle the public (no-secret) client.
- **Reconnect**: spec-derived OAuth scopes are the full per-operation catalog
  (an OpenAPI source can declare hundreds). They are requested broadly but not
  individually required, so a provider that narrows the grant to the user's
  actual access is healthy. Only custom (user-configured) scopes stay required,
  so large API sources no longer show a spurious "reconnect to grant access".

## Tests

Unit coverage across core SDK (discovery, scope handling), core API (client
metadata document), the OpenAPI plugin, and React (add-account, client form,
reconnect). `bun run typecheck` and the affected package tests pass.

## Notes

Verified by hand against a live provider: detection, document fetch, and the
authorize handshake work. A full redirect round-trip needs the host's metadata
document to be publicly reachable (a loopback or tunneled origin), since the
provider fetches the `client_id` URL.
