### PR TITLE
Add PostHog to OpenAPI source presets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,10 @@ writing e2e scenarios, see [e2e/AGENTS.md](e2e/AGENTS.md). Run
 - For code changes, run the narrowest useful verification before handing back.
 - For broad or merge-ready changes, the full gates are `bun run format:check`,
   `bun run lint`, `bun run typecheck`, and `bun run test`.
+- Always run `bun run format` before opening a PR so the diff lands
+  already-formatted. Only commit formatting changes to files your branch
+  actually touches: if `format` rewrites unrelated pre-existing files, leave
+  those out of the PR (stage just your files).
 
 ## Handing Back Work: Evidence, Not Assertions
 

--- a/packages/plugins/openapi/src/sdk/presets.ts
+++ b/packages/plugins/openapi/src/sdk/presets.ts
@@ -65,6 +65,14 @@ const openApiOnlyPresets: readonly OpenApiPreset[] = [
     featured: true,
   },
   {
+    id: "posthog",
+    name: "PostHog",
+    summary: "Product analytics, events, feature flags, and insights.",
+    url: "https://us.posthog.com/api/schema/",
+    icon: "https://svgl.app/library/posthog.svg",
+    featured: true,
+  },
+  {
     id: "exa",
     name: "Exa",
     summary: "Web search, similar links, content retrieval, and answers.",


### PR DESCRIPTION
Adds PostHog to the default OpenAPI source presets so it shows up alongside Stripe, GitHub, Sentry, etc. when adding a new source.

- URL: `https://us.posthog.com/api/schema/` (verified: returns a valid OpenAPI 3.1.0 spec titled "PostHog API")
- Icon: svgl PostHog mark, consistent with the other svgl-based presets
- Marked `featured`, placed in the observability/analytics group next to Sentry

Typecheck passes; presets are static data with no count assertions in tests.