### PR TITLE
Fix duplicate Add connection button and reflowing floating action bar

### DIFF
--- a/e2e/scenarios/openapi-add-integration-action-bar.test.ts
+++ b/e2e/scenarios/openapi-add-integration-action-bar.test.ts
@@ -1,0 +1,85 @@
+// Cross-target (browser): the Add OpenAPI source form's floating action bar.
+// Rohil (shared-tcc) reported the "Add integration" button rendering doubled /
+// ghosted on click. This pins the flow: paste a spec, click Add integration,
+// land on the created integration. The trace's DOM snapshots are the artifact
+// we use to confirm the bar is a single node (a paint artifact, not a
+// double-render). Skips on targets without a browser surface (selfhost today).
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+
+import { scenario } from "../src/scenario";
+import { Browser, Target } from "../src/services";
+
+// One server so "Add integration" is enabled straight from the preview (no
+// base-URL picker to resolve first).
+const singleServerSpec = JSON.stringify({
+  openapi: "3.0.3",
+  info: { title: "Ping API", version: "1.0.0" },
+  servers: [{ url: "https://api.example.com", description: "Production" }],
+  paths: {
+    "/ping": { get: { operationId: "ping", responses: { "200": { description: "pong" } } } },
+  },
+});
+
+scenario(
+  "OpenAPI · Add integration commits the source and the action bar is a single node",
+  {},
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const browser = yield* Browser;
+      const identity = yield* target.newIdentity();
+
+      yield* browser.session(identity, async ({ page, step }) => {
+        await step("Open the Add OpenAPI source form", async () => {
+          await page.goto("/integrations/add/openapi", { waitUntil: "networkidle" });
+          await page.getByPlaceholder("https://api.example.com/openapi.json").waitFor();
+        });
+
+        await step("Paste a single-server spec so Add integration is enabled", async () => {
+          await page.getByPlaceholder("https://api.example.com/openapi.json").fill(singleServerSpec);
+          await page.getByRole("button", { name: "Add integration" }).waitFor({ timeout: 20_000 });
+        });
+
+        await step("Exactly one action bar / Add integration button is in the DOM", async () => {
+          // The reported ghosting looked like two overlapping bars. If that were
+          // a real double-render the DOM would carry two buttons; assert it does
+          // not (so the artifact is paint-level, fixed by isolating the layer).
+          const count = await page.getByRole("button", { name: "Add integration" }).count();
+          expect(count, "a single Add integration button is rendered").toBe(1);
+        });
+
+        await step("Submitting does not reflow the bar, then lands on the integration", async () => {
+          // The reported ghost was the bar painting doubled when the submit
+          // button changed width on click. With a stable-width loading button the
+          // row must not move: Cancel stays put while the add is in flight.
+          const cancel = page.getByRole("button", { name: "Cancel" });
+          const before = await cancel.boundingBox();
+          await page.getByRole("button", { name: "Add integration" }).click();
+          // The submit button marks itself data-loading synchronously on click.
+          await page.locator('[data-slot="button"][data-loading]').first().waitFor({ timeout: 5_000 });
+          const during = await cancel.boundingBox();
+          expect(Math.round(during?.x ?? -1), "Cancel does not move when submitting").toBe(
+            Math.round(before?.x ?? -2),
+          );
+          await page.waitForURL(/\/integrations\/(?!add\b)[^/?]+$/, { timeout: 30_000 });
+          await page.getByText("Connections").first().waitFor();
+        });
+
+        await step("The empty connections state renders", async () => {
+          await page.getByText("No connections yet").waitFor({ timeout: 20_000 });
+        });
+
+        await step("The empty state shows a single add-connection CTA", async () => {
+          // Regression cover for the doubled-button report: the empty state used
+          // to render both a header "Add connection" and a card "Add a
+          // connection". Match either label so a regression is actually counted.
+          const count = await page
+            .getByRole("button", { name: /^Add (a )?connection$/i })
+            .count();
+          expect(count, "empty state shows exactly one add-connection button").toBe(1);
+        });
+      });
+    }),
+  ),
+);

--- a/packages/plugins/google/src/react/AddGoogleSource.tsx
+++ b/packages/plugins/google/src/react/AddGoogleSource.tsx
@@ -9,7 +9,6 @@ import {
 } from "@executor-js/react/plugins/integration-identity";
 import { Button } from "@executor-js/react/components/button";
 import { FloatActions } from "@executor-js/react/components/float-actions";
-import { Spinner } from "@executor-js/react/components/spinner";
 import {
   addIntegrationErrorMessage,
   FormErrorAlert,
@@ -170,9 +169,8 @@ export default function AddGoogleSource(props: {
         <Button variant="ghost" onClick={() => props.onCancel()} disabled={adding}>
           Cancel
         </Button>
-        <Button onClick={() => void handleAdd()} disabled={!canAdd || adding}>
-          {adding && <Spinner className="size-3.5" />}
-          {adding ? "Adding…" : "Connect Google"}
+        <Button onClick={() => void handleAdd()} disabled={!canAdd} loading={adding}>
+          Connect Google
         </Button>
       </FloatActions>
     </div>

--- a/packages/plugins/graphql/src/react/AddGraphqlSource.tsx
+++ b/packages/plugins/graphql/src/react/AddGraphqlSource.tsx
@@ -16,7 +16,6 @@ import {
   type AuthMethodSeed,
 } from "@executor-js/react/components/auth-method-list-editor";
 import { FloatActions } from "@executor-js/react/components/float-actions";
-import { Spinner } from "@executor-js/react/components/spinner";
 import {
   addIntegrationErrorMessage,
   FormErrorAlert,
@@ -156,9 +155,8 @@ export default function AddGraphqlSource(props: {
         <Button variant="ghost" onClick={() => props.onCancel()} disabled={adding}>
           Cancel
         </Button>
-        <Button onClick={() => void handleAdd()} disabled={!canAdd}>
-          {adding && <Spinner className="size-3.5" />}
-          {adding ? "Adding..." : "Add source"}
+        <Button onClick={() => void handleAdd()} disabled={!canAdd} loading={adding}>
+          Add source
         </Button>
       </FloatActions>
     </div>

--- a/packages/plugins/mcp/src/react/AddMcpSource.tsx
+++ b/packages/plugins/mcp/src/react/AddMcpSource.tsx
@@ -17,7 +17,6 @@ import {
 } from "@executor-js/react/components/card-stack";
 import { FloatActions } from "@executor-js/react/components/float-actions";
 import { Input } from "@executor-js/react/components/input";
-import { Spinner } from "@executor-js/react/components/spinner";
 import { TagInput } from "@executor-js/react/components/tag-input";
 import {
   integrationDisplayNameFromStdio,
@@ -473,14 +472,8 @@ export default function AddMcpSource(props: {
               Cancel
             </Button>
             {(probe || isProbing) && (
-              <Button type="button" onClick={handleAddRemote} disabled={!canAdd}>
-                {isAdding ? (
-                  <>
-                    <Spinner className="size-3.5" /> Adding…
-                  </>
-                ) : (
-                  "Add source"
-                )}
+              <Button type="button" onClick={handleAddRemote} disabled={!canAdd} loading={isAdding}>
+                Add source
               </Button>
             )}
           </FloatActions>
@@ -546,15 +539,10 @@ export default function AddMcpSource(props: {
             <Button
               type="button"
               onClick={handleAddStdio}
-              disabled={!stdioCommand.trim() || stdioAdding || stdioSlugExists}
+              disabled={!stdioCommand.trim() || stdioSlugExists}
+              loading={stdioAdding}
             >
-              {stdioAdding ? (
-                <>
-                  <Spinner className="size-3.5" /> Adding…
-                </>
-              ) : (
-                "Add source"
-              )}
+              Add source
             </Button>
           </FloatActions>
         </>

--- a/packages/plugins/microsoft/src/react/AddMicrosoftSource.tsx
+++ b/packages/plugins/microsoft/src/react/AddMicrosoftSource.tsx
@@ -9,7 +9,6 @@ import {
 } from "@executor-js/react/plugins/integration-identity";
 import { Button } from "@executor-js/react/components/button";
 import { FloatActions } from "@executor-js/react/components/float-actions";
-import { Spinner } from "@executor-js/react/components/spinner";
 import {
   addIntegrationErrorMessage,
   FormErrorAlert,
@@ -147,9 +146,8 @@ export default function AddMicrosoftSource(props: {
         <Button variant="ghost" onClick={() => props.onCancel()} disabled={adding}>
           Cancel
         </Button>
-        <Button onClick={() => void handleAdd()} disabled={!canAdd || adding}>
-          {adding && <Spinner className="size-3.5" />}
-          {adding ? "Adding..." : "Connect Microsoft"}
+        <Button onClick={() => void handleAdd()} disabled={!canAdd} loading={adding}>
+          Connect Microsoft
         </Button>
       </FloatActions>
     </div>

--- a/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
@@ -21,7 +21,7 @@ import { CardStack, CardStackContent } from "@executor-js/react/components/card-
 import { FieldLabel } from "@executor-js/react/components/field";
 import { FloatActions } from "@executor-js/react/components/float-actions";
 import { Textarea } from "@executor-js/react/components/textarea";
-import { IOSSpinner, Spinner } from "@executor-js/react/components/spinner";
+import { IOSSpinner } from "@executor-js/react/components/spinner";
 import {
   addIntegrationErrorMessage,
   errorMessageFromExit,
@@ -368,9 +368,8 @@ export default function AddOpenApiSource(props: {
           Cancel
         </Button>
         {preview && (
-          <Button onClick={() => void handleAdd()} disabled={!canAdd || adding}>
-            {adding && <Spinner className="size-3.5" />}
-            {adding ? "Adding..." : "Add integration"}
+          <Button onClick={() => void handleAdd()} disabled={!canAdd} loading={adding}>
+            Add integration
           </Button>
         )}
       </FloatActions>

--- a/packages/react/src/components/accounts-section.tsx
+++ b/packages/react/src/components/accounts-section.tsx
@@ -348,6 +348,23 @@ export function AccountsSection(props: {
 
   const loading = !AsyncResult.isSuccess(orgConnections) && !AsyncResult.isSuccess(userConnections);
 
+  // When there are zero connections the dashed empty-state card below carries
+  // its own "Add connection" CTA, so the header button would be a redundant
+  // second copy of the same action. Show the header button only outside that
+  // state (populated, or still loading).
+  const showEmptyState = !loading && totalCount === 0;
+
+  const openAddConnection = () => {
+    trackEvent("connection_add_opened", {
+      integration_slug: String(integration),
+      has_oauth_method: methods.some((m: AuthMethod) => m.kind === "oauth"),
+      has_api_key_method: methods.some(
+        (m: AuthMethod) => m.kind !== "oauth" && m.kind !== "none",
+      ),
+    });
+    setAdding(true);
+  };
+
   const modalState = reconnectHandoff ?? accountHandoff;
   const modal = (
     <AddAccountModal
@@ -371,24 +388,17 @@ export function AccountsSection(props: {
         <h3 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
           Connections
         </h3>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          onClick={() => {
-            trackEvent("connection_add_opened", {
-              integration_slug: String(integration),
-              has_oauth_method: methods.some((m: AuthMethod) => m.kind === "oauth"),
-              has_api_key_method: methods.some(
-                (m: AuthMethod) => m.kind !== "oauth" && m.kind !== "none",
-              ),
-            });
-            setAdding(true);
-          }}
-          disabled={!canAddConnection}
-        >
-          Add connection
-        </Button>
+        {!showEmptyState ? (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={openAddConnection}
+            disabled={!canAddConnection}
+          >
+            Add connection
+          </Button>
+        ) : null}
       </div>
 
       {loading ? (
@@ -396,7 +406,7 @@ export function AccountsSection(props: {
           <div className="size-1.5 animate-pulse rounded-full bg-muted-foreground/30" />
           <p className="text-sm text-muted-foreground">Loading accounts…</p>
         </div>
-      ) : totalCount === 0 ? (
+      ) : showEmptyState ? (
         <div className="rounded-lg border border-dashed border-border/60 px-6 py-8 text-center">
           <p className="text-sm font-medium text-foreground">No connections yet</p>
           <p className="mt-1 text-sm text-muted-foreground">
@@ -406,19 +416,10 @@ export function AccountsSection(props: {
             type="button"
             className="mt-4"
             size="sm"
-            onClick={() => {
-              trackEvent("connection_add_opened", {
-                integration_slug: String(integration),
-                has_oauth_method: methods.some((m: AuthMethod) => m.kind === "oauth"),
-                has_api_key_method: methods.some(
-                  (m: AuthMethod) => m.kind !== "oauth" && m.kind !== "none",
-                ),
-              });
-              setAdding(true);
-            }}
+            onClick={openAddConnection}
             disabled={!canAddConnection}
           >
-            Add a connection
+            Add connection
           </Button>
         </div>
       ) : (

--- a/packages/react/src/components/button.tsx
+++ b/packages/react/src/components/button.tsx
@@ -3,6 +3,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { Slot } from "radix-ui";
 
 import { cn } from "../lib/utils";
+import { Spinner } from "./spinner";
 
 const buttonVariants = cva(
   "inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
@@ -41,21 +42,44 @@ function Button({
   variant = "default",
   size = "default",
   asChild = false,
+  loading = false,
+  disabled,
+  children,
   ...props
 }: React.ComponentProps<"button"> &
   VariantProps<typeof buttonVariants> & {
     asChild?: boolean;
+    /** Show a centered spinner while keeping the label's footprint, so the
+     *  button (and any row it sits in) does not change width on entering the
+     *  loading state. Ignored with `asChild` (Slot requires a single child). */
+    loading?: boolean;
   }) {
   const Comp = asChild ? Slot.Root : "button";
+  const showLoading = loading && !asChild;
 
   return (
     <Comp
       data-slot="button"
       data-variant={variant}
       data-size={size}
-      className={cn(buttonVariants({ variant, size, className }))}
+      data-loading={showLoading ? "" : undefined}
+      className={cn(buttonVariants({ variant, size, className }), showLoading && "relative")}
+      disabled={disabled || loading}
       {...props}
-    />
+    >
+      {showLoading ? (
+        <>
+          {/* Reserve the label's width so the box stays the same size; overlay
+              the spinner centered on top. */}
+          <span className="invisible">{children}</span>
+          <span className="absolute inset-0 flex items-center justify-center">
+            <Spinner className="size-3.5" />
+          </span>
+        </>
+      ) : (
+        children
+      )}
+    </Comp>
   );
 }
 

--- a/packages/react/src/components/float-actions.tsx
+++ b/packages/react/src/components/float-actions.tsx
@@ -26,7 +26,18 @@ function FloatActions({ className, children }: { className?: string; children: R
   }
 
   return (
-    <CardStack className={cn("sticky shadow-lg bottom-4 left-0 right-0 mt-auto w-full", className)}>
+    // `transform-gpu` promotes the bar to its own compositing layer. Without it,
+    // when an action button changes width (e.g. "Add integration" -> "Adding...")
+    // the right-aligned row reflows and Chromium can leave a stale paint of the
+    // sticky bar, rendering it doubled/ghosted. A dedicated layer repaints
+    // atomically and avoids the artifact. Transforming the sticky element itself
+    // does not affect its stickiness.
+    <CardStack
+      className={cn(
+        "sticky shadow-lg bottom-4 left-0 right-0 mt-auto w-full transform-gpu",
+        className,
+      )}
+    >
       <div className="flex items-center justify-end gap-3 px-4 py-3">{children}</div>
     </CardStack>
   );


### PR DESCRIPTION
Two small UI fixes on the integration add/detail screens. Before/after shots are from the e2e harness (cloud target).

## 1. Duplicate add-connection button in the empty state

An integration with no connections rendered two buttons for the same action: the persistent header "Add connection" and the empty-state card "Add a connection" (note the inconsistent label). The empty state now shows a single CTA and the label is unified to "Add connection". The header button still shows once there are connections (and while loading).

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/RhysSullivan/executor/e2e-media/bug1-before-two-ctas-085e7692.png) | ![after](https://raw.githubusercontent.com/RhysSullivan/executor/e2e-media/bug1-after-single-cta-2ea64e83.png) |

## 2. Reflowing floating action bar

On the add forms the submit button changed width on click ("Add integration" became a spinner + "Adding...", which also dropped the `has-[>svg]` padding). Because the bar is right-aligned, the whole row reflowed and "Cancel" jumped ~38px. On some GPUs the sticky bar was then left with a stale composited frame, painting the bar doubled/ghosted.

`Button` gets a stable-width `loading` state (keep the label's footprint, overlay a centered spinner) so the row no longer moves; it is used across the OpenAPI/Google/Microsoft/GraphQL/MCP add forms. `FloatActions` also gets its own compositing layer (`transform-gpu`) as belt-and-suspenders against sticky stale-paint.

The images below superimpose the bar's resting and submitting states (a 50/50 blend). Before, the two states are offset, so "Cancel" and the button double up: this is the same superimposition the GPU produced. After, the states line up: the button keeps its width and the row stays put.

| Before (states offset → doubled) | After (states aligned) |
| --- | --- |
| ![before](https://raw.githubusercontent.com/RhysSullivan/executor/e2e-media/bug2-before-ghost-5833efb7.png) | ![after](https://raw.githubusercontent.com/RhysSullivan/executor/e2e-media/bug2-after-stable-f5a5295d.png) |

Note: the compositor stale-paint is hardware-dependent and does not reproduce in the headless/headed harness here; what is reproduced and asserted against is its trigger, the reflow.

## Tests

Adds an e2e scenario (`openapi-add-integration-action-bar`) that:
- asserts a single action bar / "Add integration" button is in the DOM (rules out a double render),
- commits the integration and checks the empty connections state shows exactly one add-connection CTA (matches either label, so the duplicate is actually counted), and
- asserts "Cancel" does not move while the add is in flight (the no-reflow guarantee).

The empty-state CTA assertion fails on the pre-fix code (`expected 2 to be 1`), and the no-reflow assertion fails on the pre-fix button, so both are genuine regression guards.
