### PR TITLE
Drop the empty bordered panel for no-auth connections

### DIFF
--- a/packages/react/src/components/add-account-modal.tsx
+++ b/packages/react/src/components/add-account-modal.tsx
@@ -1452,7 +1452,12 @@ function AddAccountModalView(props: AddAccountModalProps) {
                   {dcrActive ? null : (
                     <TabsContent
                       value={methodId}
-                      className="mt-0 min-w-0 space-y-5 rounded-md border border-border/60 bg-muted/15 p-4"
+                      className={cn(
+                        "mt-0 min-w-0 space-y-5",
+                        // No-auth renders no fields, so skip the framed box that
+                        // would otherwise show up as an empty bordered panel.
+                        isNoAuth ? null : "rounded-md border border-border/60 bg-muted/15 p-4",
+                      )}
                     >
                       {method?.placements && !isEnvMethod && singleInput
                         ? (() => {


### PR DESCRIPTION
The "Add connection" modal's auth-method panel always rendered a framed box (border, muted fill, padding) under the method selector. When **No authentication** is selected there are no credential fields to show, so the panel rendered as an empty bordered rectangle with nothing in it.

The frame now only applies when the panel actually has content; no-auth shows nothing between the selector and "Connection saved to".

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/RhysSullivan/executor/e2e-media/before-no-auth-empty-box-329439fc.png) | ![after](https://raw.githubusercontent.com/RhysSullivan/executor/e2e-media/after-no-auth-clean-20bb52a8.png) |

The change is scoped to the `TabsContent` className in `add-account-modal.tsx`: gate the `rounded-md border ... p-4` styles on `!isNoAuth`.
