### PR TITLE
Run panel: auto-approve operator-invoked tools

### DIFF
--- a/e2e/scenarios/run-panel-auto-approve.test.ts
+++ b/e2e/scenarios/run-panel-auto-approve.test.ts
@@ -1,0 +1,101 @@
+// Cross-target: the Run/Test panel's backend (`POST /executions`) auto-approves
+// approval-gated tools when the operator invokes them, because clicking Run in
+// the panel IS the human approval.
+//
+// The panel sends `autoApprove: true`. Here we drive the same HTTP endpoint the
+// panel uses and prove both halves of the contract against ONE tool that gates
+// itself: the `policies.create` core tool carries a `requiresApproval`
+// annotation, so with no matching policy in play the annotation is the only
+// thing that can pause the call.
+//
+//   - without `autoApprove`: the call pauses (the panel would have dead-ended
+//     on "This tool requires approval"), and the policy is not written.
+//   - with `autoApprove`: the call runs to completion and the policy is written.
+//
+// The created policy is a `block` rule on a unique, non-matching pattern, so a
+// leak cannot gate another scenario's tools; it is removed in an `ensuring`
+// finalizer regardless.
+import { randomUUID } from "node:crypto";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import { composePluginApi } from "@executor-js/api/server";
+
+import { scenario } from "../src/scenario";
+import { Api, Target } from "../src/services";
+
+const coreApi = composePluginApi([] as const);
+
+/** Sandbox code that creates a policy through the approval-gated core tool. The
+ *  pattern is unique-per-run and matches no real tool, so the rule is inert. */
+const createPolicyCode = (pattern: string) => `
+return await tools.executor.coreTools.policies.create({
+  owner: "user",
+  pattern: ${JSON.stringify(pattern)},
+  action: "block",
+});
+`;
+
+scenario(
+  "Run panel · autoApprove runs an approval-gated tool that otherwise pauses",
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const apiSurface = yield* Api;
+    const identity = yield* target.newIdentity();
+    const client = yield* apiSurface.client(coreApi, identity);
+    const pattern = `run-auto-approve-${randomUUID().slice(0, 8)}.*`;
+    const code = createPolicyCode(pattern);
+
+    const cleanup = client.policies.list().pipe(
+      Effect.flatMap((list) =>
+        Effect.forEach(
+          list.filter((p) => p.pattern === pattern),
+          (p) =>
+            client.policies
+              .remove({ params: { policyId: p.id }, payload: { owner: "user" } })
+              .pipe(Effect.ignore),
+        ),
+      ),
+      Effect.ignore,
+    );
+
+    yield* Effect.gen(function* () {
+      // Baseline: without autoApprove the gated tool pauses (the panel's old
+      // dead-end), and the side effect must not have happened.
+      const gated = yield* client.executions.execute({ payload: { code } });
+      expect(gated.status, "a gated tool pauses without autoApprove").toBe("paused");
+
+      const beforeApproval = yield* client.policies.list();
+      expect(
+        beforeApproval.some((p) => p.pattern === pattern),
+        "the policy is not written while the call is paused for approval",
+      ).toBe(false);
+
+      // Release the paused fiber so it does not linger waiting on a response.
+      if (gated.status === "paused") {
+        const executionId = (gated.structured as { readonly executionId?: string }).executionId;
+        if (executionId) {
+          yield* client.executions
+            .resume({ params: { executionId }, payload: { action: "cancel" } })
+            .pipe(Effect.ignore);
+        }
+      }
+
+      // With autoApprove the operator IS the approver: the same call runs to
+      // completion and the side effect lands.
+      const approved = yield* client.executions.execute({
+        payload: { code, autoApprove: true },
+      });
+      expect(approved.status, "autoApprove runs the gated tool to completion").toBe("completed");
+      if (approved.status !== "completed") return; // narrowing only
+      expect(approved.isError, "the auto-approved run is not an error").toBe(false);
+
+      const afterApproval = yield* client.policies.list();
+      expect(
+        afterApproval.some((p) => p.pattern === pattern),
+        "the policy is written once autoApprove runs the gated tool",
+      ).toBe(true);
+    }).pipe(Effect.ensuring(cleanup));
+  }),
+);

--- a/packages/core/api/src/executions/api.ts
+++ b/packages/core/api/src/executions/api.ts
@@ -9,6 +9,10 @@ import { InternalError } from "@executor-js/sdk/shared";
 
 const ExecuteRequest = Schema.Struct({
   code: Schema.String,
+  // When true the caller is the human approver: approval-gated tools run to
+  // completion instead of pausing. Set by the operator-facing Run/Test panel,
+  // where clicking Run is itself the approval. `block` policies still apply.
+  autoApprove: Schema.optional(Schema.Boolean),
 });
 
 const CompletedResult = Schema.Struct({

--- a/packages/core/api/src/handlers/executions.ts
+++ b/packages/core/api/src/handlers/executions.ts
@@ -34,7 +34,9 @@ export const ExecutionsHandlers = HttpApiBuilder.group(ExecutorApi, "executions"
       capture(
         Effect.gen(function* () {
           const engine = yield* ExecutionEngineService;
-          const outcome = yield* captureEngineError(engine.executeWithPause(payload.code));
+          const outcome = yield* captureEngineError(
+            engine.executeWithPause(payload.code, { autoApprove: payload.autoApprove }),
+          );
 
           if (outcome.status === "completed") {
             const formatted = formatExecuteResult(outcome.result);

--- a/packages/core/execution/src/engine.ts
+++ b/packages/core/execution/src/engine.ts
@@ -53,6 +53,10 @@ export type ResumeResponse = {
   readonly content?: Record<string, unknown>;
 };
 
+// Auto-accept every elicitation. Used by the `autoApprove` path where the
+// caller is itself the human approver (the operator-facing Run/Test panel).
+const acceptAllHandler: ElicitationHandler = () => Effect.succeed({ action: "accept" });
+
 // ---------------------------------------------------------------------------
 // Result formatting
 // ---------------------------------------------------------------------------
@@ -370,8 +374,17 @@ export type ExecutionEngine<E extends Cause.YieldableError = CodeExecutionError>
    * Execute code, intercepting the first elicitation as a pause point.
    * Use this when the host doesn't support inline elicitation.
    * Returns either a completed result or a paused execution that can be resumed.
+   *
+   * `options.autoApprove` treats the caller as the human in the loop: every
+   * elicitation is accepted inline, so an approval-gated tool runs to
+   * completion instead of pausing. The operator-facing Run/Test panel sets
+   * this because clicking Run IS the approval. `block` policies still fail
+   * before any elicitation, so this never bypasses a hard block.
    */
-  readonly executeWithPause: (code: string) => Effect.Effect<ExecutionResult, E>;
+  readonly executeWithPause: (
+    code: string,
+    options?: { readonly autoApprove?: boolean },
+  ) => Effect.Effect<ExecutionResult, E>;
 
   /**
    * Resume a paused execution. Returns a completed result, a new pause, or
@@ -455,11 +468,23 @@ export const createExecutionEngine = <E extends Cause.YieldableError = CodeExecu
    * The sandbox is forked as a daemon because paused executions can outlive the
    * caller scope that returned the first pause, such as an HTTP request handler.
    */
-  const startPausableExecution = Effect.fn("mcp.execute")(function* (code: string) {
+  const startPausableExecution = Effect.fn("mcp.execute")(function* (
+    code: string,
+    options?: { readonly autoApprove?: boolean },
+  ) {
     yield* Effect.annotateCurrentSpan({
       "mcp.execute.mode": "pausable",
       "mcp.execute.code_length": code.length,
     });
+
+    // Operator-approved invoke: run through the inline path with an accept-all
+    // handler so an approval gate resolves itself instead of pausing. Never
+    // pauses, so the caller always gets a completed result.
+    if (options?.autoApprove) {
+      yield* Effect.annotateCurrentSpan({ "mcp.execute.auto_approve": true });
+      const result = yield* runInlineExecution(code, { onElicitation: acceptAllHandler });
+      return { status: "completed", result } satisfies ExecutionResult;
+    }
 
     // Queue preserves pauses that arrive before the previous approval has
     // returned to the caller, which can happen with concurrent tool calls.

--- a/packages/core/execution/src/promise.ts
+++ b/packages/core/execution/src/promise.ts
@@ -41,7 +41,10 @@ export type ExecutionEngine = {
     code: string,
     options: { readonly onElicitation: ElicitationHandler },
   ) => Promise<ExecuteResult>;
-  readonly executeWithPause: (code: string) => Promise<ExecutionResult>;
+  readonly executeWithPause: (
+    code: string,
+    options?: { readonly autoApprove?: boolean },
+  ) => Promise<ExecutionResult>;
   readonly resume: (
     executionId: string,
     response: ResumeResponse,
@@ -149,7 +152,7 @@ export const toPromiseExecutionEngine = <E extends Cause.YieldableError>(
           Effect.tryPromise(() => options.onElicitation(ctx)).pipe(Effect.orDie),
       }),
     ),
-  executeWithPause: (code) => Effect.runPromise(engine.executeWithPause(code)),
+  executeWithPause: (code, options) => Effect.runPromise(engine.executeWithPause(code, options)),
   resume: (executionId, response) => Effect.runPromise(engine.resume(executionId, response)),
   getPausedExecution: (executionId) => Effect.runPromise(engine.getPausedExecution(executionId)),
   getDescription: () => Effect.runPromise(engine.getDescription),

--- a/packages/core/execution/src/tool-invoker.test.ts
+++ b/packages/core/execution/src/tool-invoker.test.ts
@@ -1346,6 +1346,26 @@ describe("pause/resume with multiple elicitations", () => {
     { timeout: 10000 },
   );
 
+  it.effect(
+    "autoApprove runs an eliciting tool to completion instead of pausing",
+    () =>
+      Effect.gen(function* () {
+        const executor = yield* makeElicitingExecutor();
+        const engine = createExecutionEngine({ executor, codeExecutor });
+        const code = "return await tools.api.org.main.singleApproval({});";
+
+        // Same tool that pauses without autoApprove (see the tests above) runs
+        // straight through when the caller is the approver: no pause, no
+        // executionId to resume, just the side effect's result.
+        const outcome = yield* engine.executeWithPause(code, { autoApprove: true });
+        expect(outcome.status, "autoApprove never pauses").toBe("completed");
+        if (outcome.status !== "completed") return;
+        expect(outcome.result.error).toBeUndefined();
+        expect(outcome.result.result).toMatchObject({ ok: true });
+      }),
+    { timeout: 10000 },
+  );
+
   // live clock: the sandbox timeout is a real timer, so the test must
   // actually wait for it rather than suspend on the virtual TestClock.
   it.live(

--- a/packages/react/src/components/accounts-section.tsx
+++ b/packages/react/src/components/accounts-section.tsx
@@ -2,11 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useAtomValue, useAtomSet } from "@effect/atom-react";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 import * as Exit from "effect/Exit";
-import {
-  IntegrationSlug,
-  type Connection,
-  type Owner,
-} from "@executor-js/sdk/shared";
+import { IntegrationSlug, type Connection, type Owner } from "@executor-js/sdk/shared";
 import type { IntegrationAccountHandoff } from "@executor-js/sdk/client";
 import { toast } from "sonner";
 
@@ -84,10 +80,7 @@ function AccountRow(props: {
         <CardStackEntryTitle className="flex min-w-0 items-center gap-2">
           <span className="truncate">{displayLabel}</span>
           {needsReconsent ? (
-            <Badge
-              variant="outline"
-              className="shrink-0 border-border text-muted-foreground"
-            >
+            <Badge variant="outline" className="shrink-0 border-border text-muted-foreground">
               Reconnect to grant access
             </Badge>
           ) : null}
@@ -99,8 +92,7 @@ function AccountRow(props: {
         ) : null}
         {needsReconsent ? (
           <CardStackEntryDescription className="mt-1 text-xs text-muted-foreground">
-            This connection wasn't granted all the access this integration now
-            needs.
+            This connection wasn't granted all the access this integration now needs.
           </CardStackEntryDescription>
         ) : null}
       </CardStackEntryContent>
@@ -129,11 +121,7 @@ function AccountRow(props: {
             <DropdownMenuItem className="text-sm" onClick={props.onReconnect}>
               Reconnect
             </DropdownMenuItem>
-            <DropdownMenuItem
-              variant="destructive"
-              className="text-sm"
-              onClick={props.onRemove}
-            >
+            <DropdownMenuItem variant="destructive" className="text-sm" onClick={props.onRemove}>
               Remove
             </DropdownMenuItem>
           </DropdownMenuContent>
@@ -155,9 +143,7 @@ function OwnerAccounts(props: {
   readonly declaredScopes: readonly string[] | undefined;
 }) {
   const { integration, owner } = props;
-  const connections = useAtomValue(
-    connectionsForIntegrationAtom({ integration, owner }),
-  );
+  const connections = useAtomValue(connectionsForIntegrationAtom({ integration, owner }));
   const doRemove = useAtomSet(removeConnectionOptimistic(owner), {
     mode: "promiseExit",
   });
@@ -174,9 +160,7 @@ function OwnerAccounts(props: {
     startErrorMessage: "Failed to reconnect",
   });
 
-  const rows: readonly Connection[] = AsyncResult.isSuccess(connections)
-    ? connections.value
-    : [];
+  const rows: readonly Connection[] = AsyncResult.isSuccess(connections) ? connections.value : [];
   if (rows.length === 0) return null;
 
   const handleReconnect = async (connection: Connection) => {
@@ -185,8 +169,7 @@ function OwnerAccounts(props: {
     if (reconnectMode(connection) === "oauth") {
       const method = props.methods.find(
         (candidate: AuthMethod) =>
-          candidate.kind === "oauth" &&
-          String(candidate.template) === String(connection.template),
+          candidate.kind === "oauth" && String(candidate.template) === String(connection.template),
       );
       if (
         method?.oauth?.supportsDynamicRegistration === true ||
@@ -293,18 +276,13 @@ function OwnerAccounts(props: {
 
   return (
     <CardStack>
-      {props.showOwnerLabels ? (
-        <CardStackHeader>{ownerLabel(owner)}</CardStackHeader>
-      ) : null}
+      {props.showOwnerLabels ? <CardStackHeader>{ownerLabel(owner)}</CardStackHeader> : null}
       <CardStackContent>
         {rows.map((connection: Connection) => (
           <AccountRow
             key={`${connection.owner}:${connection.integration}:${connection.name}`}
             connection={connection}
-            needsReconsent={connectionNeedsReconsent(
-              connection,
-              props.declaredScopes,
-            )}
+            needsReconsent={connectionNeedsReconsent(connection, props.declaredScopes)}
             showOwnerLabel={props.showOwnerLabels}
             onEdit={() => props.onEdit(connection)}
             onReconnect={() => void handleReconnect(connection)}
@@ -335,14 +313,10 @@ export function AccountsSection(props: {
     removeCustomMethod,
   } = props;
   const [adding, setAdding] = useState(false);
-  const [editingConnection, setEditingConnection] = useState<Connection | null>(
-    null,
-  );
-  const [reconnectHandoff, setReconnectHandoff] =
-    useState<IntegrationAccountHandoff | null>(null);
+  const [editingConnection, setEditingConnection] = useState<Connection | null>(null);
+  const [reconnectHandoff, setReconnectHandoff] = useState<IntegrationAccountHandoff | null>(null);
   const ownerDisplay = useOwnerDisplay();
-  const canAddConnection =
-    methods.length > 0 || createCustomMethod !== undefined;
+  const canAddConnection = methods.length > 0 || createCustomMethod !== undefined;
 
   useEffect(() => {
     if (accountHandoff) {
@@ -364,9 +338,7 @@ export function AccountsSection(props: {
 
   // Read both owners to decide between the grouped view and the empty CTA. The
   // grouped sub-components re-read these (effect-atom dedupes) and self-hide.
-  const orgConnections = useAtomValue(
-    connectionsForIntegrationAtom({ integration, owner: "org" }),
-  );
+  const orgConnections = useAtomValue(connectionsForIntegrationAtom({ integration, owner: "org" }));
   const userConnections = useAtomValue(
     connectionsForIntegrationAtom({ integration, owner: "user" }),
   );
@@ -377,18 +349,12 @@ export function AccountsSection(props: {
   useAtomSet(addConnectionOptimistic("user"));
 
   const totalCount = useMemo(() => {
-    const orgRows = AsyncResult.isSuccess(orgConnections)
-      ? orgConnections.value.length
-      : 0;
-    const userRows = AsyncResult.isSuccess(userConnections)
-      ? userConnections.value.length
-      : 0;
+    const orgRows = AsyncResult.isSuccess(orgConnections) ? orgConnections.value.length : 0;
+    const userRows = AsyncResult.isSuccess(userConnections) ? userConnections.value.length : 0;
     return orgRows + userRows;
   }, [orgConnections, userConnections]);
 
-  const loading =
-    !AsyncResult.isSuccess(orgConnections) &&
-    !AsyncResult.isSuccess(userConnections);
+  const loading = !AsyncResult.isSuccess(orgConnections) && !AsyncResult.isSuccess(userConnections);
 
   const modalState = reconnectHandoff ?? accountHandoff;
   const modal = (
@@ -420,9 +386,7 @@ export function AccountsSection(props: {
           onClick={() => {
             trackEvent("connection_add_opened", {
               integration_slug: String(integration),
-              has_oauth_method: methods.some(
-                (m: AuthMethod) => m.kind === "oauth",
-              ),
+              has_oauth_method: methods.some((m: AuthMethod) => m.kind === "oauth"),
               has_api_key_method: methods.some(
                 (m: AuthMethod) => m.kind !== "oauth" && m.kind !== "none",
               ),
@@ -442,9 +406,7 @@ export function AccountsSection(props: {
         </div>
       ) : totalCount === 0 ? (
         <div className="rounded-lg border border-dashed border-border/60 px-6 py-8 text-center">
-          <p className="text-sm font-medium text-foreground">
-            No connections yet
-          </p>
+          <p className="text-sm font-medium text-foreground">No connections yet</p>
           <p className="mt-1 text-sm text-muted-foreground">
             Add a connection to make this integration's tools available.
           </p>
@@ -455,9 +417,7 @@ export function AccountsSection(props: {
             onClick={() => {
               trackEvent("connection_add_opened", {
                 integration_slug: String(integration),
-                has_oauth_method: methods.some(
-                  (m: AuthMethod) => m.kind === "oauth",
-                ),
+                has_oauth_method: methods.some((m: AuthMethod) => m.kind === "oauth"),
                 has_api_key_method: methods.some(
                   (m: AuthMethod) => m.kind !== "oauth" && m.kind !== "none",
                 ),

--- a/packages/react/src/components/tool-run-panel.tsx
+++ b/packages/react/src/components/tool-run-panel.tsx
@@ -215,8 +215,10 @@ export function ToolRunPanel(props: {
 
     // Read-only invoke: pass the validated args through as JSON. Empty
     // `reactivityKeys` — invoking a tool doesn't mutate `tools.list`.
+    // `autoApprove` because the operator clicked Run: that IS the approval, so
+    // an approval-gated tool should run here instead of dead-ending on a pause.
     const code = `return await tools[${JSON.stringify(addressNoPrefix)}](${JSON.stringify(parsed)});`;
-    const exit = await doExecute({ payload: { code }, reactivityKeys: [] });
+    const exit = await doExecute({ payload: { code, autoApprove: true }, reactivityKeys: [] });
     setRunning(false);
 
     if (Exit.isFailure(exit)) {

--- a/packages/react/src/plugins/oauth-reconnect.ts
+++ b/packages/react/src/plugins/oauth-reconnect.ts
@@ -28,9 +28,7 @@ export function reconnectMode(connection: Connection): ReconnectMode {
  *  connection are exactly the branded types `oauth.start` expects, so the same
  *  connection (owner/integration/name) is re-minted with a fresh refresh token
  *  and the widened scope union. Returns null for a non-OAuth connection. */
-export function oauthReconnectPayload(
-  connection: Connection,
-): OAuthStartPayload | null {
+export function oauthReconnectPayload(connection: Connection): OAuthStartPayload | null {
   if (connection.oauthClient == null) return null;
   return {
     client: connection.oauthClient,
@@ -61,8 +59,7 @@ const OAUTH_SCOPE_ALIASES: Readonly<Record<string, string>> = {
   "https://www.googleapis.com/auth/userinfo.profile": "profile",
 };
 
-const canonicalScope = (scope: string): string =>
-  OAUTH_SCOPE_ALIASES[scope] ?? scope;
+const canonicalScope = (scope: string): string => OAUTH_SCOPE_ALIASES[scope] ?? scope;
 
 /** Normalize a scope list: trim, canonicalize known provider aliases, drop
  *  empties, de-dupe (order-preserving). A scope set is compared as a SET —
@@ -94,12 +91,8 @@ export function missingScopes(
 
 /** The scopes a connection was actually GRANTED, parsed from its space-delimited
  *  `oauthScope` record. Empty for static creds / when the AS omitted scope. */
-export function connectionGrantedScopes(
-  connection: Connection,
-): readonly string[] {
-  return connection.oauthScope
-    ? connection.oauthScope.split(/\s+/).filter(Boolean)
-    : [];
+export function connectionGrantedScopes(connection: Connection): readonly string[] {
+  return connection.oauthScope ? connection.oauthScope.split(/\s+/).filter(Boolean) : [];
 }
 
 /** Whether an OAuth connection must RECONNECT to grant newly-needed access: the
@@ -113,10 +106,7 @@ export function connectionNeedsReconsent(
   declaredScopes: readonly string[] | undefined,
 ): boolean {
   if (connection.oauthClient == null) return false;
-  return (
-    missingScopes(declaredScopes, connectionGrantedScopes(connection)).length >
-    0
-  );
+  return missingScopes(declaredScopes, connectionGrantedScopes(connection)).length > 0;
 }
 
 /** The scopes that count as REQUIRED for a connection to be considered fully


### PR DESCRIPTION
Invoking a tool through the Run/Test panel paused on approval-gated tools and dead-ended on a "This tool requires approval (a policy gates it)" message, with no way to actually run it from the panel. But the operator clicking **Run** is itself the approval, so the panel should just run the tool.

## What changed

`autoApprove` is threaded through the execute path. When set, the execution engine runs the inline accept-all handler instead of intercepting the first elicitation as a pause, so an approval-gated tool runs to completion:

- `executeWithPause(code, { autoApprove })` in the engine
- `POST /executions` accepts an optional `autoApprove`
- the Run panel sends `autoApprove: true`

Safety is preserved: `block` policies fail before any elicitation, so this never bypasses a hard block. The MCP host path is unchanged and still pauses for the model to approve.

## Before / after

Same tool, same `Require approval · npmdl.*` policy badge. Before, the panel dead-ends; after, it returns the real result (HTTP 200, real download count).

**Before**

![before](https://raw.githubusercontent.com/RhysSullivan/executor/e2e-media/before-0d5b6b16.png)

**After**

![after](https://raw.githubusercontent.com/RhysSullivan/executor/e2e-media/after-d139b59f.png)

## Tests

- New cross-target e2e scenario `e2e/scenarios/run-panel-auto-approve.test.ts`: drives the same `POST /executions` endpoint the panel uses against a tool gated by its own `requiresApproval` annotation. Without `autoApprove` the call pauses and the side effect does not happen; with `autoApprove` it runs to completion and the side effect lands. Green against a live selfhost instance.
- New engine unit test in `tool-invoker.test.ts`: the same eliciting tool that pauses without `autoApprove` runs straight to completion with it.
- Existing pause/resume suites still green (the default, non-`autoApprove` path is untouched).
