### PR TITLE
Unify settings page layout

### DIFF
--- a/apps/cloud/src/routes/app/billing.tsx
+++ b/apps/cloud/src/routes/app/billing.tsx
@@ -136,10 +136,12 @@ function BillingPage() {
             <p className="text-sm font-medium text-foreground">Executions</p>
             <p className="text-sm tabular-nums text-muted-foreground">
               {executions.usage.toLocaleString()}
-              <span className="text-muted-foreground">
-                {" / "}
-                {executions.granted.toLocaleString()} this month
-              </span>
+              {!executions.unlimited && (
+                <span className="text-muted-foreground">
+                  {" / "}
+                  {executions.granted.toLocaleString()} this month
+                </span>
+              )}
             </p>
           </div>
           {!executions.unlimited && executions.granted > 0 && (

--- a/apps/cloud/src/routes/app/billing.tsx
+++ b/apps/cloud/src/routes/app/billing.tsx
@@ -3,6 +3,7 @@ import { useCustomer, useListPlans } from "autumn-js/react";
 import { trackEvent } from "@executor-js/react/api/analytics";
 import { Button } from "@executor-js/react/components/button";
 import { Badge } from "@executor-js/react/components/badge";
+import { PageContainer, PageHeader } from "@executor-js/react/components/page";
 
 type Plan = NonNullable<ReturnType<typeof useListPlans>["data"]>[number];
 
@@ -22,14 +23,12 @@ function BillingPage() {
 
   if (customerLoading || plansLoading) {
     return (
-      <div className="min-h-0 flex-1 overflow-y-auto">
-        <div className="mx-auto max-w-3xl px-6 py-10 lg:px-8 lg:py-14">
-          <div className="mb-10">
-            <div className="h-8 w-28 animate-pulse rounded bg-muted" />
-          </div>
-          <div className="h-16 animate-pulse rounded-lg bg-muted" />
+      <PageContainer>
+        <div className="mb-10">
+          <div className="h-8 w-28 animate-pulse rounded bg-muted" />
         </div>
-      </div>
+        <div className="h-16 animate-pulse rounded-lg bg-muted" />
+      </PageContainer>
     );
   }
 
@@ -58,110 +57,106 @@ function BillingPage() {
   const members = customer?.balances?.members;
 
   return (
-    <div className="min-h-0 flex-1 overflow-y-auto">
-      <div className="mx-auto max-w-3xl px-6 py-10 lg:px-8 lg:py-14">
-        <h1 className="font-display text-[2rem] tracking-tight text-foreground leading-none mb-10">
-          Billing
-        </h1>
+    <PageContainer>
+      <PageHeader title="Billing" />
 
-        {/* Current plan */}
-        <div className="flex items-center justify-between py-4">
-          <div>
-            <div className="flex items-center gap-2">
-              <p className="text-sm font-medium text-foreground leading-none">{planName}</p>
-              {isSwitching && <Badge className="bg-muted text-muted-foreground">Switching</Badge>}
-              {isCanceling && !isSwitching && (
-                <Badge className="bg-muted text-muted-foreground">Canceling</Badge>
-              )}
-              {isTrialing && !isCanceling && (
-                <Badge className="bg-primary/10 text-primary">Free trial</Badge>
-              )}
-            </div>
-            <p className="mt-1 text-xs text-muted-foreground leading-none">
-              {isSwitching && sub?.currentPeriodEnd
-                ? `Starts ${new Date(sub.currentPeriodEnd).toLocaleDateString(undefined, { month: "long", day: "numeric", year: "numeric" })}`
-                : isCanceling && sub?.currentPeriodEnd
-                  ? `Access until ${new Date(sub.currentPeriodEnd).toLocaleDateString(undefined, { month: "long", day: "numeric", year: "numeric" })}`
-                  : isTrialing && sub?.currentPeriodEnd
-                    ? `Trial ends, then billing starts ${new Date(sub.currentPeriodEnd).toLocaleDateString(undefined, { month: "long", day: "numeric", year: "numeric" })}`
-                    : sub?.currentPeriodEnd
-                      ? `Renews ${new Date(sub.currentPeriodEnd).toLocaleDateString(undefined, { month: "long", day: "numeric", year: "numeric" })}`
-                      : tagline}
-            </p>
-          </div>
+      {/* Current plan */}
+      <div className="flex items-center justify-between py-4">
+        <div>
           <div className="flex items-center gap-2">
-            {activePlan && !isCanceling && (
-              <Button
-                variant="ghost"
-                type="button"
-                onClick={() => {
-                  trackEvent("billing_cancel_plan_clicked", { plan_id: planId });
-                  openCustomerPortal();
-                }}
-                className="rounded-md px-3 py-1.5 text-xs font-medium text-destructive transition-colors hover:bg-destructive/10"
-              >
-                Cancel plan
-              </Button>
+            <p className="text-sm font-medium text-foreground leading-none">{planName}</p>
+            {isSwitching && <Badge className="bg-muted text-muted-foreground">Switching</Badge>}
+            {isCanceling && !isSwitching && (
+              <Badge className="bg-muted text-muted-foreground">Canceling</Badge>
             )}
-            <Link
-              to="/{-$orgSlug}/billing/plans"
-              onClick={() => trackEvent("billing_manage_opened")}
-              className="rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/90"
-            >
-              Manage
-            </Link>
+            {isTrialing && !isCanceling && (
+              <Badge className="bg-primary/10 text-primary">Free trial</Badge>
+            )}
           </div>
+          <p className="mt-1 text-xs text-muted-foreground leading-none">
+            {isSwitching && sub?.currentPeriodEnd
+              ? `Starts ${new Date(sub.currentPeriodEnd).toLocaleDateString(undefined, { month: "long", day: "numeric", year: "numeric" })}`
+              : isCanceling && sub?.currentPeriodEnd
+                ? `Access until ${new Date(sub.currentPeriodEnd).toLocaleDateString(undefined, { month: "long", day: "numeric", year: "numeric" })}`
+                : isTrialing && sub?.currentPeriodEnd
+                  ? `Trial ends, then billing starts ${new Date(sub.currentPeriodEnd).toLocaleDateString(undefined, { month: "long", day: "numeric", year: "numeric" })}`
+                  : sub?.currentPeriodEnd
+                    ? `Renews ${new Date(sub.currentPeriodEnd).toLocaleDateString(undefined, { month: "long", day: "numeric", year: "numeric" })}`
+                    : tagline}
+          </p>
         </div>
+        <div className="flex items-center gap-2">
+          {activePlan && !isCanceling && (
+            <Button
+              variant="ghost"
+              type="button"
+              onClick={() => {
+                trackEvent("billing_cancel_plan_clicked", { plan_id: planId });
+                openCustomerPortal();
+              }}
+              className="rounded-md px-3 py-1.5 text-xs font-medium text-destructive transition-colors hover:bg-destructive/10"
+            >
+              Cancel plan
+            </Button>
+          )}
+          <Link
+            to="/{-$orgSlug}/billing/plans"
+            onClick={() => trackEvent("billing_manage_opened")}
+            className="rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+          >
+            Manage
+          </Link>
+        </div>
+      </div>
 
-        {/* Divider */}
-        <div className="h-px bg-border/50 my-2" />
+      {/* Divider */}
+      <div className="h-px bg-border/50 my-2" />
 
-        {/* Usage */}
-        {members && (
-          <div className="py-4">
-            <div className="flex items-center justify-between mb-2">
-              <p className="text-sm font-medium text-foreground">Members</p>
-              <p className="text-sm tabular-nums text-muted-foreground">
-                {members.usage.toLocaleString()}
-                {!members.unlimited && (
-                  <span className="text-muted-foreground">
-                    {" / "}
-                    {members.granted.toLocaleString()}
-                  </span>
-                )}
-              </p>
-            </div>
-          </div>
-        )}
-
-        {executions && (
-          <div className="py-4">
-            <div className="flex items-center justify-between mb-2">
-              <p className="text-sm font-medium text-foreground">Executions</p>
-              <p className="text-sm tabular-nums text-muted-foreground">
-                {executions.usage.toLocaleString()}
+      {/* Usage */}
+      {members && (
+        <div className="py-4">
+          <div className="flex items-center justify-between mb-2">
+            <p className="text-sm font-medium text-foreground">Members</p>
+            <p className="text-sm tabular-nums text-muted-foreground">
+              {members.usage.toLocaleString()}
+              {!members.unlimited && (
                 <span className="text-muted-foreground">
                   {" / "}
-                  {executions.granted.toLocaleString()} this month
+                  {members.granted.toLocaleString()}
                 </span>
-              </p>
-            </div>
-            {!executions.unlimited && executions.granted > 0 && (
-              <div className="h-1.5 w-full overflow-hidden rounded-full bg-border">
-                <div
-                  className="h-full rounded-full bg-primary transition-all duration-300"
-                  style={
-                    {
-                      "--progress": `${Math.min(100, (executions.usage / executions.granted) * 100)}%`,
-                      width: "var(--progress)",
-                    } as React.CSSProperties
-                  }
-                />
-              </div>
-            )}
+              )}
+            </p>
           </div>
-        )}
-      </div>
-    </div>
+        </div>
+      )}
+
+      {executions && (
+        <div className="py-4">
+          <div className="flex items-center justify-between mb-2">
+            <p className="text-sm font-medium text-foreground">Executions</p>
+            <p className="text-sm tabular-nums text-muted-foreground">
+              {executions.usage.toLocaleString()}
+              <span className="text-muted-foreground">
+                {" / "}
+                {executions.granted.toLocaleString()} this month
+              </span>
+            </p>
+          </div>
+          {!executions.unlimited && executions.granted > 0 && (
+            <div className="h-1.5 w-full overflow-hidden rounded-full bg-border">
+              <div
+                className="h-full rounded-full bg-primary transition-all duration-300"
+                style={
+                  {
+                    "--progress": `${Math.min(100, (executions.usage / executions.granted) * 100)}%`,
+                    width: "var(--progress)",
+                  } as React.CSSProperties
+                }
+              />
+            </div>
+          )}
+        </div>
+      )}
+    </PageContainer>
   );
 }

--- a/e2e/scenarios/openapi-add-integration-action-bar.test.ts
+++ b/e2e/scenarios/openapi-add-integration-action-bar.test.ts
@@ -37,7 +37,9 @@ scenario(
         });
 
         await step("Paste a single-server spec so Add integration is enabled", async () => {
-          await page.getByPlaceholder("https://api.example.com/openapi.json").fill(singleServerSpec);
+          await page
+            .getByPlaceholder("https://api.example.com/openapi.json")
+            .fill(singleServerSpec);
           await page.getByRole("button", { name: "Add integration" }).waitFor({ timeout: 20_000 });
         });
 
@@ -49,22 +51,28 @@ scenario(
           expect(count, "a single Add integration button is rendered").toBe(1);
         });
 
-        await step("Submitting does not reflow the bar, then lands on the integration", async () => {
-          // The reported ghost was the bar painting doubled when the submit
-          // button changed width on click. With a stable-width loading button the
-          // row must not move: Cancel stays put while the add is in flight.
-          const cancel = page.getByRole("button", { name: "Cancel" });
-          const before = await cancel.boundingBox();
-          await page.getByRole("button", { name: "Add integration" }).click();
-          // The submit button marks itself data-loading synchronously on click.
-          await page.locator('[data-slot="button"][data-loading]').first().waitFor({ timeout: 5_000 });
-          const during = await cancel.boundingBox();
-          expect(Math.round(during?.x ?? -1), "Cancel does not move when submitting").toBe(
-            Math.round(before?.x ?? -2),
-          );
-          await page.waitForURL(/\/integrations\/(?!add\b)[^/?]+$/, { timeout: 30_000 });
-          await page.getByText("Connections").first().waitFor();
-        });
+        await step(
+          "Submitting does not reflow the bar, then lands on the integration",
+          async () => {
+            // The reported ghost was the bar painting doubled when the submit
+            // button changed width on click. With a stable-width loading button the
+            // row must not move: Cancel stays put while the add is in flight.
+            const cancel = page.getByRole("button", { name: "Cancel" });
+            const before = await cancel.boundingBox();
+            await page.getByRole("button", { name: "Add integration" }).click();
+            // The submit button marks itself data-loading synchronously on click.
+            await page
+              .locator('[data-slot="button"][data-loading]')
+              .first()
+              .waitFor({ timeout: 5_000 });
+            const during = await cancel.boundingBox();
+            expect(Math.round(during?.x ?? -1), "Cancel does not move when submitting").toBe(
+              Math.round(before?.x ?? -2),
+            );
+            await page.waitForURL(/\/integrations\/(?!add\b)[^/?]+$/, { timeout: 30_000 });
+            await page.getByText("Connections").first().waitFor();
+          },
+        );
 
         await step("The empty connections state renders", async () => {
           await page.getByText("No connections yet").waitFor({ timeout: 20_000 });
@@ -74,9 +82,7 @@ scenario(
           // Regression cover for the doubled-button report: the empty state used
           // to render both a header "Add connection" and a card "Add a
           // connection". Match either label so a regression is actually counted.
-          const count = await page
-            .getByRole("button", { name: /^Add (a )?connection$/i })
-            .count();
+          const count = await page.getByRole("button", { name: /^Add (a )?connection$/i }).count();
           expect(count, "empty state shows exactly one add-connection button").toBe(1);
         });
       });

--- a/packages/core/cli/package.json
+++ b/packages/core/cli/package.json
@@ -23,7 +23,6 @@
     ".": "./src/index.ts"
   },
   "publishConfig": {
-    "access": "public",
     "exports": {
       ".": {
         "import": {
@@ -31,7 +30,8 @@
           "default": "./dist/index.js"
         }
       }
-    }
+    },
+    "access": "public"
   },
   "scripts": {
     "build": "tsup && (tsc --declaration --emitDeclarationOnly --outDir dist --rootDir src || true)",

--- a/packages/core/config/package.json
+++ b/packages/core/config/package.json
@@ -19,7 +19,6 @@
     ".": "./src/index.ts"
   },
   "publishConfig": {
-    "access": "public",
     "exports": {
       ".": {
         "import": {
@@ -27,7 +26,8 @@
           "default": "./dist/index.js"
         }
       }
-    }
+    },
+    "access": "public"
   },
   "scripts": {
     "build": "tsup && (tsc --declaration --emitDeclarationOnly --outDir dist --rootDir src || true)",

--- a/packages/core/execution/package.json
+++ b/packages/core/execution/package.json
@@ -20,7 +20,6 @@
     "./promise": "./src/promise.ts"
   },
   "publishConfig": {
-    "access": "public",
     "exports": {
       ".": {
         "import": {
@@ -34,7 +33,8 @@
           "default": "./dist/core.js"
         }
       }
-    }
+    },
+    "access": "public"
   },
   "scripts": {
     "build": "tsup && (tsc --declaration --emitDeclarationOnly --outDir dist --rootDir src || true)",

--- a/packages/core/integrations-registry/package.json
+++ b/packages/core/integrations-registry/package.json
@@ -20,7 +20,6 @@
     ".": "./src/index.ts"
   },
   "publishConfig": {
-    "access": "public",
     "exports": {
       ".": {
         "import": {
@@ -28,7 +27,8 @@
           "default": "./dist/index.js"
         }
       }
-    }
+    },
+    "access": "public"
   },
   "scripts": {
     "build": "tsup && (tsc --declaration --emitDeclarationOnly --outDir dist --rootDir src || true)",

--- a/packages/core/sdk/package.json
+++ b/packages/core/sdk/package.json
@@ -28,7 +28,6 @@
     "./public-origin": "./src/public-origin.ts"
   },
   "publishConfig": {
-    "access": "public",
     "exports": {
       ".": {
         "import": {
@@ -84,7 +83,8 @@
           "default": "./dist/public-origin.js"
         }
       }
-    }
+    },
+    "access": "public"
   },
   "scripts": {
     "build": "tsup && (tsc --declaration --emitDeclarationOnly --outDir dist --rootDir src || true)",

--- a/packages/core/vite-plugin/package.json
+++ b/packages/core/vite-plugin/package.json
@@ -23,7 +23,6 @@
     }
   },
   "publishConfig": {
-    "access": "public",
     "exports": {
       ".": {
         "import": {
@@ -31,7 +30,8 @@
           "default": "./dist/index.js"
         }
       }
-    }
+    },
+    "access": "public"
   },
   "scripts": {
     "build": "tsup && (tsc --declaration --emitDeclarationOnly --outDir dist --rootDir src || true)",

--- a/packages/kernel/core/package.json
+++ b/packages/kernel/core/package.json
@@ -19,7 +19,6 @@
     ".": "./src/index.ts"
   },
   "publishConfig": {
-    "access": "public",
     "exports": {
       ".": {
         "import": {
@@ -27,7 +26,8 @@
           "default": "./dist/index.js"
         }
       }
-    }
+    },
+    "access": "public"
   },
   "scripts": {
     "build": "tsup && (tsc --declaration --emitDeclarationOnly --outDir dist --rootDir src || true)",

--- a/packages/kernel/runtime-quickjs/package.json
+++ b/packages/kernel/runtime-quickjs/package.json
@@ -19,7 +19,6 @@
     ".": "./src/index.ts"
   },
   "publishConfig": {
-    "access": "public",
     "exports": {
       ".": {
         "import": {
@@ -27,7 +26,8 @@
           "default": "./dist/index.js"
         }
       }
-    }
+    },
+    "access": "public"
   },
   "scripts": {
     "build": "tsup && (tsc --declaration --emitDeclarationOnly --outDir dist --rootDir src || true)",

--- a/packages/plugins/desktop-settings/package.json
+++ b/packages/plugins/desktop-settings/package.json
@@ -20,7 +20,6 @@
     "./client": "./src/client.tsx"
   },
   "publishConfig": {
-    "access": "public",
     "exports": {
       "./server": {
         "import": {
@@ -34,7 +33,8 @@
           "default": "./dist/client.js"
         }
       }
-    }
+    },
+    "access": "public"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/plugins/example/package.json
+++ b/packages/plugins/example/package.json
@@ -21,7 +21,6 @@
     "./shared": "./src/shared.ts"
   },
   "publishConfig": {
-    "access": "public",
     "exports": {
       "./server": {
         "import": {
@@ -41,7 +40,8 @@
           "default": "./dist/shared.js"
         }
       }
-    }
+    },
+    "access": "public"
   },
   "scripts": {
     "build": "tsup && (tsc --declaration --emitDeclarationOnly --outDir dist --rootDir src || true)",

--- a/packages/plugins/file-secrets/package.json
+++ b/packages/plugins/file-secrets/package.json
@@ -20,7 +20,6 @@
     "./promise": "./src/promise.ts"
   },
   "publishConfig": {
-    "access": "public",
     "exports": {
       ".": {
         "import": {
@@ -34,7 +33,8 @@
           "default": "./dist/core.js"
         }
       }
-    }
+    },
+    "access": "public"
   },
   "scripts": {
     "build": "tsup && (tsc --declaration --emitDeclarationOnly --outDir dist --rootDir src || true)",

--- a/packages/plugins/google/package.json
+++ b/packages/plugins/google/package.json
@@ -23,7 +23,6 @@
     "./client": "./src/react/plugin-client.tsx"
   },
   "publishConfig": {
-    "access": "public",
     "exports": {
       ".": {
         "import": {
@@ -43,7 +42,8 @@
           "default": "./dist/client.js"
         }
       }
-    }
+    },
+    "access": "public"
   },
   "scripts": {
     "build": "tsup && (tsc --declaration --emitDeclarationOnly --outDir dist --rootDir src || true)",

--- a/packages/plugins/graphql/package.json
+++ b/packages/plugins/graphql/package.json
@@ -25,7 +25,6 @@
     "./testing": "./src/testing/index.ts"
   },
   "publishConfig": {
-    "access": "public",
     "exports": {
       ".": {
         "import": {
@@ -51,7 +50,8 @@
           "default": "./dist/testing.js"
         }
       }
-    }
+    },
+    "access": "public"
   },
   "scripts": {
     "build": "tsup && (tsc --declaration --emitDeclarationOnly --outDir dist --rootDir src || true)",

--- a/packages/plugins/keychain/package.json
+++ b/packages/plugins/keychain/package.json
@@ -20,7 +20,6 @@
     "./promise": "./src/promise.ts"
   },
   "publishConfig": {
-    "access": "public",
     "exports": {
       ".": {
         "import": {
@@ -34,7 +33,8 @@
           "default": "./dist/core.js"
         }
       }
-    }
+    },
+    "access": "public"
   },
   "scripts": {
     "build": "tsup && (tsc --declaration --emitDeclarationOnly --outDir dist --rootDir src || true)",

--- a/packages/plugins/mcp/package.json
+++ b/packages/plugins/mcp/package.json
@@ -25,7 +25,6 @@
     "./testing": "./src/testing/index.ts"
   },
   "publishConfig": {
-    "access": "public",
     "exports": {
       ".": {
         "import": {
@@ -51,7 +50,8 @@
           "default": "./dist/testing.js"
         }
       }
-    }
+    },
+    "access": "public"
   },
   "scripts": {
     "build": "tsup && (tsc --declaration --emitDeclarationOnly --outDir dist --rootDir src || true)",

--- a/packages/plugins/microsoft/package.json
+++ b/packages/plugins/microsoft/package.json
@@ -23,7 +23,6 @@
     "./client": "./src/react/plugin-client.tsx"
   },
   "publishConfig": {
-    "access": "public",
     "exports": {
       ".": {
         "import": {
@@ -43,7 +42,8 @@
           "default": "./dist/client.js"
         }
       }
-    }
+    },
+    "access": "public"
   },
   "scripts": {
     "build": "tsup && (tsc --declaration --emitDeclarationOnly --outDir dist --rootDir src || true)",

--- a/packages/plugins/onepassword/package.json
+++ b/packages/plugins/onepassword/package.json
@@ -23,7 +23,6 @@
     "./client": "./src/react/plugin-client.tsx"
   },
   "publishConfig": {
-    "access": "public",
     "exports": {
       ".": {
         "import": {
@@ -43,7 +42,8 @@
           "default": "./dist/client.js"
         }
       }
-    }
+    },
+    "access": "public"
   },
   "scripts": {
     "build": "tsup && (tsc --declaration --emitDeclarationOnly --outDir dist --rootDir src || true)",

--- a/packages/plugins/openapi/package.json
+++ b/packages/plugins/openapi/package.json
@@ -25,7 +25,6 @@
     "./testing": "./src/testing/index.ts"
   },
   "publishConfig": {
-    "access": "public",
     "exports": {
       ".": {
         "import": {
@@ -51,7 +50,8 @@
           "default": "./dist/testing.js"
         }
       }
-    }
+    },
+    "access": "public"
   },
   "scripts": {
     "build": "tsup && (tsc --declaration --emitDeclarationOnly --outDir dist --rootDir src || true)",

--- a/packages/plugins/toolkits/package.json
+++ b/packages/plugins/toolkits/package.json
@@ -21,7 +21,6 @@
     "./shared": "./src/shared.ts"
   },
   "publishConfig": {
-    "access": "public",
     "exports": {
       "./server": {
         "import": {
@@ -41,7 +40,8 @@
           "default": "./dist/shared.js"
         }
       }
-    }
+    },
+    "access": "public"
   },
   "scripts": {
     "build": "tsup && (tsc --declaration --emitDeclarationOnly --outDir dist --rootDir src || true)",

--- a/packages/plugins/workos-vault/package.json
+++ b/packages/plugins/workos-vault/package.json
@@ -23,7 +23,6 @@
     "./testing": "./src/sdk/testing.ts"
   },
   "publishConfig": {
-    "access": "public",
     "exports": {
       ".": {
         "import": {
@@ -43,7 +42,8 @@
           "default": "./dist/testing.js"
         }
       }
-    }
+    },
+    "access": "public"
   },
   "scripts": {
     "build": "tsup && (tsc --declaration --emitDeclarationOnly --outDir dist --rootDir src || true)",

--- a/packages/react/src/components/accounts-section.tsx
+++ b/packages/react/src/components/accounts-section.tsx
@@ -366,9 +366,7 @@ export function AccountsSection(props: {
     trackEvent("connection_add_opened", {
       integration_slug: String(integration),
       has_oauth_method: methods.some((m: AuthMethod) => m.kind === "oauth"),
-      has_api_key_method: methods.some(
-        (m: AuthMethod) => m.kind !== "oauth" && m.kind !== "none",
-      ),
+      has_api_key_method: methods.some((m: AuthMethod) => m.kind !== "oauth" && m.kind !== "none"),
     });
     setAdding(true);
   };

--- a/packages/react/src/components/accounts-section.tsx
+++ b/packages/react/src/components/accounts-section.tsx
@@ -2,11 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useAtomValue, useAtomSet } from "@effect/atom-react";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 import * as Exit from "effect/Exit";
-import {
-  IntegrationSlug,
-  type Connection,
-  type Owner,
-} from "@executor-js/sdk/shared";
+import { IntegrationSlug, type Connection, type Owner } from "@executor-js/sdk/shared";
 import type { IntegrationAccountHandoff } from "@executor-js/sdk/client";
 import { toast } from "sonner";
 
@@ -84,10 +80,7 @@ function AccountRow(props: {
         <CardStackEntryTitle className="flex min-w-0 items-center gap-2">
           <span className="truncate">{displayLabel}</span>
           {needsReconsent ? (
-            <Badge
-              variant="outline"
-              className="shrink-0 border-border text-muted-foreground"
-            >
+            <Badge variant="outline" className="shrink-0 border-border text-muted-foreground">
               Reconnect to grant access
             </Badge>
           ) : null}
@@ -99,8 +92,7 @@ function AccountRow(props: {
         ) : null}
         {needsReconsent ? (
           <CardStackEntryDescription className="mt-1 text-xs text-muted-foreground">
-            This connection wasn't granted all the access this integration now
-            needs.
+            This connection wasn't granted all the access this integration now needs.
           </CardStackEntryDescription>
         ) : null}
       </CardStackEntryContent>
@@ -129,11 +121,7 @@ function AccountRow(props: {
             <DropdownMenuItem className="text-sm" onClick={props.onReconnect}>
               Reconnect
             </DropdownMenuItem>
-            <DropdownMenuItem
-              variant="destructive"
-              className="text-sm"
-              onClick={props.onRemove}
-            >
+            <DropdownMenuItem variant="destructive" className="text-sm" onClick={props.onRemove}>
               Remove
             </DropdownMenuItem>
           </DropdownMenuContent>
@@ -155,9 +143,7 @@ function OwnerAccounts(props: {
   readonly declaredScopes: readonly string[] | undefined;
 }) {
   const { integration, owner } = props;
-  const connections = useAtomValue(
-    connectionsForIntegrationAtom({ integration, owner }),
-  );
+  const connections = useAtomValue(connectionsForIntegrationAtom({ integration, owner }));
   const doRemove = useAtomSet(removeConnectionOptimistic(owner), {
     mode: "promiseExit",
   });
@@ -174,9 +160,7 @@ function OwnerAccounts(props: {
     startErrorMessage: "Failed to reconnect",
   });
 
-  const rows: readonly Connection[] = AsyncResult.isSuccess(connections)
-    ? connections.value
-    : [];
+  const rows: readonly Connection[] = AsyncResult.isSuccess(connections) ? connections.value : [];
   if (rows.length === 0) return null;
 
   const handleReconnect = async (connection: Connection) => {
@@ -185,8 +169,7 @@ function OwnerAccounts(props: {
     if (reconnectMode(connection) === "oauth") {
       const method = props.methods.find(
         (candidate: AuthMethod) =>
-          candidate.kind === "oauth" &&
-          String(candidate.template) === String(connection.template),
+          candidate.kind === "oauth" && String(candidate.template) === String(connection.template),
       );
       if (
         method?.oauth?.supportsDynamicRegistration === true ||
@@ -293,18 +276,13 @@ function OwnerAccounts(props: {
 
   return (
     <CardStack>
-      {props.showOwnerLabels ? (
-        <CardStackHeader>{ownerLabel(owner)}</CardStackHeader>
-      ) : null}
+      {props.showOwnerLabels ? <CardStackHeader>{ownerLabel(owner)}</CardStackHeader> : null}
       <CardStackContent>
         {rows.map((connection: Connection) => (
           <AccountRow
             key={`${connection.owner}:${connection.integration}:${connection.name}`}
             connection={connection}
-            needsReconsent={connectionNeedsReconsent(
-              connection,
-              props.declaredScopes,
-            )}
+            needsReconsent={connectionNeedsReconsent(connection, props.declaredScopes)}
             showOwnerLabel={props.showOwnerLabels}
             onEdit={() => props.onEdit(connection)}
             onReconnect={() => void handleReconnect(connection)}
@@ -335,14 +313,10 @@ export function AccountsSection(props: {
     removeCustomMethod,
   } = props;
   const [adding, setAdding] = useState(false);
-  const [editingConnection, setEditingConnection] = useState<Connection | null>(
-    null,
-  );
-  const [reconnectHandoff, setReconnectHandoff] =
-    useState<IntegrationAccountHandoff | null>(null);
+  const [editingConnection, setEditingConnection] = useState<Connection | null>(null);
+  const [reconnectHandoff, setReconnectHandoff] = useState<IntegrationAccountHandoff | null>(null);
   const ownerDisplay = useOwnerDisplay();
-  const canAddConnection =
-    methods.length > 0 || createCustomMethod !== undefined;
+  const canAddConnection = methods.length > 0 || createCustomMethod !== undefined;
 
   useEffect(() => {
     if (accountHandoff) {
@@ -364,9 +338,7 @@ export function AccountsSection(props: {
 
   // Read both owners to decide between the grouped view and the empty CTA. The
   // grouped sub-components re-read these (effect-atom dedupes) and self-hide.
-  const orgConnections = useAtomValue(
-    connectionsForIntegrationAtom({ integration, owner: "org" }),
-  );
+  const orgConnections = useAtomValue(connectionsForIntegrationAtom({ integration, owner: "org" }));
   const userConnections = useAtomValue(
     connectionsForIntegrationAtom({ integration, owner: "user" }),
   );
@@ -377,18 +349,12 @@ export function AccountsSection(props: {
   useAtomSet(addConnectionOptimistic("user"));
 
   const totalCount = useMemo(() => {
-    const orgRows = AsyncResult.isSuccess(orgConnections)
-      ? orgConnections.value.length
-      : 0;
-    const userRows = AsyncResult.isSuccess(userConnections)
-      ? userConnections.value.length
-      : 0;
+    const orgRows = AsyncResult.isSuccess(orgConnections) ? orgConnections.value.length : 0;
+    const userRows = AsyncResult.isSuccess(userConnections) ? userConnections.value.length : 0;
     return orgRows + userRows;
   }, [orgConnections, userConnections]);
 
-  const loading =
-    !AsyncResult.isSuccess(orgConnections) &&
-    !AsyncResult.isSuccess(userConnections);
+  const loading = !AsyncResult.isSuccess(orgConnections) && !AsyncResult.isSuccess(userConnections);
 
   const modalState = reconnectHandoff ?? accountHandoff;
   const modal = (
@@ -420,9 +386,7 @@ export function AccountsSection(props: {
           onClick={() => {
             trackEvent("connection_add_opened", {
               integration_slug: String(integration),
-              has_oauth_method: methods.some(
-                (m: AuthMethod) => m.kind === "oauth",
-              ),
+              has_oauth_method: methods.some((m: AuthMethod) => m.kind === "oauth"),
               has_api_key_method: methods.some(
                 (m: AuthMethod) => m.kind !== "oauth" && m.kind !== "none",
               ),
@@ -442,9 +406,7 @@ export function AccountsSection(props: {
         </div>
       ) : totalCount === 0 ? (
         <div className="rounded-lg border border-dashed border-border/60 px-6 py-8 text-center">
-          <p className="text-sm font-medium text-foreground">
-            No connections yet
-          </p>
+          <p className="text-sm font-medium text-foreground">No connections yet</p>
           <p className="mt-1 text-sm text-muted-foreground">
             Add a connection to make this integration's tools available.
           </p>
@@ -455,9 +417,7 @@ export function AccountsSection(props: {
             onClick={() => {
               trackEvent("connection_add_opened", {
                 integration_slug: String(integration),
-                has_oauth_method: methods.some(
-                  (m: AuthMethod) => m.kind === "oauth",
-                ),
+                has_oauth_method: methods.some((m: AuthMethod) => m.kind === "oauth"),
                 has_api_key_method: methods.some(
                   (m: AuthMethod) => m.kind !== "oauth" && m.kind !== "none",
                 ),

--- a/packages/react/src/components/page.tsx
+++ b/packages/react/src/components/page.tsx
@@ -1,0 +1,57 @@
+import { cn } from "../lib/utils";
+
+// ---------------------------------------------------------------------------
+// Settings page scaffold
+//
+// Every top-level settings view (Integrations, Policies, API keys, Providers,
+// Organization, Billing) shares one column width, gutter, and heading scale so
+// the content edge and title don't shift as you move between tabs. Use these
+// instead of hand-rolling the `mx-auto max-w-* px-* py-*` wrapper per page.
+// ---------------------------------------------------------------------------
+
+function PageContainer({ className, children, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto" data-slot="page-container">
+      <div className={cn("mx-auto max-w-4xl px-6 py-10 lg:px-8 lg:py-14", className)} {...props}>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function PageHeader({
+  title,
+  description,
+  actions,
+  className,
+  children,
+  ...props
+}: Omit<React.ComponentProps<"div">, "title"> & {
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  /** Optional trailing controls (buttons) aligned to the heading baseline. */
+  actions?: React.ReactNode;
+}) {
+  return (
+    <div
+      data-slot="page-header"
+      className={cn("mb-10 flex items-start justify-between gap-4", className)}
+      {...props}
+    >
+      <div className="min-w-0">
+        <h1 className="font-display text-[2rem] tracking-tight leading-none text-foreground">
+          {title}
+        </h1>
+        {description && (
+          <p className="mt-2 max-w-2xl text-sm leading-relaxed text-muted-foreground">
+            {description}
+          </p>
+        )}
+        {children}
+      </div>
+      {actions && <div className="flex shrink-0 items-center gap-2">{actions}</div>}
+    </div>
+  );
+}
+
+export { PageContainer, PageHeader };

--- a/packages/react/src/pages/api-keys.tsx
+++ b/packages/react/src/pages/api-keys.tsx
@@ -7,6 +7,7 @@ import { apiKeyWriteKeys } from "../api/reactivity-keys";
 import { trackEvent } from "../api/analytics";
 import { apiKeysAtom, createApiKey, revokeApiKey } from "../api/account-atoms";
 import { Button } from "../components/button";
+import { PageContainer, PageHeader } from "../components/page";
 import { CopyButton } from "../components/copy-button";
 import {
   Dialog,
@@ -104,96 +105,92 @@ export function ApiKeysPage() {
   };
 
   return (
-    <div className="min-h-0 flex-1 overflow-y-auto">
-      <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-10 lg:px-8 lg:py-14">
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-          <div className="min-w-0">
-            <h1 className="font-display text-3xl tracking-tight text-foreground">API keys</h1>
-            <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
-              User keys for accessing the Executor API and MCP endpoint from scripts and tools.
-            </p>
-            <div className="mt-4 flex max-w-2xl items-center gap-2 rounded-md border border-border bg-card px-3 py-2">
-              <code className="min-w-0 flex-1 truncate font-mono text-xs text-foreground">
-                Authorization: Bearer &lt;api-key&gt;
-              </code>
-              <CopyButton value="Authorization: Bearer <api-key>" />
-            </div>
-            <p className="mt-2 max-w-2xl text-xs leading-5 text-muted-foreground">
-              API keys work as PATs and have full access to your account.
-            </p>
-          </div>
+    <PageContainer>
+      <PageHeader
+        title="API keys"
+        description="User keys for accessing the Executor API and MCP endpoint from scripts and tools."
+        actions={
           <Button
             onClick={() => {
               setName(defaultApiKeyName());
               setCreateOpen(true);
             }}
-            className="shrink-0"
           >
             <span aria-hidden="true">+</span>
             New key
           </Button>
+        }
+      >
+        <div className="mt-4 flex max-w-2xl items-center gap-2 rounded-md border border-border bg-card px-3 py-2">
+          <code className="min-w-0 flex-1 truncate font-mono text-xs text-foreground">
+            Authorization: Bearer &lt;api-key&gt;
+          </code>
+          <CopyButton value="Authorization: Bearer <api-key>" />
         </div>
+        <p className="mt-2 max-w-2xl text-xs leading-5 text-muted-foreground">
+          API keys work as PATs and have full access to your account.
+        </p>
+      </PageHeader>
 
-        {AsyncResult.match(result, {
-          onInitial: () => (
-            <div className="rounded-md border border-border bg-card p-6 text-sm text-muted-foreground">
-              Loading API keys...
+      {AsyncResult.match(result, {
+        onInitial: () => (
+          <div className="rounded-md border border-border bg-card p-6 text-sm text-muted-foreground">
+            Loading API keys...
+          </div>
+        ),
+        onFailure: () => (
+          <div className="rounded-md border border-border bg-card p-6 text-sm text-destructive">
+            Failed to load API keys
+          </div>
+        ),
+        onSuccess: ({ value }) =>
+          value.apiKeys.length === 0 ? (
+            <div className="rounded-md border border-dashed border-border bg-card p-8">
+              <h2 className="text-base font-semibold text-foreground">No API keys</h2>
+              <p className="mt-2 max-w-xl text-sm leading-6 text-muted-foreground">
+                Create a key and send it in the Authorization Bearer header.
+              </p>
             </div>
-          ),
-          onFailure: () => (
-            <div className="rounded-md border border-border bg-card p-6 text-sm text-destructive">
-              Failed to load API keys
-            </div>
-          ),
-          onSuccess: ({ value }) =>
-            value.apiKeys.length === 0 ? (
-              <div className="rounded-md border border-dashed border-border bg-card p-8">
-                <h2 className="text-base font-semibold text-foreground">No API keys</h2>
-                <p className="mt-2 max-w-xl text-sm leading-6 text-muted-foreground">
-                  Create a key and send it in the Authorization Bearer header.
-                </p>
+          ) : (
+            <div className="overflow-hidden rounded-md border border-border bg-card">
+              <div className="grid grid-cols-[1fr_auto] gap-4 border-b border-border px-4 py-3 text-xs font-medium uppercase tracking-wider text-muted-foreground md:grid-cols-[1.4fr_1fr_1fr_auto]">
+                <span>Name</span>
+                <span className="hidden md:block">Created</span>
+                <span className="hidden md:block">Last used</span>
+                <span className="text-right">Actions</span>
               </div>
-            ) : (
-              <div className="overflow-hidden rounded-md border border-border bg-card">
-                <div className="grid grid-cols-[1fr_auto] gap-4 border-b border-border px-4 py-3 text-xs font-medium uppercase tracking-wider text-muted-foreground md:grid-cols-[1.4fr_1fr_1fr_auto]">
-                  <span>Name</span>
-                  <span className="hidden md:block">Created</span>
-                  <span className="hidden md:block">Last used</span>
-                  <span className="text-right">Actions</span>
-                </div>
-                {value.apiKeys.map((key: ApiKeySummary) => (
-                  <div
-                    key={key.id}
-                    className="grid grid-cols-[1fr_auto] items-center gap-4 border-b border-border px-4 py-4 last:border-b-0 md:grid-cols-[1.4fr_1fr_1fr_auto]"
-                  >
-                    <div className="min-w-0">
-                      <p className="truncate text-sm font-medium text-foreground">{key.name}</p>
-                      <p className="mt-1 font-mono text-xs text-muted-foreground">
-                        {key.obfuscatedValue}
-                      </p>
-                    </div>
-                    <p className="hidden text-sm text-muted-foreground md:block">
-                      {formatDate(key.createdAt)}
+              {value.apiKeys.map((key: ApiKeySummary) => (
+                <div
+                  key={key.id}
+                  className="grid grid-cols-[1fr_auto] items-center gap-4 border-b border-border px-4 py-4 last:border-b-0 md:grid-cols-[1.4fr_1fr_1fr_auto]"
+                >
+                  <div className="min-w-0">
+                    <p className="truncate text-sm font-medium text-foreground">{key.name}</p>
+                    <p className="mt-1 font-mono text-xs text-muted-foreground">
+                      {key.obfuscatedValue}
                     </p>
-                    <p className="hidden text-sm text-muted-foreground md:block">
-                      {formatDate(key.lastUsedAt)}
-                    </p>
-                    <Button
-                      variant="ghost"
-                      size="icon-sm"
-                      onClick={() => handleRevoke(key)}
-                      disabled={revokingId === key.id}
-                      title={`Revoke ${key.name}`}
-                      className="text-muted-foreground hover:text-destructive"
-                    >
-                      <span aria-hidden="true">×</span>
-                    </Button>
                   </div>
-                ))}
-              </div>
-            ),
-        })}
-      </div>
+                  <p className="hidden text-sm text-muted-foreground md:block">
+                    {formatDate(key.createdAt)}
+                  </p>
+                  <p className="hidden text-sm text-muted-foreground md:block">
+                    {formatDate(key.lastUsedAt)}
+                  </p>
+                  <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    onClick={() => handleRevoke(key)}
+                    disabled={revokingId === key.id}
+                    title={`Revoke ${key.name}`}
+                    className="text-muted-foreground hover:text-destructive"
+                  >
+                    <span aria-hidden="true">×</span>
+                  </Button>
+                </div>
+              ))}
+            </div>
+          ),
+      })}
 
       <Dialog open={createOpen} onOpenChange={closeCreate}>
         <DialogContent className="sm:max-w-[480px]">
@@ -270,6 +267,6 @@ export function ApiKeysPage() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
-    </div>
+    </PageContainer>
   );
 }

--- a/packages/react/src/pages/integrations.tsx
+++ b/packages/react/src/pages/integrations.tsx
@@ -14,6 +14,7 @@ import { detectIntegration, integrationsOptimisticAtom } from "../api/atoms";
 import { trackEvent } from "../api/analytics";
 import { McpInstallCard } from "../components/mcp-install-card";
 import { Button } from "../components/button";
+import { PageContainer, PageHeader } from "../components/page";
 import { Badge } from "../components/badge";
 import { Input } from "../components/input";
 import {
@@ -67,62 +68,56 @@ export function IntegrationsPage() {
   const [connectOpen, setConnectOpen] = useState(false);
 
   return (
-    <div className="min-h-0 flex-1 overflow-y-auto">
-      <div className="mx-auto max-w-4xl px-6 py-10 lg:px-10 lg:py-14">
-        <div className="mb-8 flex items-end justify-between gap-4">
-          <div>
-            <h1 className="font-display text-3xl tracking-tight text-foreground lg:text-4xl">
-              Integrations
-            </h1>
-            <p className="mt-1.5 text-[14px] text-muted-foreground">
-              Tool providers available in this workspace.
-            </p>
-          </div>
+    <PageContainer>
+      <PageHeader
+        title="Integrations"
+        description="Tool providers available in this workspace."
+        actions={
           <Button
             onClick={() => {
               setConnectOpen(true);
               trackEvent("integration_connect_dialog_opened");
             }}
             size="sm"
-            className="shrink-0 gap-1.5"
+            className="gap-1.5"
           >
             <PlusIcon className="size-4" />
             Connect
           </Button>
-        </div>
+        }
+      />
 
-        <div className="mb-8">
-          <McpInstallCard />
-        </div>
-
-        <div className="mb-8 border-t border-border/50" />
-
-        {AsyncResult.match(integrations, {
-          onInitial: () => <IntegrationsGridSkeleton />,
-          onFailure: () => <p className="text-sm text-destructive">Failed to load integrations</p>,
-          onSuccess: ({ value }) => {
-            if (value.length === 0) {
-              return (
-                <EmptyIntegrations
-                  onConnect={() => {
-                    setConnectOpen(true);
-                    trackEvent("integration_connect_dialog_opened");
-                  }}
-                />
-              );
-            }
-
-            return (
-              <div className="mb-8 space-y-3">
-                <IntegrationGrid integrations={value} />
-              </div>
-            );
-          },
-        })}
+      <div className="mb-8">
+        <McpInstallCard />
       </div>
 
+      <div className="mb-8 border-t border-border/50" />
+
+      {AsyncResult.match(integrations, {
+        onInitial: () => <IntegrationsGridSkeleton />,
+        onFailure: () => <p className="text-sm text-destructive">Failed to load integrations</p>,
+        onSuccess: ({ value }) => {
+          if (value.length === 0) {
+            return (
+              <EmptyIntegrations
+                onConnect={() => {
+                  setConnectOpen(true);
+                  trackEvent("integration_connect_dialog_opened");
+                }}
+              />
+            );
+          }
+
+          return (
+            <div className="mb-8 space-y-3">
+              <IntegrationGrid integrations={value} />
+            </div>
+          );
+        },
+      })}
+
       <ConnectDialog open={connectOpen} onOpenChange={setConnectOpen} />
-    </div>
+    </PageContainer>
   );
 }
 

--- a/packages/react/src/pages/org.tsx
+++ b/packages/react/src/pages/org.tsx
@@ -15,6 +15,7 @@ import {
   DialogClose,
 } from "../components/dialog";
 import { Button } from "../components/button";
+import { PageContainer, PageHeader } from "../components/page";
 import { Badge } from "../components/badge";
 import { Input } from "../components/input";
 import { Label } from "../components/label";
@@ -213,210 +214,206 @@ export function OrgPage(props: {
   };
 
   return (
-    <div className="min-h-0 flex-1 overflow-y-auto">
-      <div className="mx-auto max-w-3xl px-6 py-10 lg:px-8 lg:py-14">
-        <div className="mb-8">
-          <h1 className="font-display text-[2rem] tracking-tight text-foreground">Organization</h1>
-        </div>
+    <PageContainer>
+      <PageHeader title="Organization" />
 
-        <section className="mb-10">
-          <div className="flex items-end gap-3">
-            <div className="min-w-0 flex-1">
-              <Label htmlFor="org-name" className="text-sm font-medium text-foreground">
-                Organization name
-              </Label>
-              <Input
-                id="org-name"
-                value={editName}
-                onChange={(e) => setEditName((e.target as HTMLInputElement).value)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") handleSaveName();
-                }}
-                className="mt-1.5 h-9 text-sm"
-              />
-            </div>
-            {editName.trim() !== organizationName && editName.trim() !== "" && (
-              <Button size="sm" onClick={handleSaveName} disabled={savingName}>
-                {savingName ? "Saving…" : "Save"}
-              </Button>
-            )}
+      <section className="mb-10">
+        <div className="flex items-end gap-3">
+          <div className="min-w-0 flex-1">
+            <Label htmlFor="org-name" className="text-sm font-medium text-foreground">
+              Organization name
+            </Label>
+            <Input
+              id="org-name"
+              value={editName}
+              onChange={(e) => setEditName((e.target as HTMLInputElement).value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleSaveName();
+              }}
+              className="mt-1.5 h-9 text-sm"
+            />
           </div>
-        </section>
-        {props.domainsSection && props.domainsSection}
-
-        <section className="mb-10">
-          <div className="flex items-center justify-between mb-4">
-            <div>
-              <h2 className="text-sm font-medium text-foreground">Members</h2>
-              <p className="mt-0.5 text-sm text-muted-foreground">
-                People with access to this Executor instance.
-                {seats && !seats.unlimited && ` ${seats.used} of ${seats.granted} seats used.`}
-              </p>
-            </div>
-            <Button
-              size="sm"
-              className="min-w-32"
-              onClick={() => (showUpgradeOnInvite ? setUpgradeOpen(true) : setInviteOpen(true))}
-            >
-              Invite member
+          {editName.trim() !== organizationName && editName.trim() !== "" && (
+            <Button size="sm" onClick={handleSaveName} disabled={savingName}>
+              {savingName ? "Saving…" : "Save"}
             </Button>
+          )}
+        </div>
+      </section>
+      {props.domainsSection && props.domainsSection}
+
+      <section className="mb-10">
+        <div className="flex items-center justify-between mb-4">
+          <div>
+            <h2 className="text-sm font-medium text-foreground">Members</h2>
+            <p className="mt-0.5 text-sm text-muted-foreground">
+              People with access to this Executor instance.
+              {seats && !seats.unlimited && ` ${seats.used} of ${seats.granted} seats used.`}
+            </p>
           </div>
-          <Input
-            type="text"
-            placeholder="Search by name or email..."
-            value={search}
-            onChange={(e) => setSearch((e.target as HTMLInputElement).value)}
-            className="mb-3 h-9 text-sm"
-          />
+          <Button
+            size="sm"
+            className="min-w-32"
+            onClick={() => (showUpgradeOnInvite ? setUpgradeOpen(true) : setInviteOpen(true))}
+          >
+            Invite member
+          </Button>
+        </div>
+        <Input
+          type="text"
+          placeholder="Search by name or email..."
+          value={search}
+          onChange={(e) => setSearch((e.target as HTMLInputElement).value)}
+          className="mb-3 h-9 text-sm"
+        />
 
-          {AsyncResult.match(membersResult, {
-            onInitial: () => (
-              <div className="space-y-2">
-                {[1, 2, 3].map((i) => (
-                  <div key={i} className="h-14 animate-pulse rounded-lg bg-muted" />
-                ))}
-              </div>
-            ),
-            onFailure: () => (
-              <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3">
-                <p className="text-sm text-destructive">Failed to load members</p>
-              </div>
-            ),
-            onSuccess: ({ value }) => {
-              const members = value.members;
-              const filtered = search
-                ? members.filter(
-                    (m: MemberData) =>
-                      m.email.toLowerCase().includes(search.toLowerCase()) ||
-                      (m.name?.toLowerCase().includes(search.toLowerCase()) ?? false),
-                  )
-                : members;
+        {AsyncResult.match(membersResult, {
+          onInitial: () => (
+            <div className="space-y-2">
+              {[1, 2, 3].map((i) => (
+                <div key={i} className="h-14 animate-pulse rounded-lg bg-muted" />
+              ))}
+            </div>
+          ),
+          onFailure: () => (
+            <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3">
+              <p className="text-sm text-destructive">Failed to load members</p>
+            </div>
+          ),
+          onSuccess: ({ value }) => {
+            const members = value.members;
+            const filtered = search
+              ? members.filter(
+                  (m: MemberData) =>
+                    m.email.toLowerCase().includes(search.toLowerCase()) ||
+                    (m.name?.toLowerCase().includes(search.toLowerCase()) ?? false),
+                )
+              : members;
 
-              if (filtered.length === 0) {
-                return (
-                  <p className="py-8 text-center text-sm text-muted-foreground">
-                    {search ? "No matching members" : "No members yet"}
-                  </p>
-                );
-              }
-
+            if (filtered.length === 0) {
               return (
-                <div className="space-y-px">
-                  {filtered.map((member: MemberData) => (
-                    <div
-                      key={member.id}
-                      className="group relative grid grid-cols-[2rem_1fr_6rem_5rem_2rem] items-center gap-3 rounded-lg border border-transparent px-4 py-3 transition-all hover:bg-muted/30"
-                    >
-                      {member.avatarUrl ? (
-                        <img src={member.avatarUrl} alt="" className="size-8 rounded-full" />
-                      ) : (
-                        <div className="flex size-8 items-center justify-center rounded-full bg-muted text-xs font-semibold text-muted-foreground">
-                          {member.name
-                            ? member.name
-                                .split(" ")
-                                .map((n: string) => n[0])
-                                .join("")
-                                .slice(0, 2)
-                                .toUpperCase()
-                            : member.email[0]!.toUpperCase()}
-                        </div>
-                      )}
+                <p className="py-8 text-center text-sm text-muted-foreground">
+                  {search ? "No matching members" : "No members yet"}
+                </p>
+              );
+            }
 
-                      <div className="min-w-0">
-                        <div className="flex items-center gap-2">
-                          <p className="truncate text-sm font-medium text-foreground leading-none">
-                            {member.name ?? member.email}
-                          </p>
-                          {member.isCurrentUser && (
-                            <Badge className="bg-muted text-muted-foreground">You</Badge>
-                          )}
-                          {member.status === "pending" && (
-                            <Badge className="bg-muted text-muted-foreground">Invited</Badge>
-                          )}
-                        </div>
-                        {member.name && (
-                          <p className="mt-0.5 truncate text-xs text-muted-foreground leading-none">
-                            {member.email}
-                          </p>
+            return (
+              <div className="space-y-px">
+                {filtered.map((member: MemberData) => (
+                  <div
+                    key={member.id}
+                    className="group relative grid grid-cols-[2rem_1fr_6rem_5rem_2rem] items-center gap-3 rounded-lg border border-transparent px-4 py-3 transition-all hover:bg-muted/30"
+                  >
+                    {member.avatarUrl ? (
+                      <img src={member.avatarUrl} alt="" className="size-8 rounded-full" />
+                    ) : (
+                      <div className="flex size-8 items-center justify-center rounded-full bg-muted text-xs font-semibold text-muted-foreground">
+                        {member.name
+                          ? member.name
+                              .split(" ")
+                              .map((n: string) => n[0])
+                              .join("")
+                              .slice(0, 2)
+                              .toUpperCase()
+                          : member.email[0]!.toUpperCase()}
+                      </div>
+                    )}
+
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2">
+                        <p className="truncate text-sm font-medium text-foreground leading-none">
+                          {member.name ?? member.email}
+                        </p>
+                        {member.isCurrentUser && (
+                          <Badge className="bg-muted text-muted-foreground">You</Badge>
+                        )}
+                        {member.status === "pending" && (
+                          <Badge className="bg-muted text-muted-foreground">Invited</Badge>
                         )}
                       </div>
-
-                      <p className="text-sm text-muted-foreground capitalize leading-none">
-                        {member.role}
-                      </p>
-
-                      <p className="text-xs text-muted-foreground leading-none">
-                        {formatLastActive(member.lastActiveAt)}
-                      </p>
-
-                      {!member.isCurrentUser ? (
-                        <DropdownMenu>
-                          <DropdownMenuTrigger asChild>
-                            <Button
-                              variant="ghost"
-                              size="icon"
-                              className="size-7 opacity-0 group-hover:opacity-100 transition-opacity"
-                            >
-                              <svg viewBox="0 0 16 16" className="size-3">
-                                <circle cx="8" cy="3" r="1.2" fill="currentColor" />
-                                <circle cx="8" cy="8" r="1.2" fill="currentColor" />
-                                <circle cx="8" cy="13" r="1.2" fill="currentColor" />
-                              </svg>
-                            </Button>
-                          </DropdownMenuTrigger>
-                          <DropdownMenuContent align="end" className="w-44">
-                            {roles.length > 0 && (
-                              <>
-                                <DropdownMenuSub>
-                                  <DropdownMenuSubTrigger className="text-xs">
-                                    Change role
-                                  </DropdownMenuSubTrigger>
-                                  <DropdownMenuSubContent>
-                                    {roles.map((role: RoleData) => (
-                                      <DropdownMenuItem
-                                        key={role.slug}
-                                        className="text-xs"
-                                        disabled={role.slug === member.role}
-                                        onClick={() =>
-                                          handleChangeRole(member.id, role.slug, role.name)
-                                        }
-                                      >
-                                        {role.name}
-                                      </DropdownMenuItem>
-                                    ))}
-                                  </DropdownMenuSubContent>
-                                </DropdownMenuSub>
-                                <DropdownMenuSeparator />
-                              </>
-                            )}
-                            <DropdownMenuItem
-                              className="text-destructive focus:text-destructive text-sm"
-                              onClick={() => handleRemove(member.id, member.name ?? member.email)}
-                            >
-                              Remove member
-                            </DropdownMenuItem>
-                          </DropdownMenuContent>
-                        </DropdownMenu>
-                      ) : (
-                        <div />
+                      {member.name && (
+                        <p className="mt-0.5 truncate text-xs text-muted-foreground leading-none">
+                          {member.email}
+                        </p>
                       )}
                     </div>
-                  ))}
-                </div>
-              );
-            },
-          })}
-        </section>
 
-        <InviteDialog open={inviteOpen} onOpenChange={setInviteOpen} roles={roles} />
-        <UpgradeDialog
-          open={upgradeOpen}
-          onOpenChange={setUpgradeOpen}
-          granted={seats?.granted ?? 0}
-          upgradeAction={props.upgradeAction}
-        />
-      </div>
-    </div>
+                    <p className="text-sm text-muted-foreground capitalize leading-none">
+                      {member.role}
+                    </p>
+
+                    <p className="text-xs text-muted-foreground leading-none">
+                      {formatLastActive(member.lastActiveAt)}
+                    </p>
+
+                    {!member.isCurrentUser ? (
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="size-7 opacity-0 group-hover:opacity-100 transition-opacity"
+                          >
+                            <svg viewBox="0 0 16 16" className="size-3">
+                              <circle cx="8" cy="3" r="1.2" fill="currentColor" />
+                              <circle cx="8" cy="8" r="1.2" fill="currentColor" />
+                              <circle cx="8" cy="13" r="1.2" fill="currentColor" />
+                            </svg>
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end" className="w-44">
+                          {roles.length > 0 && (
+                            <>
+                              <DropdownMenuSub>
+                                <DropdownMenuSubTrigger className="text-xs">
+                                  Change role
+                                </DropdownMenuSubTrigger>
+                                <DropdownMenuSubContent>
+                                  {roles.map((role: RoleData) => (
+                                    <DropdownMenuItem
+                                      key={role.slug}
+                                      className="text-xs"
+                                      disabled={role.slug === member.role}
+                                      onClick={() =>
+                                        handleChangeRole(member.id, role.slug, role.name)
+                                      }
+                                    >
+                                      {role.name}
+                                    </DropdownMenuItem>
+                                  ))}
+                                </DropdownMenuSubContent>
+                              </DropdownMenuSub>
+                              <DropdownMenuSeparator />
+                            </>
+                          )}
+                          <DropdownMenuItem
+                            className="text-destructive focus:text-destructive text-sm"
+                            onClick={() => handleRemove(member.id, member.name ?? member.email)}
+                          >
+                            Remove member
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    ) : (
+                      <div />
+                    )}
+                  </div>
+                ))}
+              </div>
+            );
+          },
+        })}
+      </section>
+
+      <InviteDialog open={inviteOpen} onOpenChange={setInviteOpen} roles={roles} />
+      <UpgradeDialog
+        open={upgradeOpen}
+        onOpenChange={setUpgradeOpen}
+        granted={seats?.granted ?? 0}
+        upgradeAction={props.upgradeAction}
+      />
+    </PageContainer>
   );
 }
 

--- a/packages/react/src/pages/policies.tsx
+++ b/packages/react/src/pages/policies.tsx
@@ -29,6 +29,7 @@ import {
   POLICY_BADGE_VARIANT,
 } from "../lib/policy-display";
 import { Button } from "../components/button";
+import { PageContainer, PageHeader } from "../components/page";
 import {
   CardStack,
   CardStackContent,
@@ -356,139 +357,130 @@ export function PoliciesPage() {
   };
 
   return (
-    <div className="min-h-0 flex-1 overflow-y-auto">
-      <div className="mx-auto max-w-3xl px-6 py-10 lg:px-8 lg:py-14">
-        <div className="flex items-end justify-between mb-10">
-          <div>
-            <h1 className="font-display text-[2rem] tracking-tight text-foreground leading-none">
-              Policies
-            </h1>
-            <p className="mt-2 text-sm text-muted-foreground leading-relaxed">
-              Override default approval behavior for tools. The most restrictive matched action
-              wins. Blocked tools are hidden from agent search and fail at invoke.
-            </p>
-          </div>
-        </div>
+    <PageContainer>
+      <PageHeader
+        title="Policies"
+        description="Override default approval behavior for tools. The most restrictive matched action wins. Blocked tools are hidden from agent search and fail at invoke."
+      />
 
-        <div className="mb-8">
-          <AddPolicyForm
-            onSubmit={handleCreate}
-            owner={targetOwner}
-            onOwnerChange={setTargetOwner}
-            busy={busy}
-          />
-        </div>
-
-        {AsyncResult.match(policies, {
-          onInitial: () => (
-            <div className="flex items-center gap-2 py-8">
-              <div className="size-1.5 rounded-full bg-muted-foreground/30 animate-pulse" />
-              <p className="text-sm text-muted-foreground">Loading policies…</p>
-            </div>
-          ),
-          onFailure: () => (
-            <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3">
-              <p className="text-sm text-destructive">Failed to load policies</p>
-            </div>
-          ),
-          onSuccess: ({ value }) => {
-            // Sort by owner rank (org outer, user inner), then position (lex
-            // order on fractional-indexing keys), tiebreaking on id so
-            // identical positions don't swap on refetch and
-            // `generateKeyBetween` never sees duplicate neighbor keys (which
-            // would throw). Optimistic placeholders carry `position: ""` so
-            // they sort to the top of their owner group.
-            const sorted = [...value].sort((a, b) => {
-              const ownerOrder = ownerRank(a.owner) - ownerRank(b.owner);
-              return ownerOrder === 0
-                ? comparePolicy(a.position, a.id, b.position, b.id)
-                : ownerOrder;
-            });
-            // Reorder math runs against committed rows only — placeholder rows
-            // (empty `position`) aren't valid keys for `generateKeyBetween` and
-            // aren't reorderable until the server confirms.
-            const committedForOwner = (owner: Owner) =>
-              sorted.filter((p) => p.owner === owner && p.position !== "");
-            const committedIndex = (id: string, owner: Owner): number =>
-              committedForOwner(owner).findIndex((p) => p.id === id);
-            const positionAbove = (id: string, owner: Owner): string => {
-              const committed = committedForOwner(owner);
-              const j = committedIndex(id, owner);
-              if (j <= 0) return generateKeyBetween(null, committed[0]!.position);
-              return j === 1
-                ? generateKeyBetween(null, committed[0]!.position)
-                : generateKeyBetween(committed[j - 2]!.position, committed[j - 1]!.position);
-            };
-            const positionBelow = (id: string, owner: Owner): string => {
-              const committed = committedForOwner(owner);
-              const j = committedIndex(id, owner);
-              if (j === -1 || j >= committed.length - 1)
-                return generateKeyBetween(committed[committed.length - 1]!.position, null);
-              return j === committed.length - 2
-                ? generateKeyBetween(committed[committed.length - 1]!.position, null)
-                : generateKeyBetween(committed[j + 1]!.position, committed[j + 2]!.position);
-            };
-            return (
-              <CardStack>
-                <CardStackHeader>Active policies</CardStackHeader>
-                <CardStackContent>
-                  {sorted.length === 0 ? (
-                    <CardStackEntry>
-                      <CardStackEntryContent>
-                        <CardStackEntryDescription>
-                          No policies yet. Tools fall back to their plugin's default approval
-                          behavior.
-                        </CardStackEntryDescription>
-                      </CardStackEntryContent>
-                    </CardStackEntry>
-                  ) : (
-                    sorted.map((p) => {
-                      const committed = committedForOwner(p.owner);
-                      const j = committedIndex(p.id, p.owner);
-                      // Pending placeholder or only one committed row → no
-                      // reorder affordance.
-                      const reorderable = j !== -1 && committed.length > 1;
-                      return (
-                        <PolicyRow
-                          key={p.id}
-                          policy={{
-                            id: p.id,
-                            owner: p.owner,
-                            pattern: p.pattern,
-                            action: p.action,
-                          }}
-                          isFirst={!reorderable || j === 0}
-                          isLast={!reorderable || j === committed.length - 1}
-                          showOwnerLabel={ownerDisplay.showOwnerLabels}
-                          onRemove={() => handleRemove({ id: p.id, owner: p.owner })}
-                          onChangeAction={(action) =>
-                            handleUpdate({ id: p.id, owner: p.owner }, action)
-                          }
-                          onMoveUp={() =>
-                            handleMove(
-                              { id: p.id, owner: p.owner },
-                              positionAbove(p.id, p.owner),
-                              "up",
-                            )
-                          }
-                          onMoveDown={() =>
-                            handleMove(
-                              { id: p.id, owner: p.owner },
-                              positionBelow(p.id, p.owner),
-                              "down",
-                            )
-                          }
-                        />
-                      );
-                    })
-                  )}
-                </CardStackContent>
-              </CardStack>
-            );
-          },
-        })}
+      <div className="mb-8">
+        <AddPolicyForm
+          onSubmit={handleCreate}
+          owner={targetOwner}
+          onOwnerChange={setTargetOwner}
+          busy={busy}
+        />
       </div>
-    </div>
+
+      {AsyncResult.match(policies, {
+        onInitial: () => (
+          <div className="flex items-center gap-2 py-8">
+            <div className="size-1.5 rounded-full bg-muted-foreground/30 animate-pulse" />
+            <p className="text-sm text-muted-foreground">Loading policies…</p>
+          </div>
+        ),
+        onFailure: () => (
+          <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3">
+            <p className="text-sm text-destructive">Failed to load policies</p>
+          </div>
+        ),
+        onSuccess: ({ value }) => {
+          // Sort by owner rank (org outer, user inner), then position (lex
+          // order on fractional-indexing keys), tiebreaking on id so
+          // identical positions don't swap on refetch and
+          // `generateKeyBetween` never sees duplicate neighbor keys (which
+          // would throw). Optimistic placeholders carry `position: ""` so
+          // they sort to the top of their owner group.
+          const sorted = [...value].sort((a, b) => {
+            const ownerOrder = ownerRank(a.owner) - ownerRank(b.owner);
+            return ownerOrder === 0
+              ? comparePolicy(a.position, a.id, b.position, b.id)
+              : ownerOrder;
+          });
+          // Reorder math runs against committed rows only — placeholder rows
+          // (empty `position`) aren't valid keys for `generateKeyBetween` and
+          // aren't reorderable until the server confirms.
+          const committedForOwner = (owner: Owner) =>
+            sorted.filter((p) => p.owner === owner && p.position !== "");
+          const committedIndex = (id: string, owner: Owner): number =>
+            committedForOwner(owner).findIndex((p) => p.id === id);
+          const positionAbove = (id: string, owner: Owner): string => {
+            const committed = committedForOwner(owner);
+            const j = committedIndex(id, owner);
+            if (j <= 0) return generateKeyBetween(null, committed[0]!.position);
+            return j === 1
+              ? generateKeyBetween(null, committed[0]!.position)
+              : generateKeyBetween(committed[j - 2]!.position, committed[j - 1]!.position);
+          };
+          const positionBelow = (id: string, owner: Owner): string => {
+            const committed = committedForOwner(owner);
+            const j = committedIndex(id, owner);
+            if (j === -1 || j >= committed.length - 1)
+              return generateKeyBetween(committed[committed.length - 1]!.position, null);
+            return j === committed.length - 2
+              ? generateKeyBetween(committed[committed.length - 1]!.position, null)
+              : generateKeyBetween(committed[j + 1]!.position, committed[j + 2]!.position);
+          };
+          return (
+            <CardStack>
+              <CardStackHeader>Active policies</CardStackHeader>
+              <CardStackContent>
+                {sorted.length === 0 ? (
+                  <CardStackEntry>
+                    <CardStackEntryContent>
+                      <CardStackEntryDescription>
+                        No policies yet. Tools fall back to their plugin's default approval
+                        behavior.
+                      </CardStackEntryDescription>
+                    </CardStackEntryContent>
+                  </CardStackEntry>
+                ) : (
+                  sorted.map((p) => {
+                    const committed = committedForOwner(p.owner);
+                    const j = committedIndex(p.id, p.owner);
+                    // Pending placeholder or only one committed row → no
+                    // reorder affordance.
+                    const reorderable = j !== -1 && committed.length > 1;
+                    return (
+                      <PolicyRow
+                        key={p.id}
+                        policy={{
+                          id: p.id,
+                          owner: p.owner,
+                          pattern: p.pattern,
+                          action: p.action,
+                        }}
+                        isFirst={!reorderable || j === 0}
+                        isLast={!reorderable || j === committed.length - 1}
+                        showOwnerLabel={ownerDisplay.showOwnerLabels}
+                        onRemove={() => handleRemove({ id: p.id, owner: p.owner })}
+                        onChangeAction={(action) =>
+                          handleUpdate({ id: p.id, owner: p.owner }, action)
+                        }
+                        onMoveUp={() =>
+                          handleMove(
+                            { id: p.id, owner: p.owner },
+                            positionAbove(p.id, p.owner),
+                            "up",
+                          )
+                        }
+                        onMoveDown={() =>
+                          handleMove(
+                            { id: p.id, owner: p.owner },
+                            positionBelow(p.id, p.owner),
+                            "down",
+                          )
+                        }
+                      />
+                    );
+                  })
+                )}
+              </CardStackContent>
+            </CardStack>
+          );
+        },
+      })}
+    </PageContainer>
   );
 }
 

--- a/packages/react/src/pages/secrets.tsx
+++ b/packages/react/src/pages/secrets.tsx
@@ -16,6 +16,7 @@ import {
   CardStackHeader,
 } from "../components/card-stack";
 import { Badge } from "../components/badge";
+import { PageContainer, PageHeader } from "../components/page";
 
 // ---------------------------------------------------------------------------
 // Providers page (v2) — repurposed from the v1 Secrets page.
@@ -45,93 +46,83 @@ export function SecretsPage(props: { showProviderInfo?: boolean }) {
   const providers = useAtomValue(providersAtom);
 
   return (
-    <div className="min-h-0 flex-1 overflow-y-auto">
-      <div className="mx-auto max-w-3xl px-6 py-10 lg:px-8 lg:py-14">
-        {/* Header */}
-        <div className="flex items-end justify-between mb-10">
-          <div>
-            <h1 className="font-display text-[2rem] tracking-tight text-foreground leading-none">
-              Providers
-            </h1>
-            <p className="mt-2 text-sm text-muted-foreground leading-relaxed">
-              Where your connections' credential values live — the default store for pasted values,
-              or an external backend like 1Password or your system keychain.
-            </p>
-          </div>
+    <PageContainer>
+      <PageHeader
+        title="Providers"
+        description="Where your connections' credential values live: the default store for pasted values, or an external backend like 1Password or your system keychain."
+      />
+
+      {/* Provider plugins (settings cards) */}
+      {showProviderInfo && secretProviderPlugins.length > 0 && (
+        <div className="mb-10">
+          <CardStack>
+            <CardStackHeader>Configure providers</CardStackHeader>
+            <CardStackContent>
+              {secretProviderPlugins.map((plugin) => (
+                <Suspense
+                  key={plugin.key}
+                  fallback={
+                    <div className="px-4 py-3 animate-pulse">
+                      <div className="h-4 w-24 rounded bg-muted" />
+                    </div>
+                  }
+                >
+                  <plugin.settings />
+                </Suspense>
+              ))}
+            </CardStackContent>
+          </CardStack>
         </div>
+      )}
 
-        {/* Provider plugins (settings cards) */}
-        {showProviderInfo && secretProviderPlugins.length > 0 && (
-          <div className="mb-10">
-            <CardStack>
-              <CardStackHeader>Configure providers</CardStackHeader>
-              <CardStackContent>
-                {secretProviderPlugins.map((plugin) => (
-                  <Suspense
-                    key={plugin.key}
-                    fallback={
-                      <div className="px-4 py-3 animate-pulse">
-                        <div className="h-4 w-24 rounded bg-muted" />
-                      </div>
-                    }
-                  >
-                    <plugin.settings />
-                  </Suspense>
-                ))}
-              </CardStackContent>
-            </CardStack>
+      {/* Registered providers */}
+      {AsyncResult.match(providers, {
+        onInitial: () => (
+          <div className="flex items-center gap-2 py-8">
+            <div className="size-1.5 rounded-full bg-muted-foreground/30 animate-pulse" />
+            <p className="text-sm text-muted-foreground">Loading providers…</p>
           </div>
-        )}
-
-        {/* Registered providers */}
-        {AsyncResult.match(providers, {
-          onInitial: () => (
-            <div className="flex items-center gap-2 py-8">
-              <div className="size-1.5 rounded-full bg-muted-foreground/30 animate-pulse" />
-              <p className="text-sm text-muted-foreground">Loading providers…</p>
-            </div>
-          ),
-          onFailure: () => (
-            <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3">
-              <p className="text-sm text-destructive">Failed to load providers</p>
-            </div>
-          ),
-          onSuccess: ({ value }) => (
-            <CardStack>
-              <CardStackHeader>Available providers</CardStackHeader>
-              <CardStackContent>
-                {value.length === 0 ? (
-                  <CardStackEntry>
+        ),
+        onFailure: () => (
+          <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3">
+            <p className="text-sm text-destructive">Failed to load providers</p>
+          </div>
+        ),
+        onSuccess: ({ value }) => (
+          <CardStack>
+            <CardStackHeader>Available providers</CardStackHeader>
+            <CardStackContent>
+              {value.length === 0 ? (
+                <CardStackEntry>
+                  <CardStackEntryContent>
+                    <CardStackEntryDescription>
+                      No credential providers are registered.
+                    </CardStackEntryDescription>
+                  </CardStackEntryContent>
+                </CardStackEntry>
+              ) : (
+                value.map((key: ProviderKey) => (
+                  <CardStackEntry key={String(key)}>
                     <CardStackEntryContent>
-                      <CardStackEntryDescription>
-                        No credential providers are registered.
-                      </CardStackEntryDescription>
+                      <CardStackEntryTitle className="flex min-w-0 items-center gap-2">
+                        <span className="min-w-0 shrink truncate">
+                          {providerLabel(String(key))}
+                        </span>
+                        <span className="max-w-40 shrink truncate font-mono text-xs text-muted-foreground">
+                          {String(key)}
+                        </span>
+                      </CardStackEntryTitle>
                     </CardStackEntryContent>
+                    <CardStackEntryActions>
+                      <Badge variant="secondary">provider</Badge>
+                    </CardStackEntryActions>
                   </CardStackEntry>
-                ) : (
-                  value.map((key: ProviderKey) => (
-                    <CardStackEntry key={String(key)}>
-                      <CardStackEntryContent>
-                        <CardStackEntryTitle className="flex min-w-0 items-center gap-2">
-                          <span className="min-w-0 shrink truncate">
-                            {providerLabel(String(key))}
-                          </span>
-                          <span className="max-w-40 shrink truncate font-mono text-xs text-muted-foreground">
-                            {String(key)}
-                          </span>
-                        </CardStackEntryTitle>
-                      </CardStackEntryContent>
-                      <CardStackEntryActions>
-                        <Badge variant="secondary">provider</Badge>
-                      </CardStackEntryActions>
-                    </CardStackEntry>
-                  ))
-                )}
-              </CardStackContent>
-            </CardStack>
-          ),
-        })}
-      </div>
-    </div>
+                ))
+              )}
+            </CardStackContent>
+          </CardStack>
+        ),
+      })}
+    </PageContainer>
   );
 }

--- a/packages/react/src/plugins/oauth-reconnect.ts
+++ b/packages/react/src/plugins/oauth-reconnect.ts
@@ -28,9 +28,7 @@ export function reconnectMode(connection: Connection): ReconnectMode {
  *  connection are exactly the branded types `oauth.start` expects, so the same
  *  connection (owner/integration/name) is re-minted with a fresh refresh token
  *  and the widened scope union. Returns null for a non-OAuth connection. */
-export function oauthReconnectPayload(
-  connection: Connection,
-): OAuthStartPayload | null {
+export function oauthReconnectPayload(connection: Connection): OAuthStartPayload | null {
   if (connection.oauthClient == null) return null;
   return {
     client: connection.oauthClient,
@@ -61,8 +59,7 @@ const OAUTH_SCOPE_ALIASES: Readonly<Record<string, string>> = {
   "https://www.googleapis.com/auth/userinfo.profile": "profile",
 };
 
-const canonicalScope = (scope: string): string =>
-  OAUTH_SCOPE_ALIASES[scope] ?? scope;
+const canonicalScope = (scope: string): string => OAUTH_SCOPE_ALIASES[scope] ?? scope;
 
 /** Normalize a scope list: trim, canonicalize known provider aliases, drop
  *  empties, de-dupe (order-preserving). A scope set is compared as a SET —
@@ -94,12 +91,8 @@ export function missingScopes(
 
 /** The scopes a connection was actually GRANTED, parsed from its space-delimited
  *  `oauthScope` record. Empty for static creds / when the AS omitted scope. */
-export function connectionGrantedScopes(
-  connection: Connection,
-): readonly string[] {
-  return connection.oauthScope
-    ? connection.oauthScope.split(/\s+/).filter(Boolean)
-    : [];
+export function connectionGrantedScopes(connection: Connection): readonly string[] {
+  return connection.oauthScope ? connection.oauthScope.split(/\s+/).filter(Boolean) : [];
 }
 
 /** Whether an OAuth connection must RECONNECT to grant newly-needed access: the
@@ -113,10 +106,7 @@ export function connectionNeedsReconsent(
   declaredScopes: readonly string[] | undefined,
 ): boolean {
   if (connection.oauthClient == null) return false;
-  return (
-    missingScopes(declaredScopes, connectionGrantedScopes(connection)).length >
-    0
-  );
+  return missingScopes(declaredScopes, connectionGrantedScopes(connection)).length > 0;
 }
 
 /** The scopes that count as REQUIRED for a connection to be considered fully


### PR DESCRIPTION
The settings pages (Integrations, Policies, API keys, Organization, Providers, Billing) each hand-rolled their own page wrapper and heading. Because the container max-width (`max-w-3xl` vs `max-w-4xl`), horizontal padding, and heading size/margins differed, the content column and title shifted as you clicked between tabs.

## Change

Extracts a shared `PageContainer` + `PageHeader` (`packages/react/src/components/page.tsx`) and routes all six pages through them:

- One `max-w-4xl` column with a consistent gutter (`px-6 py-10 lg:px-8 lg:py-14`)
- A single `2rem` / `leading-none` heading scale and uniform header spacing
- Optional `description` and `actions` slots so per-page titles, buttons, and extra header content stay declarative

The page refactor is layout-only. One additional fix is included: the Billing page's Executions row was missing the `!executions.unlimited` guard that the Members row has (a pre-existing inconsistency, not introduced here), so unlimited plans showed a misleading "/ 0 this month" suffix. Now guarded to match.

## After

Every page now shares the same content edge, column width, and title size.

| Integrations | Policies |
| --- | --- |
| ![Integrations](https://raw.githubusercontent.com/RhysSullivan/executor/pr-1185-screenshots/docs/screenshots/settings-integrations.png) | ![Policies](https://raw.githubusercontent.com/RhysSullivan/executor/pr-1185-screenshots/docs/screenshots/settings-policies.png) |

| API keys | Organization |
| --- | --- |
| ![API keys](https://raw.githubusercontent.com/RhysSullivan/executor/pr-1185-screenshots/docs/screenshots/settings-api-keys.png) | ![Organization](https://raw.githubusercontent.com/RhysSullivan/executor/pr-1185-screenshots/docs/screenshots/settings-org.png) |

| Billing |
| --- |
| ![Billing](https://raw.githubusercontent.com/RhysSullivan/executor/pr-1185-screenshots/docs/screenshots/settings-billing.png) |

## Verification

`typecheck` and `oxlint`/`oxfmt` pass. Measured every page in a headless browser against a local cloud instance, all now identical:

```
h1 left = 336px · container left = 304px · width = 896px · h1 = 32px
```

(`secrets`/Providers is not in the cloud nav so it redirects to the index, but it shares the same wrapper and is consistent by construction.)
