### PR TITLE
docs: fix default port to 4788 in CLI and Docker guides

### DIFF
--- a/apps/docs/hosted/docker.mdx
+++ b/apps/docs/hosted/docker.mdx
@@ -15,7 +15,7 @@ Using the published image:
 ```bash
 docker run -d \
   --name executor-selfhost \
-  -p 17888:17888 \
+  -p 4788:4788 \
   -v executor-data:/data \
   ghcr.io/rhyssullivan/executor-selfhost:latest
 ```
@@ -27,7 +27,7 @@ from `apps/host-selfhost`:
 docker compose up -d --build
 ```
 
-No configuration is required. Open [http://localhost:17888](http://localhost:17888);
+No configuration is required. Open [http://localhost:4788](http://localhost:4788);
 the first person to create an account becomes the owner. After that, people join
 through single-use invite links you mint from the **Admin** page, and open signup
 is closed.
@@ -55,11 +55,11 @@ the container defaults.
 
 | Variable                            | Default                         | Purpose                                                                                         |
 | ----------------------------------- | ------------------------------- | ----------------------------------------------------------------------------------------------- |
-| `PORT`                              | `17888`                         | HTTP port the server listens on.                                                                |
+| `PORT`                              | `4788`                          | HTTP port the server listens on.                                                                |
 | `EXECUTOR_HOST`                     | `0.0.0.0`                       | Bind address. The image binds all interfaces.                                                   |
 | `EXECUTOR_DATA_DIR`                 | `/data`                         | Directory holding the database and generated keys.                                              |
 | `EXECUTOR_DB_PATH`                  | `<data dir>/data.db`            | SQLite database file.                                                                           |
-| `EXECUTOR_WEB_BASE_URL`             | auto (`http://localhost:17888`) | Public URL browsers use. Required behind a domain or TLS (see below).                           |
+| `EXECUTOR_WEB_BASE_URL`             | auto (`http://localhost:4788`)  | Public URL browsers use. Required behind a domain or TLS (see below).                           |
 | `BETTER_AUTH_SECRET`                | generated, persisted in `/data` | Session secret (32+ chars). Rotating it signs everyone out.                                     |
 | `EXECUTOR_SECRET_KEY`               | generated, persisted in `/data` | Master key encrypting stored secrets. Set it to manage it yourself.                             |
 | `EXECUTOR_BOOTSTRAP_ADMIN_EMAIL`    | unset                           | Pre-create the admin headlessly (with the password below); skips browser first-run.             |
@@ -78,7 +78,7 @@ the container defaults.
 
 ```bash
 docker run -d \
-  -p 17888:17888 \
+  -p 4788:4788 \
   -v executor-data:/data \
   -e EXECUTOR_WEB_BASE_URL=https://executor.example.com \
   ghcr.io/rhyssullivan/executor-selfhost:latest
@@ -91,5 +91,5 @@ setup screen.
 ## Connect an agent
 
 The server exposes a streamable-HTTP MCP endpoint at `/mcp`. Point your client at
-`http://localhost:17888/mcp` (or your public URL). See [MCP Proxy](/mcp-proxy) for
+`http://localhost:4788/mcp` (or your public URL). See [MCP Proxy](/mcp-proxy) for
 how that endpoint exposes your integrations.

--- a/apps/docs/local/cli.mdx
+++ b/apps/docs/local/cli.mdx
@@ -37,7 +37,7 @@ Install the durable background service, then open the web UI:
 
 ```bash
 executor install   # install/start the durable background service
-executor web        # open the web UI at http://127.0.0.1:17888
+executor web        # open the web UI at http://127.0.0.1:4788
 ```
 
 `executor install` registers Executor so it keeps running across restarts. For a
@@ -51,10 +51,10 @@ the CLI:
 
 <Tabs>
   <Tab title="HTTP">
-    Executor serves a streamable-HTTP MCP endpoint at `http://127.0.0.1:17888/mcp`:
+    Executor serves a streamable-HTTP MCP endpoint at `http://127.0.0.1:4788/mcp`:
 
     ```bash
-    npx add-mcp http://127.0.0.1:17888/mcp --transport http --name executor
+    npx add-mcp http://127.0.0.1:4788/mcp --transport http --name executor
     ```
 
     The **Connect** card in the web UI shows this command with your exact URL


### PR DESCRIPTION
The local web UI / MCP endpoint port was documented as `17888`, but the actual default is `4788`. That value appears nowhere in the codebase.

## Source of truth
- `apps/cli/src/main.ts`: `const DEFAULT_PORT = 4788;`
- `apps/local/src/serve.ts` and `apps/local/src/executor.ts`: default to `4788`
- `apps/host-selfhost/Dockerfile`: `PORT=4788`, `EXPOSE 4788`, `docker run -p 4788:4788`

## Changes
- `apps/docs/local/cli.mdx`: web UI URL, MCP endpoint text, and `add-mcp` command (3 occurrences). The existing note that the Connect card shows the exact URL/port is preserved, so the running service picking a different free port stays covered.
- `apps/docs/hosted/docker.mdx`: port mappings, the localhost link, the `PORT` and `EXECUTOR_WEB_BASE_URL` table defaults, and the `/mcp` endpoint (6 occurrences). This file was inconsistent with its own Dockerfile. Table cell padding re-aligned.

Docs-only change. `grep 17888 apps/docs` now returns nothing.