### PR TITLE
fix: make CI Format pass (format broken baseline + add pre-commit hook)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Auto-format staged code with oxfmt before each commit, so the CI `format` job
+# (`oxfmt --check .`) can never fail on a commit that originated here. Activated
+# by `git config core.hooksPath .githooks`, which `bun run bootstrap` sets for
+# every fresh checkout / agent worktree.
+#
+# Behaviour: formats the staged JS/TS/JSON files in place and re-stages them.
+# oxfmt honours `.oxfmtrc.json` `ignorePatterns` even for explicitly-passed
+# paths, so generated/vendored files (bun.lock, routeTree.gen.ts, ...) are
+# skipped automatically.
+#
+# NUL-delimited end to end (handles spaces/newlines in paths) and compatible
+# with the bash 3.2 that ships on macOS, so no `mapfile`. A shell variable
+# cannot hold NUL bytes, so the staged list is read into an array directly.
+#
+# Caveat: a file that is only partially staged (staged hunk + a separate
+# unstaged hunk in the same file) gets fully re-staged after formatting. Agent
+# flows stage whole files (`git add -A`), so this is not a concern in practice.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+oxfmt="node_modules/.bin/oxfmt"
+if [[ ! -x "$oxfmt" ]]; then
+  echo "pre-commit: oxfmt not found ($oxfmt) - run 'bun run bootstrap'; skipping format." >&2
+  exit 0
+fi
+
+# Staged Added/Copied/Modified/Renamed files, restricted to extensions oxfmt
+# formats. Read NUL records into an array (no NUL-in-variable bug).
+files=()
+while IFS= read -r -d '' f; do
+  case "$f" in
+    *.ts | *.tsx | *.mts | *.cts | *.js | *.jsx | *.mjs | *.cjs | *.json | *.jsonc)
+      files+=("$f")
+      ;;
+  esac
+done < <(git diff --cached --name-only --diff-filter=ACMR -z)
+
+((${#files[@]})) || exit 0
+
+# Format in place, then re-stage whatever oxfmt may have rewritten.
+# --no-error-on-unmatched-pattern keeps the hook from failing when every staged
+# file is ignored by .oxfmtrc.json.
+"$oxfmt" --write --no-error-on-unmatched-pattern "${files[@]}"
+git add -- "${files[@]}"

--- a/packages/core/cli/package.json
+++ b/packages/core/cli/package.json
@@ -23,6 +23,7 @@
     ".": "./src/index.ts"
   },
   "publishConfig": {
+    "access": "public",
     "exports": {
       ".": {
         "import": {
@@ -30,8 +31,7 @@
           "default": "./dist/index.js"
         }
       }
-    },
-    "access": "public"
+    }
   },
   "scripts": {
     "build": "tsup && (tsc --declaration --emitDeclarationOnly --outDir dist --rootDir src || true)",

--- a/packages/core/config/package.json
+++ b/packages/core/config/package.json
@@ -19,6 +19,7 @@
     ".": "./src/index.ts"
   },
   "publishConfig": {
+    "access": "public",
     "exports": {
       ".": {
         "import": {
@@ -26,8 +27,7 @@
           "default": "./dist/index.js"
         }
       }
-    },
-    "access": "public"
+    }
   },
   "scripts": {
     "build": "tsup && (tsc --declaration --emitDeclarationOnly --outDir dist --rootDir src || true)",

--- a/packages/core/execution/package.json
+++ b/packages/core/execution/package.json
@@ -20,6 +20,7 @@
     "./promise": "./src/promise.ts"
   },
   "publishConfig": {
+    "access": "public",
     "exports": {
       ".": {
         "import": {
@@ -33,8 +34,7 @@
           "default": "./dist/core.js"
         }
       }
-    },
-    "access": "public"
+    }
   },
   "scripts": {
     "build": "tsup && (tsc --declaration --emitDeclarationOnly --outDir dist --rootDir src || true)",

--- a/packages/core/integrations-registry/package.json
+++ b/packages/core/integrations-registry/package.json
@@ -20,6 +20,7 @@
     ".": "./src/index.ts"
   },
   "publishConfig": {
+    "access": "public",
     "exports": {
       ".": {
         "import": {
@@ -27,8 +28,7 @@
           "default": "./dist/index.js"
         }
       }
-    },
-    "access": "public"
+    }
   },
   "scripts": {
     "build": "tsup && (tsc --declaration --emitDeclarationOnly --outDir dist --rootDir src || true)",

--- a/packages/core/sdk/package.json
+++ b/packages/core/sdk/package.json
@@ -28,6 +28,7 @@
     "./public-origin": "./src/public-origin.ts"
   },
   "publishConfig": {
+    "access": "public",
     "exports": {
       ".": {
         "import": {
@@ -83,8 +84,7 @@
           "default": "./dist/public-origin.js"
         }
       }
-    },
-    "access": "public"
+    }
   },
   "scripts": {
     "build": "tsup && (tsc --declaration --emitDeclarationOnly --outDir dist --rootDir src || true)",

--- a/packages/core/vite-plugin/package.json
+++ b/packages/core/vite-plugin/package.json
@@ -23,6 +23,7 @@
     }
   },
   "publishConfig": {
+    "access": "public",
     "exports": {
       ".": {
         "import": {
@@ -30,8 +31,7 @@
           "default": "./dist/index.js"
         }
       }
-    },
-    "access": "public"
+    }
   },
   "scripts": {
     "build": "tsup && (tsc --declaration --emitDeclarationOnly --outDir dist --rootDir src || true)",

--- a/packages/kernel/core/package.json
+++ b/packages/kernel/core/package.json
@@ -19,6 +19,7 @@
     ".": "./src/index.ts"
   },
   "publishConfig": {
+    "access": "public",
     "exports": {
       ".": {
         "import": {
@@ -26,8 +27,7 @@
           "default": "./dist/index.js"
         }
       }
-    },
-    "access": "public"
+    }
   },
   "scripts": {
     "build": "tsup && (tsc --declaration --emitDeclarationOnly --outDir dist --rootDir src || true)",

--- a/packages/kernel/runtime-quickjs/package.json
+++ b/packages/kernel/runtime-quickjs/package.json
@@ -19,6 +19,7 @@
     ".": "./src/index.ts"
   },
   "publishConfig": {
+    "access": "public",
     "exports": {
       ".": {
         "import": {
@@ -26,8 +27,7 @@
           "default": "./dist/index.js"
         }
       }
-    },
-    "access": "public"
+    }
   },
   "scripts": {
     "build": "tsup && (tsc --declaration --emitDeclarationOnly --outDir dist --rootDir src || true)",

--- a/packages/plugins/desktop-settings/package.json
+++ b/packages/plugins/desktop-settings/package.json
@@ -20,6 +20,7 @@
     "./client": "./src/client.tsx"
   },
   "publishConfig": {
+    "access": "public",
     "exports": {
       "./server": {
         "import": {
@@ -33,8 +34,7 @@
           "default": "./dist/client.js"
         }
       }
-    },
-    "access": "public"
+    }
   },
   "scripts": {
     "build": "tsup",

--- a/packages/plugins/example/package.json
+++ b/packages/plugins/example/package.json
@@ -21,6 +21,7 @@
     "./shared": "./src/shared.ts"
   },
   "publishConfig": {
+    "access": "public",
     "exports": {
       "./server": {
         "import": {
@@ -40,8 +41,7 @@
           "default": "./dist/shared.js"
         }
       }
-    },
-    "access": "public"
+    }
   },
   "scripts": {
     "build": "tsup && (tsc --declaration --emitDeclarationOnly --outDir dist --rootDir src || true)",

--- a/packages/plugins/file-secrets/package.json
+++ b/packages/plugins/file-secrets/package.json
@@ -20,6 +20,7 @@
     "./promise": "./src/promise.ts"
   },
   "publishConfig": {
+    "access": "public",
     "exports": {
       ".": {
         "import": {
@@ -33,8 +34,7 @@
           "default": "./dist/core.js"
         }
       }
-    },
-    "access": "public"
+    }
   },
   "scripts": {
     "build": "tsup && (tsc --declaration --emitDeclarationOnly --outDir dist --rootDir src || true)",

--- a/packages/plugins/google/package.json
+++ b/packages/plugins/google/package.json
@@ -23,6 +23,7 @@
     "./client": "./src/react/plugin-client.tsx"
   },
   "publishConfig": {
+    "access": "public",
     "exports": {
       ".": {
         "import": {
@@ -42,8 +43,7 @@
           "default": "./dist/client.js"
         }
       }
-    },
-    "access": "public"
+    }
   },
   "scripts": {
     "build": "tsup && (tsc --declaration --emitDeclarationOnly --outDir dist --rootDir src || true)",

--- a/packages/plugins/graphql/package.json
+++ b/packages/plugins/graphql/package.json
@@ -25,6 +25,7 @@
     "./testing": "./src/testing/index.ts"
   },
   "publishConfig": {
+    "access": "public",
     "exports": {
       ".": {
         "import": {
@@ -50,8 +51,7 @@
           "default": "./dist/testing.js"
         }
       }
-    },
-    "access": "public"
+    }
   },
   "scripts": {
     "build": "tsup && (tsc --declaration --emitDeclarationOnly --outDir dist --rootDir src || true)",

--- a/packages/plugins/keychain/package.json
+++ b/packages/plugins/keychain/package.json
@@ -20,6 +20,7 @@
     "./promise": "./src/promise.ts"
   },
   "publishConfig": {
+    "access": "public",
     "exports": {
       ".": {
         "import": {
@@ -33,8 +34,7 @@
           "default": "./dist/core.js"
         }
       }
-    },
-    "access": "public"
+    }
   },
   "scripts": {
     "build": "tsup && (tsc --declaration --emitDeclarationOnly --outDir dist --rootDir src || true)",

--- a/packages/plugins/mcp/package.json
+++ b/packages/plugins/mcp/package.json
@@ -25,6 +25,7 @@
     "./testing": "./src/testing/index.ts"
   },
   "publishConfig": {
+    "access": "public",
     "exports": {
       ".": {
         "import": {
@@ -50,8 +51,7 @@
           "default": "./dist/testing.js"
         }
       }
-    },
-    "access": "public"
+    }
   },
   "scripts": {
     "build": "tsup && (tsc --declaration --emitDeclarationOnly --outDir dist --rootDir src || true)",

--- a/packages/plugins/microsoft/package.json
+++ b/packages/plugins/microsoft/package.json
@@ -23,6 +23,7 @@
     "./client": "./src/react/plugin-client.tsx"
   },
   "publishConfig": {
+    "access": "public",
     "exports": {
       ".": {
         "import": {
@@ -42,8 +43,7 @@
           "default": "./dist/client.js"
         }
       }
-    },
-    "access": "public"
+    }
   },
   "scripts": {
     "build": "tsup && (tsc --declaration --emitDeclarationOnly --outDir dist --rootDir src || true)",

--- a/packages/plugins/onepassword/package.json
+++ b/packages/plugins/onepassword/package.json
@@ -23,6 +23,7 @@
     "./client": "./src/react/plugin-client.tsx"
   },
   "publishConfig": {
+    "access": "public",
     "exports": {
       ".": {
         "import": {
@@ -42,8 +43,7 @@
           "default": "./dist/client.js"
         }
       }
-    },
-    "access": "public"
+    }
   },
   "scripts": {
     "build": "tsup && (tsc --declaration --emitDeclarationOnly --outDir dist --rootDir src || true)",

--- a/packages/plugins/openapi/package.json
+++ b/packages/plugins/openapi/package.json
@@ -25,6 +25,7 @@
     "./testing": "./src/testing/index.ts"
   },
   "publishConfig": {
+    "access": "public",
     "exports": {
       ".": {
         "import": {
@@ -50,8 +51,7 @@
           "default": "./dist/testing.js"
         }
       }
-    },
-    "access": "public"
+    }
   },
   "scripts": {
     "build": "tsup && (tsc --declaration --emitDeclarationOnly --outDir dist --rootDir src || true)",

--- a/packages/plugins/toolkits/package.json
+++ b/packages/plugins/toolkits/package.json
@@ -21,6 +21,7 @@
     "./shared": "./src/shared.ts"
   },
   "publishConfig": {
+    "access": "public",
     "exports": {
       "./server": {
         "import": {
@@ -40,8 +41,7 @@
           "default": "./dist/shared.js"
         }
       }
-    },
-    "access": "public"
+    }
   },
   "scripts": {
     "build": "tsup && (tsc --declaration --emitDeclarationOnly --outDir dist --rootDir src || true)",

--- a/packages/plugins/workos-vault/package.json
+++ b/packages/plugins/workos-vault/package.json
@@ -23,6 +23,7 @@
     "./testing": "./src/sdk/testing.ts"
   },
   "publishConfig": {
+    "access": "public",
     "exports": {
       ".": {
         "import": {
@@ -42,8 +43,7 @@
           "default": "./dist/testing.js"
         }
       }
-    },
-    "access": "public"
+    }
   },
   "scripts": {
     "build": "tsup && (tsc --declaration --emitDeclarationOnly --outDir dist --rootDir src || true)",

--- a/scripts/bootstrap.ts
+++ b/scripts/bootstrap.ts
@@ -31,4 +31,10 @@ if (!existsSync(resolve(repoRoot, "node_modules/.bin/vitest"))) {
   throw new Error("bootstrap: vitest missing after install — bun install likely failed");
 }
 
+// Point git at the tracked .githooks dir so the pre-commit hook auto-formats
+// staged code with oxfmt. hooksPath is local config, never cloned or copied
+// into worktrees, so every fresh checkout and agent worktree must re-set it;
+// without it, unformatted commits slip through and CI's `format` job fails.
+run("git hooks", "git", ["config", "core.hooksPath", ".githooks"]);
+
 console.log("\n[bootstrap] done — `cd e2e && bun run test` runs the full suite.");


### PR DESCRIPTION
## The real problem

`origin/main` itself was already failing `bun run format:check` (`oxfmt --check .`): 20 `package.json` files were unformatted (publishConfig key order, `access` sorts before `exports`). Because the Format job runs on the merge result, **every PR inherited a red Format check no matter what it changed**. That is why `fmt` appeared to fail on essentially every agent PR; it was not the agents' diffs.

A secondary gap: the repo had no git hooks, so nothing formatted commits locally before they were pushed either.

## What this does

1. **`chore: format package.json publishConfig`** - formats the 20 unformatted `package.json` files so the baseline is green. The change is a pure, idempotent key reorder (verified by re-running oxfmt). The existing `changeset:version` script already runs `oxfmt .`, so the release flow keeps them formatted going forward.

2. **`ci: auto-format staged code with a pre-commit hook`** - prevention so this cannot silently come back via locally-authored commits:
   - `.githooks/pre-commit`: formats staged JS/TS/JSON with `oxfmt --write` and re-stages them. Touches only *staged* files (matching the existing 'stage just your own files' rule), honours `.oxfmtrc.json` `ignorePatterns`, NUL-safe, and no-ops when oxfmt is not installed yet.
   - `scripts/bootstrap.ts`: sets `git config core.hooksPath .githooks`. hooksPath is local config that is never cloned or copied into worktrees, so bootstrap re-applies it on every fresh checkout / agent worktree.

## Test

- After the package.json commit, `oxfmt --check .` passes across all 1533 files locally.
- The pre-commit hook was exercised with multiple staged misformatted files (including a path containing a space): all were rewritten and re-staged, and the committed blobs passed `oxfmt --check`.