### PR TITLE
fix(cloud): repoint MCP DO binding to new SQLite class (unbreaks main deploy)

### DIFF
--- a/apps/cloud/src/app.ts
+++ b/apps/cloud/src/app.ts
@@ -13,7 +13,7 @@ import { ApiKeyService } from "./auth/api-keys";
 import { cloudIdentityFailureStrategy, workosIdentityLayer } from "./auth/workos-auth-provider";
 import { DbService } from "./db/db";
 import { cloudMcpAuth } from "./mcp";
-import { McpSessionDO } from "./mcp/session-durable-object";
+import { McpSessionDOSqlite } from "./mcp/session-durable-object";
 import { ErrorCaptureLive } from "./observability";
 import { AutumnService } from "./extensions/billing/service";
 import {
@@ -112,7 +112,7 @@ const { appLayer, toWebHandler, mcpExport } = ExecutorApp.make({
     failure: cloudIdentityFailureStrategy,
     // The MCP session Durable Object class — a top-level Workers export a Layer
     // can't return; surfaced so `server.ts` can re-export it.
-    mcpExport: McpSessionDO,
+    mcpExport: McpSessionDOSqlite,
   },
   // The long-lived (boot-scoped) context provideMerge'd under everything: the
   // WorkOS control plane (the raw `WorkOSClient` + `ApiKeyService` the per-request
@@ -135,7 +135,7 @@ const { appLayer, toWebHandler, mcpExport } = ExecutorApp.make({
   requestScoped: RequestScopedServicesLive,
 });
 
-export { McpSessionDO };
+export { McpSessionDOSqlite };
 
 export const CloudAppLayer = appLayer;
 export const cloudMcpExport = mcpExport;

--- a/apps/cloud/src/mcp/agent-handler.ts
+++ b/apps/cloud/src/mcp/agent-handler.ts
@@ -15,7 +15,7 @@ import {
 import type { McpSessionProps } from "@executor-js/cloudflare/mcp/agent-durable-object";
 
 import { cloudMcpAuth } from "./auth-provider";
-import { McpSessionDO } from "./session-durable-object";
+import { McpSessionDOSqlite } from "./session-durable-object";
 
 interface McpAgentSessionStub {
   readonly validateMcpSessionOwner: (identity: {
@@ -111,7 +111,7 @@ const propsForPrincipal = (
   });
 
 export const makeCloudMcpAgentHandler = () => {
-  const serve = McpSessionDO.serve("/mcp", {
+  const serve = McpSessionDOSqlite.serve("/mcp", {
     binding: "MCP_SESSION",
     transport: "streamable-http",
   });

--- a/apps/cloud/src/mcp/session-durable-object.ts
+++ b/apps/cloud/src/mcp/session-durable-object.ts
@@ -157,7 +157,7 @@ const makeSessionServices = (dbHandle: CloudSessionDbHandle) => {
 // Durable Object
 // ---------------------------------------------------------------------------
 
-export class McpSessionDO extends McpAgentSessionDOBase<Env, CloudSessionDbHandle> {
+export class McpSessionDOSqlite extends McpAgentSessionDOBase<Env, CloudSessionDbHandle> {
   protected override openSessionDb(): CloudSessionDbHandle {
     return makeDbHandle({
       idleTimeout: LONG_LIVED_DB_IDLE_TIMEOUT_SECONDS,
@@ -181,7 +181,7 @@ export class McpSessionDO extends McpAgentSessionDOBase<Env, CloudSessionDbHandl
         elicitationMode: token.elicitationMode,
       } satisfies SessionMeta;
     }).pipe(
-      Effect.withSpan("McpSessionDO.resolveSessionMeta"),
+      Effect.withSpan("McpSessionDOSqlite.resolveSessionMeta"),
       Effect.provide(makeSessionServices(dbHandle)),
       Effect.ensuring(Effect.promise(() => dbHandle.end())),
       // oxlint-disable-next-line executor/no-effect-escape-hatch -- boundary: a vanished org is a defect; the worker already verified the bearer
@@ -208,7 +208,7 @@ export class McpSessionDO extends McpAgentSessionDOBase<Env, CloudSessionDbHandl
         // billing service degrades to a no-op tracker, so this stays inert in
         // cloud dev/preview environments that run without a billing backend.
         Effect.provide(CloudMeteredExecutionStackLayer.pipe(Layer.provide(AutumnService.Default))),
-        Effect.withSpan("McpSessionDO.makeExecutionStack"),
+        Effect.withSpan("McpSessionDOSqlite.makeExecutionStack"),
       );
       // Build the description here so `executor.connections.list()` stays under
       // the DO startup span and the MCP SDK receives a concrete string instead
@@ -235,10 +235,10 @@ export class McpSessionDO extends McpAgentSessionDOBase<Env, CloudSessionDbHandl
                   }),
               }
             : { mode: sessionElicitationMode },
-      }).pipe(Effect.withSpan("McpSessionDO.createExecutorMcpServer"));
+      }).pipe(Effect.withSpan("McpSessionDOSqlite.createExecutorMcpServer"));
       return { mcpServer, engine } satisfies BuiltMcpServer;
     }).pipe(
-      Effect.withSpan("McpSessionDO.buildMcpServer"),
+      Effect.withSpan("McpSessionDOSqlite.buildMcpServer"),
       Effect.provide(makeSessionServices(dbHandle)),
       // oxlint-disable-next-line executor/no-effect-escape-hatch -- boundary: runtime-build failures surface as the base's tapCause/cleanup defect
       Effect.orDie,

--- a/apps/cloud/src/server.ts
+++ b/apps/cloud/src/server.ts
@@ -12,7 +12,7 @@ import handler from "@tanstack/react-start/server-entry";
 import { isAppOwnedPath } from "./app-paths";
 import { makeCloudMcpAgentHandler } from "./mcp/agent-handler";
 import { classifyMcpPath, prepareMcpOrgScope } from "./mcp/mount";
-import { McpSessionDO as McpSessionDOBase } from "./mcp/session-durable-object";
+import { McpSessionDOSqlite as McpSessionDOBase } from "./mcp/session-durable-object";
 import { browserTracesResponse } from "./observability/browser-traces";
 import { flushTracerProvider, installTracerProvider } from "./observability/telemetry";
 
@@ -41,7 +41,7 @@ const sentryOptions = (env: Env) => ({
 // not a global fetch wrapper.
 // ---------------------------------------------------------------------------
 
-export const McpSessionDO = Sentry.instrumentDurableObjectWithSentry(
+export const McpSessionDOSqlite = Sentry.instrumentDurableObjectWithSentry(
   sentryOptions,
   McpSessionDOBase,
 );

--- a/apps/cloud/wrangler.jsonc
+++ b/apps/cloud/wrangler.jsonc
@@ -20,16 +20,17 @@
     "bindings": [
       {
         "name": "MCP_SESSION",
-        "class_name": "McpSessionDO",
+        "class_name": "McpSessionDOSqlite",
       },
     ],
   },
   // The MCP session DO moved to the Cloudflare Agents (`McpAgent`) base, which
-  // stores state in SQLite. `McpSessionDO` was originally created with the
+  // stores state in SQLite. The original `McpSessionDO` was created with the
   // key-value backend (`new_classes`), and Cloudflare cannot convert a live class
-  // to SQLite in place. Session state is ephemeral, so v2 deletes the KV class and
-  // v3 recreates the same name on the SQLite backend. Keeping the name avoids any
-  // binding/export rename.
+  // to SQLite in place, nor delete a class while a binding still references it.
+  // Session state is ephemeral, so v2 repoints the `MCP_SESSION` binding to a new
+  // SQLite-backed class (`McpSessionDOSqlite`) and deletes the old KV `McpSessionDO`
+  // (now unreferenced). The worker exports `McpSessionDOSqlite`, not `McpSessionDO`.
   "migrations": [
     {
       "tag": "v1",
@@ -38,10 +39,7 @@
     {
       "tag": "v2",
       "deleted_classes": ["McpSessionDO"],
-    },
-    {
-      "tag": "v3",
-      "new_sqlite_classes": ["McpSessionDO"],
+      "new_sqlite_classes": ["McpSessionDOSqlite"],
     },
   ],
   "services": [


### PR DESCRIPTION
## Why

The previous fix attempt (merged) deletes `McpSessionDO` but the `MCP_SESSION` binding still referenced it, so the **non-versioned `main` deploy** failed:

> Cannot apply --delete-class migration to class 'McpSessionDO' without also removing the binding that references it. [code: 10061]

`main` currently fails to deploy. Prod is still on the rolled-back (working KV) version.

## Fix

Use a **new** SQLite class name and move the binding to it first, so the old KV class is unreferenced and can be deleted (Cloudflare's documented KV→SQLite path):

- rename the concrete DO class + every reference → `McpSessionDOSqlite`
- `MCP_SESSION` binding → `McpSessionDOSqlite`
- migration `v2`: `deleted_classes: ["McpSessionDO"]` + `new_sqlite_classes: ["McpSessionDOSqlite"]`

## Verified locally (the part CI can't check)

The built worker exports **`McpSessionDOSqlite` ×5 and `McpSessionDO` ×0** — the deleted class is no longer exported and nothing binds it, which is exactly what error 10061 required. typecheck + lint clean.

## Deploy note

The PR Workers Build will still red with `code 10211` ("migrations must be applied via a non-versioned deployment") — that's inherent to PR preview builds and **not** a real failure. The `main` build is non-versioned (it got to applying the migration last time), so **merging applies the migration**. Migration state is `v1` (the prior attempt failed atomically), so `v2` applies cleanly on merge.