### PR TITLE
fix(cloud): unbreak main deploy — create SQLite DO without same-deploy delete

### DIFF
--- a/apps/cloud/src/server.ts
+++ b/apps/cloud/src/server.ts
@@ -1,3 +1,4 @@
+import { DurableObject } from "cloudflare:workers";
 import { SpanKind, SpanStatusCode, context, trace } from "@opentelemetry/api";
 import {
   ATTR_HTTP_REQUEST_METHOD,
@@ -45,6 +46,14 @@ export const McpSessionDOSqlite = Sentry.instrumentDurableObjectWithSentry(
   sentryOptions,
   McpSessionDOBase,
 );
+
+// Orphaned placeholder for the original key-value `McpSessionDO` class (migration
+// v1). The live MCP session DO is now `McpSessionDOSqlite` (SQLite); the
+// `MCP_SESSION` binding moved to it. Cloudflare won't delete `McpSessionDO` in the
+// same deploy that moves its binding, so the class is left unbound and is kept
+// exported here only to satisfy the migration. It can be removed in a later deploy
+// (with a `deleted_classes: ["McpSessionDO"]` migration) now that nothing binds it.
+export class McpSessionDO extends DurableObject {}
 
 // ---------------------------------------------------------------------------
 // Worker fetch handler

--- a/apps/cloud/worker-configuration.d.ts
+++ b/apps/cloud/worker-configuration.d.ts
@@ -14,7 +14,7 @@ declare namespace Cloudflare {
     WORKOS_COOKIE_PASSWORD: string;
     APP_URL: string;
     WORKOS_CLAIM_TOKEN: string;
-    MCP_SESSION: DurableObjectNamespace<import("./src/server").McpSessionDO>;
+    MCP_SESSION: DurableObjectNamespace<import("./src/server").McpSessionDOSqlite>;
     MARKETING: Fetcher /* executor-marketing */;
   }
 }

--- a/apps/cloud/wrangler.jsonc
+++ b/apps/cloud/wrangler.jsonc
@@ -25,12 +25,14 @@
     ],
   },
   // The MCP session DO moved to the Cloudflare Agents (`McpAgent`) base, which
-  // stores state in SQLite. The original `McpSessionDO` was created with the
-  // key-value backend (`new_classes`), and Cloudflare cannot convert a live class
-  // to SQLite in place, nor delete a class while a binding still references it.
-  // Session state is ephemeral, so v2 repoints the `MCP_SESSION` binding to a new
-  // SQLite-backed class (`McpSessionDOSqlite`) and deletes the old KV `McpSessionDO`
-  // (now unreferenced). The worker exports `McpSessionDOSqlite`, not `McpSessionDO`.
+  // stores state in SQLite. The original `McpSessionDO` was created on the
+  // key-value backend (`new_classes`) and cannot be converted in place. Cloudflare
+  // also refuses to delete a class in the same deploy that moves its binding (it
+  // validates the delete against the live binding), so v2 only CREATES the new
+  // SQLite class `McpSessionDOSqlite` and the `MCP_SESSION` binding moves to it.
+  // The old KV `McpSessionDO` is left orphaned (unbound, kept as a stub export in
+  // server.ts so the migration stays valid); it can be deleted in a later deploy
+  // now that nothing binds it. Session state is ephemeral, so nothing is lost.
   "migrations": [
     {
       "tag": "v1",
@@ -38,7 +40,6 @@
     },
     {
       "tag": "v2",
-      "deleted_classes": ["McpSessionDO"],
       "new_sqlite_classes": ["McpSessionDOSqlite"],
     },
   ],


### PR DESCRIPTION
## Incident state

`main` currently fails to deploy (`#1191`): Cloudflare rejects the `deleted_classes: ["McpSessionDO"]` migration with **code 10061** — it validates the delete against the *live* binding, which still points at `McpSessionDO`. So moving the binding and deleting the class can't happen in one deploy. Prod is on the rolled-back (working KV) version meanwhile.

## Fix

Stop deleting in this deploy. `v2` now **only** creates the new SQLite class and the binding moves to it:

- migration `v2`: `new_sqlite_classes: ["McpSessionDOSqlite"]` (no `deleted_classes`)
- `MCP_SESSION` binding → `McpSessionDOSqlite`
- old KV `McpSessionDO` left orphaned + unbound, kept as a stub export in `server.ts` so the migration stays valid
- regenerated `MCP_SESSION` binding type → `McpSessionDOSqlite`

No delete → no 10061. Session state is ephemeral, nothing lost.

## Verified locally
- typecheck 0, lint clean
- built worker exports `McpSessionDOSqlite` (real, bound) and `McpSessionDO` (stub) — both present, which is what the migration needs

## Expectations
- PR Workers Build will still red with `10211` (versioned uploads can't apply DO migrations) — inherent, ignore.
- The `main` deploy is non-versioned and applies the migration. This time `v2` has no delete, so the 10061 can't recur.

## Follow-up
Once this is live, a trivial later deploy can add `deleted_classes: ["McpSessionDO"]` + drop the stub (the binding is already off it).