### PR TITLE
fix(cloud): stop PR preview builds failing on DO migrations (10211)

### DIFF
--- a/apps/cloud/scripts/build.mjs
+++ b/apps/cloud/scripts/build.mjs
@@ -9,7 +9,7 @@
 
 import { spawnSync } from "node:child_process";
 import { randomBytes } from "node:crypto";
-import { rmSync } from "node:fs";
+import { readFileSync, rmSync, writeFileSync } from "node:fs";
 
 if (!process.env.VITE_PUBLIC_ANALYTICS_PATH) {
   process.env.VITE_PUBLIC_ANALYTICS_PATH = randomBytes(4).toString("hex");
@@ -30,5 +30,28 @@ for (const step of steps) {
   const result = spawnSync(step, { stdio: "inherit", shell: true });
   if (result.status !== 0) {
     process.exit(result.status ?? 1);
+  }
+}
+
+// Preview (non-production) Cloudflare Workers Builds deploy via `wrangler versions
+// upload`, which REJECTS any config containing an unapplied Durable Object
+// migration (error 10211 — "migrations must be applied via a non-versioned
+// deployment"). Preview versions share production's already-applied DO state, so
+// they neither need nor can apply migrations. Strip `migrations` from the
+// generated deploy config on non-`main` CI branches so PR preview builds stop
+// failing. Production (`main`) keeps migrations and applies them on the real,
+// non-versioned deploy. Fail-safe: only triggers on a confirmed non-`main` CI
+// branch, so it can never drop migrations from a production deploy.
+const ciBranch = process.env.WORKERS_CI_BRANCH;
+if (process.env.WORKERS_CI === "1" && ciBranch && ciBranch !== "main") {
+  const cfgUrl = new URL("../dist/server/wrangler.json", import.meta.url);
+  const cfg = JSON.parse(readFileSync(cfgUrl, "utf8"));
+  if (Array.isArray(cfg.migrations) && cfg.migrations.length > 0) {
+    delete cfg.migrations;
+    writeFileSync(cfgUrl, JSON.stringify(cfg));
+    console.log(
+      `[build] preview branch '${ciBranch}': stripped Durable Object migrations from ` +
+        `dist/server/wrangler.json (versions upload cannot apply migrations)`,
+    );
   }
 }

--- a/apps/cloud/scripts/build.mjs
+++ b/apps/cloud/scripts/build.mjs
@@ -45,6 +45,7 @@ for (const step of steps) {
 const ciBranch = process.env.WORKERS_CI_BRANCH;
 if (process.env.WORKERS_CI === "1" && ciBranch && ciBranch !== "main") {
   const cfgUrl = new URL("../dist/server/wrangler.json", import.meta.url);
+  // oxlint-disable-next-line executor/no-json-parse -- build script, not domain code; wrangler emits plain JSON
   const cfg = JSON.parse(readFileSync(cfgUrl, "utf8"));
   if (Array.isArray(cfg.migrations) && cfg.migrations.length > 0) {
     delete cfg.migrations;


### PR DESCRIPTION
## Problem

Preview (non-`main`) Workers Builds deploy via `wrangler versions upload`, which rejects any config containing a Durable Object migration with **error 10211** ("migrations must be applied via a non-versioned deployment"). Since `apps/cloud`'s `wrangler.jsonc` carries the DO migration ledger (`v1`/`v2`), every PR's preview build fails.

## Fix

`build.mjs` strips `migrations` from the generated `dist/server/wrangler.json` **only on non-`main` CI branches** (`WORKERS_CI=1` + `WORKERS_CI_BRANCH !== "main"`). Previews share production's already-applied DO state, so they don't need (and can't apply) migrations. `main` keeps migrations and applies them on the real, non-versioned deploy.

Fail-safe by construction: it only ever strips on a confirmed non-`main` CI branch, so it can't drop migrations from a production deploy. Confirmed via the CF build log that the strip takes effect (the earlier error moved from `10211` to a different one once stripped).

## Scope note

This intentionally does **not** delete the orphaned KV `McpSessionDO` class. That class is unbound and harmless, the migration ledger must stay regardless, and a delete-class PR's own preview build can't pass anyway. Left as-is with its one-line stub export.

## Verified locally
- typecheck 0, lint clean
- normal/`main` build keeps migrations; preview-branch build logs the strip and emits no migrations in the deploy config