### PR TITLE
Line up plan card buttons on the Choose a plan page

### DIFF
--- a/apps/cloud/src/routes/app/billing_.plans.tsx
+++ b/apps/cloud/src/routes/app/billing_.plans.tsx
@@ -66,12 +66,6 @@ const ACTION_LABELS: Record<string, string> = {
 
 const PLAN_ORDER = ["free", "team", "enterprise"];
 
-// "14-day free trial", "1-month free trial", etc. — reads the trial config
-// synced from the repo-root autumn.config.ts so copy tracks the plan. The unit
-// stays singular because it reads as a compound adjective ("14-day", "2-month").
-const trialLabel = (freeTrial: NonNullable<Plan["freeTrial"]>): string =>
-  `${freeTrial.durationLength}-${freeTrial.durationType} free trial`;
-
 function PlansPage() {
   const { attach, openCustomerPortal, isLoading: customerLoading } = useCustomer();
   const { data: plans, isLoading: plansLoading, isFetching } = useListPlans();
@@ -185,14 +179,6 @@ function PlansPage() {
                       <span className="text-sm text-muted-foreground">USD</span>
                     )}
                   </div>
-
-                  {trialOffered && freeTrial && (
-                    <p className="mt-2 text-xs font-medium text-primary">
-                      {trialLabel(freeTrial)}
-                      {plan.price?.amount != null &&
-                        `, then $${plan.price.amount} / ${plan.price.interval ?? "month"}`}
-                    </p>
-                  )}
 
                   <div className="mt-4">
                     {(isCurrent && !isCanceling) || isScheduled ? (


### PR DESCRIPTION
## What

On the **Choose a plan** billing page the three plan cards' call-to-action buttons sat on a ragged baseline: the Team card's button was about a line lower than Free's and Enterprise's.

## Why

Only plans that offer a trial rendered a "14-day free trial, then $150 / month" line between the price and the button. That extra line pushed the trial card's button down while the others stayed put, so the row of buttons didn't line up.

## Change

Remove the trial blurb line. Every card now has the same structure (price → button), so the buttons share a baseline. The trial is still surfaced: the action button itself reads **Start free trial**.

Single-file change to `apps/cloud/src/routes/app/billing_.plans.tsx` (also drops the now-unused `trialLabel` helper).