### PR TITLE
Fix floating auth tab strip for transparent-DCR OAuth connect modal

### DIFF
--- a/e2e/selfhost/connection-modal-dcr-card.test.ts
+++ b/e2e/selfhost/connection-modal-dcr-card.test.ts
@@ -1,0 +1,87 @@
+// Selfhost (browser, recorded): the add-connection modal for a transparent-DCR
+// OAuth MCP integration must render its body card, not just a floating tab
+// strip. A remote MCP integration that declares an oauth2 method is DCR-capable
+// (supportsDynamicRegistration), so the modal skips the app picker. When the
+// integration also offers the custom-method "+" the method tab strip renders.
+//
+// The regression this guards: the OAuth tab's TabsContent card (the "No app to
+// choose / automatic setup" explainer) was gated out whenever DCR was active,
+// leaving the tab strip with no card under it and a detached-looking border.
+// The same gate also made that explainer unreachable dead code. The per-step
+// screenshots are the artifact.
+import { randomBytes } from "node:crypto";
+
+import { Effect } from "effect";
+import { composePluginApi } from "@executor-js/api/server";
+import { mcpHttpPlugin } from "@executor-js/plugin-mcp/api";
+import { makeGreetingMcpServer, serveMcpServer } from "@executor-js/plugin-mcp/testing";
+import { IntegrationSlug } from "@executor-js/sdk/shared";
+
+import { scenario } from "../src/scenario";
+import { Api, Browser, Target } from "../src/services";
+
+const api = composePluginApi([mcpHttpPlugin()] as const);
+
+scenario(
+  "Connections · the add-connection modal for a transparent-DCR OAuth MCP renders its body card under the tab strip",
+  {},
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const browser = yield* Browser;
+      const { client: makeApiClient } = yield* Api;
+
+      // A remote MCP integration declaring an oauth2 method: remote + oauth2 is
+      // transparent-DCR (supportsDynamicRegistration true), so the modal skips
+      // the BYO-app picker. The server is never dialed here — opening the modal
+      // only reads the declared template.
+      const server = yield* serveMcpServer(() => makeGreetingMcpServer());
+      const identity = yield* target.newIdentity();
+      const client = yield* makeApiClient(api, identity);
+      const slug = `mcp-dcr-card-${randomBytes(3).toString("hex")}`;
+
+      yield* client.mcp.addServer({
+        payload: {
+          transport: "remote",
+          name: "DCR OAuth MCP",
+          endpoint: server.endpoint,
+          slug,
+          authenticationTemplate: [{ kind: "oauth2" }],
+        },
+      });
+
+      // Remove the integration afterward — selfhost identities share one tenant,
+      // so a leaked integration would bleed into other scenarios.
+      yield* Effect.gen(function* () {
+        yield* browser.session(identity, async ({ page, step }) => {
+          const dialog = page.getByRole("dialog");
+
+          await step("Open the integration's add-connection modal", async () => {
+            await page.goto(`/integrations/${slug}`, { waitUntil: "networkidle" });
+            await page.getByRole("button", { name: "Add connection" }).first().click();
+            await dialog.waitFor({ state: "visible" });
+          });
+
+          await step("The OAuth tab and the custom-method + are present", async () => {
+            await dialog.getByRole("tab", { name: "OAuth" }).waitFor();
+            await dialog.getByRole("button", { name: "Add authentication method" }).waitFor();
+          });
+
+          await step("The OAuth tab has its body card, not a floating tab strip", async () => {
+            // The card the fix restores: the DCR explainer that anchors the tab
+            // strip. Before the fix the TabsContent was gated out for DCR, so
+            // this copy was unreachable and the tabs floated with no card.
+            await dialog.getByText("No app to choose").waitFor({ timeout: 15_000 });
+            await dialog.getByText(/supports automatic setup/).waitFor({ timeout: 15_000 });
+          });
+        });
+      }).pipe(
+        Effect.ensuring(
+          client.mcp
+            .removeServer({ params: { slug: IntegrationSlug.make(slug) } })
+            .pipe(Effect.ignore),
+        ),
+      );
+    }),
+  ),
+);

--- a/packages/react/src/components/add-account-modal.tsx
+++ b/packages/react/src/components/add-account-modal.tsx
@@ -1722,186 +1722,184 @@ function AddAccountModalView(props: AddAccountModalProps) {
                     </div>
                   </TabsList>
 
-                  {dcrActive ? null : (
-                    <TabsContent
-                      value={methodId}
-                      className={cn(
-                        "mt-0 min-w-0 space-y-5",
-                        // No-auth renders no fields, so skip the framed box that
-                        // would otherwise show up as an empty bordered panel.
-                        // Otherwise the panel attaches to the tab header above
-                        // (square top, rounded bottom).
-                        isNoAuth
-                          ? null
-                          : "rounded-b-md rounded-t-none border border-border/60 bg-muted/15 p-4",
-                      )}
-                    >
-                      {method?.placements && !isEnvMethod && singleInput && !singleCredentialAffix
-                        ? (() => {
-                            const shown = method.placements.filter((p) => p.carrier !== "env");
-                            return shown.length > 0 ? (
-                              <div className="flex flex-wrap gap-x-3.5 gap-y-1">
-                                {shown.map((placement, i: number) => (
-                                  <PlacementLine key={i} placement={placement} />
-                                ))}
-                              </div>
-                            ) : null;
-                          })()
-                        : null}
+                  <TabsContent
+                    value={methodId}
+                    className={cn(
+                      "mt-0 min-w-0 space-y-5",
+                      // No-auth renders no fields, so skip the framed box that
+                      // would otherwise show up as an empty bordered panel.
+                      // Otherwise the panel attaches to the tab header above
+                      // (square top, rounded bottom).
+                      isNoAuth
+                        ? null
+                        : "rounded-b-md rounded-t-none border border-border/60 bg-muted/15 p-4",
+                    )}
+                  >
+                    {method?.placements && !isEnvMethod && singleInput && !singleCredentialAffix
+                      ? (() => {
+                          const shown = method.placements.filter((p) => p.carrier !== "env");
+                          return shown.length > 0 ? (
+                            <div className="flex flex-wrap gap-x-3.5 gap-y-1">
+                              {shown.map((placement, i: number) => (
+                                <PlacementLine key={i} placement={placement} />
+                              ))}
+                            </div>
+                          ) : null;
+                        })()
+                      : null}
 
-                      {!isNoAuth && (
-                        <div className="space-y-2">
-                          <StepHeader index={2} label={authStepLabel} />
+                    {!isNoAuth && (
+                      <div className="space-y-2">
+                        <StepHeader index={2} label={authStepLabel} />
 
-                          {isOAuth && method ? (
-                            cimdActive ? (
-                              <div className="space-y-2 rounded-lg border border-ring/40 bg-accent/30 px-3 py-3">
-                                <p className="text-sm font-medium">No app registration</p>
-                                <p className="text-xs text-muted-foreground">
-                                  {cimdConnecting
-                                    ? `Connecting to ${integrationName}…`
-                                    : `${integrationName} supports Client ID Metadata Document OAuth. We'll use this Executor host's public client metadata document and sign you in.`}
-                                </p>
-                              </div>
-                            ) : dcrActive ? (
-                              // Transparent DCR: no picker. We register an app for you and run
-                              // the OAuth flow with a single Connect click.
-                              <div className="space-y-2 rounded-lg border border-ring/40 bg-accent/30 px-3 py-3">
-                                <p className="text-sm font-medium">No app to choose</p>
-                                <p className="text-xs text-muted-foreground">
-                                  {dcrConnecting
-                                    ? `Connecting to ${integrationName}…`
-                                    : `${integrationName} supports automatic setup. We register an app for you and sign you in — no client ID or app to pick.`}
-                                </p>
-                              </div>
-                            ) : oauthLoading ? (
-                              <p className="text-xs text-muted-foreground">Loading OAuth apps…</p>
-                            ) : (
-                              <div className="space-y-3">
-                                {dcrFallbackMessage ? (
-                                  <div
-                                    role="alert"
-                                    className="space-y-1 rounded-lg border border-destructive/40 bg-destructive/5 px-3 py-3"
-                                  >
-                                    <p className="text-sm font-medium text-destructive">
-                                      Couldn&apos;t set up {integrationName} automatically
-                                    </p>
-                                    <p className="text-xs text-muted-foreground">
-                                      {dcrFallbackMessage}
-                                    </p>
-                                    <p className="text-xs text-muted-foreground">
-                                      Register an app below to connect.
-                                    </p>
-                                  </div>
-                                ) : null}
-                                {/* No registered app matched the integration's endpoint:
+                        {isOAuth && method ? (
+                          cimdActive ? (
+                            <div className="space-y-2 rounded-lg border border-ring/40 bg-accent/30 px-3 py-3">
+                              <p className="text-sm font-medium">No app registration</p>
+                              <p className="text-xs text-muted-foreground">
+                                {cimdConnecting
+                                  ? `Connecting to ${integrationName}…`
+                                  : `${integrationName} supports Client ID Metadata Document OAuth. We'll use this Executor host's public client metadata document and sign you in.`}
+                              </p>
+                            </div>
+                          ) : dcrActive ? (
+                            // Transparent DCR: no picker. We register an app for you and run
+                            // the OAuth flow with a single Connect click.
+                            <div className="space-y-2 rounded-lg border border-ring/40 bg-accent/30 px-3 py-3">
+                              <p className="text-sm font-medium">No app to choose</p>
+                              <p className="text-xs text-muted-foreground">
+                                {dcrConnecting
+                                  ? `Connecting to ${integrationName}…`
+                                  : `${integrationName} supports automatic setup. We register an app for you and sign you in — no client ID or app to pick.`}
+                              </p>
+                            </div>
+                          ) : oauthLoading ? (
+                            <p className="text-xs text-muted-foreground">Loading OAuth apps…</p>
+                          ) : (
+                            <div className="space-y-3">
+                              {dcrFallbackMessage ? (
+                                <div
+                                  role="alert"
+                                  className="space-y-1 rounded-lg border border-destructive/40 bg-destructive/5 px-3 py-3"
+                                >
+                                  <p className="text-sm font-medium text-destructive">
+                                    Couldn&apos;t set up {integrationName} automatically
+                                  </p>
+                                  <p className="text-xs text-muted-foreground">
+                                    {dcrFallbackMessage}
+                                  </p>
+                                  <p className="text-xs text-muted-foreground">
+                                    Register an app below to connect.
+                                  </p>
+                                </div>
+                              ) : null}
+                              {/* No registered app matched the integration's endpoint:
                         empty state + a prominent register CTA, and an opt-in
                         collapsed "use a different registered app" escape hatch. */}
-                                {oauthDisplayRegisterCTA && (
-                                  <div className="space-y-3 rounded-lg border border-border/60 bg-muted/20 px-3 py-3">
-                                    <p className="text-sm font-medium">
-                                      No app for {integrationName} yet
-                                    </p>
-                                    <p className="text-xs text-muted-foreground">
-                                      None of your registered apps target this integration's OAuth
-                                      endpoint. Register one to connect.
-                                    </p>
-                                    <div className="flex flex-wrap items-center gap-2 pt-1">
-                                      <Button
-                                        type="button"
-                                        size="sm"
-                                        onClick={() => setRegisteringOAuthClient(true)}
-                                      >
-                                        {dcrFallbackMessage
-                                          ? "Manually register an app"
-                                          : "Register app"}
-                                      </Button>
-                                      {oauthOtherApps.length > 0 && !showOtherApps ? (
-                                        <Button
-                                          type="button"
-                                          variant="outline"
-                                          size="sm"
-                                          onClick={() => setShowOtherApps(true)}
-                                        >
-                                          Use another app
-                                        </Button>
-                                      ) : null}
-                                    </div>
-                                    {oauthOtherApps.length > 0 && showOtherApps ? (
-                                      <RadioGroup
-                                        value={selectedApp}
-                                        onValueChange={setPickedApp}
-                                        className="gap-2 pt-1"
-                                      >
-                                        {oauthOtherApps.map((app: OAuthClientOption) => (
-                                          <OAuthAppRadioRow
-                                            key={String(app.slug)}
-                                            app={app}
-                                            idPrefix="other-app"
-                                            variant="other"
-                                            showOwnerLabel={ownerDisplay.showOwnerLabels}
-                                            onManage={manageHandlersFor(app)}
-                                          />
-                                        ))}
-                                      </RadioGroup>
-                                    ) : null}
-                                  </div>
-                                )}
-
-                                {oauthApps.length > 0 && (
-                                  <RadioGroup
-                                    value={selectedApp}
-                                    onValueChange={setPickedApp}
-                                    className="gap-2"
-                                  >
-                                    {oauthApps.map((app: OAuthClientOption) => (
-                                      <OAuthAppRadioRow
-                                        key={String(app.slug)}
-                                        app={app}
-                                        idPrefix="app"
-                                        variant="matched"
-                                        showOwnerLabel={ownerDisplay.showOwnerLabels}
-                                        onManage={manageHandlersFor(app)}
-                                      />
-                                    ))}
+                              {oauthDisplayRegisterCTA && (
+                                <div className="space-y-3 rounded-lg border border-border/60 bg-muted/20 px-3 py-3">
+                                  <p className="text-sm font-medium">
+                                    No app for {integrationName} yet
+                                  </p>
+                                  <p className="text-xs text-muted-foreground">
+                                    None of your registered apps target this integration's OAuth
+                                    endpoint. Register one to connect.
+                                  </p>
+                                  <div className="flex flex-wrap items-center gap-2 pt-1">
                                     <Button
                                       type="button"
-                                      variant="outline"
-                                      className="h-auto justify-start gap-3 rounded-lg border-dashed border-border/60 px-3 py-2.5 text-sm font-normal text-muted-foreground hover:text-foreground"
+                                      size="sm"
                                       onClick={() => setRegisteringOAuthClient(true)}
                                     >
-                                      <PlusIcon className="size-4" />
-                                      Register a new app
+                                      {dcrFallbackMessage
+                                        ? "Manually register an app"
+                                        : "Register app"}
                                     </Button>
-                                  </RadioGroup>
-                                )}
-                              </div>
-                            )
-                          ) : (
-                            <CredentialValueFields
-                              inputs={credentialInputs}
-                              singleInput={singleInput}
-                              showLabels={isEnvMethod}
-                              affix={singleCredentialAffix}
-                              allowExternalProvider={!isEnvMethod}
-                              values={values}
-                              onValuesChange={setValues}
-                              origin={credentialOrigin}
-                              onOriginChange={(next) => {
-                                setCredentialOrigin(next);
-                                if (next === "paste") setOnePasswordItemId("");
-                              }}
-                              onePasswordItemId={onePasswordItemId}
-                              onOnePasswordItemIdChange={setOnePasswordItemId}
-                            />
-                          )}
-                          {isOAuth && oauthPopup.error ? (
-                            <p className="text-xs text-destructive">{oauthPopup.error}</p>
-                          ) : null}
-                        </div>
-                      )}
-                    </TabsContent>
-                  )}
+                                    {oauthOtherApps.length > 0 && !showOtherApps ? (
+                                      <Button
+                                        type="button"
+                                        variant="outline"
+                                        size="sm"
+                                        onClick={() => setShowOtherApps(true)}
+                                      >
+                                        Use another app
+                                      </Button>
+                                    ) : null}
+                                  </div>
+                                  {oauthOtherApps.length > 0 && showOtherApps ? (
+                                    <RadioGroup
+                                      value={selectedApp}
+                                      onValueChange={setPickedApp}
+                                      className="gap-2 pt-1"
+                                    >
+                                      {oauthOtherApps.map((app: OAuthClientOption) => (
+                                        <OAuthAppRadioRow
+                                          key={String(app.slug)}
+                                          app={app}
+                                          idPrefix="other-app"
+                                          variant="other"
+                                          showOwnerLabel={ownerDisplay.showOwnerLabels}
+                                          onManage={manageHandlersFor(app)}
+                                        />
+                                      ))}
+                                    </RadioGroup>
+                                  ) : null}
+                                </div>
+                              )}
+
+                              {oauthApps.length > 0 && (
+                                <RadioGroup
+                                  value={selectedApp}
+                                  onValueChange={setPickedApp}
+                                  className="gap-2"
+                                >
+                                  {oauthApps.map((app: OAuthClientOption) => (
+                                    <OAuthAppRadioRow
+                                      key={String(app.slug)}
+                                      app={app}
+                                      idPrefix="app"
+                                      variant="matched"
+                                      showOwnerLabel={ownerDisplay.showOwnerLabels}
+                                      onManage={manageHandlersFor(app)}
+                                    />
+                                  ))}
+                                  <Button
+                                    type="button"
+                                    variant="outline"
+                                    className="h-auto justify-start gap-3 rounded-lg border-dashed border-border/60 px-3 py-2.5 text-sm font-normal text-muted-foreground hover:text-foreground"
+                                    onClick={() => setRegisteringOAuthClient(true)}
+                                  >
+                                    <PlusIcon className="size-4" />
+                                    Register a new app
+                                  </Button>
+                                </RadioGroup>
+                              )}
+                            </div>
+                          )
+                        ) : (
+                          <CredentialValueFields
+                            inputs={credentialInputs}
+                            singleInput={singleInput}
+                            showLabels={isEnvMethod}
+                            affix={singleCredentialAffix}
+                            allowExternalProvider={!isEnvMethod}
+                            values={values}
+                            onValuesChange={setValues}
+                            origin={credentialOrigin}
+                            onOriginChange={(next) => {
+                              setCredentialOrigin(next);
+                              if (next === "paste") setOnePasswordItemId("");
+                            }}
+                            onePasswordItemId={onePasswordItemId}
+                            onOnePasswordItemIdChange={setOnePasswordItemId}
+                          />
+                        )}
+                        {isOAuth && oauthPopup.error ? (
+                          <p className="text-xs text-destructive">{oauthPopup.error}</p>
+                        ) : null}
+                      </div>
+                    )}
+                  </TabsContent>
                 </Tabs>
               )}
 


### PR DESCRIPTION
## Problem

In the add-connection modal, the auth-method tab strip and its body live in a `Tabs` -> `TabsList` -> `TabsContent` group. The `TabsContent` card was wrapped in `{dcrActive ? null : (...)}`, so whenever an OAuth integration used transparent dynamic client registration (the MCP OAuth case) the card was suppressed.

The tab strip itself still renders whenever a custom-method `+` is available. The result: the OAuth tab plus the `+` floated with no card beneath it, and the tab strip's border looked detached (it jumped straight to "Connection saved to").

That same wrapper had a second symptom: the in-card "No app to choose" DCR explainer was written inside a `dcrActive ?` branch within the gated `TabsContent`, which the outer `dcrActive ? null` made permanently unreachable dead code.

## Fix

Always render the `TabsContent` card and let the inner `dcrActive` / `cimdActive` branches show their explainer. The tab strip gets its body back, and the DCR/CIMD explainer is now live instead of dead. The change is purely the removal of the `{dcrActive ? null : (...)}` gate; the rest of the diff is the block de-indenting by two spaces.

## Before / after

- Before: OAuth tab and `+` floating, no card, modal jumps to "Connection saved to".
- After: the OAuth tab sits on its "No app to choose / supports automatic setup" card.

## Verification

New selfhost browser scenario `e2e/selfhost/connection-modal-dcr-card.test.ts`: registers a remote MCP integration declaring an `oauth2` method (which makes it DCR-capable), opens the add-connection modal, and asserts the OAuth tab's body card renders under the tab strip. It passes on this branch and fails on the pre-fix code (the asserted copy was unreachable), so it guards the regression. Per-step screenshots and video are captured as run artifacts.
