### PR TITLE
Fix self-host/Cloudflare update card always showing; show version in the dashboard

### DIFF
--- a/.changeset/selfhost-update-card-version.md
+++ b/.changeset/selfhost-update-card-version.md
@@ -1,0 +1,7 @@
+---
+"@executor-js/host-selfhost": patch
+"@executor-js/host-cloudflare": patch
+"@executor-js/react": patch
+---
+
+Fix the self-host and Cloudflare web dashboards showing "update available" even on the latest version. The builds baked a placeholder version (`0.0.0-selfhost` / `0.0.0-cloudflare`) into the shell, so the update check always compared as behind. They now bake the real release version, and the sidebar footer shows the running version so you can see what you are on.

--- a/apps/host-cloudflare/vite.config.ts
+++ b/apps/host-cloudflare/vite.config.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
 import { defineConfig } from "vite";
@@ -7,6 +8,15 @@ import { tanstackRouter } from "@tanstack/router-plugin/vite";
 import executorVitePlugin from "@executor-js/vite-plugin";
 
 import { routes } from "./tsr.routes";
+
+// The real release version (matches the published `executor` dist-tags the
+// update card compares against). A placeholder here made the card read as
+// permanently "behind".
+// oxlint-disable-next-line executor/no-json-parse -- boundary: Vite config reads the version from package.json at build time
+const cliPackage = JSON.parse(
+  readFileSync(new URL("../cli/package.json", import.meta.url), "utf8"),
+) as { version?: string };
+const EXECUTOR_VERSION = cliPackage.version;
 
 // ---------------------------------------------------------------------------
 // Cloudflare web SPA. The SAME shared @executor-js/react shell + pages as cloud
@@ -36,7 +46,7 @@ export default defineConfig({
     dedupe: ["react", "react-dom"],
   },
   define: {
-    "import.meta.env.VITE_APP_VERSION": JSON.stringify("0.0.0-cloudflare"),
+    "import.meta.env.VITE_APP_VERSION": JSON.stringify(EXECUTOR_VERSION ?? "0.0.0"),
     // Cloudflare upgrades by redeploying the Worker (wrangler deploy), not npm,
     // so the update card links to the upgrade guide instead of a command.
     "import.meta.env.VITE_UPGRADE_HINT": JSON.stringify("cloudflare"),

--- a/apps/host-selfhost/vite.config.ts
+++ b/apps/host-selfhost/vite.config.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { Readable } from "node:stream";
 import { fileURLToPath } from "node:url";
 
@@ -9,6 +10,16 @@ import executorVitePlugin from "@executor-js/vite-plugin";
 
 import { routes } from "./tsr.routes";
 import { stripMcpOrgSegment } from "./src/mcp/org-path";
+
+// The real release version (matches the published `executor` dist-tags the
+// update card compares against), read from the CLI package the same way
+// apps/local does. A placeholder here made the card read as permanently
+// "behind", see the update-check comparison in @executor-js/react.
+// oxlint-disable-next-line executor/no-json-parse -- boundary: Vite config reads the version from package.json at build time
+const cliPackage = JSON.parse(
+  readFileSync(new URL("../cli/package.json", import.meta.url), "utf8"),
+) as { version?: string };
+const EXECUTOR_VERSION = cliPackage.version;
 
 // Self-host web SPA. Mirrors @executor-js/app's vite plugin bundle, but points
 // the TanStack router codegen at THIS app's routes (web/routes) so we get the
@@ -140,7 +151,7 @@ export default defineConfig({
     dedupe: ["react", "react-dom"],
   },
   define: {
-    "import.meta.env.VITE_APP_VERSION": JSON.stringify("0.0.0-selfhost"),
+    "import.meta.env.VITE_APP_VERSION": JSON.stringify(EXECUTOR_VERSION ?? "0.0.0"),
     // Self-host upgrades by pulling/rebuilding the image (or git + rebuild), not
     // npm, so the update card links to the upgrade guide instead of a command.
     "import.meta.env.VITE_UPGRADE_HINT": JSON.stringify("selfhost"),

--- a/e2e/cloudflare/update-card-render.test.ts
+++ b/e2e/cloudflare/update-card-render.test.ts
@@ -1,8 +1,15 @@
 // Cloudflare-only: the update card paints on the Cloudflare-served web shell
 // (Workers Static Assets + the Worker route). See ../src/update-card-render.ts
 // for the shared body.
-import { registerUpdateCardRenderScenario } from "../src/update-card-render";
+import {
+  registerUpdateCardCurrentScenario,
+  registerUpdateCardRenderScenario,
+} from "../src/update-card-render";
 
 registerUpdateCardRenderScenario(
   "Cloudflare · the web shell sidebar surfaces the update-available card",
+);
+
+registerUpdateCardCurrentScenario(
+  "Cloudflare · no update card when current, and the footer shows the version",
 );

--- a/e2e/selfhost/update-card-render.test.ts
+++ b/e2e/selfhost/update-card-render.test.ts
@@ -1,8 +1,15 @@
 // Selfhost-only (runs on the dev server AND the production Docker image): the
 // update card paints on the self-host web shell. See
 // ../src/update-card-render.ts for the shared body.
-import { registerUpdateCardRenderScenario } from "../src/update-card-render";
+import {
+  registerUpdateCardCurrentScenario,
+  registerUpdateCardRenderScenario,
+} from "../src/update-card-render";
 
 registerUpdateCardRenderScenario(
   "Selfhost · the web shell sidebar surfaces the update-available card",
+);
+
+registerUpdateCardCurrentScenario(
+  "Selfhost · no update card when current, and the footer shows the version",
 );

--- a/e2e/src/update-card-render.ts
+++ b/e2e/src/update-card-render.ts
@@ -56,3 +56,52 @@ export const registerUpdateCardRenderScenario = (name: string): void =>
       });
     }),
   );
+
+// Regression for the "card always shows on Docker even on the latest version"
+// report: a placeholder build version (0.0.0-selfhost / 0.0.0-cloudflare) made
+// the comparison permanently "behind". With the real version baked in, a
+// published version that is NOT newer must leave the card hidden, and the
+// sidebar footer must show the running version (the other half of the report).
+export const registerUpdateCardCurrentScenario = (name: string): void =>
+  scenario(
+    name,
+    { timeout: 120_000 },
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const browser = yield* Browser;
+      const identity = yield* target.newIdentity();
+
+      yield* browser.session(identity, async ({ page, step }) => {
+        // Report a published version OLDER than this build, i.e. the build is
+        // current. With the placeholder version this still showed the card.
+        await page.route("**/v1/app/npm/dist-tags", (route) =>
+          route.fulfill({
+            contentType: "application/json",
+            body: JSON.stringify({ latest: "0.0.1", beta: "0.0.1-beta.1" }),
+          }),
+        );
+
+        await step("Open the console", async () => {
+          await page.goto("/", { waitUntil: "networkidle" });
+          await page.getByRole("heading", { name: "Integrations" }).waitFor({ timeout: 60_000 });
+        });
+
+        await step("No update card, and the footer shows the running version", async () => {
+          // The footer version proves the build injects a real semver, not a
+          // placeholder, which is what makes the comparison correct.
+          const version = page
+            .locator("aside")
+            .getByText(/^v\d+\.\d+\.\d+/)
+            .first();
+          await version.waitFor({ timeout: 10_000 });
+          // The mocked update check resolves on mount; give the state a beat to
+          // settle, then assert the card stayed hidden.
+          await page.waitForTimeout(750);
+          expect(
+            await page.getByText("Update available").count(),
+            "no update card when the build is current",
+          ).toBe(0);
+        });
+      });
+    }),
+  );

--- a/packages/react/src/multiplayer/shell.tsx
+++ b/packages/react/src/multiplayer/shell.tsx
@@ -59,6 +59,13 @@ export const defaultShellNavItems: ReadonlyArray<ShellNavItem> = [
  *  via {@link ShellProps.docsUrl}. */
 export const DEFAULT_DOCS_URL = "https://executor.sh/docs";
 
+// The build version, surfaced in the sidebar footer so self-hosters can see
+// what they're running (and sanity-check the update card). Undefined on builds
+// that don't inject it (e.g. cloud) — then the line is hidden.
+const APP_VERSION = (
+  import.meta as ImportMeta & { readonly env?: { readonly VITE_APP_VERSION?: string } }
+).env?.VITE_APP_VERSION;
+
 // Scope-relative path -> the route id under the optional org segment
 // ("/" -> "/{-$orgSlug}", "/policies" -> "/{-$orgSlug}/policies"). Loosely
 // typed on purpose: host-specific items ("/admin", "/billing") resolve against
@@ -367,6 +374,11 @@ function SidebarContent(
 
       <div className="shrink-0 border-t border-sidebar-border p-2">
         <DocsLink href={props.docsUrl ?? DEFAULT_DOCS_URL} onNavigate={props.onNavigate} />
+        {APP_VERSION && (
+          <p className="px-2.5 pt-1.5 font-mono text-[11px] text-muted-foreground tabular-nums">
+            v{APP_VERSION}
+          </p>
+        )}
       </div>
 
       {props.supportSlot && <div className="shrink-0 px-2 pb-2">{props.supportSlot}</div>}


### PR DESCRIPTION
Fixes a user report: on a Docker (Railway) self-host, the sidebar "update available" card showed even when running the latest version. Same report asked to surface the version in the dashboard. Both come from one root cause.

## Root cause

The self-host and Cloudflare builds baked a **placeholder** `VITE_APP_VERSION` (`0.0.0-selfhost` / `0.0.0-cloudflare`) into the web shell. The update card compares that against the published `executor` dist-tags, so `compareVersions("0.0.0-selfhost", "1.5.23")` was always `-1` — permanently "behind", regardless of the deployed version. (The npm CLI and desktop builds already bake the real version, so they were fine.)

## Fix

- `apps/host-selfhost` and `apps/host-cloudflare` vite builds now read the real release version from the CLI package, exactly as `apps/local` does. The Docker image and Worker are built at the release tag, so this matches the published version.
- The multiplayer shell sidebar footer now shows `v<version>` (it showed no version before), so self-hosters can see what they are on. Hidden on builds that do not inject a version (e.g. cloud).

After the fix: a build that is current shows **no card** and displays its version; when a newer version is published, the card returns.

![no card when current, version in footer](https://raw.githubusercontent.com/RhysSullivan/executor/e2e-media/selfhost-no-card-version-cebaea87.png)

## Testing

- e2e `selfhost|cloudflare/update-card-render.test.ts` now has two scenarios each, both green on the real self-host and Cloudflare UIs:
  - behind -> the card shows (existing), and
  - current -> NO card, and the footer shows the running version (new regression test). With the old placeholder this test fails because the card would show even against an older published version.
- Format, lint, typecheck pass.

Note: deployed instances pick this up on their next image pull / redeploy (the version is baked at build time).