### PR TITLE
Proxy /authors to marketing so blog author avatars resolve

### DIFF
--- a/apps/cloud/src/edge/marketing.test.ts
+++ b/apps/cloud/src/edge/marketing.test.ts
@@ -18,6 +18,9 @@ describe("isMarketingPath", () => {
     "/llms.txt",
     "/og-image.png",
     "/_astro/app.css",
+    // The blog author card loads its avatar from marketing's public/authors;
+    // without this the pfp 404s on every post.
+    "/authors/rhys-sullivan.png",
   ];
   for (const pathname of marketing) {
     it(`proxies ${pathname} to marketing`, () => {

--- a/apps/cloud/src/edge/marketing.ts
+++ b/apps/cloud/src/edge/marketing.ts
@@ -22,6 +22,7 @@ const MARKETING_PATHS = [
   "/llms.txt",
   "/api/detect",
   "/_astro",
+  "/authors",
   "/og-image.png",
   "/pattern-graph-paper.svg",
 ];


### PR DESCRIPTION
## Problem

Author profile pictures 404 on every published blog post (e.g. https://executor.sh/blog/why-mcp-had-growing-pains/). The author card loads its avatar from `/authors/rhys-sullivan.png`, which returns 404 in production.

## Cause

On `executor.sh` the cloud worker owns the apex domain and only proxies an allow-list of paths (`MARKETING_PATHS` in `apps/cloud/src/edge/marketing.ts`) to the `executor-marketing` worker; everything else falls through to the auth gate. The avatars live in marketing's `public/authors/`, but `/authors` was never on the allow-list, so requests for it never reached the marketing worker. (`/og-image.png` and `/pattern-graph-paper.svg` are listed individually, and the favicons that resolve are actually served by cloud's own copies, which masked the gap.)

## Fix

Add `/authors` to the allow-list. The prefix match (`startsWith(`${p}/`)`) covers every file under it, so all current and future author avatars resolve. Extends the `isMarketingPath` unit test to cover `/authors/rhys-sullivan.png`.

```
Test Files  1 passed (1)
     Tests  16 passed (16)
```