### PR TITLE
fix(mcp): tolerate legacy session meta with no resource

### DIFF
--- a/packages/hosts/cloudflare/src/mcp/agent-session-durable-object.ts
+++ b/packages/hosts/cloudflare/src/mcp/agent-session-durable-object.ts
@@ -14,7 +14,7 @@ import {
   PAUSED_APPROVAL_TIMEOUT_MS,
   type PausedExecutionHooks,
 } from "@executor-js/host-mcp/tool-server";
-import type { McpResource } from "@executor-js/host-mcp";
+import { defaultMcpResource, type McpResource } from "@executor-js/host-mcp";
 
 import type { IncomingPropagationHeaders, McpElicitationMode } from "./do-headers";
 import {
@@ -290,7 +290,13 @@ export abstract class McpAgentSessionDOBase<
     return Effect.promise(async () => {
       if (this.sessionMeta) return this.sessionMeta;
       const stored = await this.ctx.storage.get<SessionMeta>(SESSION_META_KEY);
-      this.sessionMeta = stored ?? null;
+      // Backfill `resource` for sessions persisted before scoped toolkits added
+      // the field. Their stored meta has no `resource`, and every such session
+      // was minted against the default `/mcp` endpoint, so default it here
+      // rather than let owner validation read `.kind` off undefined.
+      this.sessionMeta = stored
+        ? { ...stored, resource: stored.resource ?? defaultMcpResource }
+        : null;
       return this.sessionMeta;
     }).pipe(Effect.withSpan("mcp.session.load_meta"));
   }

--- a/packages/hosts/mcp/src/resource-key.test.ts
+++ b/packages/hosts/mcp/src/resource-key.test.ts
@@ -1,0 +1,36 @@
+// ---------------------------------------------------------------------------
+// `mcpResourceKey` must never throw on a missing resource.
+//
+// Sessions persisted before scoped toolkits added the `resource` field
+// deserialize with `resource: undefined`. Owner validation keys the stored
+// session's resource against the request's, so an unguarded `resource.kind`
+// read there threw `TypeError: Cannot read properties of undefined (reading
+// 'kind')` on every reconnect to a legacy session. A missing resource is a
+// default `/mcp` session, so it must key to "default".
+// ---------------------------------------------------------------------------
+
+import { describe, expect, it } from "@effect/vitest";
+
+import { defaultMcpResource, mcpResourceKey } from "./index";
+
+describe("mcpResourceKey", () => {
+  it('keys the default resource to "default"', () => {
+    expect(mcpResourceKey(defaultMcpResource)).toBe("default");
+    expect(mcpResourceKey({ kind: "default" })).toBe("default");
+  });
+
+  it('keys a toolkit resource to "toolkit:<slug>"', () => {
+    expect(mcpResourceKey({ kind: "toolkit", slug: "github" })).toBe("toolkit:github");
+  });
+
+  it("treats a missing resource (legacy session meta) as the default key", () => {
+    expect(mcpResourceKey(undefined)).toBe("default");
+    expect(mcpResourceKey(null)).toBe("default");
+  });
+
+  it("matches a legacy (missing) resource against an explicit default resource", () => {
+    // The exact comparison owner validation performs: a reconnect carries the
+    // default resource, the stored legacy meta carries none, and they match.
+    expect(mcpResourceKey(undefined)).toBe(mcpResourceKey(defaultMcpResource));
+  });
+});

--- a/packages/hosts/mcp/src/seams.ts
+++ b/packages/hosts/mcp/src/seams.ts
@@ -72,8 +72,12 @@ export type McpResource =
 
 export const defaultMcpResource: McpResource = { kind: "default" };
 
-export const mcpResourceKey = (resource: McpResource): string =>
-  resource.kind === "default" ? "default" : `toolkit:${resource.slug}`;
+// Tolerates a missing resource (null/undefined): sessions persisted before
+// scoped toolkits existed have no `resource` field, and every such session was
+// minted against the default `/mcp` endpoint, so a missing resource keys to
+// "default". Keeping this guard here means no caller can throw on legacy data.
+export const mcpResourceKey = (resource: McpResource | null | undefined): string =>
+  resource && resource.kind !== "default" ? `toolkit:${resource.slug}` : "default";
 
 // ---------------------------------------------------------------------------
 // AuthOutcome — the result of `McpAuthProvider.authenticate`.


### PR DESCRIPTION
## Problem

Reconnecting to an older MCP session throws in the session Durable Object:

```
TypeError: Cannot read properties of undefined (reading 'kind')
    at mcpResourceKey (seams.ts)
    at mcp.session.validate_owner
    at McpSessionDO.handleRequest
```

The `resource` field was added to `SessionMeta` when scoped toolkits landed. Sessions persisted in Durable Object storage before that have no `resource` key. `loadSessionMeta` reads stored bytes and casts to `SessionMeta` without backfilling, so `resource` comes back `undefined`. On reconnect (`GET /mcp` with an existing `mcp-session-id`), owner validation calls `mcpResourceKey(sessionMeta.resource)`, and `mcpResourceKey` reads `.kind` off `undefined` and throws.

Observed in prod telemetry at roughly 33 distinct sessions/day (each failure records on 3 nested spans, so raw error-span counts are ~3x that). The edge request returns 200, but the affected session fails owner validation and the user has to start a new session.

## Fix

Every session minted before scoped toolkits was a default `/mcp` session, so a missing `resource` is the default resource:

- Backfill `resource` to `defaultMcpResource` when loading stored session meta, healing legacy data at the storage boundary.
- Harden `mcpResourceKey` to accept `null`/`undefined` and key it to `"default"`, so no caller can throw on a missing resource.

## Tests

New `resource-key.test.ts` covers the guard: default, toolkit, and missing (null/undefined) resources, plus the legacy-vs-default match owner validation performs. Existing host-mcp (52) and host-cloudflare (11) suites pass; full `typecheck` is green.