### PR TITLE
Accept string bodies for octet-stream uploads

### DIFF
--- a/.changeset/octet-stream-string-body.md
+++ b/.changeset/octet-stream-string-body.md
@@ -1,0 +1,5 @@
+---
+"@executor-js/plugin-openapi": patch
+---
+
+Allow a plain string `body` for octet-stream uploads again. Operations like Microsoft Graph's drive item content upload were rejecting string bodies with "request body must be bytes; provide bodyBase64", even though the request layer already sends a string through fine. String bodies now go through as UTF-8 bytes; binary content still uses `bodyBase64`.

--- a/packages/plugins/openapi/src/sdk/invoke.ts
+++ b/packages/plugins/openapi/src/sdk/invoke.ts
@@ -782,7 +782,16 @@ export const invoke = Effect.fn("OpenApi.invoke")(function* (
         binaryBody?.ok === true && !octetStreamContent && isOctetStream(rb.contentType)
           ? rb.contentType
           : (selected?.contentType ?? rb.contentType);
-      if (isOctetStream(chosenCt) && toUint8Array(bodyValue) === null) {
+      // A `bodyBase64` arg already decoded to bytes above. A plain string
+      // `body` is the long-standing way callers pass (text) octet-stream
+      // upload content, and applyRequestBody sends it through as-is, so let it
+      // past. Only a genuinely non-byte, non-string shape (an object, say)
+      // can't be uploaded as octet-stream and needs `bodyBase64`.
+      if (
+        isOctetStream(chosenCt) &&
+        typeof bodyValue !== "string" &&
+        toUint8Array(bodyValue) === null
+      ) {
         return yield* new OpenApiInvocationError({
           message: "application/octet-stream request body must be bytes; provide `bodyBase64`",
           statusCode: Option.none(),

--- a/packages/plugins/openapi/src/sdk/non-json-body.test.ts
+++ b/packages/plugins/openapi/src/sdk/non-json-body.test.ts
@@ -368,7 +368,7 @@ describe("OpenAPI non-JSON request body dispatch", () => {
     }),
   );
 
-  it.effect("application/octet-stream: string body fails before dispatch", () =>
+  it.effect("application/octet-stream: string body passes through as UTF-8 bytes", () =>
     Effect.gen(function* () {
       const { server, captured } = yield* startEchoServer({
         payload: Schema.Uint8Array.pipe(HttpApiSchema.asUint8Array()),
@@ -380,15 +380,16 @@ describe("OpenAPI non-JSON request body dispatch", () => {
         slug: "bin_string_body",
       });
 
-      const exit = yield* executor
-        .execute(conn.address("body.submit"), {
-          body: "3q2+7w==",
-        })
-        .pipe(Effect.exit);
+      // A plain string `body` is the long-standing way callers upload text
+      // content to an octet-stream endpoint, so it must reach the wire rather
+      // than failing. It is sent verbatim as UTF-8 bytes (not base64-decoded),
+      // which preserves the pre-bodyBase64 behavior; binary uploads still use
+      // `bodyBase64`.
+      const text = "plain file contents, not base64";
+      yield* executor.execute(conn.address("body.submit"), { body: text });
 
-      expect(Exit.isFailure(exit)).toBe(true);
-      expect(captured.contentType).toBe("");
-      expect(captured.body.length).toBe(0);
+      expect(captured.contentType).toBe("application/octet-stream");
+      expect(captured.body.toString("utf8")).toBe(text);
     }),
   );
 


### PR DESCRIPTION
## What

Octet-stream operations were rejecting a plain string `body` with `application/octet-stream request body must be bytes; provide bodyBase64`. This broke uploads that pass text content as a string, like the Microsoft Graph drive item content update (`drivesUpdateItemsContent`).

## Why

The `bodyBase64` work (#1137) added a strict guard that throws whenever an octet-stream body isn't already bytes. But `applyRequestBody` has always handled a string body for octet-stream (it sends it as-is), so the guard rejected a shape the request layer was happy to send. Callers passing string content started failing once that path shipped.

## Fix

Only reject when the body is neither bytes nor a string. A string `body` goes through as UTF-8 bytes (the long-standing behavior); genuinely binary content still uses `bodyBase64`, and an object body is still rejected.

Updated the octet-stream test that asserted the old "string body fails" behavior to assert it now passes through as UTF-8 bytes. Full `non-json-body` suite passes (28 tests).