### PR TITLE
Add OAuth2 client_credentials auth for MCP and GraphQL integrations

### DIFF
--- a/apps/cloud/drizzle/0008_brief_paper_doll.sql
+++ b/apps/cloud/drizzle/0008_brief_paper_doll.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "oauth_client" ADD COLUMN "token_endpoint_auth_method" text;

--- a/apps/cloud/drizzle/meta/0008_snapshot.json
+++ b/apps/cloud/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,1278 @@
+{
+  "id": "9315a6db-2974-4717-b54f-4b6e4f183582",
+  "prevId": "2f557ed1-5afc-431b-8623-2a2162793f43",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memberships": {
+      "name": "memberships",
+      "schema": "",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "memberships_account_id_accounts_id_fk": {
+          "name": "memberships_account_id_accounts_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memberships_organization_id_organizations_id_fk": {
+          "name": "memberships_organization_id_organizations_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "organizations",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "memberships_account_id_organization_id_pk": {
+          "name": "memberships_account_id_organization_id_pk",
+          "columns": ["account_id", "organization_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blob": {
+      "name": "blob",
+      "schema": "",
+      "columns": {
+        "namespace": {
+          "name": "namespace",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "blob_id_uidx": {
+          "name": "blob_id_uidx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connection": {
+      "name": "connection",
+      "schema": "",
+      "columns": {
+        "integration": {
+          "name": "integration",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template": {
+          "name": "template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_ids": {
+          "name": "item_ids",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity_label": {
+          "name": "identity_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tools_synced_at": {
+          "name": "tools_synced_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_client": {
+          "name": "oauth_client",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_client_owner": {
+          "name": "oauth_client_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_item_id": {
+          "name": "refresh_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_scope": {
+          "name": "oauth_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_token_url": {
+          "name": "oauth_token_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_state": {
+          "name": "provider_state",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "connection_uidx": {
+          "name": "connection_uidx",
+          "columns": [
+            {
+              "expression": "tenant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integration",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.definition": {
+      "name": "definition",
+      "schema": "",
+      "columns": {
+        "integration": {
+          "name": "integration",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection": {
+          "name": "connection",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema": {
+          "name": "schema",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "definition_uidx": {
+          "name": "definition_uidx",
+          "columns": [
+            {
+              "expression": "tenant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integration",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration": {
+      "name": "integration",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_revised_at": {
+          "name": "config_revised_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "can_remove": {
+          "name": "can_remove",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "can_refresh": {
+          "name": "can_refresh",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "integration_uidx": {
+          "name": "integration_uidx",
+          "columns": [
+            {
+              "expression": "tenant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_client": {
+      "name": "oauth_client",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorization_url": {
+          "name": "authorization_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_url": {
+          "name": "token_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grant": {
+          "name": "grant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret_item_id": {
+          "name": "client_secret_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_kind": {
+          "name": "origin_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_integration": {
+          "name": "origin_integration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_client_uidx": {
+          "name": "oauth_client_uidx",
+          "columns": [
+            {
+              "expression": "tenant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_session": {
+      "name": "oauth_session",
+      "schema": "",
+      "columns": {
+        "state": {
+          "name": "state",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_slug": {
+          "name": "client_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration": {
+          "name": "integration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template": {
+          "name": "template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_url": {
+          "name": "redirect_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pkce_verifier": {
+          "name": "pkce_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_label": {
+          "name": "identity_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_session_uidx": {
+          "name": "oauth_session_uidx",
+          "columns": [
+            {
+              "expression": "tenant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plugin_storage": {
+      "name": "plugin_storage",
+      "schema": "",
+      "columns": {
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection": {
+          "name": "collection",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "plugin_storage_uidx": {
+          "name": "plugin_storage_uidx",
+          "columns": [
+            {
+              "expression": "tenant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "plugin_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "collection",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.private_executor_cloud_settings": {
+      "name": "private_executor_cloud_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.0.0'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tool": {
+      "name": "tool",
+      "schema": "",
+      "columns": {
+        "integration": {
+          "name": "integration",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection": {
+          "name": "connection",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_schema": {
+          "name": "input_schema",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_schema": {
+          "name": "output_schema",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annotations": {
+          "name": "annotations",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tool_uidx": {
+          "name": "tool_uidx",
+          "columns": [
+            {
+              "expression": "tenant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integration",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tool_policy": {
+      "name": "tool_policy",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tool_policy_uidx": {
+          "name": "tool_policy_uidx",
+          "columns": [
+            {
+              "expression": "tenant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/cloud/drizzle/meta/_journal.json
+++ b/apps/cloud/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1782149425764,
       "tag": "0007_red_dragon_lord",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1782760715913,
+      "tag": "0008_brief_paper_doll",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/cloud/src/db/executor-schema.ts
+++ b/apps/cloud/src/db/executor-schema.ts
@@ -81,6 +81,7 @@ export const oauth_client = pgTable(
     client_id: text("client_id").notNull(),
     client_secret_item_id: text("client_secret_item_id"),
     resource: text("resource"),
+    token_endpoint_auth_method: text("token_endpoint_auth_method"),
     origin_kind: text("origin_kind"),
     origin_integration: text("origin_integration"),
     created_at: timestamp("created_at").notNull(),

--- a/apps/local/drizzle/0003_small_sir_ram.sql
+++ b/apps/local/drizzle/0003_small_sir_ram.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `oauth_client` ADD `token_endpoint_auth_method` text;

--- a/apps/local/drizzle/meta/0003_snapshot.json
+++ b/apps/local/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,920 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "e549d89e-1e3d-41bf-a0e4-faeee66daf02",
+  "prevId": "03321915-aef6-4791-9558-7fc82273af05",
+  "tables": {
+    "blob": {
+      "name": "blob",
+      "columns": {
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "blob_id_uidx": {
+          "name": "blob_id_uidx",
+          "columns": ["id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "connection": {
+      "name": "connection",
+      "columns": {
+        "integration": {
+          "name": "integration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template": {
+          "name": "template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_ids": {
+          "name": "item_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identity_label": {
+          "name": "identity_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_client": {
+          "name": "oauth_client",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_client_owner": {
+          "name": "oauth_client_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_item_id": {
+          "name": "refresh_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_scope": {
+          "name": "oauth_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_token_url": {
+          "name": "oauth_token_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_state": {
+          "name": "provider_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connection_uidx": {
+          "name": "connection_uidx",
+          "columns": ["tenant", "owner", "subject", "integration", "name"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "definition": {
+      "name": "definition",
+      "columns": {
+        "integration": {
+          "name": "integration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connection": {
+          "name": "connection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schema": {
+          "name": "schema",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "definition_uidx": {
+          "name": "definition_uidx",
+          "columns": ["tenant", "owner", "subject", "integration", "connection", "name"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "integration": {
+      "name": "integration",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "can_remove": {
+          "name": "can_remove",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "can_refresh": {
+          "name": "can_refresh",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "integration_uidx": {
+          "name": "integration_uidx",
+          "columns": ["tenant", "slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_client": {
+      "name": "oauth_client",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "authorization_url": {
+          "name": "authorization_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_url": {
+          "name": "token_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "grant": {
+          "name": "grant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_secret_item_id": {
+          "name": "client_secret_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "origin_kind": {
+          "name": "origin_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "origin_integration": {
+          "name": "origin_integration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_client_uidx": {
+          "name": "oauth_client_uidx",
+          "columns": ["tenant", "owner", "subject", "slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_session": {
+      "name": "oauth_session",
+      "columns": {
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_slug": {
+          "name": "client_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "integration": {
+          "name": "integration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template": {
+          "name": "template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "redirect_url": {
+          "name": "redirect_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pkce_verifier": {
+          "name": "pkce_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "identity_label": {
+          "name": "identity_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_session_uidx": {
+          "name": "oauth_session_uidx",
+          "columns": ["tenant", "state"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plugin_storage": {
+      "name": "plugin_storage",
+      "columns": {
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection": {
+          "name": "collection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "plugin_storage_uidx": {
+          "name": "plugin_storage_uidx",
+          "columns": ["tenant", "owner", "subject", "plugin_id", "collection", "key"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tool": {
+      "name": "tool",
+      "columns": {
+        "integration": {
+          "name": "integration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connection": {
+          "name": "connection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_schema": {
+          "name": "input_schema",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_schema": {
+          "name": "output_schema",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "annotations": {
+          "name": "annotations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tool_uidx": {
+          "name": "tool_uidx",
+          "columns": ["tenant", "owner", "subject", "integration", "connection", "name"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tool_policy": {
+      "name": "tool_policy",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tool_policy_uidx": {
+          "name": "tool_policy_uidx",
+          "columns": ["tenant", "owner", "subject", "id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/local/drizzle/meta/_journal.json
+++ b/apps/local/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1782150869757,
       "tag": "0002_empty_rictor",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1782760745289,
+      "tag": "0003_small_sir_ram",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/local/src/db/executor-schema.ts
+++ b/apps/local/src/db/executor-schema.ts
@@ -73,6 +73,7 @@ export const oauth_client = sqliteTable(
     client_id: text("client_id").notNull(),
     client_secret_item_id: text("client_secret_item_id"),
     resource: text("resource"),
+    token_endpoint_auth_method: text("token_endpoint_auth_method"),
     origin_kind: text("origin_kind"),
     origin_integration: text("origin_integration"),
     created_at: integer("created_at").notNull(),

--- a/packages/core/api/src/handlers/oauth.ts
+++ b/packages/core/api/src/handlers/oauth.ts
@@ -103,6 +103,7 @@ export const OAuthHandlers = HttpApiBuilder.group(ExecutorApi, "oauth", (handler
             clientId: payload.clientId,
             clientSecret: payload.clientSecret,
             resource: payload.resource ?? null,
+            tokenEndpointAuthMethod: payload.tokenEndpointAuthMethod,
           });
           return { client };
         }),

--- a/packages/core/api/src/integrations/api.ts
+++ b/packages/core/api/src/integrations/api.ts
@@ -52,6 +52,8 @@ const OAuthDescriptor = Schema.Struct({
   registrationEndpoint: Schema.optional(Schema.String),
   supportsDynamicRegistration: Schema.optional(Schema.Boolean),
   supportsClientIdMetadataDocument: Schema.optional(Schema.Boolean),
+  defaultGrant: Schema.optional(Schema.Literals(["authorization_code", "client_credentials"])),
+  defaultTokenEndpointAuthMethod: Schema.optional(Schema.Literals(["body", "basic"])),
 });
 
 /** A single declared auth method — mirrors the SDK's `AuthMethodDescriptor`. */

--- a/packages/core/api/src/oauth/api.ts
+++ b/packages/core/api/src/oauth/api.ts
@@ -65,6 +65,9 @@ const CreateClientPayload = Schema.Struct({
   clientId: Schema.String,
   clientSecret: Schema.String,
   resource: Schema.optional(Schema.NullOr(Schema.String)),
+  /** Token-endpoint client auth: "body" (client_secret_post, default) or
+   *  "basic" (client_secret_basic). Omitted means "body". */
+  tokenEndpointAuthMethod: Schema.optional(Schema.Literals(["body", "basic"])),
 });
 
 const CreateClientResponse = Schema.Struct({
@@ -110,6 +113,8 @@ const OAuthClientSummaryResponse = Schema.Struct({
   tokenUrl: Schema.String,
   resource: Schema.optional(Schema.NullOr(Schema.String)),
   clientId: Schema.String,
+  /** Token-endpoint client auth ("body" | "basic"); omitted means "body". */
+  tokenEndpointAuthMethod: Schema.optional(Schema.Literals(["body", "basic"])),
   origin: Schema.Union([
     Schema.Struct({ kind: Schema.Literal("manual") }),
     Schema.Struct({

--- a/packages/core/sdk/src/client.ts
+++ b/packages/core/sdk/src/client.ts
@@ -134,6 +134,8 @@ export interface IntegrationAccountHandoff {
     readonly authorizationUrl?: string;
     readonly tokenUrl?: string;
     readonly resource?: string;
+    /** Token-endpoint client auth to preselect ("body" | "basic"). */
+    readonly tokenEndpointAuthMethod?: "body" | "basic";
   };
 }
 

--- a/packages/core/sdk/src/core-schema.ts
+++ b/packages/core/sdk/src/core-schema.ts
@@ -208,6 +208,10 @@ export const coreTables = defineTables({
       // re-minted access token stays bound to the same resource. Null when the
       // provider doesn't use resource indicators.
       resource: nullableTextColumn("resource"),
+      // How the client authenticates to the token endpoint: "body"
+      // (client_secret_post) or "basic" (client_secret_basic). Null in old
+      // databases is treated as "body" by the service layer (parseClientAuthMethod).
+      token_endpoint_auth_method: nullableTextColumn("token_endpoint_auth_method"),
       // Where this oauth_client came from. Null in old databases is treated as
       // "manual" by the service layer.
       origin_kind: nullableTextColumn("origin_kind"),

--- a/packages/core/sdk/src/core-tools.ts
+++ b/packages/core/sdk/src/core-tools.ts
@@ -220,6 +220,8 @@ const OAuthClientOutput = Schema.Struct({
   tokenUrl: Schema.String,
   resource: Schema.optional(Schema.NullOr(Schema.String)),
   clientId: Schema.String,
+  /** Token-endpoint client auth ("body" | "basic"); omitted means "body". */
+  tokenEndpointAuthMethod: Schema.optional(Schema.Literals(["body", "basic"])),
   origin: Schema.Union([
     Schema.Struct({ kind: Schema.Literal("manual") }),
     Schema.Struct({
@@ -257,6 +259,9 @@ const OAuthCreateClientHandoffInput = Schema.Struct({
   authorizationUrl: Schema.optional(Schema.String),
   tokenUrl: Schema.optional(Schema.String),
   resource: Schema.optional(Schema.NullOr(Schema.String)),
+  /** Pre-fill the token-endpoint client auth ("body" | "basic"). Lets an agent
+   *  hand off a Basic-only client (e.g. Linear client_credentials) correctly. */
+  tokenEndpointAuthMethod: Schema.optional(Schema.Literals(["body", "basic"])),
   label: Schema.optional(Schema.String),
 });
 const OAuthCreateClientHandoffOutput = Schema.Struct({
@@ -488,6 +493,11 @@ const oauthClientCreateHandoffUrl = (
   if (input.authorizationUrl !== undefined) search.set("authorizationUrl", input.authorizationUrl);
   if (input.tokenUrl !== undefined) search.set("tokenUrl", input.tokenUrl);
   if (input.resource != null && input.resource.length > 0) search.set("resource", input.resource);
+  // Only materialize a non-default "basic" (matches the persist/load/list
+  // convention). Emitting "body" here would override a method's advertised
+  // "basic" default in the connect-UI prefill precedence and break Basic-only
+  // providers like Linear.
+  if (input.tokenEndpointAuthMethod === "basic") search.set("tokenEndpointAuthMethod", "basic");
   if (input.label !== undefined) search.set("label", input.label);
   const orgPrefix = orgSlug !== undefined && orgSlug.length > 0 ? `/${orgSlug}` : "";
   const path = `${orgPrefix}/integrations/${encodeURIComponent(input.integration)}?${search.toString()}`;
@@ -677,6 +687,10 @@ export const coreToolsPlugin = definePlugin((options: CoreToolsPluginOptions = {
                 tokenUrl: client.tokenUrl,
                 resource: client.resource ?? null,
                 clientId: client.clientId,
+                // Only present when "basic"; omitted means the "body" default.
+                ...(client.tokenEndpointAuthMethod === "basic"
+                  ? { tokenEndpointAuthMethod: "basic" as const }
+                  : {}),
               })),
             })),
         }),

--- a/packages/core/sdk/src/executor.test.ts
+++ b/packages/core/sdk/src/executor.test.ts
@@ -300,6 +300,43 @@ describe("createExecutor", () => {
     }),
   );
 
+  it.effect("oauth client handoff URL carries 'basic' but omits the implicit 'body'", () =>
+    Effect.gen(function* () {
+      const executor = yield* makeTestExecutor({
+        coreTools: { webBaseUrl: "http://localhost:3000" },
+      });
+
+      const basic = yield* executor.execute(
+        ToolAddress.make("executor.coreTools.oauth.clients.createHandoff"),
+        {
+          integration: String(INTEG),
+          owner: "org",
+          grant: "client_credentials",
+          tokenUrl: "https://auth.linear.app/oauth/token",
+          tokenEndpointAuthMethod: "basic",
+        },
+      );
+      const basicUrl = new URL((basic as { readonly url: string }).url);
+      expect(basicUrl.searchParams.get("grant")).toBe("client_credentials");
+      expect(basicUrl.searchParams.get("tokenEndpointAuthMethod")).toBe("basic");
+
+      // "body" is the implicit default and must NOT be materialized in the URL
+      // (else it would override a method's advertised "basic" default).
+      const body = yield* executor.execute(
+        ToolAddress.make("executor.coreTools.oauth.clients.createHandoff"),
+        {
+          integration: String(INTEG),
+          owner: "org",
+          grant: "client_credentials",
+          tokenUrl: "https://auth.example/token",
+          tokenEndpointAuthMethod: "body",
+        },
+      );
+      const bodyUrl = new URL((body as { readonly url: string }).url);
+      expect(bodyUrl.searchParams.has("tokenEndpointAuthMethod")).toBe(false);
+    }),
+  );
+
   it.effect("starts a client-credentials connection through the oauth.start tool", () =>
     Effect.scoped(
       Effect.gen(function* () {

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -143,6 +143,7 @@ import { collectReferencedDefinitions } from "./schema-refs";
 import {
   refreshAccessToken,
   exchangeClientCredentials,
+  parseClientAuthMethod,
   shouldRefreshToken,
   type OAuthEndpointUrlPolicy,
 } from "./oauth-helpers";
@@ -1456,6 +1457,12 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
           ? String(row.oauth_token_url)
           : String(clientRow.token_url);
 
+        // How this app authenticates to the token endpoint ("body" | "basic").
+        // Null on old rows resolves to "body" (client_secret_post). Threaded
+        // into both the client_credentials re-mint and the refresh_token call so
+        // Basic-only providers (e.g. Linear) keep working across refreshes.
+        const clientAuth = parseClientAuthMethod(clientRow.token_endpoint_auth_method);
+
         // client_credentials (machine-to-machine) has NO refresh token — the
         // token is RE-MINTED from the client id/secret. The authorization_code
         // path below needs a stored refresh token. Branching on grant here is
@@ -1469,6 +1476,7 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
                 clientSecret,
                 scopes: grantedScopes,
                 resource: clientRow.resource ? String(clientRow.resource) : undefined,
+                clientAuth,
                 endpointUrlPolicy: config.oauthEndpointUrlPolicy,
                 fetch: config.fetch,
               }).pipe(
@@ -1502,6 +1510,7 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
                   // RFC 8707: keep the re-minted token bound to the same resource
                   // (MCP servers require this on refresh).
                   resource: clientRow.resource ? String(clientRow.resource) : undefined,
+                  clientAuth,
                   endpointUrlPolicy: config.oauthEndpointUrlPolicy,
                   fetch: config.fetch,
                 }).pipe(

--- a/packages/core/sdk/src/integration.ts
+++ b/packages/core/sdk/src/integration.ts
@@ -1,4 +1,5 @@
 import type { IntegrationSlug } from "./ids";
+import type { ClientAuthMethod, OAuthGrant } from "./oauth-client";
 
 /* Core knows only an integration's catalog identity — slug + description + which
  * plugin (`kind`) owns it. The type-specific shape (openapi auth templates + spec,
@@ -62,6 +63,14 @@ export interface AuthMethodOAuthDescriptor {
    *  clients. The UI can create a local public OAuth client using this host's
    *  metadata-document URL as `client_id`, with no provider app registration. */
   readonly supportsClientIdMetadataDocument?: boolean;
+  /** Default OAuth grant to preselect when registering an app for this method.
+   *  `"client_credentials"` makes the connect UI register a service-account app
+   *  (no per-user sign-in) and mint inline. Absent means `"authorization_code"`. */
+  readonly defaultGrant?: OAuthGrant;
+  /** Default token-endpoint client-auth to preselect (e.g. `"basic"` for
+   *  providers like Linear that require HTTP Basic on the client_credentials
+   *  token request). Only `"basic"` is ever advertised; absent means `"body"`. */
+  readonly defaultTokenEndpointAuthMethod?: ClientAuthMethod;
 }
 
 /** A single declared auth method on an integration's catalog response. */

--- a/packages/core/sdk/src/oauth-client.ts
+++ b/packages/core/sdk/src/oauth-client.ts
@@ -3,6 +3,12 @@ import { Schema } from "effect";
 
 import type { Connection } from "./connection";
 import type { StorageFailure } from "./fuma-runtime";
+import type { ClientAuthMethod } from "./oauth-helpers";
+
+/** Re-exported so the public OAuth contract surface (`@executor-js/sdk/shared`)
+ *  carries the token-endpoint client-auth method alongside the client shapes
+ *  that use it, without consumers importing the server-only flow helpers. */
+export type { ClientAuthMethod } from "./oauth-helpers";
 import {
   type AuthTemplateSlug,
   type ConnectionName,
@@ -61,6 +67,12 @@ export interface OAuthClient {
   /** RFC 8707 Resource Indicator (MCP). Carried so the refresh request can keep
    *  the re-minted token bound to the same resource. Null/omitted otherwise. */
   readonly resource?: string | null;
+  /** How the client authenticates to the token endpoint: `"body"`
+   *  (`client_secret_post`, the default) or `"basic"` (`client_secret_basic`,
+   *  base64 `client_id:client_secret` in the Authorization header). Some
+   *  providers (e.g. Linear's client_credentials grant) only accept Basic.
+   *  Omitted/undefined is treated as `"body"` throughout. */
+  readonly tokenEndpointAuthMethod?: ClientAuthMethod;
 }
 
 export type OAuthClientOrigin =
@@ -86,6 +98,10 @@ export interface OAuthClientSummary {
   readonly tokenUrl: string;
   readonly resource?: string | null;
   readonly clientId: string;
+  /** Token-endpoint client authentication method ("body" | "basic"); see
+   *  {@link OAuthClient.tokenEndpointAuthMethod}. Surfaced so the UI can show
+   *  and re-edit how a registered app authenticates. */
+  readonly tokenEndpointAuthMethod?: ClientAuthMethod;
   readonly origin: OAuthClientOrigin;
 }
 

--- a/packages/core/sdk/src/oauth-flow.test.ts
+++ b/packages/core/sdk/src/oauth-flow.test.ts
@@ -366,6 +366,137 @@ describe("oauth.start / oauth.complete", () => {
     ),
   );
 
+  it.effect(
+    "client_credentials with tokenEndpointAuthMethod=basic sends HTTP Basic to the token endpoint",
+    () =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          // The AS is configured to REJECT body (client_secret_post) auth, so a
+          // successful inline mint proves the executor actually sent HTTP Basic.
+          const server = yield* serveOAuthTestServer({
+            scopes: ["read"],
+            requireClientAuthMethod: "basic",
+          });
+          const { executor } = yield* makeTestWorkspaceHarness({ plugins, redirectUri: null });
+          yield* executor.acme.seed();
+
+          yield* executor.oauth.createClient({
+            owner: "org",
+            slug: CLIENT,
+            authorizationUrl: server.authorizationEndpoint,
+            tokenUrl: server.tokenEndpoint,
+            grant: "client_credentials",
+            clientId: "test-client",
+            clientSecret: "test-secret",
+            tokenEndpointAuthMethod: "basic",
+          });
+
+          const started = yield* executor.oauth.start({
+            owner: "org",
+            client: CLIENT,
+            clientOwner: "org",
+            name: ConnectionName.make("cc"),
+            integration: INTEG,
+            template: TEMPLATE,
+          });
+          expect(started.status).toBe("connected");
+          // The single token request used HTTP Basic, not body params.
+          expect(yield* server.tokenRequestAuthMethods).toEqual(["basic"]);
+        }),
+      ),
+  );
+
+  it.effect("client_credentials without Basic is rejected by a Basic-only token endpoint", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const server = yield* serveOAuthTestServer({
+          scopes: ["read"],
+          requireClientAuthMethod: "basic",
+        });
+        const { executor } = yield* makeTestWorkspaceHarness({ plugins, redirectUri: null });
+        yield* executor.acme.seed();
+
+        // No tokenEndpointAuthMethod => the "body" (client_secret_post) default,
+        // which the Basic-only AS rejects. Proves the field actually changes the
+        // wire behavior rather than being inert.
+        yield* executor.oauth.createClient({
+          owner: "org",
+          slug: CLIENT,
+          authorizationUrl: server.authorizationEndpoint,
+          tokenUrl: server.tokenEndpoint,
+          grant: "client_credentials",
+          clientId: "test-client",
+          clientSecret: "test-secret",
+        });
+
+        const error = yield* Effect.flip(
+          executor.oauth.start({
+            owner: "org",
+            client: CLIENT,
+            clientOwner: "org",
+            name: ConnectionName.make("cc"),
+            integration: INTEG,
+            template: TEMPLATE,
+          }),
+        );
+        expect(Predicate.isTagged("OAuthStartError")(error)).toBe(true);
+        expect(yield* server.tokenRequestAuthMethods).toEqual(["body"]);
+      }),
+    ),
+  );
+
+  it.effect(
+    "authorization_code with tokenEndpointAuthMethod=basic sends HTTP Basic on the code exchange",
+    () =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          // The Basic-only AS rejects body, so a successful code exchange proves
+          // clientAuth is threaded into the authorization_code complete path too.
+          const server = yield* serveOAuthTestServer({
+            scopes: ["read"],
+            requireClientAuthMethod: "basic",
+          });
+          const { executor } = yield* makeTestWorkspaceHarness({
+            plugins,
+            redirectUri: "https://app.test/oauth/callback",
+          });
+          yield* executor.acme.seed();
+
+          yield* executor.oauth.createClient({
+            owner: "org",
+            slug: CLIENT,
+            authorizationUrl: server.authorizationEndpoint,
+            tokenUrl: server.tokenEndpoint,
+            grant: "authorization_code",
+            clientId: "test-client",
+            clientSecret: "test-secret",
+            tokenEndpointAuthMethod: "basic",
+          });
+
+          const started = yield* executor.oauth.start({
+            owner: "org",
+            client: CLIENT,
+            clientOwner: "org",
+            name: ConnectionName.make("main"),
+            integration: INTEG,
+            template: TEMPLATE,
+          });
+          expect(started.status).toBe("redirect");
+          if (started.status !== "redirect") return;
+          const callback = yield* server.completeAuthorizationCodeFlow({
+            authorizationUrl: started.authorizationUrl,
+          });
+          const connection = yield* executor.oauth.complete({
+            state: started.state,
+            code: callback.code,
+          });
+          expect(connection.name).toBe("main");
+          // Only the code exchange hit /token, and it used HTTP Basic.
+          expect(yield* server.tokenRequestAuthMethods).toEqual(["basic"]);
+        }),
+      ),
+  );
+
   it.effect("complete with an unknown state fails OAuthSessionNotFoundError", () =>
     Effect.scoped(
       Effect.gen(function* () {
@@ -485,6 +616,67 @@ describe("oauth.start / oauth.complete", () => {
 });
 
 describe("oauth token refresh in resolveConnectionValue", () => {
+  it.effect("an expired client_credentials connection re-mints via HTTP Basic", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        // Basic-only AS: every token request (initial mint AND the expiry
+        // re-mint) must carry HTTP Basic or it 401s.
+        const server = yield* serveOAuthTestServer({
+          scopes: ["read"],
+          requireClientAuthMethod: "basic",
+        });
+        const harness = yield* makeTestWorkspaceHarness({ plugins, redirectUri: null });
+        const { executor, config } = harness;
+        yield* executor.acme.seed();
+
+        yield* executor.oauth.createClient({
+          owner: "org",
+          slug: CLIENT,
+          authorizationUrl: server.authorizationEndpoint,
+          tokenUrl: server.tokenEndpoint,
+          grant: "client_credentials",
+          clientId: "test-client",
+          clientSecret: "test-secret",
+          tokenEndpointAuthMethod: "basic",
+        });
+
+        const started = yield* executor.oauth.start({
+          owner: "org",
+          client: CLIENT,
+          clientOwner: "org",
+          name: ConnectionName.make("cc"),
+          integration: INTEG,
+          template: TEMPLATE,
+        });
+        expect(started.status).toBe("connected");
+
+        const firstToken = (yield* executor.execute(
+          ToolAddress.make("tools.acme.org.cc.whoami"),
+          {},
+        )) as { token: string };
+        expect(firstToken.token).toMatch(/^at_/);
+
+        // client_credentials has no refresh token; expiring forces a fresh mint.
+        yield* Effect.promise(() =>
+          config.db.updateMany("connection", {
+            where: (b) => b("name", "=", "cc"),
+            set: { expires_at: Date.now() - 60_000 },
+          }),
+        );
+
+        const refreshedToken = (yield* executor.execute(
+          ToolAddress.make("tools.acme.org.cc.whoami"),
+          {},
+        )) as { token: string };
+        expect(refreshedToken.token).toMatch(/^at_/);
+        expect(refreshedToken.token).not.toBe(firstToken.token);
+        expect(yield* server.acceptsAccessToken(refreshedToken.token)).toBe(true);
+        // Both the initial mint and the re-mint authenticated via HTTP Basic.
+        expect(yield* server.tokenRequestAuthMethods).toEqual(["basic", "basic"]);
+      }),
+    ),
+  );
+
   it.effect("an expired access token is refreshed before resolving", () =>
     Effect.scoped(
       Effect.gen(function* () {

--- a/packages/core/sdk/src/oauth-helpers.ts
+++ b/packages/core/sdk/src/oauth-helpers.ts
@@ -383,6 +383,14 @@ export type ClientAuthMethod = "body" | "basic";
  */
 export const DEFAULT_CLIENT_AUTH_METHOD: ClientAuthMethod = "body";
 
+/** Resolve a stored/raw token-endpoint client-auth value to a {@link
+ *  ClientAuthMethod}. Only `"basic"` is distinguished; everything else,
+ *  including null (old `oauth_client` rows) and unknown strings, falls through
+ *  to {@link DEFAULT_CLIENT_AUTH_METHOD} (`"body"`). Unlike the OAuth grant,
+ *  an unrecognised value here is a benign default, not a corrupt-row error. */
+export const parseClientAuthMethod = (value: unknown): ClientAuthMethod =>
+  value === "basic" ? "basic" : DEFAULT_CLIENT_AUTH_METHOD;
+
 const asFromTokenUrl = (
   tokenUrl: string,
   endpointUrlPolicy: OAuthEndpointUrlPolicy = {},

--- a/packages/core/sdk/src/oauth-list-clients.test.ts
+++ b/packages/core/sdk/src/oauth-list-clients.test.ts
@@ -106,6 +106,43 @@ describe("oauth.listClients", () => {
     ),
   );
 
+  it.effect("round-trips tokenEndpointAuthMethod: only 'basic' is materialized", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const { executor } = yield* makeTestWorkspaceHarness({ plugins });
+
+        yield* executor.oauth.createClient({
+          owner: "org",
+          slug: ORG_CLIENT,
+          authorizationUrl: "",
+          tokenUrl: "https://acme.test/token",
+          grant: "client_credentials",
+          clientId: "basic-client",
+          clientSecret: "s3cret",
+          tokenEndpointAuthMethod: "basic",
+        });
+        // A second client with the default (body) method, sent explicitly.
+        yield* executor.oauth.createClient({
+          owner: "user",
+          slug: USER_CLIENT,
+          authorizationUrl: "",
+          tokenUrl: "https://byo.test/token",
+          grant: "client_credentials",
+          clientId: "body-client",
+          clientSecret: "s3cret",
+          tokenEndpointAuthMethod: "body",
+        });
+
+        const bySlug = new Map(
+          (yield* executor.oauth.listClients()).map((c) => [String(c.slug), c]),
+        );
+        // "basic" surfaces on the summary; "body" stays implicit (omitted).
+        expect(bySlug.get(String(ORG_CLIENT))?.tokenEndpointAuthMethod).toBe("basic");
+        expect(bySlug.get(String(USER_CLIENT))?.tokenEndpointAuthMethod).toBeUndefined();
+      }),
+    ),
+  );
+
   it.effect("hides another user's clients from the caller", () =>
     Effect.scoped(
       Effect.gen(function* () {

--- a/packages/core/sdk/src/oauth-service.ts
+++ b/packages/core/sdk/src/oauth-service.ts
@@ -65,7 +65,9 @@ import {
   exchangeAuthorizationCode,
   exchangeClientCredentials,
   isLoopbackHttpUrl,
+  parseClientAuthMethod,
   rebindTokenEndpointHostToCallbackDomain,
+  type ClientAuthMethod,
   type OAuth2TokenResponse,
   type OAuthEndpointUrlPolicy,
 } from "./oauth-helpers";
@@ -277,6 +279,8 @@ interface LoadedOAuthClient {
   /** Resolved literal secret (read from the provider via the stored item id). */
   readonly clientSecret: string;
   readonly resource: string | null;
+  /** Resolved token-endpoint client auth method ("body" | "basic"). */
+  readonly tokenEndpointAuthMethod: ClientAuthMethod;
 }
 
 /** Where an OAuth app's client secret is stored in the default writable
@@ -511,6 +515,9 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
           client_id: input.clientId,
           client_secret_item_id: clientSecretItemIdValue,
           resource: input.resource ?? null,
+          // Persist only a non-default ("basic") method; "body"/undefined stays
+          // null, which parseClientAuthMethod resolves back to the "body" default.
+          token_endpoint_auth_method: input.tokenEndpointAuthMethod === "basic" ? "basic" : null,
           origin_kind: input.origin?.kind ?? "manual",
           origin_integration:
             input.origin?.kind === "dynamic_client_registration"
@@ -679,6 +686,11 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
               tokenUrl: String(row.token_url),
               resource: row.resource == null ? null : String(row.resource),
               clientId: String(row.client_id),
+              // Only surface a non-default ("basic") method; "body" is implicit
+              // (undefined), matching how it is persisted and sent on create.
+              ...(parseClientAuthMethod(row.token_endpoint_auth_method) === "basic"
+                ? { tokenEndpointAuthMethod: "basic" as const }
+                : {}),
               origin: parseOAuthClientOrigin(row),
             } satisfies OAuthClientSummary);
           }),
@@ -735,6 +747,7 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
               clientId: String(row.client_id),
               clientSecret,
               resource: row.resource == null ? null : String(row.resource),
+              tokenEndpointAuthMethod: parseClientAuthMethod(row.token_endpoint_auth_method),
             } satisfies LoadedOAuthClient;
           });
         }),
@@ -809,6 +822,7 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
           clientSecret: client.clientSecret,
           scopes: requestedScopes,
           resource: client.resource ?? undefined,
+          clientAuth: client.tokenEndpointAuthMethod,
           endpointUrlPolicy: deps.endpointUrlPolicy,
           fetch,
         }).pipe(
@@ -1003,6 +1017,7 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
         codeVerifier: session.pkceVerifier,
         code: input.code,
         resource: client.resource ?? undefined,
+        clientAuth: client.tokenEndpointAuthMethod,
         endpointUrlPolicy: deps.endpointUrlPolicy,
         fetch,
       }).pipe(

--- a/packages/core/sdk/src/shared.ts
+++ b/packages/core/sdk/src/shared.ts
@@ -108,6 +108,7 @@ export {
 // OAuth wire contracts (data + tagged errors; the flow impl is server-only).
 export {
   type OAuthGrant,
+  type ClientAuthMethod,
   type OAuthAuthentication,
   type OAuthClient,
   type OAuthClientSummary,

--- a/packages/core/sdk/src/testing/oauth-test-server.ts
+++ b/packages/core/sdk/src/testing/oauth-test-server.ts
@@ -58,6 +58,13 @@ export interface OAuthTestServerOptions {
    *  `redirect_uris` entry is approved. Mirrors authorization servers (e.g.
    *  Vercel) that only accept loopback redirect URIs for anonymous DCR. */
   readonly approveRedirectUri?: (uri: string) => boolean;
+  /** When set, the `/token` endpoint ENFORCES a client-auth transport on every
+   *  request. `"basic"` rejects (401 invalid_client) any request that does not
+   *  carry HTTP Basic credentials (proves the client used `client_secret_basic`,
+   *  as Linear's client_credentials grant requires); `"body"` rejects any
+   *  request that carries HTTP Basic (forces `client_secret_post`). Omitting it
+   *  keeps the permissive default that accepts either. */
+  readonly requireClientAuthMethod?: "basic" | "body";
 }
 
 export interface OAuthTestServerShape {
@@ -85,6 +92,11 @@ export interface OAuthTestServerShape {
   readonly requests: Effect.Effect<readonly OAuthTestServerRequest[]>;
   readonly clearRequests: Effect.Effect<void>;
   readonly issuedAccessTokens: Effect.Effect<readonly string[]>;
+  /** Ordered log of which client-auth transport (`"basic"` | `"body"`) each
+   *  `/token` request used, by arrival order; reset by `clearRequests`. Use it
+   *  to assert that `exchangeClientCredentials` / `refreshAccessToken` actually
+   *  sent credentials via HTTP Basic rather than in the form body. */
+  readonly tokenRequestAuthMethods: Effect.Effect<readonly ("basic" | "body")[]>;
   readonly acceptsAccessToken: (token: string) => Effect.Effect<boolean>;
   readonly acceptsAuthorizationHeader: (
     authorization: string | null | undefined,
@@ -159,6 +171,21 @@ const parseJsonObject = (body: string): Readonly<Record<string, unknown>> | null
 const arrayOfStrings = (value: unknown): readonly string[] =>
   Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
 
+// RFC 6749 §2.3.1: the client id and secret in an HTTP Basic header are each
+// `application/x-www-form-urlencoded` BEFORE base64, so a spec-compliant server
+// must form-decode them after splitting. oauth4webapi's ClientSecretBasic
+// percent-encodes (e.g. `test-client` -> `test%2Dclient`); without decoding,
+// the id would never match (the body/`client_secret_post` path gets this for
+// free via URLSearchParams). Falls back to the raw slice on malformed input.
+const formDecode = (value: string): string => {
+  // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: decodeURIComponent throws on malformed percent-escapes; fall back to raw
+  try {
+    return decodeURIComponent(value.replace(/\+/g, " "));
+  } catch {
+    return value;
+  }
+};
+
 const decodeBasicAuthorization = (
   value: string | undefined,
 ): { readonly username: string; readonly password: string } | null => {
@@ -169,8 +196,8 @@ const decodeBasicAuthorization = (
   const separator = decoded.indexOf(":");
   if (separator < 0) return null;
   return {
-    username: decoded.slice(0, separator),
-    password: decoded.slice(separator + 1),
+    username: formDecode(decoded.slice(0, separator)),
+    password: formDecode(decoded.slice(separator + 1)),
   };
 };
 
@@ -407,6 +434,8 @@ export const serveOAuthTestServer = (
   Effect.gen(function* () {
     const requests = yield* Ref.make<readonly OAuthTestServerRequest[]>([]);
     const issuedAccessTokens = yield* Ref.make<ReadonlySet<string>>(new Set());
+    const tokenRequestAuthMethods = yield* Ref.make<readonly ("basic" | "body")[]>([]);
+    const requireClientAuthMethod = options.requireClientAuthMethod;
     const users = {
       [options.defaultUsername ?? "alice"]: options.defaultPassword ?? "password",
       ...(options.users ?? {}),
@@ -602,6 +631,25 @@ export const serveOAuthTestServer = (
         if (requestUrl.pathname === "/token" && request.method === "POST") {
           const params = new URLSearchParams(body);
           const basic = decodeBasicAuthorization(headers.authorization);
+          // Record which client-auth transport this /token call used, then (when
+          // configured) enforce a required one. Recording happens for ALL grant
+          // types so tests can assert the transport on any flow.
+          const usedAuthMethod: "basic" | "body" = basic ? "basic" : "body";
+          yield* Ref.update(tokenRequestAuthMethods, (all) => [...all, usedAuthMethod]);
+          if (requireClientAuthMethod === "basic" && !basic) {
+            return oauthError(
+              401,
+              "invalid_client",
+              "This authorization server requires HTTP Basic client authentication",
+            );
+          }
+          if (requireClientAuthMethod === "body" && basic) {
+            return oauthError(
+              401,
+              "invalid_client",
+              "This authorization server requires client_secret_post (body) client authentication",
+            );
+          }
           const clientId = basic?.username ?? params.get("client_id");
           const clientSecret = basic?.password ?? params.get("client_secret");
           const client = clientId ? clients.get(clientId) : undefined;
@@ -748,8 +796,11 @@ export const serveOAuthTestServer = (
         tokenEndpoint: `${issuerUrl}/token`,
       }),
       requests: Ref.get(requests),
-      clearRequests: Ref.set(requests, []),
+      clearRequests: Effect.all([Ref.set(requests, []), Ref.set(tokenRequestAuthMethods, [])]).pipe(
+        Effect.asVoid,
+      ),
       issuedAccessTokens: accessTokenSet.pipe(Effect.map((tokens) => [...tokens])),
+      tokenRequestAuthMethods: Ref.get(tokenRequestAuthMethods),
       acceptsAccessToken: (token) => accessTokenSet.pipe(Effect.map((tokens) => tokens.has(token))),
       acceptsAuthorizationHeader: (authorization) => {
         const token = authorization?.replace(/^Bearer\s+/i, "");

--- a/packages/plugins/graphql/src/react/AddGraphqlSource.tsx
+++ b/packages/plugins/graphql/src/react/AddGraphqlSource.tsx
@@ -25,14 +25,18 @@ import {
 
 import { addGraphqlIntegrationOptimistic } from "./atoms";
 import { GraphqlSourceFields } from "./GraphqlSourceFields";
-import { graphqlAuthMethodInputsFromPlacements } from "./auth-method-config";
+import {
+  graphqlAuthMethodInputFromEditorValue,
+  graphqlAuthMethodInputsFromPlacements,
+} from "./auth-method-config";
 import type { GraphqlAuthMethodInput } from "../sdk/types";
 
 // v2 GraphQL add flow: register the integration with its declared auth-method
-// LIST (the shared `AuthMethodListEditor` — GraphQL stays header/query apiKey;
-// OAuth is hidden), then route to the integration's detail hub. Connection
-// creation is no longer part of the add flow — accounts are added from the hub
-// (P6: add without auth, connect later).
+// LIST (the shared `AuthMethodListEditor`: header/query apiKey plus oauth2,
+// which may be endpoint-less bearer-render or endpointful / service-account
+// when a token endpoint is provided), then route to the integration's detail
+// hub. Connection creation is no longer part of the add flow; accounts are
+// added from the hub (P6: add without auth, connect later).
 
 // GraphQL has no add-time detection, so the list starts empty (module constant
 // — a fresh [] every render would re-seed the list each render).
@@ -62,11 +66,18 @@ export default function AddGraphqlSource(props: {
   // register nothing.
   const authenticationTemplate = useMemo<readonly GraphqlAuthMethodInput[]>(
     () =>
-      authMethodList.rows.flatMap((row: AuthMethodRow) =>
-        row.value.kind === "apikey"
-          ? graphqlAuthMethodInputsFromPlacements(row.value.placements)
-          : [],
-      ),
+      authMethodList.rows.flatMap((row: AuthMethodRow) => {
+        if (row.value.kind === "apikey") {
+          return graphqlAuthMethodInputsFromPlacements(row.value.placements);
+        }
+        // An oauth row registers one oauth2 method. With a token endpoint it is
+        // an endpointful / service-account method; without one it is the legacy
+        // bearer-render method. `none` rows register nothing.
+        if (row.value.kind === "oauth") {
+          return [graphqlAuthMethodInputFromEditorValue(row.value)];
+        }
+        return [];
+      }),
     [authMethodList.rows],
   );
 
@@ -142,7 +153,7 @@ export default function AddGraphqlSource(props: {
 
       <AuthMethodListEditor
         list={authMethodList}
-        allowedKinds={["none", "apikey"]}
+        allowedKinds={["none", "apikey", "oauth"]}
         emptyHint="No authentication declared. Add a method, or add the source without auth and connect an account from the integration page later."
         footerHint="Every method here is registered with the source. Connect an account from the integration page after adding."
       />

--- a/packages/plugins/graphql/src/react/auth-method-config.test.ts
+++ b/packages/plugins/graphql/src/react/auth-method-config.test.ts
@@ -13,14 +13,30 @@ describe("graphqlAuthMethodInputFromEditorValue", () => {
     expect(graphqlAuthMethodInputFromEditorValue({ kind: "none" })).toEqual({ kind: "none" });
   });
 
-  it("maps 'oauth' → { kind: 'oauth2' } (graphql oauth stores no endpoints)", () => {
+  it("maps an endpointful 'oauth' value → { kind: 'oauth2' } preserving endpoints/scopes", () => {
     const value: AuthTemplateEditorValue = {
       kind: "oauth",
       authorizationUrl: "https://a.example.com/auth",
       tokenUrl: "https://a.example.com/token",
       scopes: ["read"],
     };
-    expect(graphqlAuthMethodInputFromEditorValue(value)).toEqual({ kind: "oauth2" });
+    expect(graphqlAuthMethodInputFromEditorValue(value)).toEqual({
+      kind: "oauth2",
+      authorizationUrl: "https://a.example.com/auth",
+      tokenUrl: "https://a.example.com/token",
+      scopes: ["read"],
+    });
+  });
+
+  it("maps an endpoint-less 'oauth' value → bare { kind: 'oauth2' } (bearer-render only)", () => {
+    expect(
+      graphqlAuthMethodInputFromEditorValue({
+        kind: "oauth",
+        authorizationUrl: "",
+        tokenUrl: "",
+        scopes: [],
+      }),
+    ).toEqual({ kind: "oauth2" });
   });
 
   it("maps a header placement to an apikey method (prefix preserved)", () => {

--- a/packages/plugins/graphql/src/react/auth-method-config.ts
+++ b/packages/plugins/graphql/src/react/auth-method-config.ts
@@ -22,16 +22,29 @@ import type {
   GraphqlAuthMethod,
   GraphqlAuthMethodInput,
   GraphqlCanonicalAuthMethodInput,
+  GraphqlOAuthMethod,
 } from "../sdk/types";
 
-const oauthAuthMethod = (slug: string): AuthMethod => ({
-  id: slug,
+const oauthAuthMethod = (method: GraphqlOAuthMethod): AuthMethod => ({
+  id: method.slug,
   label: "OAuth",
   kind: "oauth",
-  source: slug.startsWith("custom_") ? "custom" : "spec",
-  template: AuthTemplateSlug.make(slug),
+  source: method.slug.startsWith("custom_") ? "custom" : "spec",
+  template: AuthTemplateSlug.make(method.slug),
   placements: [],
-  oauth: {},
+  // Mirror the server's describeGraphqlAuthMethods: surface stored endpoints +
+  // defaults so the connect UI can register + mint a client_credentials app.
+  // Endpoint-less methods emit an empty oauth object (prior behavior).
+  oauth: {
+    ...(method.authorizationUrl !== undefined ? { authorizationUrl: method.authorizationUrl } : {}),
+    ...(method.tokenUrl !== undefined ? { tokenUrl: method.tokenUrl } : {}),
+    ...(method.resource !== undefined ? { resource: method.resource } : {}),
+    ...(method.scopes !== undefined ? { scopes: method.scopes } : {}),
+    ...(method.defaultGrant !== undefined ? { defaultGrant: method.defaultGrant } : {}),
+    ...(method.defaultTokenEndpointAuthMethod !== undefined
+      ? { defaultTokenEndpointAuthMethod: method.defaultTokenEndpointAuthMethod }
+      : {}),
+  },
 });
 
 /** Convert a generic editor value into one GraphQL auth-method input (no slug
@@ -41,7 +54,19 @@ const oauthAuthMethod = (slug: string): AuthMethod => ({
 export function graphqlAuthMethodInputFromEditorValue(
   value: AuthTemplateEditorValue,
 ): GraphqlAuthMethodInput {
-  if (value.kind === "oauth") return { kind: "oauth2" };
+  if (value.kind === "oauth") {
+    // Preserve any endpoints/scopes the editor carries (an endpointful /
+    // service-account method) so a read-modify-write round-trip does not
+    // discard them. The integration-level defaultGrant /
+    // defaultTokenEndpointAuthMethod are not surfaced by the generic editor and
+    // are set via addIntegration / the agent config, not here.
+    return {
+      kind: "oauth2",
+      ...(value.authorizationUrl ? { authorizationUrl: value.authorizationUrl } : {}),
+      ...(value.tokenUrl ? { tokenUrl: value.tokenUrl } : {}),
+      ...(value.scopes && value.scopes.length > 0 ? { scopes: [...value.scopes] } : {}),
+    };
+  }
   return (sharedMethodInputFromEditorValue(value) ?? { kind: "none" }) as GraphqlAuthMethodInput;
 }
 
@@ -50,8 +75,14 @@ export function editorValueFromGraphqlAuthMethod(
   method: GraphqlAuthMethod,
 ): AuthTemplateEditorValue {
   if (method.kind === "oauth2") {
-    // GraphQL oauth methods store no endpoints — only the bearer rendering.
-    return { kind: "oauth", authorizationUrl: "", tokenUrl: "", scopes: [] };
+    // Endpointful methods seed the editor with their stored endpoints/scopes;
+    // endpoint-less (bearer-render-only) methods yield empty fields as before.
+    return {
+      kind: "oauth",
+      authorizationUrl: method.authorizationUrl ?? "",
+      tokenUrl: method.tokenUrl ?? "",
+      scopes: method.scopes ? [...method.scopes] : [],
+    };
   }
   return editorValueFromSharedMethod(method);
 }
@@ -61,7 +92,7 @@ export function editorValueFromGraphqlAuthMethod(
  *  user-created methods (removable from the hub). */
 export function authMethodsFromConfig(methods: readonly GraphqlAuthMethod[]): AuthMethod[] {
   return methods.map((method: GraphqlAuthMethod): AuthMethod => {
-    if (method.kind === "oauth2") return oauthAuthMethod(method.slug);
+    if (method.kind === "oauth2") return oauthAuthMethod(method);
     return authMethodFromSharedTemplate(method);
   });
 }

--- a/packages/plugins/graphql/src/sdk/client-credentials.test.ts
+++ b/packages/plugins/graphql/src/sdk/client-credentials.test.ts
@@ -1,0 +1,89 @@
+import { expect, layer } from "@effect/vitest";
+import { Effect, Layer } from "effect";
+
+import {
+  AuthTemplateSlug,
+  ConnectionName,
+  IntegrationSlug,
+  OAuthClientSlug,
+  ToolAddress,
+  createExecutor,
+} from "@executor-js/sdk";
+import { OAuthTestServer, makeTestConfig, memoryCredentialsPlugin } from "@executor-js/sdk/testing";
+
+import { graphqlPlugin } from "./plugin";
+import { GraphqlTestServer, makeGreetingGraphqlSchema } from "../testing";
+
+// End-to-end proof of the GraphQL service-account flow: a shared OAuth2
+// client_credentials app mints a token the executor refreshes itself, and that
+// token authenticates GraphQL introspection (at connect) AND query execution.
+// The authorization server REQUIRES HTTP Basic on the token request, so a green
+// run proves the executor sent `client_secret_basic` end to end.
+const TestLayer = GraphqlTestServer.layerWithOAuth({ schema: makeGreetingGraphqlSchema() }).pipe(
+  Layer.provideMerge(OAuthTestServer.layer({ requireClientAuthMethod: "basic", scopes: ["read"] })),
+);
+
+layer(TestLayer, { timeout: "20 seconds" })(
+  "GraphQL client_credentials (service account) e2e",
+  (it) => {
+    it.effect("mints a client_credentials connection via HTTP Basic and runs a query", () =>
+      Effect.gen(function* () {
+        const oauth = yield* OAuthTestServer;
+        const server = yield* GraphqlTestServer;
+
+        const executor = yield* createExecutor(
+          makeTestConfig({ plugins: [memoryCredentialsPlugin(), graphqlPlugin()] as const }),
+        );
+
+        // Endpointful oauth2 method: declares the token endpoint + the
+        // service-account defaults. No introspectionJson (introspection is
+        // deferred to connect and runs with the minted token).
+        yield* executor.graphql.addIntegration({
+          endpoint: server.endpoint,
+          slug: "linear_graphql",
+          authenticationTemplate: [
+            {
+              kind: "oauth2",
+              slug: "oauth2",
+              tokenUrl: oauth.tokenEndpoint,
+              scopes: ["read"],
+              defaultGrant: "client_credentials",
+              defaultTokenEndpointAuthMethod: "basic",
+            },
+          ],
+        });
+
+        yield* executor.oauth.createClient({
+          owner: "org",
+          slug: OAuthClientSlug.make("linear-bot"),
+          authorizationUrl: "",
+          tokenUrl: oauth.tokenEndpoint,
+          grant: "client_credentials",
+          clientId: "test-client",
+          clientSecret: "test-secret",
+          tokenEndpointAuthMethod: "basic",
+        });
+
+        const started = yield* executor.oauth.start({
+          owner: "org",
+          client: OAuthClientSlug.make("linear-bot"),
+          clientOwner: "org",
+          name: ConnectionName.make("main"),
+          integration: IntegrationSlug.make("linear_graphql"),
+          template: AuthTemplateSlug.make("oauth2"),
+        });
+        expect(started.status).toBe("connected");
+
+        const result = yield* executor.execute(
+          ToolAddress.make("tools.linear_graphql.org.main.query.hello"),
+          { name: "Ada" },
+        );
+        expect(result).toEqual({ ok: true, data: { hello: "Hello Ada" } });
+
+        // The single token mint authenticated via HTTP Basic; introspection and
+        // the query reused the stored (unexpired) token, so no further mints.
+        expect(yield* oauth.tokenRequestAuthMethods).toEqual(["basic"]);
+      }),
+    );
+  },
+);

--- a/packages/plugins/graphql/src/sdk/describe-auth-methods.test.ts
+++ b/packages/plugins/graphql/src/sdk/describe-auth-methods.test.ts
@@ -135,6 +135,40 @@ describe("describeGraphqlAuthMethods", () => {
     ]);
   });
 
+  it("projects an endpointful oauth2 method with the service-account defaults", () => {
+    const methods = describeGraphqlAuthMethods(
+      recordWith({
+        endpoint: "https://x.example/graphql",
+        name: "x",
+        authenticationTemplate: [
+          {
+            kind: "oauth2",
+            slug: "oauth",
+            tokenUrl: "https://auth.linear.app/oauth/token",
+            scopes: ["read"],
+            defaultGrant: "client_credentials",
+            defaultTokenEndpointAuthMethod: "basic",
+          },
+        ],
+      }),
+    );
+
+    expect(methods).toEqual([
+      {
+        id: "oauth",
+        label: "OAuth",
+        kind: "oauth",
+        template: "oauth",
+        oauth: {
+          tokenUrl: "https://auth.linear.app/oauth/token",
+          scopes: ["read"],
+          defaultGrant: "client_credentials",
+          defaultTokenEndpointAuthMethod: "basic",
+        },
+      },
+    ]);
+  });
+
   it("projects a none method to a no-auth descriptor", () => {
     const methods = describeGraphqlAuthMethods(
       recordWith({

--- a/packages/plugins/graphql/src/sdk/plugin.ts
+++ b/packages/plugins/graphql/src/sdk/plugin.ts
@@ -607,7 +607,23 @@ export const describeGraphqlAuthMethods = (
         label: "OAuth",
         kind: "oauth",
         template: method.slug,
-        oauth: {},
+        // Advertise the stored endpoints (when this is an endpointful /
+        // service-account method) so the connect UI can register + mint a
+        // client without the user pasting a token endpoint. An endpoint-less
+        // oauth2 method (bearer-render only) emits an empty oauth object,
+        // preserving the prior behavior.
+        oauth: {
+          ...(method.authorizationUrl !== undefined
+            ? { authorizationUrl: method.authorizationUrl }
+            : {}),
+          ...(method.tokenUrl !== undefined ? { tokenUrl: method.tokenUrl } : {}),
+          ...(method.resource !== undefined ? { resource: method.resource } : {}),
+          ...(method.scopes !== undefined ? { scopes: method.scopes } : {}),
+          ...(method.defaultGrant !== undefined ? { defaultGrant: method.defaultGrant } : {}),
+          ...(method.defaultTokenEndpointAuthMethod !== undefined
+            ? { defaultTokenEndpointAuthMethod: method.defaultTokenEndpointAuthMethod }
+            : {}),
+        },
       };
     }
     return describeNoneAuthMethod(method.slug);

--- a/packages/plugins/graphql/src/sdk/types.ts
+++ b/packages/plugins/graphql/src/sdk/types.ts
@@ -98,6 +98,26 @@ export const GraphqlOAuthMethod = Schema.Struct({
   header: Schema.optional(Schema.String),
   /** The token prefix. Defaults to `Bearer `. */
   prefix: Schema.optional(Schema.String),
+  // Endpointful fields, present when the method declares its OAuth endpoints up
+  // front (a service-account / client_credentials flow) rather than leaving the
+  // token to a bearer-only render. They are advertised on the auth-method
+  // descriptor so the connect UI can register + mint a client without the user
+  // pasting endpoints. Token minting/refresh is core's job; rendering is
+  // unchanged (the resolved token is still written as the bearer).
+  /** OAuth2 authorization endpoint (authorization_code flows). */
+  authorizationUrl: Schema.optional(Schema.String),
+  /** OAuth2 token endpoint. Its presence marks this method as endpointful. */
+  tokenUrl: Schema.optional(Schema.String),
+  /** RFC 8707 resource indicator, when the provider uses one. */
+  resource: Schema.optional(Schema.NullOr(Schema.String)),
+  /** Scopes to request. */
+  scopes: Schema.optional(Schema.Array(Schema.String)),
+  /** Default grant to preselect when registering an app ("client_credentials"
+   *  for a shared service-account identity). Absent means authorization_code. */
+  defaultGrant: Schema.optional(Schema.Literals(["authorization_code", "client_credentials"])),
+  /** Default token-endpoint client auth to preselect; only "basic" is ever
+   *  materialized (e.g. Linear). Absent means the "body" default. */
+  defaultTokenEndpointAuthMethod: Schema.optional(Schema.Literals(["body", "basic"])),
 });
 export type GraphqlOAuthMethod = typeof GraphqlOAuthMethod.Type;
 
@@ -117,6 +137,12 @@ export const GraphqlAuthMethodInput = Schema.Union([
     kind: Schema.Literal("oauth2"),
     header: Schema.optional(Schema.String),
     prefix: Schema.optional(Schema.String),
+    authorizationUrl: Schema.optional(Schema.String),
+    tokenUrl: Schema.optional(Schema.String),
+    resource: Schema.optional(Schema.NullOr(Schema.String)),
+    scopes: Schema.optional(Schema.Array(Schema.String)),
+    defaultGrant: Schema.optional(Schema.Literals(["authorization_code", "client_credentials"])),
+    defaultTokenEndpointAuthMethod: Schema.optional(Schema.Literals(["body", "basic"])),
   }),
   // Credential methods are authored request-shaped — the ONE apikey input
   // dialect: `{ type: "apiKey", headers: { Authorization: ["Bearer ",

--- a/packages/plugins/mcp/src/react/EditMcpSource.tsx
+++ b/packages/plugins/mcp/src/react/EditMcpSource.tsx
@@ -98,14 +98,27 @@ function RemoteEdit(props: {
   // The edited methods, slugs preserved for seeded rows so existing
   // connections (bound by template slug) stay attached. New rows omit the
   // slug — the backend assigns kind-based ones.
-  const editedMethods = useMemo<readonly McpCanonicalAuthMethodInput[]>(
-    () =>
-      list.rows.map((row: AuthMethodRow): McpCanonicalAuthMethodInput => {
-        const input = mcpAuthMethodInputFromEditorValue(row.value);
-        return row.seedSlug !== undefined ? { ...input, slug: row.seedSlug } : input;
-      }),
-    [list.rows],
-  );
+  const editedMethods = useMemo<readonly McpCanonicalAuthMethodInput[]>(() => {
+    const storedBySlug = new Map(
+      server.config.authenticationTemplate.map((method) => [method.slug, method] as const),
+    );
+    return list.rows.map((row: AuthMethodRow): McpCanonicalAuthMethodInput => {
+      const input = mcpAuthMethodInputFromEditorValue(row.value);
+      if (row.seedSlug === undefined) return input;
+      // Preserve the OAuth fields the generic editor does not surface
+      // (resource, defaultGrant, defaultTokenEndpointAuthMethod) by merging the
+      // editor-derived input onto the original stored method. Without this, an
+      // unrelated auth edit (this flow REPLACES the whole template) would
+      // silently strip a configured service-account / client_credentials method
+      // back to discovery. Editor-surfaced fields (tokenUrl, scopes,
+      // authorizationUrl) on `input` still win.
+      const original = storedBySlug.get(row.seedSlug);
+      if (input.kind === "oauth2" && original?.kind === "oauth2") {
+        return { ...original, ...input, slug: row.seedSlug };
+      }
+      return { ...input, slug: row.seedSlug };
+    });
+  }, [list.rows, server.config.authenticationTemplate]);
 
   const methodsChanged = useMemo(() => {
     const stored = server.config.authenticationTemplate;
@@ -117,6 +130,16 @@ function RemoteEdit(props: {
       if (method.kind !== current.kind) return true;
       if (method.kind === "apikey" && current.kind === "apikey") {
         return !samePlacements(method.placements, current.placements);
+      }
+      // Detect edits to the endpointful oauth2 fields the editor surfaces so a
+      // token-endpoint / scope change is saved (the non-editable defaults are
+      // merged through unchanged above).
+      if (method.kind === "oauth2" && current.kind === "oauth2") {
+        return (
+          (method.tokenUrl ?? "") !== (current.tokenUrl ?? "") ||
+          (method.authorizationUrl ?? "") !== (current.authorizationUrl ?? "") ||
+          (method.scopes ?? []).join(" ") !== (current.scopes ?? []).join(" ")
+        );
       }
       return false;
     });

--- a/packages/plugins/mcp/src/react/auth-method-config.test.ts
+++ b/packages/plugins/mcp/src/react/auth-method-config.test.ts
@@ -13,14 +13,30 @@ describe("mcpAuthMethodInputFromEditorValue", () => {
     expect(mcpAuthMethodInputFromEditorValue({ kind: "none" })).toEqual({ kind: "none" });
   });
 
-  it("maps 'oauth' → { kind: 'oauth2' } (endpoints/scopes are resolved at connect time)", () => {
+  it("maps an endpointful 'oauth' value → { kind: 'oauth2' } preserving endpoints/scopes", () => {
     const value: AuthTemplateEditorValue = {
       kind: "oauth",
       authorizationUrl: "https://a.example.com/auth",
       tokenUrl: "https://a.example.com/token",
       scopes: ["mcp.read"],
     };
-    expect(mcpAuthMethodInputFromEditorValue(value)).toEqual({ kind: "oauth2" });
+    expect(mcpAuthMethodInputFromEditorValue(value)).toEqual({
+      kind: "oauth2",
+      authorizationUrl: "https://a.example.com/auth",
+      tokenUrl: "https://a.example.com/token",
+      scopes: ["mcp.read"],
+    });
+  });
+
+  it("maps a discovery 'oauth' value (no endpoints) → bare { kind: 'oauth2' }", () => {
+    expect(
+      mcpAuthMethodInputFromEditorValue({
+        kind: "oauth",
+        authorizationUrl: "",
+        tokenUrl: "",
+        scopes: [],
+      }),
+    ).toEqual({ kind: "oauth2" });
   });
 
   it("maps a header placement to an apikey method (prefix preserved)", () => {

--- a/packages/plugins/mcp/src/react/auth-method-config.ts
+++ b/packages/plugins/mcp/src/react/auth-method-config.ts
@@ -21,6 +21,7 @@ import type {
   McpAuthMethod,
   McpAuthMethodInput,
   McpCanonicalAuthMethodInput,
+  McpOAuthMethod,
   McpStdioEnvMethod,
 } from "../sdk/types";
 
@@ -48,14 +49,33 @@ export const mcpWireAuthInput = (
   method: McpAuthMethod | McpCanonicalAuthMethodInput,
 ): McpAuthMethodInput => wireAuthInputFromShared(method) as McpAuthMethodInput;
 
-const oauthAuthMethod = (slug: string, endpoint: string): AuthMethod => ({
-  id: slug,
+const oauthAuthMethod = (method: McpOAuthMethod, endpoint: string): AuthMethod => ({
+  id: method.slug,
   label: "OAuth",
   kind: "oauth",
-  source: slug.startsWith("custom_") ? "custom" : "spec",
-  template: AuthTemplateSlug.make(slug),
+  source: method.slug.startsWith("custom_") ? "custom" : "spec",
+  template: AuthTemplateSlug.make(method.slug),
   placements: [],
-  oauth: { discoveryUrl: endpoint, supportsDynamicRegistration: true },
+  // Endpointful (tokenUrl present): advertise the stored endpoints + defaults so
+  // the connect UI registers + mints a client (e.g. client_credentials) WITHOUT
+  // probing for dynamic registration. No discoveryUrl/supportsDynamicRegistration
+  // here keeps the modal's DCR gate off. Discovery-at-connect methods keep the
+  // prior shape (probe the MCP endpoint live).
+  oauth:
+    method.tokenUrl != null
+      ? {
+          ...(method.authorizationUrl !== undefined
+            ? { authorizationUrl: method.authorizationUrl }
+            : {}),
+          tokenUrl: method.tokenUrl,
+          ...(method.resource !== undefined ? { resource: method.resource } : {}),
+          ...(method.scopes !== undefined ? { scopes: method.scopes } : {}),
+          ...(method.defaultGrant !== undefined ? { defaultGrant: method.defaultGrant } : {}),
+          ...(method.defaultTokenEndpointAuthMethod !== undefined
+            ? { defaultTokenEndpointAuthMethod: method.defaultTokenEndpointAuthMethod }
+            : {}),
+        }
+      : { discoveryUrl: endpoint, supportsDynamicRegistration: true },
 });
 
 /** Convert a generic editor value into one MCP auth-method input (no slug —
@@ -65,7 +85,18 @@ const oauthAuthMethod = (slug: string, endpoint: string): AuthMethod => ({
 export function mcpAuthMethodInputFromEditorValue(
   value: AuthTemplateEditorValue,
 ): McpCanonicalAuthMethodInput {
-  if (value.kind === "oauth") return { kind: "oauth2" };
+  if (value.kind === "oauth") {
+    // Preserve endpoints/scopes the editor carries (an endpointful /
+    // service-account method) so a read-modify-write round-trip keeps them.
+    // defaultGrant / defaultTokenEndpointAuthMethod are integration-level config
+    // set via addServer / the agent, not surfaced by the generic editor.
+    return {
+      kind: "oauth2",
+      ...(value.authorizationUrl ? { authorizationUrl: value.authorizationUrl } : {}),
+      ...(value.tokenUrl ? { tokenUrl: value.tokenUrl } : {}),
+      ...(value.scopes && value.scopes.length > 0 ? { scopes: [...value.scopes] } : {}),
+    };
+  }
   return (sharedMethodInputFromEditorValue(value) ?? {
     kind: "none",
   }) as McpCanonicalAuthMethodInput;
@@ -74,7 +105,14 @@ export function mcpAuthMethodInputFromEditorValue(
 /** Convert one stored MCP method into the generic editor value. */
 export function editorValueFromMcpAuthMethod(method: McpAuthMethod): AuthTemplateEditorValue {
   if (method.kind === "oauth2") {
-    return { kind: "oauth", authorizationUrl: "", tokenUrl: "", scopes: [] };
+    // Endpointful methods seed the editor with their stored endpoints/scopes;
+    // discovery-at-connect methods yield empty fields as before.
+    return {
+      kind: "oauth",
+      authorizationUrl: method.authorizationUrl ?? "",
+      tokenUrl: method.tokenUrl ?? "",
+      scopes: method.scopes ? [...method.scopes] : [],
+    };
   }
   if (method.kind === "stdio_env") return stdioEnvEditorValue(method);
   return editorValueFromSharedMethod(method);
@@ -89,7 +127,7 @@ export function authMethodsFromConfig(
   endpoint: string,
 ): AuthMethod[] {
   return methods.map((method: McpAuthMethod): AuthMethod => {
-    if (method.kind === "oauth2") return oauthAuthMethod(method.slug, endpoint);
+    if (method.kind === "oauth2") return oauthAuthMethod(method, endpoint);
     if (method.kind === "stdio_env") return stdioEnvAuthMethod(method);
     return authMethodFromSharedTemplate(method);
   });

--- a/packages/plugins/mcp/src/sdk/client-credentials.test.ts
+++ b/packages/plugins/mcp/src/sdk/client-credentials.test.ts
@@ -1,0 +1,102 @@
+import { expect, layer } from "@effect/vitest";
+import { Effect } from "effect";
+
+import {
+  AuthTemplateSlug,
+  ConnectionName,
+  IntegrationSlug,
+  OAuthClientSlug,
+  ToolAddress,
+  createExecutor,
+} from "@executor-js/sdk";
+import { OAuthTestServer, makeTestConfig, memoryCredentialsPlugin } from "@executor-js/sdk/testing";
+
+import { mcpPlugin } from "./plugin";
+import { makeEchoMcpServer, serveMcpServerWithOAuth } from "../testing";
+
+// End-to-end proof of the MCP service-account flow: a shared OAuth2
+// client_credentials app (one bot identity, no per-user sign-in) mints a token
+// the executor refreshes itself, and that token authenticates real MCP tool
+// calls. The authorization server REQUIRES HTTP Basic on the token request
+// (Linear's client_credentials grant does), so a green run proves the executor
+// sent `client_secret_basic` end to end, not just that some token worked.
+layer(OAuthTestServer.layer({ requireClientAuthMethod: "basic", scopes: ["read"] }), {
+  timeout: "20 seconds",
+})("MCP client_credentials (service account) e2e", (it) => {
+  it.effect("mints a client_credentials connection via HTTP Basic and invokes a tool", () =>
+    Effect.gen(function* () {
+      const oauth = yield* OAuthTestServer;
+      const server = yield* serveMcpServerWithOAuth(
+        () =>
+          makeEchoMcpServer({
+            name: "linear-mcp",
+            toolName: "hello",
+            toolDescription: "Greets a person",
+            inputName: "name",
+            text: (name) => `Hello ${name}`,
+          }),
+        { path: "/mcp" },
+      );
+
+      const executor = yield* createExecutor(
+        makeTestConfig({ plugins: [memoryCredentialsPlugin(), mcpPlugin()] as const }),
+      );
+
+      // Register the MCP integration with an ENDPOINTFUL oauth2 method declaring
+      // the token endpoint, scopes, and the service-account defaults. This is
+      // what makes the connect flow offer client_credentials with Basic.
+      yield* executor.mcp.addServer({
+        name: "Linear MCP",
+        endpoint: server.endpoint,
+        slug: "linear_mcp",
+        authenticationTemplate: [
+          {
+            kind: "oauth2",
+            tokenUrl: oauth.tokenEndpoint,
+            scopes: ["read"],
+            defaultGrant: "client_credentials",
+            defaultTokenEndpointAuthMethod: "basic",
+          },
+        ],
+      });
+
+      // The shared bot app: a confidential client_credentials client that
+      // authenticates to the token endpoint via HTTP Basic.
+      yield* executor.oauth.createClient({
+        owner: "org",
+        slug: OAuthClientSlug.make("linear-bot"),
+        authorizationUrl: "",
+        tokenUrl: oauth.tokenEndpoint,
+        grant: "client_credentials",
+        clientId: "test-client",
+        clientSecret: "test-secret",
+        tokenEndpointAuthMethod: "basic",
+        resource: server.endpoint,
+      });
+
+      const started = yield* executor.oauth.start({
+        owner: "org",
+        client: OAuthClientSlug.make("linear-bot"),
+        clientOwner: "org",
+        name: ConnectionName.make("main"),
+        integration: IntegrationSlug.make("linear_mcp"),
+        template: AuthTemplateSlug.make("oauth2"),
+      });
+      // No browser redirect: the connection is minted inline.
+      expect(started.status).toBe("connected");
+
+      // The minted token authenticates a real MCP tool call through the SDK
+      // transport (the server validates the Bearer against the OAuth server).
+      const result = yield* executor.execute(ToolAddress.make("tools.linear_mcp.org.main.hello"), {
+        name: "Ada",
+      });
+      expect(result).toMatchObject({
+        ok: true,
+        data: { content: [{ type: "text", text: "Hello Ada" }] },
+      });
+
+      // The token endpoint only ever saw HTTP Basic client auth.
+      expect(yield* oauth.tokenRequestAuthMethods).toEqual(["basic"]);
+    }),
+  );
+});

--- a/packages/plugins/mcp/src/sdk/describe-auth-methods.test.ts
+++ b/packages/plugins/mcp/src/sdk/describe-auth-methods.test.ts
@@ -47,6 +47,43 @@ describe("describeMcpAuthMethods", () => {
     ]);
   });
 
+  it("projects an endpointful oauth2 method (tokenUrl) with the service-account defaults", () => {
+    const methods = describeMcpAuthMethods(
+      recordWith({
+        transport: "remote",
+        endpoint: "https://x.example/mcp",
+        authenticationTemplate: [
+          {
+            slug: "oauth2",
+            kind: "oauth2",
+            tokenUrl: "https://auth.linear.app/oauth/token",
+            scopes: ["read", "write"],
+            defaultGrant: "client_credentials",
+            defaultTokenEndpointAuthMethod: "basic",
+          },
+        ],
+      }),
+    );
+
+    // Endpointful methods advertise the token endpoint + defaults and must NOT
+    // set discoveryUrl / supportsDynamicRegistration (that keeps the connect
+    // UI's DCR gate off, routing to the pre-seeded BYO-app form).
+    expect(methods).toEqual([
+      {
+        id: "oauth2",
+        label: "OAuth",
+        kind: "oauth",
+        template: "oauth2",
+        oauth: {
+          tokenUrl: "https://auth.linear.app/oauth/token",
+          scopes: ["read", "write"],
+          defaultGrant: "client_credentials",
+          defaultTokenEndpointAuthMethod: "basic",
+        },
+      },
+    ]);
+  });
+
   it("projects an apikey header method carrying the placement", () => {
     const methods = describeMcpAuthMethods(
       recordWith({

--- a/packages/plugins/mcp/src/sdk/plugin.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.ts
@@ -600,13 +600,39 @@ export const describeMcpAuthMethods = (
     if (method.kind === "stdio_env") return describeStdioEnvAuthMethod(method);
     if (method.kind === "apikey") return describeApiKeyAuthMethod(method);
     if (method.kind === "oauth2") {
+      // Endpointful method (tokenUrl declared up front, e.g. a client_credentials
+      // service-account flow): advertise the stored endpoints + defaults and do
+      // NOT set discoveryUrl / supportsDynamicRegistration. That keeps the connect
+      // UI's DCR gate (isDcr) false, so it renders the BYO-app form pre-seeded with
+      // defaultGrant rather than probing the token URL for dynamic registration.
+      if (method.tokenUrl != null) {
+        return {
+          id: method.slug,
+          label: "OAuth",
+          kind: "oauth",
+          template: method.slug,
+          oauth: {
+            ...(method.authorizationUrl !== undefined
+              ? { authorizationUrl: method.authorizationUrl }
+              : {}),
+            tokenUrl: method.tokenUrl,
+            ...(method.resource !== undefined ? { resource: method.resource } : {}),
+            ...(method.scopes !== undefined ? { scopes: method.scopes } : {}),
+            ...(method.defaultGrant !== undefined ? { defaultGrant: method.defaultGrant } : {}),
+            ...(method.defaultTokenEndpointAuthMethod !== undefined
+              ? { defaultTokenEndpointAuthMethod: method.defaultTokenEndpointAuthMethod }
+              : {}),
+          },
+        };
+      }
+      // Discovery-at-connect method (no stored token endpoint): probe the
+      // server's metadata live. Only remote configs carry an endpoint; stdio
+      // never reaches here with oauth2.
       return {
         id: method.slug,
         label: "OAuth",
         kind: "oauth",
         template: method.slug,
-        // Only remote configs carry an endpoint; stdio never reaches here with
-        // oauth2.
         oauth: {
           discoveryUrl: config.transport === "remote" ? config.endpoint : undefined,
           supportsDynamicRegistration: true,

--- a/packages/plugins/mcp/src/sdk/types.ts
+++ b/packages/plugins/mcp/src/sdk/types.ts
@@ -51,6 +51,28 @@ export type McpTransport = typeof McpTransport.Type;
 export const McpOAuthMethod = Schema.Struct({
   slug: Schema.String,
   kind: Schema.Literal("oauth2"),
+  // Endpointful fields. When `tokenUrl` is present this is an endpointful
+  // method (the token endpoint is known up front, e.g. a client_credentials
+  // service-account flow) rather than the default discovery-at-connect method
+  // (whose endpoints are probed live from the server's `.well-known`). The
+  // fields are advertised on the auth-method descriptor so the connect UI can
+  // register + mint a client without the user pasting endpoints. Runtime is
+  // unchanged: the resolved (refreshing) token is still applied as a Bearer via
+  // the MCP SDK's OAuthClientProvider, regardless of how it was minted.
+  /** OAuth2 authorization endpoint (authorization_code flows). */
+  authorizationUrl: Schema.optional(Schema.String),
+  /** OAuth2 token endpoint. Its presence marks this method as endpointful. */
+  tokenUrl: Schema.optional(Schema.String),
+  /** RFC 8707 resource indicator, when the provider uses one. */
+  resource: Schema.optional(Schema.NullOr(Schema.String)),
+  /** Scopes to request. */
+  scopes: Schema.optional(Schema.Array(Schema.String)),
+  /** Default grant to preselect when registering an app ("client_credentials"
+   *  for a shared service-account identity). Absent means authorization_code. */
+  defaultGrant: Schema.optional(Schema.Literals(["authorization_code", "client_credentials"])),
+  /** Default token-endpoint client auth to preselect; only "basic" is ever
+   *  materialized (e.g. Linear). Absent means the "body" default. */
+  defaultTokenEndpointAuthMethod: Schema.optional(Schema.Literals(["body", "basic"])),
 });
 export type McpOAuthMethod = typeof McpOAuthMethod.Type;
 
@@ -114,7 +136,16 @@ export const mcpAuthMethodFromShorthand = (auth: McpAuthShorthand): McpAuthMetho
  *  `normalizeMcpAuthMethods` backfills it. */
 export const McpAuthMethodInput = Schema.Union([
   Schema.Struct({ slug: Schema.optional(Schema.String), kind: Schema.Literal("none") }),
-  Schema.Struct({ slug: Schema.optional(Schema.String), kind: Schema.Literal("oauth2") }),
+  Schema.Struct({
+    slug: Schema.optional(Schema.String),
+    kind: Schema.Literal("oauth2"),
+    authorizationUrl: Schema.optional(Schema.String),
+    tokenUrl: Schema.optional(Schema.String),
+    resource: Schema.optional(Schema.NullOr(Schema.String)),
+    scopes: Schema.optional(Schema.Array(Schema.String)),
+    defaultGrant: Schema.optional(Schema.Literals(["authorization_code", "client_credentials"])),
+    defaultTokenEndpointAuthMethod: Schema.optional(Schema.Literals(["body", "basic"])),
+  }),
   // Credential methods are authored request-shaped — the ONE apikey input
   // dialect: `{ type: "apiKey", headers: { Authorization: ["Bearer ",
   // variable("token")] }, queryParams: { … } }`. Stored configs and the

--- a/packages/react/src/api/atoms.tsx
+++ b/packages/react/src/api/atoms.tsx
@@ -460,6 +460,7 @@ export const createOAuthClientOptimistic = oauthClientsOptimisticAtom.pipe(
           readonly grant: OAuthGrant;
           readonly clientId: string;
           readonly resource?: string | null;
+          readonly tokenEndpointAuthMethod?: "body" | "basic";
         };
       },
     ) =>
@@ -472,6 +473,10 @@ export const createOAuthClientOptimistic = oauthClientsOptimisticAtom.pipe(
           tokenUrl: arg.payload.tokenUrl,
           resource: arg.payload.resource ?? null,
           clientId: arg.payload.clientId,
+          // Mirror the persisted convention: only carry a non-default "basic".
+          ...(arg.payload.tokenEndpointAuthMethod === "basic"
+            ? { tokenEndpointAuthMethod: "basic" as const }
+            : {}),
           origin: { kind: "manual" },
         };
         const index = rows.findIndex(

--- a/packages/react/src/components/add-account-modal.tsx
+++ b/packages/react/src/components/add-account-modal.tsx
@@ -995,6 +995,9 @@ function AddAccountModalView(props: AddAccountModalProps) {
       ...(oauthClientHandoff.tokenUrl ? { tokenUrl: oauthClientHandoff.tokenUrl } : {}),
       ...(oauthClientHandoff.resource ? { resource: oauthClientHandoff.resource } : {}),
       ...(grant ? { grant } : {}),
+      ...(oauthClientHandoff.tokenEndpointAuthMethod
+        ? { tokenEndpointAuthMethod: oauthClientHandoff.tokenEndpointAuthMethod }
+        : {}),
       ...(oauthClientHandoff.clientId ? { clientId: oauthClientHandoff.clientId } : {}),
     };
   }, [oauthClientHandoff]);
@@ -1563,6 +1566,9 @@ function AddAccountModalView(props: AddAccountModalProps) {
                   tokenUrl: editingClient.tokenUrl,
                   resource: editingClient.resource ?? null,
                   grant: editingClient.grant,
+                  // Carry the stored auth method so editing a Basic client and
+                  // saving does not silently rewrite the row to body.
+                  tokenEndpointAuthMethod: editingClient.tokenEndpointAuthMethod,
                   clientId: editingClient.clientId,
                 }}
                 onCreated={() => setEditingClient(null)}
@@ -1608,7 +1614,20 @@ function AddAccountModalView(props: AddAccountModalProps) {
                     undefined,
                   tokenEndpointAuthMethodsSupported:
                     oauthFallbackProbe?.tokenEndpointAuthMethodsSupported,
-                  ...(oauthHandoffPrefill?.grant ? { grant: oauthHandoffPrefill.grant } : {}),
+                  // Grant: agent handoff wins, else the method's advertised
+                  // defaultGrant (e.g. a Linear MCP preset declaring
+                  // client_credentials), else the form's own default.
+                  ...(oauthHandoffPrefill?.grant
+                    ? { grant: oauthHandoffPrefill.grant }
+                    : method.oauth?.defaultGrant
+                      ? { grant: method.oauth.defaultGrant }
+                      : {}),
+                  // Same precedence for the token-endpoint client auth method.
+                  ...(oauthHandoffPrefill?.tokenEndpointAuthMethod
+                    ? { tokenEndpointAuthMethod: oauthHandoffPrefill.tokenEndpointAuthMethod }
+                    : method.oauth?.defaultTokenEndpointAuthMethod
+                      ? { tokenEndpointAuthMethod: method.oauth.defaultTokenEndpointAuthMethod }
+                      : {}),
                   ...(oauthHandoffPrefill?.clientId
                     ? { clientId: oauthHandoffPrefill.clientId }
                     : {}),

--- a/packages/react/src/components/oauth-client-form.tsx
+++ b/packages/react/src/components/oauth-client-form.tsx
@@ -1,7 +1,12 @@
 import { useMemo, useState } from "react";
 import { useAtomSet } from "@effect/atom-react";
 import * as Exit from "effect/Exit";
-import { OAuthClientSlug, type OAuthGrant, type Owner } from "@executor-js/sdk/shared";
+import {
+  OAuthClientSlug,
+  type ClientAuthMethod,
+  type OAuthGrant,
+  type Owner,
+} from "@executor-js/sdk/shared";
 import { toast } from "sonner";
 
 import { createOAuthClientOptimistic, probeOAuth, registerDynamicOAuthClient } from "../api/atoms";
@@ -48,6 +53,11 @@ export interface OAuthClientFormPrefill {
    *  and they are only sent when no declared scopes exist. */
   readonly discoveredScopes?: readonly string[];
   readonly grant?: OAuthGrant;
+  /** Default token-endpoint client-auth method to preselect ("body" |
+   *  "basic"). Lets an integration whose provider only accepts HTTP Basic at
+   *  the token endpoint (e.g. Linear's client_credentials grant) seed the
+   *  correct choice. Defaults to "body" (client_secret_post). */
+  readonly tokenEndpointAuthMethod?: ClientAuthMethod;
   /** Client id to seed (e.g. when editing an existing app). NOT a secret — the
    *  secret is never returned, so it is always re-entered. */
   readonly clientId?: string;
@@ -144,6 +154,9 @@ export function OAuthClientForm(props: {
   );
   const [name, setName] = useState(integrationName);
   const [grant, setGrant] = useState<OAuthGrant>(prefill?.grant ?? "authorization_code");
+  const [tokenEndpointAuthMethod, setTokenEndpointAuthMethod] = useState<ClientAuthMethod>(
+    prefill?.tokenEndpointAuthMethod ?? "body",
+  );
   const [clientId, setClientId] = useState(prefill?.clientId ?? "");
   const [clientSecret, setClientSecret] = useState("");
   const [issuerUrl, setIssuerUrl] = useState("");
@@ -287,6 +300,10 @@ export function OAuthClientForm(props: {
         clientId: clientId.trim(),
         clientSecret: clientSecret.trim(),
         resource,
+        // Only send a non-default method; "body" is the server-side default.
+        ...(tokenEndpointAuthMethod === "basic"
+          ? { tokenEndpointAuthMethod: "basic" as const }
+          : {}),
       },
       reactivityKeys: oauthClientWriteKeys,
     });
@@ -469,6 +486,54 @@ export function OAuthClientForm(props: {
           />
         </div>
       </div>
+
+      {/* token-endpoint client auth, only relevant when a secret is sent.
+          Most providers accept the secret in the request body
+          (client_secret_post); some (e.g. Linear's client_credentials grant)
+          require HTTP Basic. Hidden for public clients with no secret. */}
+      {clientSecret.trim().length > 0 || grant === "client_credentials" ? (
+        <div className="space-y-2">
+          <Label className="text-xs text-muted-foreground">Client authentication</Label>
+          <RadioGroup
+            value={tokenEndpointAuthMethod}
+            onValueChange={(next: string) => setTokenEndpointAuthMethod(next as ClientAuthMethod)}
+            className="gap-2"
+          >
+            {(
+              [
+                {
+                  value: "body",
+                  label: "Request body",
+                  hint: "client_secret_post (default)",
+                },
+                {
+                  value: "basic",
+                  label: "HTTP Basic",
+                  hint: "client_secret_basic (e.g. Linear)",
+                },
+              ] as const
+            ).map((option) => (
+              <Label
+                key={option.value}
+                htmlFor={`token-auth-${option.value}`}
+                className="flex cursor-pointer items-start gap-3 rounded-lg border border-border/60 bg-background/40 px-3 py-2 font-normal has-[:checked]:border-ring has-[:checked]:bg-accent/40"
+              >
+                <RadioGroupItem
+                  id={`token-auth-${option.value}`}
+                  value={option.value}
+                  className="mt-0.5"
+                />
+                <span className="min-w-0 flex-1">
+                  <span className="block text-sm font-medium">{option.label}</span>
+                  <span className="block font-mono text-xs text-muted-foreground">
+                    {option.hint}
+                  </span>
+                </span>
+              </Label>
+            ))}
+          </RadioGroup>
+        </div>
+      ) : null}
 
       {/* endpoints + scopes — collapsed when the integration already declares them */}
       {endpointsKnown && !showEndpoints ? (

--- a/packages/react/src/lib/auth-placements.tsx
+++ b/packages/react/src/lib/auth-placements.tsx
@@ -74,6 +74,13 @@ export interface AuthMethodOAuth {
    *  `client_id` is this host's metadata document URL, with no provider-side app
    *  registration. */
   readonly supportsClientIdMetadataDocument?: boolean;
+  /** Default OAuth grant to preselect for this method (`"client_credentials"`
+   *  drives the service-account / no-user-sign-in connect path). Absent means
+   *  `"authorization_code"`. */
+  readonly defaultGrant?: "authorization_code" | "client_credentials";
+  /** Default token-endpoint client-auth to preselect (`"basic"` for providers
+   *  that require HTTP Basic). Only `"basic"` is advertised; absent means body. */
+  readonly defaultTokenEndpointAuthMethod?: "body" | "basic";
 }
 
 export interface AuthMethod {
@@ -175,6 +182,8 @@ function authMethodFromDescriptor(descriptor: AuthMethodDescriptor): AuthMethod 
         discoveryUrl: oauth?.discoveryUrl,
         supportsDynamicRegistration: oauth?.supportsDynamicRegistration,
         supportsClientIdMetadataDocument: oauth?.supportsClientIdMetadataDocument,
+        defaultGrant: oauth?.defaultGrant,
+        defaultTokenEndpointAuthMethod: oauth?.defaultTokenEndpointAuthMethod,
       },
     };
   }

--- a/packages/react/src/pages/integration-detail.tsx
+++ b/packages/react/src/pages/integration-detail.tsx
@@ -119,6 +119,7 @@ export function IntegrationDetailPage(props: { namespace: string }) {
       const authorizationUrl = search.get("authorizationUrl");
       const tokenUrl = search.get("tokenUrl");
       const resource = search.get("resource");
+      const tokenEndpointAuthMethod = search.get("tokenEndpointAuthMethod");
       return {
         ...(slug != null && slug.length > 0 ? { slug } : {}),
         ...(grant != null && grant.length > 0 ? { grant } : {}),
@@ -126,6 +127,9 @@ export function IntegrationDetailPage(props: { namespace: string }) {
         ...(authorizationUrl != null && authorizationUrl.length > 0 ? { authorizationUrl } : {}),
         ...(tokenUrl != null && tokenUrl.length > 0 ? { tokenUrl } : {}),
         ...(resource != null && resource.length > 0 ? { resource } : {}),
+        ...(tokenEndpointAuthMethod === "basic" || tokenEndpointAuthMethod === "body"
+          ? { tokenEndpointAuthMethod }
+          : {}),
       };
     })();
     return {


### PR DESCRIPTION
## Summary

Adds OAuth2 `client_credentials` (service-account) support to the **MCP** and **GraphQL** plugins. Previously these integrations could only authenticate OAuth via the interactive `authorization_code` flow (acts as the connecting user) or a static, never-refreshed bearer string. Now an integration can declare a token endpoint and have executor mint and refresh a `client_credentials` token itself: one shared app identity, no per-user sign-in.

The token mint/refresh/storage machinery already lived in `core/sdk` and is grant-aware. The bulk of this change is making the MCP and GraphQL auth methods **endpoint-ful** (carry `tokenUrl` + `scopes` + `resource`) so they can hand that machinery a token endpoint, and reusing the existing connect/start flow (which is plugin-agnostic).

## What changed

- **core:** a per-client `token_endpoint_auth_method` (`"body"` | `"basic"`), threaded through the `client_credentials` mint, the `authorization_code` exchange, and the refresh/re-mint path. Some providers (e.g. Linear's `client_credentials` grant) require HTTP Basic at the token endpoint, which nothing persisted before. Only `"basic"` is ever materialized; `"body"` (`client_secret_post`) stays the implicit default, so existing clients and rows are untouched. Nullable column + generated cloud/local migrations (each a single `ADD COLUMN`).
- **descriptor:** `defaultGrant` + `defaultTokenEndpointAuthMethod` on the shared auth-method descriptor (SDK type, API wire mirror, React type), consumed by the shared add-account connect flow so a service-account integration pre-fills the right grant and client-auth.
- **graphql / mcp:** `oauth2` methods gain optional endpoint fields; `describe-auth-methods` and the React converters round-trip them. GraphQL's Add UI now allows the `oauth` kind. **MCP runtime is unchanged** (the resolved, refreshing token still flows through the MCP SDK's `OAuthClientProvider`); endpoint-ful methods omit `discoveryUrl` so the DCR path stays off and the pre-seeded BYO-app form is used.
- **agent surface:** `oauth.clients.list` and `oauth.clients.createHandoff` round-trip the field.

## Tests

- `OAuthTestServer` can now enforce and record the client-auth transport (`requireClientAuthMethod` + a `tokenRequestAuthMethods` ledger), plus a spec fix to URL-decode HTTP Basic credentials per RFC 6749 §2.3.1.
- Core: HTTP Basic on the `client_credentials` mint, body-rejected, expiry re-mint, and the `authorization_code` exchange; `oauth.clients.list` round-trip; `createHandoff` URL materializes only `basic`.
- Real end-to-end `client_credentials` tests for **both** MCP and GraphQL: mint a token via Basic, then make a real tool call / query through the transport and assert the token was accepted and Basic was used.

Full `typecheck`, `lint`, `format:check`, and `test` are green.

## Notes

- GraphQL has no edit sheet, so the read-modify-write field-loss class does not apply there (add-only).
- Verifying client_credentials against Linear specifically requires toggling "client credentials tokens" on in the provider's OAuth app.

Draft: opening for review of the approach before finalizing.
