### PR TITLE
Refresh homepage nav

### DIFF
--- a/apps/marketing/src/lib/github.ts
+++ b/apps/marketing/src/lib/github.ts
@@ -1,0 +1,64 @@
+// GitHub repo metadata for the nav's "Star on GitHub" pill.
+//
+// The marketing site is SSR (astro.config `output: "server"`) on Cloudflare
+// Workers, so this runs per request rather than at build time. To keep that
+// cheap and resilient we:
+//   - memoize the count in module scope with a TTL, so a warm isolate hits the
+//     GitHub API at most once per window and dedupes concurrent requests;
+//   - hint Cloudflare to edge-cache the upstream response (ignored by Node in
+//     `astro dev`);
+//   - time out fast so a slow upstream never holds up the homepage; and
+//   - resolve to null on any failure, in which case the nav simply drops the
+//     count and keeps the link.
+
+const REPO = "RhysSullivan/executor";
+
+export const GITHUB_REPO_URL = `https://github.com/${REPO}`;
+
+/** Compact star count, e.g. 1234 -> "1.2k". */
+export function formatStars(n: number): string {
+  return n >= 1000 ? `${(n / 1000).toFixed(1).replace(/\.0$/, "")}k` : String(n);
+}
+
+const TTL_OK_MS = 30 * 60 * 1000; // cache a real count for ~30 min per isolate
+const TTL_FAIL_MS = 60 * 1000; // but retry soon after a miss, never pin a null
+const TIMEOUT_MS = 4000;
+
+let cached: { value: number | null; at: number } | null = null;
+let inflight: Promise<number | null> | null = null;
+
+async function fetchStars(): Promise<number | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  try {
+    const init: RequestInit & { cf?: { cacheTtl: number; cacheEverything: boolean } } = {
+      headers: { "User-Agent": "executor.sh", Accept: "application/vnd.github+json" },
+      signal: controller.signal,
+      cf: { cacheTtl: 1800, cacheEverything: true },
+    };
+    const res = await fetch(`https://api.github.com/repos/${REPO}`, init);
+    if (!res.ok) return null;
+    const data = (await res.json()) as { stargazers_count?: number };
+    return typeof data.stargazers_count === "number" ? data.stargazers_count : null;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Live star count, memoized per isolate with a TTL. null when unavailable. */
+export function getStars(): Promise<number | null> {
+  const now = Date.now();
+  if (cached) {
+    const ttl = cached.value != null ? TTL_OK_MS : TTL_FAIL_MS;
+    if (now - cached.at < ttl) return Promise.resolve(cached.value);
+  }
+  if (inflight) return inflight;
+  inflight = fetchStars().then((value) => {
+    cached = { value, at: Date.now() };
+    inflight = null;
+    return value;
+  });
+  return inflight;
+}

--- a/apps/marketing/src/pages/index.astro
+++ b/apps/marketing/src/pages/index.astro
@@ -6,8 +6,14 @@ import { SelfHostContactModal } from "../components/self-host-contact-modal";
 // Imported so Vite emits it as a hashed build asset (served from /_astro/...);
 // the deploy pipeline does not pick up newly added /public files.
 import ycBackedBy from "../assets/yc-backed-by.svg?url";
+import { getStars, formatStars } from "../lib/github";
 
 const GH = "https://github.com/RhysSullivan/executor";
+// Cloud sign-in. Same origin in prod: the cloud Worker owns executor.sh and
+// /api/* is app-owned (apps/cloud/src/app-paths.ts), so this hits the WorkOS
+// login flow directly. Returning users land here; new users use Get started.
+const SIGN_IN = "/api/auth/login";
+const stars = await getStars();
 
 // Copied to the clipboard by the "Set up with your agent" hero CTA. A visitor
 // pastes it into their coding agent (Claude, Cursor, ...) and the agent picks
@@ -63,7 +69,7 @@ Source (and the place to start if something breaks): https://github.com/RhysSull
 
     <div class="relative z-10">
       {/* ─── NAV ─── */}
-      <nav>
+      <nav class="border-b border-rule bg-surface">
         <div
           class="max-w-[1200px] mx-auto px-6 sm:px-10 h-14 flex items-center justify-between"
         >
@@ -73,28 +79,49 @@ Source (and the place to start if something breaks): https://github.com/RhysSull
               >executor</span
             >
           </a>
-          <div class="flex items-center gap-5">
-            <a
-              href="#pricing"
-              class="text-[14px] font-medium text-ink-2 hover:text-ink transition-colors hidden sm:inline"
-              >Pricing</a
-            >
-            <a
-              href="https://executor.sh/docs"
-              class="text-[14px] font-medium text-ink-2 hover:text-ink transition-colors hidden sm:inline"
-              >Docs</a
-            >
-            <a
-              href="/blog"
-              class="text-[14px] font-medium text-ink-2 hover:text-ink transition-colors hidden sm:inline"
-              >Blog</a
-            >
-            <a
-              href={GH}
-              class="text-[14px] font-medium text-ink-2 hover:text-ink transition-colors"
-              >GitHub</a
-            >
-            <a href="#install" class="btn-primary">Get started →</a>
+          <div class="flex items-center gap-6 sm:gap-7">
+            <div class="flex items-center gap-5">
+              <a
+                href={GH}
+                target="_blank"
+                rel="noopener"
+                class="gh-star"
+                aria-label="Star Executor on GitHub"
+              >
+                <svg
+                  class="gh-star__ico"
+                  width="13"
+                  height="13"
+                  viewBox="0 0 16 16"
+                  aria-hidden="true"
+                >
+                  <path
+                    fill="#e3b341"
+                    d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25z"
+                  ></path>
+                </svg>
+                <span class="hidden sm:inline">star on github</span>
+                {stars != null && <span class="gh-star__n">{formatStars(stars)}</span>}
+              </a>
+              <a
+                href="https://executor.sh/docs"
+                class="text-[14px] font-medium text-ink-2 hover:text-ink transition-colors hidden sm:inline"
+                >Docs</a
+              >
+              <a
+                href="/blog"
+                class="text-[14px] font-medium text-ink-2 hover:text-ink transition-colors hidden sm:inline"
+                >Blog</a
+              >
+            </div>
+            <div class="flex items-center gap-4">
+              <a
+                href={SIGN_IN}
+                class="text-[14px] font-medium text-ink-2 hover:text-ink transition-colors hidden sm:inline"
+                >Sign in</a
+              >
+              <a href="#install" class="btn-primary btn-primary--nav">Get started →</a>
+            </div>
           </div>
         </div>
       </nav>

--- a/apps/marketing/src/styles/global.css
+++ b/apps/marketing/src/styles/global.css
@@ -138,6 +138,16 @@ body {
   background: #1f1f24;
 }
 
+/* Compact nav variant: height matched to the gh-star pill (and its 7px radius)
+   so the right cluster reads as one even row. */
+.btn-primary--nav {
+  display: inline-flex;
+  align-items: center;
+  height: 31px;
+  padding: 0 0.95rem;
+  border-radius: 7px;
+}
+
 /* Light, bordered counterpart to .btn-primary, a real secondary CTA. Sized to
    match .btn-primary--hero so it balances under the hero's primary button. */
 .btn-secondary {
@@ -180,6 +190,38 @@ body {
 }
 .btn-link:hover {
   color: var(--color-ink);
+}
+
+/* GitHub "star on github" pill (nav), matching integrations.sh: a gold star,
+   a lowercase mono label, and the count behind a hairline divider. All mono,
+   the metadata voice. The star is the one bit of color, kept to the icon. */
+.gh-star {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 5px 11px;
+  border: 1px solid var(--color-rule);
+  border-radius: 7px;
+  color: var(--color-ink-2);
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  white-space: nowrap;
+  transition:
+    color 0.15s ease,
+    border-color 0.15s ease;
+}
+.gh-star:hover {
+  color: var(--color-ink);
+  border-color: var(--color-rule-strong);
+}
+.gh-star__ico {
+  flex-shrink: 0;
+}
+.gh-star__n {
+  font-variant-numeric: tabular-nums;
+  color: var(--color-ink-3);
+  padding-left: 8px;
+  border-left: 1px solid var(--color-rule);
 }
 
 .copy-icons {


### PR DESCRIPTION
Updates the marketing homepage nav:

- **Drop the Pricing link** from the nav (the pricing section further down the page is unchanged).
- **GitHub link → star-on-github pill** showing the live repo star count. The count is fetched server-side with a short in-memory TTL cache, a fast timeout, and a graceful fallback (the count just drops if the API is unavailable). Placed at the left of the right-hand cluster.
- **Add a top-level Sign in link** pointing at the cloud auth flow (`/api/auth/login`).
- **Nav band** is now opaque with a bottom hairline, so the hero's graph-paper grid no longer bleeds through it.
- **Tidier rhythm:** browse links and the auth cluster are grouped, and the nav Get started button is sized to match the pill height.

Scoped entirely to `apps/marketing`.