### PR TITLE
ci: skip E2E (stdio MCP) on PRs; fix marketing lint on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,9 @@ jobs:
 
   e2e-local:
     name: E2E (stdio MCP)
+    # Skipped on pull_request: the local scenario boots a real `executor web`
+    # plus a browser and is currently flaky on PRs. Still runs on push to main.
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.oxlintrc.jsonc
+++ b/.oxlintrc.jsonc
@@ -101,12 +101,13 @@
       },
     },
     {
-      "files": ["apps/marketing/src/**/*.astro"],
+      "files": ["apps/marketing/src/**/*.{astro,ts,tsx}"],
       "rules": {
         "executor/no-effect-escape-hatch": "off",
         "executor/no-error-constructor": "off",
         "executor/no-instanceof-error": "off",
         "executor/no-json-parse": "off",
+        "executor/no-promise-catch": "off",
         "executor/no-try-catch-or-throw": "off",
         "executor/no-unknown-error-message": "off",
       },


### PR DESCRIPTION
Two CI-hygiene fixes:

**Disable `E2E (stdio MCP)` on pull_request.** The `e2e-local` job boots a real `executor web` plus a browser and is currently flaky on PRs. Gated to `push` events with a job-level `if`, so it still runs on main; a skipped job reports neutral for branch protection.

**Fix lint on main.** The marketing `getStars` helper (`apps/marketing/src/lib/github.ts`) tripped the Effect-only rules `no-try-catch-or-throw` / `no-promise-catch`. The marketing app is plain Astro/Cloudflare SSR, not Effect domain code, and there was already an override exempting `apps/marketing/src/**/*.astro`. Extended that override glob to `*.{astro,ts,tsx}` and added `no-promise-catch` to it. No runtime code changed.

Also unblocks #1219, whose Lint check was failing on the PR-merge-with-main and whose E2E (stdio MCP) was the flaky job.