### PR TITLE
fix(host-selfhost): serve correct Cache-Control for the web app

### DIFF
--- a/.changeset/selfhost-spa-cache-headers.md
+++ b/.changeset/selfhost-spa-cache-headers.md
@@ -1,0 +1,5 @@
+---
+"@executor-js/host-selfhost": patch
+---
+
+Send correct `Cache-Control` headers for the self-hosted web app. The SPA shell (`index.html`) and its client-route fallbacks are now served with `no-cache`, so a new deploy is picked up on the next visit instead of the browser rendering a stale UI from cache until a hard refresh. Content-hashed `/assets/*` are served `immutable` and cached long-term.

--- a/apps/host-selfhost/src/serve.ts
+++ b/apps/host-selfhost/src/serve.ts
@@ -35,6 +35,7 @@ import {
 import { stripMcpOrgSegment } from "./mcp/org-path";
 
 const distDir = fileURLToPath(new URL("../dist/", import.meta.url));
+const assetsDir = fileURLToPath(new URL("../dist/assets/", import.meta.url));
 
 // Rewrite `/<org>/mcp` (and its OAuth discovery path) to the bare path before
 // routing, so the "Connect an agent" card's org-pinned URL reaches the real
@@ -71,14 +72,32 @@ export const startServer = async (): Promise<void> => {
   const config = loadConfig();
   const { AppLayer, betterAuth } = await makeSelfHostApp();
 
-  // Serve the built SPA. Specific API/docs/auth/mcp routes take precedence;
-  // `spa: true` falls back to index.html for any other path (client routing).
-  const StaticLive = HttpStaticServer.layer({ root: distDir, spa: true }).pipe(
-    Layer.provide(BunFileSystem.layer),
-    Layer.provide(BunPath.layer),
-  );
+  // Serve the built SPA, split by cacheability so a redeploy is picked up at
+  // once instead of stranding browsers on a stale shell:
+  //   - `/assets/*` are Vite content-hashed (a new build emits new filenames),
+  //     so they're safe to cache forever.
+  //   - index.html (and the SPA fallback for client routes) is the mutable
+  //     entry point that references those hashes; it must always revalidate, or
+  //     a browser keeps an old index.html plus its old hashed bundles (still in
+  //     cache) and renders a stale UI until a hard refresh.
+  // Without explicit headers `HttpStaticServer` sends no Cache-Control at all,
+  // so browsers heuristically cache index.html across deploys. The hashed
+  // `/assets` route is the more specific match, so it wins over the SPA
+  // catch-all. Other built-in API/docs/auth/mcp routes still take precedence;
+  // `spa: true` falls back to index.html for any remaining path (client routing).
+  const AssetsLive = HttpStaticServer.layer({
+    root: assetsDir,
+    prefix: "/assets",
+    cacheControl: "public, max-age=31536000, immutable",
+  }).pipe(Layer.provide(BunFileSystem.layer), Layer.provide(BunPath.layer));
 
-  const ServerLive = HttpRouter.serve(Layer.mergeAll(AppLayer, StaticLive), {
+  const SpaLive = HttpStaticServer.layer({
+    root: distDir,
+    spa: true,
+    cacheControl: "no-cache",
+  }).pipe(Layer.provide(BunFileSystem.layer), Layer.provide(BunPath.layer));
+
+  const ServerLive = HttpRouter.serve(Layer.mergeAll(AppLayer, AssetsLive, SpaLive), {
     middleware: selfHostHttpMiddleware(betterAuth),
   }).pipe(
     Layer.provide(


### PR DESCRIPTION
## Problem

On a self-hosted instance, the web app could look like it had **two different versions of the UI**: visiting the root showed an older build, while navigating to a route like `/default` (or hard-refreshing) showed the newer build.

The cause is HTTP caching. The server served `index.html` with an `ETag`/`Last-Modified` but **no `Cache-Control`**, so browsers apply heuristic freshness and reuse the cached entry document across deploys. Because the content-hashed `/assets/*` bundles from the previous visit are also still in the browser cache, a revisit to a previously-loaded URL renders an entirely-cached old shell + old bundles (the old UI), with no network hit. A URL the browser never cached as a document fetches fresh and shows the new UI. A hard refresh "fixes" it, which is the fingerprint of this bug.

The same shell with no `Cache-Control` can also produce a *broken* page rather than just an old one, if the browser evicted some old hashed chunks but kept the old `index.html`, the new shell's now-missing chunks fail to load.

## Fix

Split static serving by cacheability:

- `/assets/*` (Vite content-hashed, new build emits new filenames) -> `public, max-age=31536000, immutable`
- `index.html` and its SPA fallbacks (the mutable entry point) -> `no-cache`, so the shell always revalidates (ETag -> `304` when unchanged, a fresh `200` after a deploy)

The hashed `/assets` route is the more specific match, so it wins over the SPA catch-all. API/auth/MCP/docs routes are unaffected. This mirrors how the desktop/local server already serves its shell (`no-store` on `index.html`).

## Verification

Built and booted the real self-host server, then checked each path class:

| Path | Status | `Cache-Control` |
| --- | --- | --- |
| `/`, `/default`, `/default/policies` | 200 | `no-cache` |
| `/assets/index-*.js` | 200 | `public, max-age=31536000, immutable` |
| `/assets/<missing>.js` | 404 | (no HTML fallback, so stale chunks don't 200-as-HTML) |
| `/api/health` | 200 | untouched (JSON) |
| conditional `GET /` (`If-None-Match`) | 304 | 0 bytes (revalidation stays cheap) |

Gates: typecheck, lint, format, and the host-selfhost suite (70/70) all pass.
