### PR TITLE
chore(release): ship the self-hosted Cache-Control fix as a patch (1.5.26)

### DIFF
--- a/.changeset/selfhost-spa-cache-headers.md
+++ b/.changeset/selfhost-spa-cache-headers.md
@@ -1,4 +1,5 @@
 ---
+"executor": patch
 "@executor-js/host-selfhost": patch
 ---
 


### PR DESCRIPTION
Follow-up to #1221 so the self-hosted `Cache-Control` fix actually ships.

#1221 landed the fix with a `@executor-js/host-selfhost`-only changeset. That package is private and outside the `fixed` release group, so it does not bump the CLI/train version, and the self-host Docker image only publishes when the CLI version bumps (`publish-executor-package.yml` dispatches `publish-selfhost-docker.yml` on the release tag). As-is, the fix would sit on `main` without a self-host release.

This adds an `executor` patch to the existing changeset so the `fixed` group cascades to the next patch and the self-host image rebuilds and publishes.

Verified locally with `changeset version` from a pristine `main`: `executor` goes **1.5.25 -> 1.5.26** (patch only, no minor), and the fix's body becomes the 1.5.26 release-notes entry.
