### PR TITLE
test: allow slow storage recovery tests to finish

### DIFF
--- a/apps/local/src/db/owned-database.test.ts
+++ b/apps/local/src/db/owned-database.test.ts
@@ -213,7 +213,7 @@ describe("openOwnedLocalDatabase", () => {
       // The next sole owner resumes the journaled flip during open (recovery
       // runs completeJournaledFlip before the serving connection opens). The
       // steady-state migrate then sees an already-v2 DB, so migration.migrated
-      // is false even though the on-disk DB is now v2 — the cleared journal and
+      // is false even though the on-disk DB is now v2, the cleared journal and
       // the v2 rows are the real proof.
       const owned = await openOwnedLocalDatabase({
         dataDir,
@@ -237,7 +237,7 @@ describe("openOwnedLocalDatabase", () => {
       child.child.stderr.destroy();
       rmSync(workDir, { recursive: true, force: true });
     }
-  });
+  }, 15_000);
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/local/src/db/v1-v2-migration.test.ts
+++ b/apps/local/src/db/v1-v2-migration.test.ts
@@ -48,7 +48,7 @@ const decodeMigrationJournalForTest = Schema.decodeUnknownSync(
   Schema.fromJsonString(MigrationJournalForTest),
 );
 const decodeUnknownJson = Schema.decodeUnknownSync(Schema.fromJsonString(Schema.Unknown));
-// Preserves every journal field (`when`, `breakpoints`, …) — drizzle's
+// Preserves every journal field (`when`, `breakpoints`, ...), drizzle's
 // migrator needs them, so only `entries` is typed for the truncation filter.
 const decodeJournal = (text: string) =>
   decodeUnknownJson(text) as {
@@ -1249,7 +1249,7 @@ describe("local v1 -> v2 migration", () => {
     expect(result.migrated).toBe(true);
     expect(existsSync(`${dbPath}.v1-v2-migration.json`)).toBe(false);
     await assertMigratedStripeDbAndSecret({ dbPath, scopeId, secret, walMarker });
-  });
+  }, 15_000);
 
   it("recovers when killed after external secret writes but before SQL commit", async () => {
     const scopeId = "executor-secrets-before-commit";
@@ -1782,7 +1782,7 @@ describe("local v1 -> v2 migration", () => {
   });
 
   // Regression: a database last touched by a release OLDER than v1-final
-  // (pre-0011 — no `plugin_storage` table) must be replayed through the
+  // (pre-0011, no `plugin_storage` table) must be replayed through the
   // bundled legacy drizzle chain before the v1→v2 data migration reads it.
   // Without the replay, migration crashed with "no such table: plugin_storage"
   // on every fresh 1.5.0 install over old data.

--- a/packages/core/sdk/src/plugin-storage.test.ts
+++ b/packages/core/sdk/src/plugin-storage.test.ts
@@ -222,29 +222,32 @@ describe("plugin storage collections", () => {
     }),
   );
 
-  it.effect("bulk puts large plugin storage row sets in bounded batches", () =>
-    Effect.gen(function* () {
-      const executor = yield* makeTestExecutor({
-        backend: "sqlite",
-        plugins: [executionHistoryPlugin] as const,
-      });
-      const rows = Array.from({ length: 7_000 }, (_, index) => ({
-        key: `large-call-${String(index).padStart(5, "0")}`,
-        data: call({
-          runId: "run-large-bulk",
-          toolId: index % 2 === 0 ? "browser" : "shell",
-          status: "ok",
-          startedAt: new Date(Date.UTC(2026, 4, 29, 12, 0, index)).toISOString(),
-        }),
-      }));
+  it.effect(
+    "bulk puts large plugin storage row sets in bounded batches",
+    () =>
+      Effect.gen(function* () {
+        const executor = yield* makeTestExecutor({
+          backend: "sqlite",
+          plugins: [executionHistoryPlugin] as const,
+        });
+        const rows = Array.from({ length: 7_000 }, (_, index) => ({
+          key: `large-call-${String(index).padStart(5, "0")}`,
+          data: call({
+            runId: "run-large-bulk",
+            toolId: index % 2 === 0 ? "browser" : "shell",
+            status: "ok",
+            startedAt: new Date(Date.UTC(2026, 4, 29, 12, 0, index)).toISOString(),
+          }),
+        }));
 
-      yield* executor.executionHistory.recordMany("org", rows);
+        yield* executor.executionHistory.recordMany("org", rows);
 
-      const count = yield* executor.executionHistory.count({
-        where: { runId: "run-large-bulk" },
-      });
-      expect(count).toBe(rows.length);
-    }),
+        const count = yield* executor.executionHistory.count({
+          where: { runId: "run-large-bulk" },
+        });
+        expect(count).toBe(rows.length);
+      }),
+    15_000,
   );
 
   it.effect("user rows shadow org rows on read; both share one plugin_storage table", () =>


### PR DESCRIPTION
## Summary

- Add explicit 15s timeouts to three intentionally slow storage and migration recovery tests.
- Remove em dashes in touched comments so the edited files follow repo prose rules.

## Verification

- bun run format:check
- bun run lint
- bun run typecheck
- bun run test
