### PR TITLE
Bind Cmd+[ / Cmd+] to back/forward in the desktop app

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -989,12 +989,44 @@ const installApplicationMenu = () => {
     label: "File",
     submenu: [{ role: "close" }],
   };
+  // The web shell navigates with browser history (TanStack Router pushState),
+  // but Electron binds none of the history shortcuts by default and the menu is
+  // built from roles, none of which carry Back/Forward. So the standard macOS
+  // Cmd+[ / Cmd+] (Ctrl+[ / Ctrl+] elsewhere) are dead keys inside the desktop
+  // window, with no browser chrome to fall back on. Bind them here, driving the
+  // focused window's navigation history. canGo* guards keep the keys no-ops at
+  // the ends of the stack, matching how they behave in a browser.
+  const navigateHistory = (direction: "back" | "forward") => {
+    const nav = BrowserWindow.getFocusedWindow()?.webContents.navigationHistory;
+    if (!nav) return;
+    if (direction === "back") {
+      if (nav.canGoBack()) nav.goBack();
+    } else if (nav.canGoForward()) {
+      nav.goForward();
+    }
+  };
+  const historyMenu: MenuItemConstructorOptions = {
+    label: "History",
+    submenu: [
+      {
+        label: "Back",
+        accelerator: "CmdOrCtrl+[",
+        click: () => navigateHistory("back"),
+      },
+      {
+        label: "Forward",
+        accelerator: "CmdOrCtrl+]",
+        click: () => navigateHistory("forward"),
+      },
+    ],
+  };
   Menu.setApplicationMenu(
     Menu.buildFromTemplate([
       appMenu,
       fileMenu,
       { role: "editMenu" },
       { role: "viewMenu" },
+      historyMenu,
       { role: "windowMenu" },
     ]),
   );


### PR DESCRIPTION
## Problem

In the desktop app, the standard macOS back/forward shortcuts (Cmd+[ and Cmd+]) do nothing. The window loads the web shell, which navigates with browser history (TanStack Router pushState). On the web the browser chrome handles those keys, but inside the Electron window there is no chrome, and the application menu is built entirely from Electron roles (editMenu, viewMenu, windowMenu), none of which carry Back or Forward. Electron binds none of these shortcuts by default, so the keys were dead.

## Fix

Add a History menu with Back (Cmd+[) and Forward (Cmd+]), Ctrl+[ / Ctrl+] on Windows and Linux, that drives the focused window's `webContents.navigationHistory`. The `canGoBack` / `canGoForward` guards make the keys no-ops at the ends of the history stack, matching how they behave in a browser. This follows the existing pattern in the same file where an explicit File menu was added purely to bind the Cmd+W close accelerator. It also places these shortcuts where Safari and Chrome put them.

## Verification

- `bun run typecheck` (apps/desktop), `oxlint` with `--deny-warnings`, and `oxfmt --check` all pass.
- This is a native menu accelerator, so it is not exercised by the web e2e harness. Manual check: open the app, navigate between a few views, then press Cmd+[ to go back and Cmd+] to go forward.