### PR TITLE
Add a skills tool and slim the execute description

### DIFF
--- a/e2e/scenarios/tool-descriptions.test.ts
+++ b/e2e/scenarios/tool-descriptions.test.ts
@@ -398,13 +398,13 @@ scenario(
         const graphqlTools = yield* snapshotFor(graphqlSlug);
 
         // The execute tool's description over the real MCP surface — the
-        // connection-prefix inventory an MCP client (and its model) reads.
+        // connected-integration inventory an MCP client (and its model) reads.
         // Only this run's lines: the shared selfhost admin may have other
-        // connections in the inventory.
+        // integrations in the inventory.
         const readInventory = () =>
           Effect.map(mcp.session(identity).describeTools(), (mcpTools) =>
             (mcpTools.find((tool) => tool.name === "execute")?.description ?? "")
-              .split("## Available connection prefixes")[1]
+              .split("## Available integrations")[1]
               ?.split("\n")
               .filter(
                 (line) =>

--- a/packages/core/execution/README.md
+++ b/packages/core/execution/README.md
@@ -99,10 +99,21 @@ import type { ExecutionEngine } from "@executor-js/execution";
 
 declare const engine: ExecutionEngine;
 
-const docs = await engine.getDescription();
-// Returns the canonical "use tools.search(), then tools.describe.tool(), then call …"
-// workflow prose + per-namespace tool listing. Feed this to an LLM so it knows
-// how to drive the sandbox.
+const description = await engine.getDescription();
+// Returns the short `execute` tool description: a one-line intro, a pointer to
+// the `execute` skill, and the live connection-prefix inventory. Feed this to
+// an LLM as the execute tool's description.
+```
+
+The full "use tools.search(), then tools.describe.tool(), then call ..." workflow
+prose lives in the `execute` skill rather than the always-loaded description, so a
+model that never runs code does not pay for it. MCP hosts expose it through the
+`skills` tool; to read it directly:
+
+```ts
+import { EXECUTE_SKILL } from "@executor-js/execution";
+
+const howTo = EXECUTE_SKILL.body;
 ```
 
 ## Using with Effect

--- a/packages/core/execution/src/description.test.ts
+++ b/packages/core/execution/src/description.test.ts
@@ -37,9 +37,9 @@ const GITHUB = IntegrationSlug.make("github");
 const SLACK = IntegrationSlug.make("slack");
 const TEMPLATE = AuthTemplateSlug.make("apiKey");
 
-// v2 port: available entries are saved connection prefixes, not integration
-// slugs. Multiple saved connections can point at the same integration, and the
-// callable path needs `<integration>.<owner>.<connection>`.
+// The execute description lists the top-level integrations the user has
+// connected: one bare line per integration slug, deduped across connections,
+// names only (no per-integration descriptions).
 const githubPlugin = definePlugin(() => ({
   id: "github-plugin" as const,
   credentialProviders: [memoryProvider()],
@@ -68,8 +68,10 @@ const slackPlugin = definePlugin(() => ({
   }),
 }))();
 
+const occurrences = (haystack: string, needle: string): number => haystack.split(needle).length - 1;
+
 describe("buildExecuteDescription", () => {
-  it.effect("renders real connection prefixes separately through the real executor flow", () =>
+  it.effect("lists the connected integrations, not the connection prefixes", () =>
     Effect.gen(function* () {
       const executor = yield* createExecutor(
         makeTestConfig({ plugins: [slackPlugin, githubPlugin] as const }),
@@ -93,72 +95,36 @@ describe("buildExecuteDescription", () => {
 
       const description = yield* buildExecuteDescription(executor);
 
-      // Stable anchor from the workflow preamble.
+      // Stable anchor from the short preamble.
       expect(description).toContain("Execute TypeScript in a sandboxed runtime");
-      expect(description).toContain("Use `emit(value)` to append user-visible output");
-      expect(description).toContain("Emit any attachment with `emit(result.data)`");
-      expect(description).toContain("pass an MCP content block to `emit(...)`");
-      expect(description).toContain("`emit(ToolFile)` is MIME-based");
-      expect(description).toContain(
-        "Returning a `ToolFile`, a `ToolResult`, an MCP content block, or a bare base64 string does not emit content",
-      );
-      expect(description).toContain("## Available connection prefixes");
-      expect(description).toContain("- `github.org.prod`");
-      expect(description).toContain("- `github.user.personal`");
-      expect(description).not.toContain("## Available namespaces");
+      // The full how-to now lives behind the `skills` tool, so the description
+      // points there rather than inlining the workflow/rules.
+      expect(description).toContain('skills({ name: "execute" })');
+      expect(description).not.toContain("Use `emit(value)` to append user-visible output");
+      expect(description).not.toContain("## Workflow");
+      expect(description).not.toContain("## Rules");
+      // Top-level integration slug, deduped across the two github connections.
+      expect(description).toContain("## Available integrations");
+      expect(description).toContain("- `github`");
+      expect(occurrences(description, "- `github`")).toBe(1);
+      // The per-connection prefixes are gone.
+      expect(description).not.toContain("github.org.prod");
+      expect(description).not.toContain("github.user.personal");
+      // Slack is registered but unconnected, so it is not listed.
+      expect(description).not.toContain("- `slack`");
       expect(description).not.toContain("workspace messages");
       expect(description).not.toContain("`github-plugin`");
       expect(description).not.toContain("`slack-plugin`");
-      expect(description).not.toContain("- `github`");
-
-      const orgIdx = description.indexOf("`github.org.prod`");
-      const userIdx = description.indexOf("`github.user.personal`");
-      expect(orgIdx).toBeGreaterThan(-1);
-      expect(userIdx).toBeGreaterThan(-1);
-      expect(orgIdx).toBeLessThan(userIdx);
     }),
   );
 
-  it.effect("annotates prefixes with connection or integration descriptions", () =>
+  it.effect("lists integration names only, with no descriptions", () =>
     Effect.gen(function* () {
       const executor = yield* createExecutor(
         makeTestConfig({ plugins: [slackPlugin, githubPlugin] as const }),
       );
       yield* executor["slack-plugin"].seed();
       yield* executor["github-plugin"].seed();
-      yield* executor.connections.create({
-        owner: "org",
-        name: ConnectionName.make("prod"),
-        integration: GITHUB,
-        template: TEMPLATE,
-        value: "org-token",
-        description: "Production org — issues and PRs only.",
-      });
-      yield* executor.connections.create({
-        owner: "user",
-        name: ConnectionName.make("personal"),
-        integration: GITHUB,
-        template: TEMPLATE,
-        value: "user-token",
-      });
-
-      const description = yield* buildExecuteDescription(executor);
-
-      // The curated connection description rides its prefix line.
-      expect(description).toContain("- `github.org.prod` — Production org — issues and PRs only.");
-      // No connection description and the integration description ("GitHub")
-      // just restates the slug — the line stays bare.
-      expect(description).toContain("- `github.user.personal`");
-      expect(description).not.toContain("- `github.user.personal` —");
-    }),
-  );
-
-  it.effect("falls back to a meaningful integration description", () =>
-    Effect.gen(function* () {
-      const executor = yield* createExecutor(
-        makeTestConfig({ plugins: [slackPlugin, githubPlugin] as const }),
-      );
-      yield* executor["slack-plugin"].seed();
       yield* executor.connections.create({
         owner: "org",
         name: ConnectionName.make("main"),
@@ -166,21 +132,61 @@ describe("buildExecuteDescription", () => {
         template: TEMPLATE,
         value: "slack-token",
       });
+      yield* executor.connections.create({
+        owner: "org",
+        name: ConnectionName.make("prod"),
+        integration: GITHUB,
+        template: TEMPLATE,
+        value: "org-token",
+      });
 
       const description = yield* buildExecuteDescription(executor);
 
-      expect(description).toContain("- `slack.org.main` — Send and read workspace messages.");
+      // Bare slugs, sorted, with no per-integration description riding the line
+      // (Slack's "Send and read workspace messages." is dropped).
+      expect(description).toContain("- `github`");
+      expect(description).toContain("- `slack`");
+      expect(description).not.toContain("Send and read workspace messages");
+      expect(description).not.toContain("- `slack` —");
+      expect(description).not.toContain("- `github` —");
     }),
   );
 
-  it.effect("omits the Available connection prefixes section when no connections exist", () =>
+  it.effect("dedupes many connections of one integration into a single line", () =>
+    Effect.gen(function* () {
+      const executor = yield* createExecutor(makeTestConfig({ plugins: [githubPlugin] as const }));
+      yield* executor["github-plugin"].seed();
+      yield* executor.connections.create({
+        owner: "org",
+        name: ConnectionName.make("prod"),
+        integration: GITHUB,
+        template: TEMPLATE,
+        value: "org-token",
+      });
+      yield* executor.connections.create({
+        owner: "user",
+        name: ConnectionName.make("personal"),
+        integration: GITHUB,
+        template: TEMPLATE,
+        value: "user-token",
+      });
+
+      const description = yield* buildExecuteDescription(executor);
+
+      expect(occurrences(description, "- `github`")).toBe(1);
+      expect(description).not.toContain(".org.prod");
+      expect(description).not.toContain(".user.personal");
+    }),
+  );
+
+  it.effect("omits the Available integrations section when no connections exist", () =>
     Effect.gen(function* () {
       const executor = yield* createExecutor(makeTestConfig({ plugins: [] as const }));
 
       const description = yield* buildExecuteDescription(executor);
 
       expect(description).toContain("Execute TypeScript in a sandboxed runtime");
-      expect(description).not.toContain("## Available connection prefixes");
+      expect(description).not.toContain("## Available integrations");
     }),
   );
 });

--- a/packages/core/execution/src/description.ts
+++ b/packages/core/execution/src/description.ts
@@ -1,17 +1,22 @@
 import { Effect } from "effect";
-import type { Connection, Integration, Executor } from "@executor-js/sdk/core";
+import type { Connection, Executor } from "@executor-js/sdk/core";
 
 /**
- * Builds a tool description dynamically.
+ * Builds the `execute` tool description dynamically.
  *
  * Structure:
- *   1. Workflow (top — critical, least likely to be truncated)
- *   2. Available connection prefixes (bottom)
- *
- * v2: callable API tools are scoped by saved connections. A tool's sandbox
- * address is `tools.<integration>.<owner>.<connection>.<tool>`, so the useful
- * inventory is the connection prefix rather than only the integration slug.
+ *   1. One-line intro + pointer to the `execute` skill (the full how-to lives
+ *      behind the `skills` tool, see ./skills.ts, to keep this always-loaded
+ *      description small)
+ *   2. Available integrations (the live, per-session inventory): the top-level
+ *      integration slugs the user has connected, deduped across connections,
+ *      names only. The same block is appended to the `execute` skill content.
  */
+
+/** The header that opens the live integration inventory. Exported so the host
+ *  can locate (and re-use) the inventory block inside the built description. */
+export const INTEGRATION_INVENTORY_HEADER = "## Available integrations";
+
 export const buildExecuteDescription = (executor: Executor): Effect.Effect<string> =>
   Effect.gen(function* () {
     const connections: readonly Connection[] = yield* executor.connections.list().pipe(
@@ -19,15 +24,20 @@ export const buildExecuteDescription = (executor: Executor): Effect.Effect<strin
       Effect.orDie,
       Effect.withSpan("executor.connections.list"),
     );
-    const integrations: readonly Integration[] = yield* executor.integrations.list().pipe(
-      // oxlint-disable-next-line executor/no-effect-escape-hatch -- boundary: same getDescription error-channel constraint as connections.list above
-      Effect.orDie,
-      Effect.withSpan("executor.integrations.list"),
-    );
 
-    const description = yield* Effect.sync(() =>
-      formatDescription(connections.map((connection) => connectionEntry(connection, integrations))),
-    ).pipe(
+    const description = yield* Effect.sync(() => {
+      const lines = [
+        "Execute TypeScript in a sandboxed runtime.",
+        "",
+        'Before writing code, call `skills({ name: "execute" })` for the workflow on how to use this tool.',
+      ];
+      const inventory = formatIntegrationInventory(connections);
+      if (inventory.length > 0) {
+        lines.push("");
+        lines.push(inventory);
+      }
+      return lines.join("\n");
+    }).pipe(
       Effect.withSpan("schema.compile.description", {
         attributes: { "executor.connection_count": connections.length },
       }),
@@ -58,99 +68,26 @@ const connectionPath = (connection: Connection): string => {
   return address.startsWith("tools.") ? address.slice("tools.".length) : address;
 };
 
-/** One inventory line: the callable prefix plus the best available context.
- *  Connection description wins (the user wrote it about THIS credential);
- *  otherwise the integration description, unless it is just the slug again. */
-interface ConnectionInventoryEntry {
-  readonly prefix: string;
-  readonly description?: string;
-}
+// The live inventory block: the top-level integrations the user has connected,
+// one bare line per integration slug (deduped across connections, sorted), no
+// per-connection prefixes and no descriptions. Empty string when nothing is
+// connected.
+const INVENTORY_LIMIT = 50;
 
-const inventoryNote = (
-  text: string | null | undefined,
-  identityEchoes: readonly string[],
-): string | undefined => {
-  const firstLine = (text ?? "").split("\n", 1)[0]!.trim();
-  if (firstLine.length === 0) return undefined;
-  // A description that just restates the slug or display name carries no
-  // information beyond identity — drop it from the inventory line.
-  if (identityEchoes.some((echo) => firstLine.toLowerCase() === echo.toLowerCase())) {
-    return undefined;
-  }
-  return firstLine.length > 140 ? `${firstLine.slice(0, 139)}…` : firstLine;
-};
-
-const connectionEntry = (
-  connection: Connection,
-  integrations: readonly Integration[],
-): ConnectionInventoryEntry => {
-  const slug = String(connection.integration);
-  const integration = integrations.find((candidate) => String(candidate.slug) === slug);
-  const identityEchoes = [slug, ...(integration ? [integration.name] : [])];
-  return {
-    prefix: connectionPath(connection),
-    description:
-      inventoryNote(connection.description, identityEchoes) ??
-      inventoryNote(integration?.description, identityEchoes),
-  };
-};
-
-const formatDescription = (connectionEntries: readonly ConnectionInventoryEntry[]): string => {
-  const lines: string[] = [
-    "Execute TypeScript in a sandboxed runtime with access to configured API tools.",
+const formatIntegrationInventory = (connections: readonly Connection[]): string => {
+  const slugs = [...new Set(connections.map((connection) => String(connection.integration)))].sort(
+    (a, b) => a.localeCompare(b),
+  );
+  if (slugs.length === 0) return "";
+  const shown = slugs.slice(0, INVENTORY_LIMIT);
+  const lines = [
+    INTEGRATION_INVENTORY_HEADER,
     "",
-    "## Workflow",
-    "",
-    '1. `const { items: matches } = await tools.search({ query: "<intent + key nouns>", limit: 12 });`',
-    '2. `const path = matches[0]?.path; if (!path) return "No matching tools found.";`',
-    "3. `const details = await tools.describe.tool({ path });`",
-    "4. Use `details.inputTypeScript` / `details.outputTypeScript` and `details.typeScriptDefinitions` for compact shapes.",
-    "5. Use `tools.executor.coreTools.connections.list({})` when you need live saved-connection inventory.",
-    "6. Call the tool: `const result = await tools.<path>(input);`",
-    "",
-    "## Rules",
-    "",
-    "- `tools.search()` returns paginated, ranked matches: `{ items, total, hasMore, nextOffset }`. Best-first. Use short intent phrases like `github issues`, `repo details`, or `create calendar event`.",
-    '- When you already know the namespace, narrow with `tools.search({ namespace: "github", query: "issues" })`.',
-    "- `tools.executor.coreTools.connections.list({})` returns saved connections with `{ address, integration, owner, name, ... }`. The `address` field includes the leading `tools.` root.",
-    "- Tool calls return a value union: `{ ok: true, data }` for success or `{ ok: false, error: { code, message, status?, details?, retryable? } }` for expected tool/domain failures. Branch on `result.ok`.",
-    "- `data` is the upstream payload itself. HTTP-backed tools (OpenAPI) also set `http: { status, headers }` beside `data` — read `result.http?.headers` for pagination (Link) or rate-limit headers.",
-    "- Use `emit(value)` to append user-visible output and return `undefined`. Plain values become MCP text content. MCP content blocks are forwarded as-is. `ToolFile` values are rendered by MIME. Emitted output goes to the user, not back to you; the result envelope reports an `emitted` count so you can confirm it landed, but to read a value yourself, `return` it.",
-    '- File-returning tools may return `ToolFile` values: `{ _tag: "ToolFile", name?, mimeType, encoding: "base64", data, byteLength }`. Emit any attachment with `emit(result.data)`.',
-    '- To emit MCP-native content directly, pass an MCP content block to `emit(...)`, such as `{ type: "image", data, mimeType }`, `{ type: "audio", data, mimeType }`, `{ type: "text", text }`, `{ type: "resource", resource }`, or `{ type: "resource_link", uri, name, ... }`.',
-    "- `emit(ToolFile)` is MIME-based: `image/*` becomes MCP image content, `audio/*` becomes MCP audio content, text-like files become decoded text, and other binary files become embedded MCP resources.",
-    "- `return` is only for ordinary structured data. Returning a `ToolFile`, a `ToolResult`, an MCP content block, or a bare base64 string does not emit content to the MCP client.",
-    "- Some providers, including Gmail, return attachment bytes without a public URL. To send that attachment to another API from code, decode `ToolFile.data` from base64 and pass the bytes to that API's upload/file input.",
-    "- If `tools.search()` returns `hasMore: true` and you didn't find what you need, fetch the next page: `tools.search({ query, offset: nextOffset, limit })`.",
-    "- Always use the full address when calling tools: `tools.<integration>.<owner>.<connection>.<tool>(args)`. The `path` returned by `tools.search()` / `tools.describe.tool()` is already the exact path under `tools` — call `tools[path]` rather than guessing segments.",
-    "- The `tools` object is a lazy proxy — `Object.keys(tools)` won't work. Use `tools.search()` or `tools.executor.coreTools.connections.list({})` instead.",
-    '- Pass an object to system tools, e.g. `tools.search({ query: "..." })`, `tools.executor.coreTools.connections.list({})`, and `tools.describe.tool({ path })`.',
-    '- `tools.describe.tool()` returns compact TypeScript shapes. Use `inputTypeScript`, `outputTypeScript`, and `typeScriptDefinitions`. If the path doesn\'t resolve, the result carries `error: { code: "tool_not_found", suggestions }` — use a suggestion instead of retrying the same path.',
-    "- For tools that return large collections (e.g. `getStates`, `getAll`), filter results in code rather than calling per-item tools.",
-    "- Do not use `fetch` — all API calls go through `tools.*`.",
-    "- If execution pauses for interaction, resume it with the returned `resumePayload`.",
-    "- TypeScript type syntax (`: T`, `as T`, generics, interfaces, type aliases) is stripped before execution — feel free to write idiomatic TypeScript using the shapes from `tools.describe.tool()`. Decorators and `enum` are not supported.",
+    "Integrations you have connected. Their tools live under `tools.<integration>.…`.",
+    ...shown.map((slug) => `- \`${slug}\``),
   ];
-
-  if (connectionEntries.length > 0) {
-    lines.push("");
-    lines.push("## Available connection prefixes");
-    lines.push("");
-    lines.push("These are paths under `tools.`; append the final tool segment.");
-    const sorted = [...connectionEntries]
-      .sort((a, b) => a.prefix.localeCompare(b.prefix))
-      .slice(0, 50);
-    for (const entry of sorted) {
-      lines.push(
-        entry.description
-          ? `- \`${entry.prefix}\` — ${entry.description}`
-          : `- \`${entry.prefix}\``,
-      );
-    }
-    if (connectionEntries.length > sorted.length) {
-      lines.push(`- ... ${connectionEntries.length - sorted.length} more`);
-    }
+  if (slugs.length > shown.length) {
+    lines.push(`- ... ${slugs.length - shown.length} more`);
   }
-
   return lines.join("\n");
 };

--- a/packages/core/execution/src/index.ts
+++ b/packages/core/execution/src/index.ts
@@ -9,7 +9,8 @@ export {
   type ResumeResponse,
 } from "./engine";
 
-export { buildExecuteDescription } from "./description";
+export { buildExecuteDescription, INTEGRATION_INVENTORY_HEADER } from "./description";
+export { EXECUTE_SKILL, SKILLS, findSkill, renderSkillsIndex, type Skill } from "./skills";
 export { ExecutionToolError } from "./errors";
 export {
   defaultToolDiscoveryProvider,

--- a/packages/core/execution/src/skills.test.ts
+++ b/packages/core/execution/src/skills.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import { EXECUTE_SKILL, SKILLS, findSkill, renderSkillsIndex } from "./skills";
+
+describe("skills registry", () => {
+  it("includes the execute skill with the full how-to body", () => {
+    expect(SKILLS).toContain(EXECUTE_SKILL);
+    // The workflow + rules that the execute description used to inline now live
+    // in the skill body.
+    expect(EXECUTE_SKILL.body).toContain("## Workflow");
+    expect(EXECUTE_SKILL.body).toContain("## Rules");
+    expect(EXECUTE_SKILL.body).toContain("Use `emit(value)` to append user-visible output");
+    expect(EXECUTE_SKILL.body).toContain(
+      "Do not use `fetch` — all API calls go through `tools.*`.",
+    );
+  });
+
+  it("finds a skill by exact name and misses unknown names", () => {
+    expect(findSkill("execute")).toBe(EXECUTE_SKILL);
+    expect(findSkill("Execute")).toBeUndefined();
+    expect(findSkill("nope")).toBeUndefined();
+  });
+
+  it("renders an index that lists every skill with its summary", () => {
+    const index = renderSkillsIndex();
+    expect(index).toContain('skills({ name: "<name>" })');
+    for (const skill of SKILLS) {
+      expect(index).toContain(`- \`${skill.name}\` — ${skill.summary}`);
+    }
+  });
+});

--- a/packages/core/execution/src/skills.ts
+++ b/packages/core/execution/src/skills.ts
@@ -1,0 +1,88 @@
+/**
+ * On-demand documentation served through the MCP `skills` tool.
+ *
+ * The long-form how-to for calling integrations used to live in the `execute`
+ * tool description, which every session loads into its prompt up front. That
+ * is pure context bloat: a model that never calls `execute` still pays for the
+ * whole calling-convention essay. Moving it behind a tool lets the `execute`
+ * description carry only the live connection inventory plus a pointer here, and
+ * the model fetches the full guide the moment it actually needs it.
+ *
+ * A skill is a static, named markdown document. The registry is intentionally
+ * tiny and hand-curated, not a plugin surface: add an entry only when a tool
+ * genuinely needs its own how-to behind the same `skills` door.
+ */
+
+export interface Skill {
+  /** Stable identifier the model passes to the `skills` tool. */
+  readonly name: string;
+  /** One-line summary, shown when the `skills` tool lists what is available. */
+  readonly summary: string;
+  /** The full markdown body returned when the skill is fetched by name. */
+  readonly body: string;
+}
+
+// The `execute` how-to. This is the body lifted verbatim out of the old
+// `buildExecuteDescription` (Workflow + Rules); the description now points
+// here instead of inlining it.
+const EXECUTE_SKILL_BODY = [
+  "# execute",
+  "",
+  "Execute TypeScript in a sandboxed runtime with access to configured API tools.",
+  "",
+  "## Workflow",
+  "",
+  '1. `const { items: matches } = await tools.search({ query: "<intent + key nouns>", limit: 12 });`',
+  '2. `const path = matches[0]?.path; if (!path) return "No matching tools found.";`',
+  "3. `const details = await tools.describe.tool({ path });`",
+  "4. Use `details.inputTypeScript` / `details.outputTypeScript` and `details.typeScriptDefinitions` for compact shapes.",
+  "5. Use `tools.executor.coreTools.connections.list({})` when you need live saved-connection inventory.",
+  "6. Call the tool: `const result = await tools.<path>(input);`",
+  "",
+  "## Rules",
+  "",
+  "- `tools.search()` returns paginated, ranked matches: `{ items, total, hasMore, nextOffset }`. Best-first. Use short intent phrases like `github issues`, `repo details`, or `create calendar event`.",
+  '- When you already know the namespace, narrow with `tools.search({ namespace: "github", query: "issues" })`.',
+  "- `tools.executor.coreTools.connections.list({})` returns saved connections with `{ address, integration, owner, name, ... }`. The `address` field includes the leading `tools.` root.",
+  "- Tool calls return a value union: `{ ok: true, data }` for success or `{ ok: false, error: { code, message, status?, details?, retryable? } }` for expected tool/domain failures. Branch on `result.ok`.",
+  "- `data` is the upstream payload itself. HTTP-backed tools (OpenAPI) also set `http: { status, headers }` beside `data` — read `result.http?.headers` for pagination (Link) or rate-limit headers.",
+  "- Use `emit(value)` to append user-visible output and return `undefined`. Plain values become MCP text content. MCP content blocks are forwarded as-is. `ToolFile` values are rendered by MIME. Emitted output goes to the user, not back to you; the result envelope reports an `emitted` count so you can confirm it landed, but to read a value yourself, `return` it.",
+  '- File-returning tools may return `ToolFile` values: `{ _tag: "ToolFile", name?, mimeType, encoding: "base64", data, byteLength }`. Emit any attachment with `emit(result.data)`.',
+  '- To emit MCP-native content directly, pass an MCP content block to `emit(...)`, such as `{ type: "image", data, mimeType }`, `{ type: "audio", data, mimeType }`, `{ type: "text", text }`, `{ type: "resource", resource }`, or `{ type: "resource_link", uri, name, ... }`.',
+  "- `emit(ToolFile)` is MIME-based: `image/*` becomes MCP image content, `audio/*` becomes MCP audio content, text-like files become decoded text, and other binary files become embedded MCP resources.",
+  "- `return` is only for ordinary structured data. Returning a `ToolFile`, a `ToolResult`, an MCP content block, or a bare base64 string does not emit content to the MCP client.",
+  "- Some providers, including Gmail, return attachment bytes without a public URL. To send that attachment to another API from code, decode `ToolFile.data` from base64 and pass the bytes to that API's upload/file input.",
+  "- If `tools.search()` returns `hasMore: true` and you didn't find what you need, fetch the next page: `tools.search({ query, offset: nextOffset, limit })`.",
+  "- Always use the full address when calling tools: `tools.<integration>.<owner>.<connection>.<tool>(args)`. The `path` returned by `tools.search()` / `tools.describe.tool()` is already the exact path under `tools` — call `tools[path]` rather than guessing segments.",
+  "- The `tools` object is a lazy proxy — `Object.keys(tools)` won't work. Use `tools.search()` or `tools.executor.coreTools.connections.list({})` instead.",
+  '- Pass an object to system tools, e.g. `tools.search({ query: "..." })`, `tools.executor.coreTools.connections.list({})`, and `tools.describe.tool({ path })`.',
+  '- `tools.describe.tool()` returns compact TypeScript shapes. Use `inputTypeScript`, `outputTypeScript`, and `typeScriptDefinitions`. If the path doesn\'t resolve, the result carries `error: { code: "tool_not_found", suggestions }` — use a suggestion instead of retrying the same path.',
+  "- For tools that return large collections (e.g. `getStates`, `getAll`), filter results in code rather than calling per-item tools.",
+  "- Do not use `fetch` — all API calls go through `tools.*`.",
+  "- If execution pauses for interaction, resume it with the returned `resumePayload`.",
+  "- TypeScript type syntax (`: T`, `as T`, generics, interfaces, type aliases) is stripped before execution — feel free to write idiomatic TypeScript using the shapes from `tools.describe.tool()`. Decorators and `enum` are not supported.",
+].join("\n");
+
+export const EXECUTE_SKILL: Skill = {
+  name: "execute",
+  summary:
+    "How to call integrations from the execute sandbox: search the catalog, read a tool's shape, call it, emit results, and resume paused runs.",
+  body: EXECUTE_SKILL_BODY,
+};
+
+/** The full skill catalog. Hand-curated; keep it small. */
+export const SKILLS: readonly Skill[] = [EXECUTE_SKILL];
+
+/** Look up a skill by its exact name. */
+export const findSkill = (name: string): Skill | undefined =>
+  SKILLS.find((skill) => skill.name === name);
+
+/** The index the `skills` tool returns when called without a name (or with an
+ *  unknown one): every skill's name and one-line summary, plus how to fetch
+ *  the body. */
+export const renderSkillsIndex = (): string =>
+  [
+    'Available skills. Fetch one with `skills({ name: "<name>" })`.',
+    "",
+    ...SKILLS.map((skill) => `- \`${skill.name}\` — ${skill.summary}`),
+  ].join("\n");

--- a/packages/hosts/mcp/src/tool-server.test.ts
+++ b/packages/hosts/mcp/src/tool-server.test.ts
@@ -1424,3 +1424,80 @@ describe("MCP host server — multiple elicitations", () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// skills tool
+// ---------------------------------------------------------------------------
+
+describe("MCP host server — skills tool", () => {
+  it("registers a skills tool alongside execute", async () => {
+    await withClient(makeStubEngine({}), NO_CAPS, async (client) => {
+      const { tools } = await client.listTools();
+      expect(tools.map((t) => t.name)).toContain("skills");
+    });
+  });
+
+  it("returns the execute skill body by name", async () => {
+    await withClient(makeStubEngine({}), NO_CAPS, async (client) => {
+      const result = await client.callTool({
+        name: "skills",
+        arguments: { name: "execute" },
+      });
+      const text = textOf(result);
+      // The how-to that the execute description used to inline.
+      expect(text).toContain("## Workflow");
+      expect(text).toContain("## Rules");
+      expect(text).toContain("Use `emit(value)` to append user-visible output");
+      expect(result.isError).toBeFalsy();
+      // The body is the payload, returned ONLY as text content. Attaching a
+      // partial structuredContent ({status,name}) makes clients that prefer
+      // structured output surface that and drop the text, so the guide silently
+      // fails to load. Pin the single-channel shape so that can't regress.
+      expect(result.structuredContent).toBeUndefined();
+    });
+  });
+
+  it("appends the live integration inventory to the execute skill", async () => {
+    const description = [
+      "Execute TypeScript in a sandboxed runtime.",
+      "",
+      "## Available integrations",
+      "",
+      "Integrations you have connected. Their tools live under `tools.<integration>.…`.",
+      "- `acme`",
+    ].join("\n");
+    await withClient(makeStubEngine({ description }), NO_CAPS, async (client) => {
+      const result = await client.callTool({ name: "skills", arguments: { name: "execute" } });
+      const text = textOf(result);
+      // The how-to body still comes first ...
+      expect(text).toContain("## Workflow");
+      // ... and the live inventory the description carries is appended.
+      expect(text).toContain("## Available integrations");
+      expect(text).toContain("- `acme`");
+    });
+  });
+
+  it("lists available skills when called without a name", async () => {
+    await withClient(makeStubEngine({}), NO_CAPS, async (client) => {
+      const result = await client.callTool({
+        name: "skills",
+        arguments: {},
+      });
+      expect(textOf(result)).toContain("`execute`");
+      expect(result.structuredContent).toBeUndefined();
+    });
+  });
+
+  it("reports an unknown skill name as an error and lists valid names", async () => {
+    await withClient(makeStubEngine({}), NO_CAPS, async (client) => {
+      const result = await client.callTool({
+        name: "skills",
+        arguments: { name: "nope" },
+      });
+      expect(result.isError).toBe(true);
+      expect(textOf(result)).toContain('No skill named "nope"');
+      expect(textOf(result)).toContain("`execute`");
+      expect(result.structuredContent).toBeUndefined();
+    });
+  });
+});

--- a/packages/hosts/mcp/src/tool-server.ts
+++ b/packages/hosts/mcp/src/tool-server.ts
@@ -23,6 +23,10 @@ import {
   createExecutionEngine,
   formatExecuteResult,
   formatPausedExecution,
+  findSkill,
+  renderSkillsIndex,
+  EXECUTE_SKILL,
+  INTEGRATION_INVENTORY_HEADER,
   type ExecutionEngine,
   type ExecutionEngineConfig,
   type ResumeResponse,
@@ -518,6 +522,47 @@ const missingExecutionResult = (executionId: string): McpToolResult => ({
   isError: true,
 });
 
+// The `skills` tool serves named, static how-to docs (see the execution
+// package's skills registry). No name -> the index; a known name -> that
+// skill's body; an unknown name -> the index plus a not-found note so the model
+// retries with a listed name instead of the same miss.
+//
+// The skill body IS the payload, returned as plain text content. We do NOT
+// attach `structuredContent`: a client that prefers structured output (Claude
+// Code does) will surface only that and drop the text, so the long-form guide
+// silently fails to load. The not-found case keeps `isError` (a separate field
+// clients honor) so a bad name still reads as a failure.
+//
+// The `execute` skill also gets the live integration inventory appended, the
+// same block the execute tool description carries, so a model reading the guide
+// sees what is connected without a second round trip.
+const skillsResult = (name: string | undefined, executeInventory: string): McpToolResult => {
+  const trimmed = name?.trim();
+  if (!trimmed) {
+    return { content: [{ type: "text", text: renderSkillsIndex() }] };
+  }
+  const skill = findSkill(trimmed);
+  if (!skill) {
+    return {
+      content: [{ type: "text", text: `No skill named "${trimmed}".\n\n${renderSkillsIndex()}` }],
+      isError: true,
+    };
+  }
+  const text =
+    skill.name === EXECUTE_SKILL.name && executeInventory.length > 0
+      ? `${skill.body}\n\n${executeInventory}`
+      : skill.body;
+  return { content: [{ type: "text", text }] };
+};
+
+/** Pull the live integration inventory block out of the built execute
+ *  description (it runs from its header to the end), so the `skills` tool can
+ *  re-use it without rebuilding the inventory from the executor. */
+const extractInventory = (description: string): string => {
+  const index = description.indexOf(INTEGRATION_INVENTORY_HEADER);
+  return index === -1 ? "" : description.slice(index).trimEnd();
+};
+
 const JsonObjectFromString = Schema.fromJsonString(Schema.Record(Schema.String, Schema.Unknown));
 const decodeJsonObjectString = Schema.decodeUnknownOption(JsonObjectFromString);
 
@@ -539,6 +584,9 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
     const description =
       config.description ??
       (yield* engine.getDescription.pipe(Effect.withSpan("mcp.host.get_description")));
+    // The same live integration inventory the description carries, re-used by
+    // the `skills` tool so the `execute` guide lists what is connected too.
+    const executeInventory = extractInventory(description);
 
     // Captured at construction time. SDK callbacks fire later (often
     // deferred past the outer Effect's await), so we use the runtime to
@@ -773,6 +821,30 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
     ).pipe(
       Effect.withSpan("mcp.host.register_tool", {
         attributes: { "mcp.tool.name": "execute" },
+      }),
+    );
+
+    yield* Effect.sync(() =>
+      server.registerTool(
+        "skills",
+        {
+          description: [
+            "Fetch a named how-to skill. Skills hold the long-form guidance that would otherwise bloat another tool's always-loaded description.",
+            'Call `skills({ name: "execute" })` for the full guide to writing code for the `execute` tool (search the catalog, call tools, emit results, resume paused runs).',
+            "Call with no name to list the available skills.",
+          ].join("\n"),
+          inputSchema: {
+            name: z
+              .string()
+              .optional()
+              .describe('The skill to fetch, e.g. "execute". Omit to list available skills.'),
+          },
+        },
+        ({ name }) => runToolEffect(Effect.succeed(skillsResult(name, executeInventory))),
+      ),
+    ).pipe(
+      Effect.withSpan("mcp.host.register_tool", {
+        attributes: { "mcp.tool.name": "skills" },
       }),
     );
 

--- a/packages/react/src/components/metadata-edit-sheet.tsx
+++ b/packages/react/src/components/metadata-edit-sheet.tsx
@@ -29,8 +29,9 @@ import { Textarea } from "./textarea";
 // editing the description is editing what the model sees.
 // ---------------------------------------------------------------------------
 
-/** The connection's callable prefix under `tools.` — the line item agents see
- *  in the execute tool's "Available connection prefixes" inventory. */
+/** The connection's callable prefix under `tools.`: the path an agent reaches
+ *  this connection's tools through (`tools.<prefix>.<tool>`). The execute tool's
+ *  inventory now lists integrations, not per-connection prefixes. */
 const connectionPrefix = (connection: Connection): string => {
   const address = String(connection.address);
   return address.startsWith("tools.") ? address.slice("tools.".length) : address;


### PR DESCRIPTION
## What

Move the `execute` tool's how-to out of its always-loaded MCP description and behind a new `skills` tool, so a session only loads the calling-convention guide when it asks for it.

- **New `skills` tool.** `skills({ name: "execute" })` returns the full guide (search the catalog, describe a tool, call it, emit results, resume paused runs). `skills()` with no name lists what is available; an unknown name returns the list plus a not-found marker.
- **Slimmer `execute` description.** It now carries a one-line intro, a pointer to the skill, and a names-only list of the integrations the user has connected (deduped across connections, no per-connection prefixes or descriptions).
- **Inventory in the skill too.** The `execute` skill content appends the same live integration list, so a model reading the guide sees what is connected without a second round trip.

## Why

The workflow/rules prose used to sit in the execute tool description, which every session loads up front whether or not it ever runs code. Moving it behind a tool is progressive disclosure: the model fetches the manual on demand.

The skill result is plain text content only, with no `structuredContent`. A partial `structuredContent` made clients that prefer structured output surface that and drop the text, so the guide silently failed to load.

## Tests

`@executor-js/execution` and `@executor-js/host-mcp` suites cover the registry, the description rendering (names-only, deduped), the skills tool result shape, and the inventory embedding.