### PR TITLE
fix: preserve OAuth popup session state

### DIFF
--- a/packages/core/api/src/oauth-popup.test.ts
+++ b/packages/core/api/src/oauth-popup.test.ts
@@ -7,6 +7,7 @@
 
 import { describe, expect, it } from "@effect/vitest";
 import { Data, Effect, Schema } from "effect";
+import { encodeOAuthCallbackState } from "@executor-js/sdk";
 
 import {
   OAUTH_POPUP_MESSAGE_TYPE,
@@ -201,6 +202,31 @@ describe("runOAuthCallback", () => {
     expect(received).toEqual([
       { state: "s1", code: "code1", error: null, callbackDomain: "us5.datadoghq.com" },
     ]);
+  });
+
+  it("completes wrapped callback state with the raw OAuth session state", async () => {
+    const providerState = encodeOAuthCallbackState({ state: "session-raw", orgSlug: "default" });
+    const received: Array<{ state: string }> = [];
+
+    const html = await Effect.runPromise(
+      runOAuthCallback<GoogleAuth, never, never>({
+        complete: (params) => {
+          received.push({ state: params.state });
+          return Effect.succeed({
+            kind: "oauth2",
+            accessTokenSecretId: "s",
+            refreshTokenSecretId: null,
+          });
+        },
+        urlParams: { state: providerState, code: "code1" },
+        toErrorMessage: () => ({ short: "" }),
+        channelName: "c",
+      }),
+    );
+
+    expect(received).toEqual([{ state: "session-raw" }]);
+    expect(html).toContain('"sessionId":"session-raw"');
+    expect(html).not.toContain(`"sessionId":"${providerState}"`);
   });
 
   it("falls back to `site` for the regional domain and defaults to null", async () => {

--- a/packages/core/api/src/oauth-popup.ts
+++ b/packages/core/api/src/oauth-popup.ts
@@ -12,7 +12,11 @@
 
 import { Cause, Effect } from "effect";
 
-import { OAUTH_POPUP_MESSAGE_TYPE, type OAuthPopupResult } from "@executor-js/sdk";
+import {
+  decodeOAuthCallbackState,
+  OAUTH_POPUP_MESSAGE_TYPE,
+  type OAuthPopupResult,
+} from "@executor-js/sdk";
 
 export { OAUTH_POPUP_MESSAGE_TYPE, isOAuthPopupResult } from "@executor-js/sdk";
 export type { OAuthPopupResult } from "@executor-js/sdk";
@@ -178,11 +182,13 @@ export const runOAuthCallback = <TAuth, E, R>(
   input: RunOAuthCallbackInput<TAuth, E, R>,
 ): Effect.Effect<string, never, R> => {
   const providerError = providerErrorMessage(input.urlParams);
+  const callbackState = decodeOAuthCallbackState(input.urlParams.state);
+  const sessionId = callbackState?.state ?? input.urlParams.state;
   const result =
     providerError == null
       ? input
           .complete({
-            state: input.urlParams.state,
+            state: sessionId,
             code: input.urlParams.code ?? null,
             error: null,
             callbackDomain: input.urlParams.domain ?? input.urlParams.site ?? null,
@@ -192,7 +198,7 @@ export const runOAuthCallback = <TAuth, E, R>(
               (auth): OAuthPopupResult<TAuth> => ({
                 type: OAUTH_POPUP_MESSAGE_TYPE,
                 ok: true,
-                sessionId: input.urlParams.state,
+                sessionId,
                 ...auth,
               }),
             ),
@@ -200,7 +206,7 @@ export const runOAuthCallback = <TAuth, E, R>(
       : Effect.succeed<OAuthPopupResult<TAuth>>({
           type: OAUTH_POPUP_MESSAGE_TYPE,
           ok: false,
-          sessionId: input.urlParams.state ?? null,
+          sessionId,
           error: providerError.short,
           ...(providerError.details ? { errorDetails: providerError.details } : {}),
         });
@@ -211,7 +217,7 @@ export const runOAuthCallback = <TAuth, E, R>(
       return Effect.succeed<OAuthPopupResult<TAuth>>({
         type: OAUTH_POPUP_MESSAGE_TYPE,
         ok: false,
-        sessionId: input.urlParams.state ?? null,
+        sessionId,
         error: short,
         ...(details && details !== short ? { errorDetails: details } : {}),
       });


### PR DESCRIPTION
## Summary

OAuth sessions persist a raw random state token. When a self-hosted flow starts from the organization context, the authorization request wraps that token with the organization slug before sending it to the provider. The provider echoes the wrapped value back on callback, but the shared callback handler passed it directly to `oauth.complete`, which looks up sessions by the raw token.

Cloud already unwraps this state at its request boundary because it must use `orgSlug` to select the right tenant before constructing the executor. Self-host is single-tenant, so it does not need org routing on callback, but it still needs the raw token for session lookup.

This decodes wrapped callback state in the shared popup callback path and uses the raw token for both OAuth completion and popup result correlation. Raw callback state still passes through unchanged.

## Testing

- `bun run --cwd packages/core/api test -- oauth-popup.test.ts`
- `bun run --cwd e2e test:selfhost -- selfhost/oauth-callback-unauthenticated.test.ts`

The self-host e2e test was failing before this fix with `OAuth session expired or not found` on the callback page, and now passes.