### PR TITLE
Release 1.5.27: changesets for OAuth popup fix + desktop nav keybindings

### DIFF
--- a/.changeset/desktop-nav-keybindings.md
+++ b/.changeset/desktop-nav-keybindings.md
@@ -1,0 +1,5 @@
+---
+"@executor-js/desktop": patch
+---
+
+Bind Cmd+[ and Cmd+] to navigate back and forward in the desktop app.

--- a/.changeset/oauth-popup-session-state.md
+++ b/.changeset/oauth-popup-session-state.md
@@ -1,0 +1,5 @@
+---
+"@executor-js/api": patch
+---
+
+Fix self-hosted OAuth popup callbacks failing with "OAuth session expired or not found". When a flow starts from an organization context, the state token is wrapped with the org slug before it is sent to the provider. The shared popup callback now unwraps that state and uses the raw token for both session lookup and popup result correlation, while raw (unwrapped) callback state continues to pass through unchanged.


### PR DESCRIPTION
Cuts a patch release (**v1.5.27**) for the changes that have accumulated on \`main\` since v1.5.26 without changesets.

### Changesets added
- **\`@executor-js/api\` (patch)** — OAuth popup session-state fix ([#1235](https://github.com/RhysSullivan/executor/pull/1235)). Self-hosted OAuth popup callbacks were failing with "OAuth session expired or not found" when a flow started from an org context; the shared popup callback now unwraps the org-wrapped state and looks the session up by the raw token.
- **\`@executor-js/desktop\` (patch)** — Bind Cmd+[ / Cmd+] to back/forward in the desktop app ([#1228](https://github.com/RhysSullivan/executor/pull/1228)).

The two other commits since v1.5.26 are internal (AGENTS.md trim [#1229](https://github.com/RhysSullivan/executor/pull/1229), a slow-test tweak [#1226](https://github.com/RhysSullivan/executor/pull/1226)) and don't warrant changelog entries.

### Effect
\`@executor-js/desktop\` is in the fixed version group, so merging this bumps the whole group — including \`executor\` (the CLI) — from 1.5.26 → **1.5.27**, and \`@executor-js/api\` 1.4.46 → 1.4.47. After merge, the Release workflow opens the "Version Packages" PR; merging that pushes the \`v1.5.27\` tag and publishes.

\`changeset status\` verified: all bumps are **patch**, no minor/major.