### PR TITLE
changelog: record the skills tool in 1.5.27

### DIFF
--- a/packages/core/execution/CHANGELOG.md
+++ b/packages/core/execution/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Patch Changes
 
+- Add a `skills` tool and slim the always-loaded `execute` description. The execute tool's calling-convention guide now lives behind `skills({ name: "execute" })`, so a session loads it on demand instead of carrying it up front. The `execute` description keeps a one-line intro, a pointer to the skill, and a names-only list of the integrations the user has connected (deduped across connections, no per-connection prefixes).
+
 - Updated dependencies []:
   - @executor-js/sdk@1.5.27
   - @executor-js/codemode-core@1.5.27


### PR DESCRIPTION
[#1230](https://github.com/RhysSullivan/executor/pull/1230) (\`Add a skills tool and slim the execute description\`) merged to \`main\` between the 1.5.27 changeset PR and the Version Packages PR, without its own changeset. It therefore shipped in **1.5.27** with no changelog entry.

This adds the entry directly to \`@executor-js/execution\`'s existing \`## 1.5.27\` section (where a changeset for that feature would have landed), so the changelog reflects what the release actually contains. No version change: 1.5.27 is already cut.

Changesets only ever prepend new version sections on release, so this hand-edit to an existing section is safe and won't conflict with future releases.