### PR TITLE
fix(react): keep native select options readable in dark mode

### DIFF
--- a/.changeset/native-select-dark-mode.md
+++ b/.changeset/native-select-dark-mode.md
@@ -1,0 +1,5 @@
+---
+"@executor-js/react": patch
+---
+
+Keep native `<select>` dropdown options readable in dark mode. The console themes through `prefers-color-scheme` and never sets a `.dark` class, so Tailwind `dark:` utilities never matched and the native option popup rendered with a light color scheme over dark text. `NativeSelect` now uses a solid themed surface (`bg-popover`) and pins `color-scheme` to the active theme, so the browser draws a matching, readable popup.

--- a/packages/react/src/components/native-select.tsx
+++ b/packages/react/src/components/native-select.tsx
@@ -28,7 +28,7 @@ function NativeSelect({
         className={cn(
           "h-9 w-full min-w-0 appearance-none rounded-md border border-input bg-popover text-popover-foreground px-3 py-2 pr-9 text-sm shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground placeholder:text-muted-foreground hover:bg-accent disabled:pointer-events-none disabled:cursor-not-allowed data-[size=sm]:h-8 data-[size=sm]:py-1",
           "focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
-          "aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40",
+          "aria-invalid:border-destructive aria-invalid:ring-destructive/20",
           className,
         )}
         {...props}

--- a/packages/react/src/components/native-select.tsx
+++ b/packages/react/src/components/native-select.tsx
@@ -1,24 +1,32 @@
 import * as React from "react";
 import { ChevronDownIcon } from "lucide-react";
 
+import { useIsDark } from "../hooks/use-is-dark";
 import { cn } from "../lib/utils";
 
 function NativeSelect({
   className,
   size = "default",
+  style,
   ...props
 }: Omit<React.ComponentProps<"select">, "size"> & { size?: "sm" | "default" }) {
+  const isDark = useIsDark();
   return (
     <div
       className="group/native-select relative w-fit has-[select:disabled]:opacity-50"
       data-slot="native-select-wrapper"
     >
+      {/* The native option popup follows the select's opaque background and
+          color-scheme, not option-level styles. Give it a solid themed surface
+          and pin color-scheme so options stay readable in dark mode, which is
+          driven by prefers-color-scheme (no .dark class in this app). */}
       {/* oxlint-disable-next-line react/forbid-elements */}
       <select
         data-slot="native-select"
         data-size={size}
+        style={{ colorScheme: isDark ? "dark" : "light", ...style }}
         className={cn(
-          "h-9 w-full min-w-0 appearance-none rounded-md border border-input bg-transparent px-3 py-2 pr-9 text-sm shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed data-[size=sm]:h-8 data-[size=sm]:py-1 dark:bg-input/30 dark:hover:bg-input/50",
+          "h-9 w-full min-w-0 appearance-none rounded-md border border-input bg-popover text-popover-foreground px-3 py-2 pr-9 text-sm shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground placeholder:text-muted-foreground hover:bg-accent disabled:pointer-events-none disabled:cursor-not-allowed data-[size=sm]:h-8 data-[size=sm]:py-1",
           "focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
           "aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40",
           className,


### PR DESCRIPTION
## Problem

Native `<select>` dropdowns render unreadable option popups in dark mode (#1227). The Resume-approvals dropdown on the MCP connect card is the visible surface, but every `NativeSelect` in the console is affected.

## Root cause

The console themes through `@media (prefers-color-scheme: dark)` and never sets a `.dark` class, so Tailwind's `dark:` utilities (gated on `.dark` via `@custom-variant`) never match and are effectively dead. `NativeSelect` relied on `dark:bg-input/30` for its dark surface and set no `color-scheme`, leaving it `bg-transparent`. A native option popup follows the control's opaque `background-color` and `color-scheme`, not `<option>` styles, so in dark mode the browser drew a light popup and the inherited light text was unreadable.

## Fix

- Give the control a solid themed surface: `bg-popover text-popover-foreground` (opaque, flips with the theme tokens) plus `hover:bg-accent`.
- Pin `color-scheme` to the active theme via the existing `useIsDark()` hook, so the browser renders a matching popup.
- Drop the dead `dark:` background utilities.

`NativeSelect` is a shared component, so all of its usages are fixed at once.

## Verification

- `format:check`, `lint` (0 warnings / 0 errors), `typecheck` (42/42), and the `@executor-js/react` test suite (189/189) pass.
- Verified live in host-selfhost on the Resume-approvals dropdown in both dark and light: the select's computed `color-scheme` and background/text flip correctly with the OS theme (dark `#141414` / `#ededed`, light `#ffffff` / `#111111`), which is what makes the native popup readable.

Fixes #1227
