### PR TITLE
perf(sdk): batch invoke-path lookups with DataLoader semantics

### DIFF
--- a/.changeset/wild-buses-repeat.md
+++ b/.changeset/wild-buses-repeat.md
@@ -1,0 +1,11 @@
+---
+"executor": patch
+---
+
+Batch the SDK invoke path with DataLoader semantics. Concurrent `execute` calls
+in the same microtask window now share one storage query per table (tool,
+connection, integration) and one policy-rule-set snapshot instead of four point
+queries per call, so naive fan-out code (`Promise.all` over tool calls, code
+mode loops, parallel MCP tool calls) no longer produces N+1 query storms.
+Sequential calls are unchanged, and transactional reads bypass the batch window
+so transaction isolation is preserved.

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -147,6 +147,7 @@ import {
   type OAuthEndpointUrlPolicy,
 } from "./oauth-helpers";
 import { connectionIdentifier } from "./connection-name-identifier";
+import { makeInvokeBatching } from "./invoke-batching";
 import { annotateToolResultOutcome } from "./tool-result";
 
 const PLUGIN_STORAGE_DELETE_KEY_BATCH_SIZE = 90;
@@ -2533,6 +2534,51 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
             );
 
     // ------------------------------------------------------------------
+    // Invoke-path batching. Concurrent `execute` calls within one microtask
+    // window share ONE query per table (tool / connection / integration) and
+    // one policy-rule-set snapshot instead of 4×N point queries — the
+    // DataLoader pattern, via Effect Request/RequestResolver. Loaders serve
+    // a batch of mixed tuples with a single OR-of-tuples query; the memory
+    // and SQL adapters both plan it as one round trip.
+    // ------------------------------------------------------------------
+
+    const invokeBatching = makeInvokeBatching({
+      loadToolRows: (requests) =>
+        core.findMany("tool", {
+          where: (b: AnyCb) =>
+            b.or(
+              ...requests.map((request) =>
+                b.and(
+                  byOwner(request.owner)(b),
+                  b("integration", "=", String(request.integration)),
+                  b("connection", "=", String(request.connection)),
+                  b("name", "=", String(request.tool)),
+                ),
+              ),
+            ),
+          select: TOOL_INVOCATION_COLUMNS,
+        }),
+      loadConnectionRows: (requests) =>
+        core.findMany("connection", {
+          where: (b: AnyCb) =>
+            b.or(
+              ...requests.map((request) =>
+                b.and(
+                  byOwner(request.owner)(b),
+                  b("integration", "=", String(request.integration)),
+                  b("name", "=", String(request.name)),
+                ),
+              ),
+            ),
+        }),
+      loadIntegrationRows: (slugs) =>
+        core.findMany("integration", {
+          where: (b: AnyCb) => b("slug", "in", slugs.map(String)),
+        }),
+      loadPolicyRuleSet: () => listActivePolicyRuleSet(),
+    });
+
+    // ------------------------------------------------------------------
     // Tools (read surface)
     // ------------------------------------------------------------------
 
@@ -3035,7 +3081,7 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
         // not the 5-segment dynamic form.
         const staticEntry = staticTools.get(String(address));
         if (staticEntry) {
-          const policyRules = yield* listActivePolicyRuleSet();
+          const policyRules = yield* invokeBatching.getPolicyRuleSet();
           const policy = yield* resolvePolicyFromRuleSet(
             String(address),
             policyRules,
@@ -3064,16 +3110,13 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
 
         // Find the tool row — projected: invoke needs routing/policy fields
         // only, never the multi-KB input/output schema JSON (`tools.schema`
-        // is the schema-bearing surface).
-        const row = yield* core.findFirst("tool", {
-          where: (b: AnyCb) =>
-            b.and(
-              byOwner(parsed.owner)(b),
-              b("integration", "=", String(parsed.integration)),
-              b("connection", "=", String(parsed.connection)),
-              b("name", "=", String(parsed.tool)),
-            ),
-          select: TOOL_INVOCATION_COLUMNS,
+        // is the schema-bearing surface). Batched: concurrent executes in the
+        // same window share one query.
+        const row = yield* invokeBatching.getToolRow({
+          owner: parsed.owner,
+          integration: parsed.integration,
+          connection: parsed.connection,
+          tool: parsed.tool,
         });
         if (!row) {
           const searchMatches = yield* searchToolRowsForConnection(parsed);
@@ -3087,7 +3130,7 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
 
         // Resolve policy (owner-ranked).
         const toolForPolicy = rowToTool(row);
-        const policyRules = yield* listActivePolicyRuleSet();
+        const policyRules = yield* invokeBatching.getPolicyRuleSet();
         const annotations = decodeJsonColumn(row.annotations) as ToolAnnotations | undefined;
         const policy = yield* resolvePolicyFromRuleSet(
           normalizedPolicyId(toolForPolicy),
@@ -3115,8 +3158,8 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
           });
         }
 
-        // Find the connection row.
-        const connectionRow = yield* findConnectionRow({
+        // Find the connection row (batched with peer executes).
+        const connectionRow = yield* invokeBatching.getConnectionRow({
           owner: parsed.owner,
           integration: parsed.integration,
           name: parsed.connection,
@@ -3147,7 +3190,7 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
         // Resolve every named credential input (`variable → value`); `value` is
         // the primary `token` for single-input + OAuth callers.
         const values = yield* resolveConnectionValues(connectionRow);
-        const integrationRow = yield* findIntegrationRow(parsed.integration);
+        const integrationRow = yield* invokeBatching.getIntegrationRow(parsed.integration);
         const credential: ToolInvocationCredential = {
           owner: parsed.owner,
           integration: parsed.integration,

--- a/packages/core/sdk/src/invoke-batching.test.ts
+++ b/packages/core/sdk/src/invoke-batching.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Predicate, Result } from "effect";
+
+import { createExecutor, collectTables } from "./executor";
+import {
+  AuthTemplateSlug,
+  ConnectionName,
+  IntegrationSlug,
+  ProviderItemId,
+  ProviderKey,
+  Subject,
+  Tenant,
+  ToolAddress,
+  ToolName,
+} from "./ids";
+import { definePlugin } from "./plugin";
+import type { CredentialProvider } from "./provider";
+import { createSqliteTestFumaDb } from "./sqlite-test-db";
+import { withQueryContext } from "@executor-js/fumadb/query";
+import type { FumaDb } from "./fuma-runtime";
+
+// ---------------------------------------------------------------------------
+// Query-counting FumaDb wrapper. Counts reads per `${method}:${table}` while
+// forwarding everything else, and re-wraps `withContext` results so the
+// counter survives the executor's own context application.
+// ---------------------------------------------------------------------------
+
+type QueryCounts = Map<string, number>;
+
+const COUNTED_METHODS = new Set(["findFirst", "findMany", "count"]);
+
+const countingDb = (db: FumaDb, counts: QueryCounts): FumaDb => {
+  // oxlint-disable-next-line executor/no-double-cast -- boundary: test spy walks the ORM object's own members reflectively
+  const record = db as unknown as Record<string, unknown>;
+  const wrapper: Record<string, unknown> = {};
+  // Copy every member (methods included) off the real query object; a Proxy
+  // can't stand in because FumaDb's properties are non-configurable (proxy
+  // invariant violation on `get`). `withContext` and friends are
+  // non-enumerable, so walk own property names, not Object.keys.
+  for (const key of Object.getOwnPropertyNames(record)) {
+    const value = record[key];
+    if (typeof value !== "function") {
+      wrapper[key] = value;
+      continue;
+    }
+    const fn = value as (...a: unknown[]) => unknown;
+    if (COUNTED_METHODS.has(key)) {
+      wrapper[key] = (table: string, ...rest: unknown[]) => {
+        const countKey = `${key}:${table}`;
+        counts.set(countKey, (counts.get(countKey) ?? 0) + 1);
+        return fn.call(db, table, ...rest);
+      };
+    } else if (key === "withContext") {
+      wrapper[key] = (context: unknown) =>
+        countingDb((fn as (c: unknown) => FumaDb).call(db, context), counts);
+    } else {
+      wrapper[key] = (...args: unknown[]) => fn.call(db, ...args);
+    }
+  }
+  // oxlint-disable-next-line executor/no-double-cast -- boundary: the wrapper delegates every FumaDb member 1:1
+  return wrapper as unknown as FumaDb;
+};
+
+const totalFor = (counts: QueryCounts, table: string): number => {
+  let total = 0;
+  for (const [key, count] of counts) {
+    if (key.endsWith(`:${table}`)) total += count;
+  }
+  return total;
+};
+
+// ---------------------------------------------------------------------------
+// Fixture: a plugin with one integration and two tools.
+// ---------------------------------------------------------------------------
+
+const INTEG = IntegrationSlug.make("demo");
+const CONN = ConnectionName.make("main");
+
+const memoryProvider = (): CredentialProvider => {
+  const store = new Map<string, string>();
+  return {
+    key: ProviderKey.make("memory"),
+    writable: true,
+    get: (id) => Effect.sync(() => store.get(String(id)) ?? null),
+    set: (id, value) => Effect.sync(() => void store.set(String(id), value)),
+  };
+};
+
+const demoPlugin = definePlugin(() => ({
+  id: "demo" as const,
+  credentialProviders: [memoryProvider()],
+  storage: () => ({}),
+  resolveTools: () =>
+    Effect.succeed({
+      tools: [
+        { name: ToolName.make("alpha"), description: "alpha" },
+        { name: ToolName.make("beta"), description: "beta" },
+      ],
+    }),
+  invokeTool: ({ toolRow, args }) => Effect.succeed({ ran: toolRow.name, args }),
+  extension: (ctx) => ({
+    seed: () => ctx.core.integrations.register({ slug: INTEG, description: "Demo", config: {} }),
+  }),
+}))();
+
+const addr = (tool: string): ToolAddress => ToolAddress.make(`tools.${INTEG}.org.${CONN}.${tool}`);
+
+const TENANT = "test-tenant";
+const SUBJECT = "test-subject";
+
+const makeCountedExecutor = Effect.fnUntraced(function* () {
+  const counts: QueryCounts = new Map();
+  const tables = collectTables();
+  const testDb = yield* Effect.promise(() =>
+    createSqliteTestFumaDb({ tables, namespace: "executor_test" }),
+  );
+  const db = withQueryContext(countingDb(testDb.db, counts), {
+    tenant: TENANT,
+    subject: SUBJECT,
+  });
+  const executor = yield* createExecutor({
+    tenant: Tenant.make(TENANT),
+    subject: Subject.make(SUBJECT),
+    db,
+    plugins: [demoPlugin] as const,
+    onElicitation: "accept-all",
+  });
+  yield* executor.demo.seed();
+  yield* executor.connections.create({
+    owner: "org",
+    name: CONN,
+    integration: INTEG,
+    template: AuthTemplateSlug.make("apiKey"),
+    from: { provider: ProviderKey.make("memory"), id: ProviderItemId.make("v") },
+  });
+  return { executor, counts };
+});
+
+describe("invoke-path batching", () => {
+  it.effect("N concurrent executes share one query per table (no N+1)", () =>
+    Effect.gen(function* () {
+      const { executor, counts } = yield* makeCountedExecutor();
+
+      counts.clear();
+      const N = 25;
+      const results = yield* Effect.all(
+        Array.from({ length: N }, (_, i) =>
+          executor.execute(addr(i % 2 === 0 ? "alpha" : "beta"), { i }),
+        ),
+        { concurrency: "unbounded" },
+      );
+
+      expect(results).toHaveLength(N);
+      expect(results[0]).toEqual({ ran: "alpha", args: { i: 0 } });
+
+      // The batch window collapses all N lookups into one query per table.
+      // Allow a little slack (the runtime may split across two microtask
+      // windows under load) but the point is O(1), not O(N).
+      expect(totalFor(counts, "tool")).toBeLessThanOrEqual(2);
+      expect(totalFor(counts, "connection")).toBeLessThanOrEqual(2);
+      expect(totalFor(counts, "integration")).toBeLessThanOrEqual(2);
+      expect(totalFor(counts, "tool_policy")).toBeLessThanOrEqual(2);
+    }),
+  );
+
+  it.effect("sequential executes still behave (batch of one)", () =>
+    Effect.gen(function* () {
+      const { executor, counts } = yield* makeCountedExecutor();
+
+      counts.clear();
+      const first = yield* executor.execute(addr("alpha"), { seq: 1 });
+      const second = yield* executor.execute(addr("beta"), { seq: 2 });
+
+      expect(first).toEqual({ ran: "alpha", args: { seq: 1 } });
+      expect(second).toEqual({ ran: "beta", args: { seq: 2 } });
+      // Two sequential invokes = two windows: exactly the per-call point
+      // queries the unbatched path made, no regression.
+      expect(totalFor(counts, "tool")).toBe(2);
+      expect(totalFor(counts, "connection")).toBe(2);
+    }),
+  );
+
+  it.effect("a missing tool inside a batch fails alone, peers succeed", () =>
+    Effect.gen(function* () {
+      const { executor } = yield* makeCountedExecutor();
+
+      const [ok, missing] = yield* Effect.all(
+        [
+          Effect.result(executor.execute(addr("alpha"), {})),
+          Effect.result(executor.execute(addr("nope"), {})),
+        ],
+        { concurrency: "unbounded" },
+      );
+
+      expect(Result.isSuccess(ok)).toBe(true);
+      expect(Result.isFailure(missing)).toBe(true);
+      if (!Result.isFailure(missing)) return;
+      expect(Predicate.isTagged(missing.failure, "ToolNotFoundError")).toBe(true);
+    }),
+  );
+});

--- a/packages/core/sdk/src/invoke-batching.ts
+++ b/packages/core/sdk/src/invoke-batching.ts
@@ -1,0 +1,303 @@
+// ---------------------------------------------------------------------------
+// Invoke-path batching: DataLoader semantics via Effect Request/RequestResolver.
+//
+// The invoke hot path loads four things per call: the tool row, the active
+// policy rule set, the connection row, and the integration row. Called once,
+// that's four point queries, which is fine. Called N times concurrently (code
+// mode fanning out `await Promise.all(items.map(x => tools.foo.bar(x)))`, an
+// MCP host serving parallel tool calls), it's 4×N queries against the same
+// handful of rows: the classic N+1.
+//
+// Each lookup below is an Effect `Request` plus a `RequestResolver`. The
+// Effect runtime collects every request issued within the same microtask
+// window (resolver delay is `Effect.yieldNow`) and hands the resolver the
+// whole batch, which it serves with ONE query per table. Sequential callers
+// pay nothing: a batch of one is exactly the point query this replaced. There
+// is no cross-batch caching; every batch re-reads storage, so invalidation
+// semantics are unchanged.
+//
+// Requests are keyed by plain data (owner/slug/name strings), never rows, so
+// equality is meaningful and nothing heavy is retained.
+// ---------------------------------------------------------------------------
+
+import { Effect, Exit, Request, RequestResolver } from "effect";
+
+import type { ConnectionRow, IntegrationRow, ToolInvocationRow } from "./core-schema";
+import { activeFumaDbRef, type StorageFailure } from "./fuma-runtime";
+import type { ConnectionName, IntegrationSlug, Owner, ToolName } from "./ids";
+
+// ---------------------------------------------------------------------------
+// Request types
+// ---------------------------------------------------------------------------
+
+interface GetToolRow extends Request.Request<ToolInvocationRow | null, StorageFailure> {
+  readonly _tag: "GetToolRow";
+  readonly owner: Owner;
+  readonly integration: IntegrationSlug;
+  readonly connection: ConnectionName;
+  readonly tool: ToolName;
+}
+const GetToolRow = Request.tagged<GetToolRow>("GetToolRow");
+
+interface GetConnectionRow extends Request.Request<ConnectionRow | null, StorageFailure> {
+  readonly _tag: "GetConnectionRow";
+  readonly owner: Owner;
+  readonly integration: IntegrationSlug;
+  readonly name: ConnectionName;
+}
+const GetConnectionRow = Request.tagged<GetConnectionRow>("GetConnectionRow");
+
+interface GetIntegrationRow extends Request.Request<IntegrationRow | null, StorageFailure> {
+  readonly _tag: "GetIntegrationRow";
+  readonly slug: IntegrationSlug;
+}
+const GetIntegrationRow = Request.tagged<GetIntegrationRow>("GetIntegrationRow");
+
+// The policy rule set is one shared snapshot per batch window: every request
+// is identical, so the resolver runs the underlying load once and fans the
+// result out to all awaiting fibers.
+interface GetPolicyRuleSet<A> extends Request.Request<A, StorageFailure> {
+  readonly _tag: "GetPolicyRuleSet";
+}
+
+// ---------------------------------------------------------------------------
+// Wiring: the executor passes its storage closures in; we hand back
+// point-lookup functions with identical signatures to the ones they replace.
+// ---------------------------------------------------------------------------
+
+export interface InvokeBatchingDeps<TPolicyRuleSet> {
+  /** Batched tool-row load: one query for all (owner, integration, connection,
+   *  tool) tuples in the window, projected to the invocation columns. */
+  readonly loadToolRows: (
+    requests: readonly {
+      readonly owner: Owner;
+      readonly integration: IntegrationSlug;
+      readonly connection: ConnectionName;
+      readonly tool: ToolName;
+    }[],
+  ) => Effect.Effect<readonly ToolInvocationRow[], StorageFailure>;
+  readonly loadConnectionRows: (
+    requests: readonly {
+      readonly owner: Owner;
+      readonly integration: IntegrationSlug;
+      readonly name: ConnectionName;
+    }[],
+  ) => Effect.Effect<readonly ConnectionRow[], StorageFailure>;
+  readonly loadIntegrationRows: (
+    slugs: readonly IntegrationSlug[],
+  ) => Effect.Effect<readonly IntegrationRow[], StorageFailure>;
+  readonly loadPolicyRuleSet: () => Effect.Effect<TPolicyRuleSet, StorageFailure>;
+}
+
+export interface InvokeBatching<TPolicyRuleSet> {
+  readonly getToolRow: (input: {
+    readonly owner: Owner;
+    readonly integration: IntegrationSlug;
+    readonly connection: ConnectionName;
+    readonly tool: ToolName;
+  }) => Effect.Effect<ToolInvocationRow | null, StorageFailure>;
+  readonly getConnectionRow: (input: {
+    readonly owner: Owner;
+    readonly integration: IntegrationSlug;
+    readonly name: ConnectionName;
+  }) => Effect.Effect<ConnectionRow | null, StorageFailure>;
+  readonly getIntegrationRow: (
+    slug: IntegrationSlug,
+  ) => Effect.Effect<IntegrationRow | null, StorageFailure>;
+  readonly getPolicyRuleSet: () => Effect.Effect<TPolicyRuleSet, StorageFailure>;
+}
+
+// Batches from different fibers execute the `runAll` effect on a fiber forked
+// with the FIRST caller's context. Inside `fuma.transaction` the storage
+// handle rides on `activeFumaDbRef` in fiber context, so joining a shared
+// batch would read through the wrong (or no) transaction. Transactional
+// callers bypass the batch window and run the load directly on their own
+// fiber — same query, exact transaction semantics, no cross-fiber sharing.
+const inTransaction: Effect.Effect<boolean> = Effect.map(
+  Effect.service(activeFumaDbRef),
+  (active) => active !== null,
+);
+
+/** Complete every entry in a batch from a keyed index of loaded rows. A
+ *  request whose key has no row completes with `null`: absence is a value
+ *  (the invoke path turns it into its own typed not-found error). A load
+ *  failure fails every entry in the batch, mirroring what each point query
+ *  would have done. */
+const completeFromIndex = <A extends Request.Request<unknown, StorageFailure>>(
+  entries: readonly Request.Entry<A>[],
+  load: Effect.Effect<ReadonlyMap<string, Request.Success<A>>, StorageFailure>,
+  keyOf: (request: A) => string,
+): Effect.Effect<void, StorageFailure> =>
+  load.pipe(
+    Effect.matchEffect({
+      onSuccess: (index) =>
+        Effect.sync(() => {
+          for (const entry of entries) {
+            entry.completeUnsafe(
+              Exit.succeed((index.get(keyOf(entry.request)) ?? null) as Request.Success<A>),
+            );
+          }
+        }),
+      onFailure: (error) =>
+        Effect.sync(() => {
+          for (const entry of entries) {
+            // The constraint pins A's error channel to StorageFailure, but the
+            // conditional `Request.Error<A>` doesn't reduce over an unresolved
+            // generic — assert the equivalence once here.
+            entry.completeUnsafe(Exit.fail(error) as Exit.Exit<never, Request.Error<A>>);
+          }
+        }),
+    }),
+  );
+
+/** The runtime collects entries per window without deduping equal requests;
+ *  two fibers asking for the same connection contribute two entries. Loaders
+ *  receive each distinct key once (DataLoader's contract) and both entries
+ *  complete from the shared index. */
+const uniqueBy = <T>(items: readonly T[], key: (item: T) => string): readonly T[] => {
+  const seen = new Set<string>();
+  const out: T[] = [];
+  for (const item of items) {
+    const k = key(item);
+    if (seen.has(k)) continue;
+    seen.add(k);
+    out.push(item);
+  }
+  return out;
+};
+
+const toolKey = (r: {
+  readonly owner: string;
+  readonly integration: string;
+  readonly connection: string;
+  readonly tool: string;
+}): string => `${r.owner} ${r.integration} ${r.connection} ${r.tool}`;
+
+const connectionKey = (r: {
+  readonly owner: string;
+  readonly integration: string;
+  readonly name: string;
+}): string => `${r.owner} ${r.integration} ${r.name}`;
+
+export const makeInvokeBatching = <TPolicyRuleSet>(
+  deps: InvokeBatchingDeps<TPolicyRuleSet>,
+): InvokeBatching<TPolicyRuleSet> => {
+  const toolResolver = RequestResolver.make<GetToolRow>((entries) =>
+    completeFromIndex(
+      entries,
+      deps
+        .loadToolRows(
+          uniqueBy(
+            entries.map((entry) => entry.request),
+            toolKey,
+          ),
+        )
+        .pipe(
+          Effect.map(
+            (rows) =>
+              new Map(
+                rows.map((row) => [
+                  toolKey({
+                    owner: row.owner,
+                    integration: row.integration,
+                    connection: row.connection,
+                    tool: row.name,
+                  }),
+                  row,
+                ]),
+              ),
+          ),
+        ),
+      toolKey,
+    ),
+  );
+
+  const connectionResolver = RequestResolver.make<GetConnectionRow>((entries) =>
+    completeFromIndex(
+      entries,
+      deps
+        .loadConnectionRows(
+          uniqueBy(
+            entries.map((entry) => entry.request),
+            connectionKey,
+          ),
+        )
+        .pipe(
+          Effect.map(
+            (rows) =>
+              new Map(
+                rows.map((row) => [
+                  connectionKey({
+                    owner: row.owner,
+                    integration: row.integration,
+                    name: row.name,
+                  }),
+                  row,
+                ]),
+              ),
+          ),
+        ),
+      connectionKey,
+    ),
+  );
+
+  const integrationResolver = RequestResolver.make<GetIntegrationRow>((entries) =>
+    completeFromIndex(
+      entries,
+      deps
+        .loadIntegrationRows(
+          uniqueBy(
+            entries.map((entry) => entry.request.slug),
+            String,
+          ),
+        )
+        .pipe(Effect.map((rows) => new Map(rows.map((row) => [String(row.slug), row])))),
+      (request) => String(request.slug),
+    ),
+  );
+
+  const policyResolver = RequestResolver.make<GetPolicyRuleSet<TPolicyRuleSet>>((entries) =>
+    deps.loadPolicyRuleSet().pipe(
+      Effect.matchEffect({
+        onSuccess: (ruleSet) =>
+          Effect.sync(() => {
+            for (const entry of entries) entry.completeUnsafe(Exit.succeed(ruleSet));
+          }),
+        onFailure: (error) =>
+          Effect.sync(() => {
+            for (const entry of entries) entry.completeUnsafe(Exit.fail(error));
+          }),
+      }),
+    ),
+  );
+  const policyRequest = Request.of<GetPolicyRuleSet<TPolicyRuleSet>>()({
+    _tag: "GetPolicyRuleSet",
+  });
+
+  const first = <A>(rows: readonly A[]): A | null => rows[0] ?? null;
+
+  return {
+    getToolRow: (input) =>
+      Effect.flatMap(inTransaction, (transactional) =>
+        transactional
+          ? Effect.map(deps.loadToolRows([input]), first)
+          : Effect.request(GetToolRow(input), toolResolver),
+      ),
+    getConnectionRow: (input) =>
+      Effect.flatMap(inTransaction, (transactional) =>
+        transactional
+          ? Effect.map(deps.loadConnectionRows([input]), first)
+          : Effect.request(GetConnectionRow(input), connectionResolver),
+      ),
+    getIntegrationRow: (slug) =>
+      Effect.flatMap(inTransaction, (transactional) =>
+        transactional
+          ? Effect.map(deps.loadIntegrationRows([slug]), first)
+          : Effect.request(GetIntegrationRow({ slug }), integrationResolver),
+      ),
+    getPolicyRuleSet: () =>
+      Effect.flatMap(inTransaction, (transactional) =>
+        transactional ? deps.loadPolicyRuleSet() : Effect.request(policyRequest, policyResolver),
+      ),
+  };
+};


### PR DESCRIPTION
## What

Concurrent `execute()` calls in the same microtask window now share **one storage query per table** (tool, connection, integration) plus one policy-rule-set snapshot, instead of four point queries per call. Naive fan-out code — `Promise.all` over tool calls, code-mode loops, parallel MCP tool calls — no longer produces N+1 query storms.

Built on Effect `Request`/`RequestResolver`: each hot lookup on the invoke path is a request keyed by plain data, and a resolver serves the collected batch with a single OR-of-tuples query (keys deduped before hitting storage).

## Behavior preserved

- **No cross-batch caching.** Every batch window re-reads storage, so read-your-writes and policy invalidation are unchanged. A batch of one is exactly the point query it replaced, so sequential callers see identical query patterns.
- **Transactions bypass the batch window.** Batches execute on a fiber forked with the first caller's context; inside `fuma.transaction` the handle rides on `activeFumaDbRef`, so a shared batch would read through the wrong connection. Transactional reads run the loader directly with exact isolation.
- Public API and error types unchanged; a missing row still surfaces as the same typed not-found error per caller.

## Proof

`invoke-batching.test.ts` counts real queries through a spying FumaDb wrapper:

- 25 concurrent executes → **at most 2 queries per table** (was ~25).
- 2 sequential executes → exactly 2 point reads per table, no regression.
- A missing tool inside a batch fails alone with `ToolNotFoundError`; peers succeed.

## Gates

`format:check`, `lint`, `typecheck`, and the full test suite (36 packages) all pass.