### PR TITLE
fix(mcp): keep tool catalogs in sync with the server's live tool set

### DIFF
--- a/.changeset/mcp-tool-catalog-sync.md
+++ b/.changeset/mcp-tool-catalog-sync.md
@@ -1,0 +1,23 @@
+---
+"@executor-js/plugin-mcp": patch
+"@executor-js/sdk": patch
+---
+
+Keep MCP tool catalogs in sync with the server's live tool set. Previously a
+connection's tools were listed once at create time and never updated unless the
+integration's config changed or a user clicked Refresh, so server-side tool
+changes silently broke invocations.
+
+- `tools/list` discovery now follows `nextCursor` pagination per the MCP spec,
+  so servers with paginated catalogs list completely instead of first-page-only.
+- The client handles `notifications/tools/list_changed` received during a tool
+  call and marks the connection's persisted catalog stale; the next tools read
+  re-lists from the server.
+- An unknown-tool rejection from the server (protocol error or the reference
+  SDK's error envelope) returns a typed `mcp_tool_unknown` failure telling the
+  caller to re-list, and marks the catalog stale so it heals on the next read.
+- Remote catalogs now also refresh on read once older than a freshness TTL
+  (`ExecutorConfig.toolsSyncTtlMs`, default 15 minutes, `null` to disable),
+  covering servers that change tools without notifying.
+- A failed listing (server unreachable, auth not ready) no longer wipes the
+  previously persisted catalog; it is kept and retried after the TTL.

--- a/e2e/scenarios/mcp-catalog-sync-ui.test.ts
+++ b/e2e/scenarios/mcp-catalog-sync-ui.test.ts
@@ -1,0 +1,111 @@
+// Cross-target (browser): MCP tool-catalog freshness, FILMED through the real
+// web UI. The session video + per-step screenshots are the artifact: a user
+// adds a live MCP server, sees its tool in the Tools tab, runs a tool that
+// renames the server's catalog mid-call (the server pushes
+// `notifications/tools/list_changed` on the open connection), and then WATCHES
+// the Tools tab serve the renamed catalog on the next visit — no Refresh
+// click anywhere in the journey. The old behavior freezes this UI on the
+// stale tool forever.
+import { randomBytes } from "node:crypto";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import { makeMutableCatalogMcpServer, serveMcpServer } from "@executor-js/plugin-mcp/testing";
+
+import { scenario } from "../src/scenario";
+import { Browser, Target } from "../src/services";
+
+scenario(
+  "MCP catalog · the Tools tab follows a server-side rename after a list_changed notification",
+  {},
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const browser = yield* Browser;
+
+      // A real MCP server whose `rename_greet` tool renames `greet` →
+      // `greet_v2` mid-call and notifies the open connection. The server name
+      // is unique per run (it derives the integration namespace) so runs can't
+      // collide on targets whose identities share one tenant.
+      const mutable = makeMutableCatalogMcpServer({
+        name: `catalog-sync-${randomBytes(3).toString("hex")}`,
+      });
+      const server = yield* serveMcpServer(mutable.factory);
+      const identity = yield* target.newIdentity();
+
+      yield* browser.session(identity, async ({ page, step }) => {
+        await step("Open the add-MCP flow pointed at the live server", async () => {
+          await page.goto(`/integrations/add/mcp?url=${encodeURIComponent(server.endpoint)}`, {
+            waitUntil: "networkidle",
+          });
+          // The URL auto-probes (debounced); the method list appears once the
+          // probe lands — an open server seeds the detected no-auth method.
+          await page.getByText("How does this server authenticate?").waitFor();
+          await page.getByText("Method 1 · Detected").waitFor();
+        });
+
+        await step("Add the source", async () => {
+          await page.getByRole("button", { name: "Add source" }).click();
+          await page.waitForURL(/\/integrations\/(?!add\b)[^/?]+$/, { timeout: 30_000 });
+          await page.getByText("Connections").first().waitFor();
+        });
+
+        await step("Connect with no authentication", async () => {
+          await page.getByRole("button", { name: "Add connection" }).first().click();
+          await page.getByRole("tab", { name: "No authentication" }).waitFor();
+          await page.getByRole("button", { name: "Add connection" }).last().click();
+          // The connect flow dials the server and produces the tool catalog.
+          await page.getByText("Connection added").waitFor();
+        });
+
+        // Tools render as a collapsed dotted-name tree (namespace → leaf);
+        // typing in the filter box expands every match, so it is both the
+        // reveal mechanism and a search the video shows off.
+        const filterTools = async (query: string) => {
+          const filter = page.getByPlaceholder(/^Filter \d+ tools/);
+          await filter.waitFor();
+          await filter.fill(query);
+        };
+
+        // A tool's tree row is a button whose accessible name is the full
+        // leaf label — filter-highlight <mark> spans inside the label don't
+        // fragment it, so exact role queries can't false-match a substring
+        // (`greet` inside `greet_v2`).
+        const toolRow = (name: string) => page.getByRole("button", { name, exact: true }).first();
+
+        await step("The Tools tab lists the server's v1 catalog", async () => {
+          await page.getByRole("tab", { name: "Tools" }).click();
+          await filterTools("greet");
+          await toolRow(mutable.initialToolName).waitFor();
+          await toolRow("rename_greet").waitFor();
+        });
+
+        await step("Run rename_greet — the server renames its catalog mid-call", async () => {
+          await toolRow("rename_greet").click();
+          await page.getByRole("tab", { name: "Run" }).click();
+          await page.getByRole("button", { name: "Run", exact: true }).click();
+          // The result card proves the call reached the server (the payload
+          // renders inside a highlighted code block, so assert the badge);
+          // the server pushed list_changed on the same open connection.
+          await page.getByText("Result").first().waitFor();
+          await page.getByText("Success").first().waitFor();
+        });
+
+        await step("Revisit Tools — the catalog followed the rename by itself", async () => {
+          // Re-enter the page: a fresh tools read. The list_changed the server
+          // sent during the call marked the catalog stale, so THIS read
+          // re-lists — the renamed tool appears with no Refresh click.
+          await page.reload({ waitUntil: "networkidle" });
+          await page.getByRole("tab", { name: "Tools" }).click();
+          await filterTools("greet");
+          await toolRow(mutable.renamedToolName).waitFor({ timeout: 30_000 });
+        });
+
+        const staleToolStillListed = await toolRow(mutable.initialToolName)
+          .isVisible()
+          .catch(() => false);
+        expect(staleToolStillListed, "the retired tool left the catalog").toBe(false);
+      });
+    }),
+  ),
+);

--- a/e2e/scenarios/mcp-catalog-sync.test.ts
+++ b/e2e/scenarios/mcp-catalog-sync.test.ts
@@ -1,0 +1,526 @@
+// Cross-target: MCP tool-catalog freshness — the "the server changed its tools
+// and executor noticed" promise. A connection's catalog used to be listed once
+// at create time and never again: a server-side rename left stale tools failing
+// forever and new tools invisible until a human clicked Refresh. These journeys
+// prove the catalog now converges on its own, driven only through public
+// surfaces (typed API + sandbox executions) against real MCP servers whose
+// catalogs mutate mid-scenario:
+//
+//   1. list_changed — a tool call mutates the server's catalog mid-call; the
+//      server pushes `notifications/tools/list_changed` on the open connection
+//      and the very next tools read re-lists. No refresh, no second failing
+//      invocation: the notification alone drives convergence.
+//   2. unknown-tool self-heal — the catalog mutates OUTSIDE any call window
+//      (no notification to react to). Invoking the retired tool fails with the
+//      typed `mcp_tool_unknown` error telling the agent to re-list, and that
+//      failure alone heals the catalog for the next read.
+//   3. pagination — a server that pages `tools/list` with `nextCursor` gets
+//      its WHOLE catalog registered, not just the first page.
+//   4. outage resilience — a re-list against a dead server keeps the
+//      previously working catalog instead of wiping it, and converges to the
+//      server's new catalog once it comes back.
+import { randomBytes } from "node:crypto";
+import { createServer } from "node:http";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import { composePluginApi } from "@executor-js/api/server";
+import { mcpHttpPlugin } from "@executor-js/plugin-mcp/api";
+import { makeMutableCatalogMcpServer, serveMcpServer } from "@executor-js/plugin-mcp/testing";
+import { AuthTemplateSlug, ConnectionName, IntegrationSlug } from "@executor-js/sdk/shared";
+
+import { scenario } from "../src/scenario";
+import { Api, Target } from "../src/services";
+
+const api = composePluginApi([mcpHttpPlugin()] as const);
+
+const freshSlug = (prefix: string): string => `${prefix}_${randomBytes(4).toString("hex")}`;
+
+// Sandbox code for the agent path: call one addressed MCP tool and return the
+// ToolResult envelope fields the assertions need. Tool failures are values in
+// the sandbox (`{ ok: false, error }`), not exceptions.
+const invokeToolCode = (slug: string, connection: string, tool: string, args: unknown) => `
+const result = await tools.${slug}.org.${connection}.${tool}(${JSON.stringify(args)});
+return { ok: result.ok, payload: result.ok ? result.data : result.error };
+`;
+
+type SandboxToolOutcome = {
+  readonly ok: boolean;
+  readonly payload?: {
+    readonly code?: string;
+    readonly message?: string;
+  };
+};
+
+// ---------------------------------------------------------------------------
+// A minimal streamable-http MCP fixture with a MUTABLE catalog and a kill
+// switch, for the journeys the SDK test server can't express: multi-page
+// tools/list responses and a server that goes down between listings. Speaks
+// just enough JSON-RPC for the discovery path (initialize, notifications/*,
+// tools/list).
+// ---------------------------------------------------------------------------
+
+type PagedMcpFixture = {
+  readonly url: string;
+  /** Replace the catalog; each inner array is one tools/list page. */
+  readonly setPages: (pages: readonly (readonly string[])[]) => void;
+  /** true → every request answers 503, as an unreachable server would. */
+  readonly setDead: (dead: boolean) => void;
+};
+
+const servePagedMcpFixture = (initialPages: readonly (readonly string[])[]) =>
+  Effect.acquireRelease(
+    Effect.callback<PagedMcpFixture & { readonly close: () => void }>((resume) => {
+      let pages = initialPages;
+      let dead = false;
+
+      const server = createServer((request, response) => {
+        const respondJson = (status: number, body: unknown) => {
+          response.writeHead(status, { "content-type": "application/json" });
+          response.end(JSON.stringify(body));
+        };
+
+        if (dead) {
+          response.writeHead(503, { "content-type": "text/plain" });
+          response.end("fixture is down");
+          return;
+        }
+        if (request.method === "GET") {
+          // 405 = "no standalone SSE stream" — an expected shape the client
+          // handles without error.
+          response.writeHead(405, { "content-type": "text/plain" });
+          response.end("SSE disabled");
+          return;
+        }
+
+        let body = "";
+        request.on("data", (chunk: unknown) => {
+          body += String(chunk);
+        });
+        request.on("end", () => {
+          const rpc = JSON.parse(body) as {
+            readonly id?: string | number | null;
+            readonly method?: string;
+            readonly params?: { readonly cursor?: string };
+          };
+
+          if (rpc.method === "initialize") {
+            respondJson(200, {
+              jsonrpc: "2.0",
+              id: rpc.id ?? null,
+              result: {
+                protocolVersion: "2025-06-18",
+                capabilities: { tools: { listChanged: true } },
+                serverInfo: { name: "paged-catalog-fixture", version: "1.0.0" },
+              },
+            });
+            return;
+          }
+          if (rpc.method?.startsWith("notifications/")) {
+            response.writeHead(202);
+            response.end();
+            return;
+          }
+          if (rpc.method === "tools/list") {
+            const cursor = rpc.params?.cursor;
+            const index = cursor === undefined ? 0 : Number(cursor.replace("page-", ""));
+            const page = pages[index] ?? [];
+            const nextCursor = index + 1 < pages.length ? `page-${index + 1}` : undefined;
+            respondJson(200, {
+              jsonrpc: "2.0",
+              id: rpc.id ?? null,
+              result: {
+                tools: page.map((name) => ({
+                  name,
+                  description: `Tool ${name}`,
+                  inputSchema: { type: "object", properties: {} },
+                })),
+                ...(nextCursor === undefined ? {} : { nextCursor }),
+              },
+            });
+            return;
+          }
+          respondJson(200, {
+            jsonrpc: "2.0",
+            id: rpc.id ?? null,
+            error: { code: -32601, message: `Method not found: ${rpc.method}` },
+          });
+        });
+      });
+
+      server.listen(0, "127.0.0.1", () => {
+        const address = server.address();
+        const port = typeof address === "object" && address ? address.port : 0;
+        resume(
+          Effect.succeed({
+            url: `http://127.0.0.1:${port}/mcp`,
+            setPages: (next: readonly (readonly string[])[]) => {
+              pages = next;
+            },
+            setDead: (next: boolean) => {
+              dead = next;
+            },
+            close: () => {
+              server.close();
+              server.closeAllConnections();
+            },
+          }),
+        );
+      });
+    }),
+    (fixture) => Effect.sync(fixture.close),
+  );
+
+// ---------------------------------------------------------------------------
+// 1. list_changed received during a call window → next read re-lists
+// ---------------------------------------------------------------------------
+
+scenario(
+  "MCP catalog · a list_changed notification during a call refreshes the catalog on the next read",
+  {},
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const { client: makeApiClient } = yield* Api;
+      const identity = yield* target.newIdentity();
+      const client = yield* makeApiClient(api, identity);
+      const slug = freshSlug("mcp_notify");
+
+      // A real MCP server (SDK McpServer over streamable-http) whose
+      // `rename_greet` tool renames `greet` → `greet_v2` mid-call, emitting
+      // `notifications/tools/list_changed` on the open connection.
+      const mutable = makeMutableCatalogMcpServer();
+      const server = yield* serveMcpServer(mutable.factory);
+
+      yield* client.mcp.addServer({
+        payload: { transport: "remote", name: "Mutable catalog MCP", endpoint: server.url, slug },
+      });
+
+      yield* Effect.gen(function* () {
+        yield* client.connections.create({
+          payload: {
+            owner: "org",
+            name: ConnectionName.make("main"),
+            integration: IntegrationSlug.make(slug),
+            template: AuthTemplateSlug.make("none"),
+            value: "",
+          },
+        });
+
+        const toolNames = Effect.map(
+          client.tools.list({ query: { integration: IntegrationSlug.make(slug) } }),
+          (tools) => tools.map((tool) => String(tool.name)).sort(),
+        );
+
+        expect(yield* toolNames, "the initial catalog holds the v1 tool").toEqual([
+          mutable.initialToolName,
+          "rename_greet",
+        ]);
+
+        // The catalog mutates DURING this call; the notification arrives on
+        // the same connection the call rides.
+        const executed = yield* client.executions.execute({
+          payload: { code: invokeToolCode(slug, "main", "rename_greet", {}), autoApprove: true },
+        });
+        expect(executed.status, "the mutating call completed").toBe("completed");
+        const outcome = JSON.parse(executed.text) as SandboxToolOutcome;
+        expect(outcome.ok, executed.text).toBe(true);
+
+        // THE promise: no refresh click, no failing retry — the very next
+        // tools read already serves the renamed catalog.
+        expect(yield* toolNames, "the next read follows the notification").toEqual([
+          mutable.renamedToolName,
+          "rename_greet",
+        ]);
+      }).pipe(
+        Effect.ensuring(
+          Effect.gen(function* () {
+            yield* client.connections
+              .remove({
+                params: {
+                  owner: "org",
+                  integration: IntegrationSlug.make(slug),
+                  name: ConnectionName.make("main"),
+                },
+              })
+              .pipe(Effect.ignore);
+            yield* client.mcp
+              .removeServer({ params: { slug: IntegrationSlug.make(slug) } })
+              .pipe(Effect.ignore);
+          }),
+        ),
+      );
+    }),
+  ),
+);
+
+// ---------------------------------------------------------------------------
+// 2. drift with NO notification → typed unknown-tool failure → self-heal
+// ---------------------------------------------------------------------------
+
+scenario(
+  "MCP catalog · calling a tool the server retired fails typed and heals the catalog",
+  {},
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const { client: makeApiClient } = yield* Api;
+      const identity = yield* target.newIdentity();
+      const client = yield* makeApiClient(api, identity);
+      const slug = freshSlug("mcp_drift");
+
+      const mutable = makeMutableCatalogMcpServer();
+      const server = yield* serveMcpServer(mutable.factory);
+
+      yield* client.mcp.addServer({
+        payload: { transport: "remote", name: "Drifting catalog MCP", endpoint: server.url, slug },
+      });
+
+      yield* Effect.gen(function* () {
+        yield* client.connections.create({
+          payload: {
+            owner: "org",
+            name: ConnectionName.make("main"),
+            integration: IntegrationSlug.make(slug),
+            template: AuthTemplateSlug.make("none"),
+            value: "",
+          },
+        });
+
+        const toolNames = Effect.map(
+          client.tools.list({ query: { integration: IntegrationSlug.make(slug) } }),
+          (tools) => tools.map((tool) => String(tool.name)).sort(),
+        );
+
+        expect(yield* toolNames, "the catalog was registered against v1").toContain(
+          mutable.initialToolName,
+        );
+
+        // The server owner ships a rename while executor holds NO connection —
+        // there is no notification to react to; executor's catalog is drifted
+        // and it cannot know yet.
+        mutable.renameTool();
+
+        // An agent (trusting the stale catalog) calls the retired tool. The
+        // spec answer is an unknown-tool error; executor must surface it as a
+        // typed, actionable failure — not a generic error the agent retries
+        // blindly.
+        const executed = yield* client.executions.execute({
+          payload: {
+            code: invokeToolCode(slug, "main", mutable.initialToolName, { name: "world" }),
+            autoApprove: true,
+          },
+        });
+        expect(executed.status, "the failing call still completes the sandbox").toBe("completed");
+        const outcome = JSON.parse(executed.text) as SandboxToolOutcome;
+        expect(outcome.ok, "the stale invocation reports failure as a value").toBe(false);
+        expect(outcome.payload?.code, "the failure is the typed drift error").toBe(
+          "mcp_tool_unknown",
+        );
+        expect(
+          outcome.payload?.message,
+          "the message tells the agent to re-list, not retry",
+        ).toContain("list tools again");
+
+        // The failure alone marked the catalog stale: the next read converges
+        // with no refresh click and no waiting on a freshness window.
+        const healed = yield* toolNames;
+        expect(healed, "the healed catalog serves the renamed tool").toContain(
+          mutable.renamedToolName,
+        );
+        expect(healed, "the retired tool is gone from the catalog").not.toContain(
+          mutable.initialToolName,
+        );
+      }).pipe(
+        Effect.ensuring(
+          Effect.gen(function* () {
+            yield* client.connections
+              .remove({
+                params: {
+                  owner: "org",
+                  integration: IntegrationSlug.make(slug),
+                  name: ConnectionName.make("main"),
+                },
+              })
+              .pipe(Effect.ignore);
+            yield* client.mcp
+              .removeServer({ params: { slug: IntegrationSlug.make(slug) } })
+              .pipe(Effect.ignore);
+          }),
+        ),
+      );
+    }),
+  ),
+);
+
+// ---------------------------------------------------------------------------
+// 3. paginated tools/list → the whole catalog registers, not page one
+// ---------------------------------------------------------------------------
+
+scenario(
+  "MCP catalog · a server that pages tools/list registers its whole catalog",
+  {},
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const { client: makeApiClient } = yield* Api;
+      const identity = yield* target.newIdentity();
+      const client = yield* makeApiClient(api, identity);
+      const slug = freshSlug("mcp_paged");
+
+      // Two pages: [alpha, beta] then [gamma]. A first-page-only client
+      // registers two tools and silently loses gamma.
+      const fixture = yield* servePagedMcpFixture([["alpha", "beta"], ["gamma"]]);
+
+      yield* client.mcp.addServer({
+        payload: {
+          transport: "remote",
+          name: "Paged catalog MCP",
+          endpoint: fixture.url,
+          slug,
+          remoteTransport: "streamable-http",
+        },
+      });
+
+      yield* Effect.gen(function* () {
+        yield* client.connections.create({
+          payload: {
+            owner: "org",
+            name: ConnectionName.make("main"),
+            integration: IntegrationSlug.make(slug),
+            template: AuthTemplateSlug.make("none"),
+            value: "",
+          },
+        });
+
+        const tools = yield* client.tools.list({
+          query: { integration: IntegrationSlug.make(slug) },
+        });
+        expect(
+          tools.map((tool) => String(tool.name)).sort(),
+          "every page of the catalog registered",
+        ).toEqual(["alpha", "beta", "gamma"]);
+      }).pipe(
+        Effect.ensuring(
+          Effect.gen(function* () {
+            yield* client.connections
+              .remove({
+                params: {
+                  owner: "org",
+                  integration: IntegrationSlug.make(slug),
+                  name: ConnectionName.make("main"),
+                },
+              })
+              .pipe(Effect.ignore);
+            yield* client.mcp
+              .removeServer({ params: { slug: IntegrationSlug.make(slug) } })
+              .pipe(Effect.ignore);
+          }),
+        ),
+      );
+    }),
+  ),
+);
+
+// ---------------------------------------------------------------------------
+// 4. a re-list against a dead server keeps the working catalog
+// ---------------------------------------------------------------------------
+
+scenario(
+  "MCP catalog · an outage during refresh keeps the working catalog and recovery converges",
+  {},
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const { client: makeApiClient } = yield* Api;
+      const identity = yield* target.newIdentity();
+      const client = yield* makeApiClient(api, identity);
+      const slug = freshSlug("mcp_outage");
+
+      const fixture = yield* servePagedMcpFixture([["alpha", "beta"]]);
+
+      yield* client.mcp.addServer({
+        payload: {
+          transport: "remote",
+          name: "Flaky MCP",
+          endpoint: fixture.url,
+          slug,
+          remoteTransport: "streamable-http",
+        },
+      });
+
+      yield* Effect.gen(function* () {
+        yield* client.connections.create({
+          payload: {
+            owner: "org",
+            name: ConnectionName.make("main"),
+            integration: IntegrationSlug.make(slug),
+            template: AuthTemplateSlug.make("none"),
+            value: "",
+          },
+        });
+
+        const connectionParams = {
+          owner: "org",
+          integration: IntegrationSlug.make(slug),
+          name: ConnectionName.make("main"),
+        } as const;
+        const toolNames = Effect.map(
+          client.tools.list({ query: { integration: IntegrationSlug.make(slug) } }),
+          (tools) => tools.map((tool) => String(tool.name)).sort(),
+        );
+
+        expect(yield* toolNames, "the catalog registered while the server was up").toEqual([
+          "alpha",
+          "beta",
+        ]);
+
+        // The server goes down; a refresh (the UI button / agent tool path)
+        // re-lists against a dead endpoint. The listing is non-authoritative:
+        // it must NOT wipe the working catalog.
+        fixture.setDead(true);
+        const refreshedWhileDown = yield* client.connections.refresh({
+          params: connectionParams,
+        });
+        expect(
+          refreshedWhileDown.map((tool) => String(tool.name)).sort(),
+          "refresh during the outage answers the kept catalog",
+        ).toEqual(["alpha", "beta"]);
+        expect(yield* toolNames, "the outage never wiped the working tools").toEqual([
+          "alpha",
+          "beta",
+        ]);
+
+        // The server comes back CHANGED (beta retired, delta added). A
+        // refresh now converges to the live catalog.
+        fixture.setDead(false);
+        fixture.setPages([["alpha", "delta"]]);
+        const refreshedAfterRecovery = yield* client.connections.refresh({
+          params: connectionParams,
+        });
+        expect(
+          refreshedAfterRecovery.map((tool) => String(tool.name)).sort(),
+          "refresh after recovery serves the server's new catalog",
+        ).toEqual(["alpha", "delta"]);
+        expect(yield* toolNames, "the read surface follows").toEqual(["alpha", "delta"]);
+      }).pipe(
+        Effect.ensuring(
+          Effect.gen(function* () {
+            yield* client.connections
+              .remove({
+                params: {
+                  owner: "org",
+                  integration: IntegrationSlug.make(slug),
+                  name: ConnectionName.make("main"),
+                },
+              })
+              .pipe(Effect.ignore);
+            yield* client.mcp
+              .removeServer({ params: { slug: IntegrationSlug.make(slug) } })
+              .pipe(Effect.ignore);
+          }),
+        ),
+      );
+    }),
+  ),
+);

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -389,7 +389,20 @@ export interface ExecutorConfig<TPlugins extends readonly AnyPlugin[] = readonly
     readonly orgSlug?: string;
     readonly includeProviders?: boolean;
   };
+  /**
+   * How long a connection's persisted tool catalog stays fresh when its plugin
+   * lists a live remote catalog (`plugin.remoteToolCatalog`, e.g. MCP servers,
+   * whose tool sets change server-side with no executor-visible signal). Once
+   * older than this, the catalog is re-listed on the next tools read. Defaults
+   * to 15 minutes; pass `null` to disable time-based re-sync (stale-mark and
+   * config-revision re-sync still apply).
+   */
+  readonly toolsSyncTtlMs?: number | null;
 }
+
+/** Default freshness window for remote-catalog connections (see
+ *  `ExecutorConfig.toolsSyncTtlMs`). */
+export const DEFAULT_TOOLS_SYNC_TTL_MS = 15 * 60 * 1000;
 
 // ---------------------------------------------------------------------------
 // collectTables — return the executor-owned Fuma table set. Plugins persist
@@ -1955,6 +1968,17 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
             ),
           );
 
+        if (result.incomplete === true) {
+          // Non-authoritative listing (source unreachable, auth not ready).
+          // Keep the existing catalog — replacing it would wipe working tools
+          // over a transient outage — and stamp the sync time anyway so a down
+          // server isn't re-dialed on every read; the freshness TTL re-attempts
+          // later.
+          yield* stampSynced;
+          const keptRows = yield* core.findMany("tool", { where });
+          return keptRows.map((row) => rowToTool(row as ConnectionToolRow));
+        }
+
         const now = new Date();
         const toolRows = result.tools.map((tool: ToolDef) => ({
           tenant: keys.tenant,
@@ -2448,6 +2472,21 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
         return yield* produceConnectionTools(integrationRow, ref);
       });
 
+    // Clear the sync stamp so the next tools read re-produces this connection's
+    // catalog. The deferred variant of `connectionsRefresh` for signals that
+    // arrive mid-invocation (an MCP `notifications/tools/list_changed`, an
+    // unknown-tool rejection) where re-listing inline would block the caller.
+    const connectionsMarkToolsStale = (ref: ConnectionRef): Effect.Effect<void, StorageFailure> =>
+      core.updateMany("connection", {
+        where: (b: AnyCb) =>
+          b.and(
+            byOwner(ref.owner)(b),
+            b("integration", "=", String(ref.integration)),
+            b("name", "=", String(ref.name)),
+          ),
+        set: { tools_synced_at: null },
+      });
+
     // ------------------------------------------------------------------
     // Active policy source.
     // ------------------------------------------------------------------
@@ -2561,31 +2600,86 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
       return true;
     };
 
-    // Rebuild any visible connection whose tool catalog predates its
-    // integration's last tool-affecting config change. The change's author
-    // could only rewrite catalogs in their own partition (owner policy);
-    // every other subject converges here, on their own read, under their own
-    // binding. Best-effort: a failed rebuild leaves the stale-but-working
-    // catalog in place and retries on the next read.
+    // How long a remote-catalog connection's persisted tools stay fresh
+    // (`ExecutorConfig.toolsSyncTtlMs`; `null` disables time-based re-sync).
+    const toolsSyncTtlMs =
+      config.toolsSyncTtlMs === undefined ? DEFAULT_TOOLS_SYNC_TTL_MS : config.toolsSyncTtlMs;
+
+    // Rebuild any visible connection whose persisted tool catalog is stale.
+    // Three triggers:
+    //  - stale-marked: `tools_synced_at` is NULL (`connections.markToolsStale`
+    //    — an MCP `tools/list_changed` notification or unknown-tool rejection
+    //    cleared it mid-invocation);
+    //  - config-revised: the integration's last tool-affecting config change
+    //    postdates the connection's catalog. The change's author could only
+    //    rewrite catalogs in their own partition (owner policy); every other
+    //    subject converges here, on their own read, under their own binding;
+    //  - expired: the plugin lists a live remote catalog (an MCP server, whose
+    //    tool set can change with no executor-visible signal) and the catalog
+    //    is older than the freshness TTL.
+    // Best-effort: a failed rebuild leaves the stale-but-working catalog in
+    // place and retries on the next read.
     const syncStaleConnectionTools = Effect.gen(function* () {
-      const revised = yield* core.findMany("integration", {
-        where: (b: AnyCb) => b.isNotNull("config_revised_at"),
-      });
-      if (revised.length === 0) return;
-      const revisedAt = new Map(
-        revised.map((row) => [row.slug, Number(row.config_revised_at)] as const),
+      const integrations = yield* core.findMany("integration", {});
+      if (integrations.length === 0) return;
+      const integrationBySlug = new Map(integrations.map((row) => [row.slug, row] as const));
+      // The TTL only matters when a loaded plugin actually lists a live remote
+      // catalog; otherwise skip it so age alone never widens the stale query.
+      const anyRemoteCatalog = Array.from(runtimes.values()).some(
+        (runtime) => runtime.plugin.remoteToolCatalog === true,
       );
+      const cutoff =
+        toolsSyncTtlMs == null || !anyRemoteCatalog ? null : Date.now() - toolsSyncTtlMs;
+
+      // Bound the scan to potentially-stale rows: stale-marked (NULL stamp) or
+      // synced before the latest instant any trigger could fire at (the TTL
+      // cutoff / the newest config revision). Per-row trigger checks below
+      // re-verify against each row's own integration; in steady state this
+      // query returns nothing and the read pays one indexed lookup.
+      const latestRevision = integrations.reduce<number | null>(
+        (max, row) =>
+          row.config_revised_at == null
+            ? max
+            : Math.max(max ?? Number(row.config_revised_at), Number(row.config_revised_at)),
+        null,
+      );
+      const staleBefore =
+        cutoff === null && latestRevision === null
+          ? null
+          : Math.max(cutoff ?? Number.MIN_SAFE_INTEGER, latestRevision ?? Number.MIN_SAFE_INTEGER);
+
       const connections = yield* core.findMany("connection", {
-        where: (b: AnyCb) => b.or(...revised.map((row) => b("integration", "=", row.slug))),
+        where: (b: AnyCb) =>
+          staleBefore === null
+            ? b.isNull("tools_synced_at")
+            : b.or(b.isNull("tools_synced_at"), b("tools_synced_at", "<", staleBefore)),
       });
       for (const connection of connections) {
-        const revisedTime = revisedAt.get(connection.integration);
-        if (revisedTime === undefined) continue;
-        const syncedAt =
-          connection.tools_synced_at == null ? 0 : Number(connection.tools_synced_at);
-        if (syncedAt >= revisedTime) continue;
-        const integrationRow = revised.find((row) => row.slug === connection.integration);
+        const integrationRow = integrationBySlug.get(connection.integration);
         if (!integrationRow) continue;
+        const runtime = runtimes.get(integrationRow.plugin_id);
+        // Only re-produce catalogs this executor can actually re-list —
+        // rebuilding under an unloaded plugin would clear a working catalog.
+        // (A loaded plugin without `resolveTools` still flows through:
+        // `produceConnectionTools` runs its clear-and-stamp cleanup path.)
+        if (!runtime) continue;
+
+        const syncedAt =
+          connection.tools_synced_at == null ? null : Number(connection.tools_synced_at);
+        const revisedTime =
+          integrationRow.config_revised_at == null
+            ? null
+            : Number(integrationRow.config_revised_at);
+
+        const staleMarked = syncedAt === null;
+        const configRevised = revisedTime !== null && (syncedAt ?? 0) < revisedTime;
+        const expired =
+          cutoff !== null &&
+          runtime.plugin.remoteToolCatalog === true &&
+          syncedAt !== null &&
+          syncedAt < cutoff;
+        if (!staleMarked && !configRevised && !expired) continue;
+
         yield* produceConnectionTools(integrationRow, {
           owner: connection.owner as Owner,
           integration: IntegrationSlug.make(connection.integration),
@@ -3319,6 +3413,7 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
           update: (ref, input) => connectionsUpdate(ref, input),
           remove: (ref) => connectionsRemove(ref),
           refresh: (ref) => connectionsRefresh(ref),
+          markToolsStale: (ref) => connectionsMarkToolsStale(ref),
           resolveValue: (ref) => resolveConnectionValueByRef(ref),
         },
         providers: {

--- a/packages/core/sdk/src/plugin.ts
+++ b/packages/core/sdk/src/plugin.ts
@@ -219,6 +219,12 @@ export interface PluginCtx<TStore = unknown> {
       readonly Tool[],
       ConnectionNotFoundError | IntegrationNotFoundError | StorageFailure
     >;
+    /** Mark a connection's persisted tool catalog stale (clears its sync
+     *  stamp) without re-listing inline. The next tools read re-produces it.
+     *  For signals that arrive mid-invocation — e.g. an MCP server sending
+     *  `notifications/tools/list_changed` or rejecting a call as an unknown
+     *  tool — where an inline `refresh` would block the caller. */
+    readonly markToolsStale: (ref: ConnectionRef) => Effect.Effect<void, StorageFailure>;
     /** Resolve a connection's value through its provider (and OAuth refresh).
      *  null if the provider can't produce one. */
     readonly resolveValue: (ref: ConnectionRef) => Effect.Effect<string | null, StorageFailure>;
@@ -276,6 +282,13 @@ export interface ResolveToolsResult {
   readonly tools: readonly ToolDef[];
   /** Shared JSON-schema `$defs` reachable from the tools' `$ref`s. */
   readonly definitions?: Record<string, unknown>;
+  /** The source could not be (fully) enumerated: unreachable server, auth not
+   *  ready, listing aborted. The result is non-authoritative, so the executor
+   *  keeps the connection's existing persisted catalog instead of replacing it
+   *  (a transient outage must not wipe working tools). Omit / `false` when the
+   *  listing is authoritative, including a genuine "this source has zero
+   *  tools". */
+  readonly incomplete?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -517,6 +530,14 @@ export interface PluginSpec<
   readonly resolveTools?: (
     input: ResolveToolsInput<TStore>,
   ) => Effect.Effect<ResolveToolsResult, StorageFailure>;
+
+  /** Declare that `resolveTools` lists a live remote catalog (an MCP server)
+   *  that can change without any executor-side config change. Core keeps such
+   *  connections fresh: their persisted tools are re-listed on a tools read
+   *  once older than the executor's `toolsSyncTtlMs`, in addition to the
+   *  config-revision and stale-mark triggers every plugin gets. Leave unset
+   *  for catalogs derived purely from stored state (specs, static config). */
+  readonly remoteToolCatalog?: boolean;
 
   /** Invoke a dynamic tool. Called when the static-handler map doesn't have the
    *  address. The plugin applies `input.credential` to the outbound request. */

--- a/packages/plugins/mcp/src/sdk/catalog-sync.test.ts
+++ b/packages/plugins/mcp/src/sdk/catalog-sync.test.ts
@@ -1,0 +1,250 @@
+// ---------------------------------------------------------------------------
+// MCP tool-catalog freshness (end-to-end).
+//
+// The persisted per-connection tool catalog must converge with the server's
+// live tool set. Spec inputs the executor reacts to:
+//   - `notifications/tools/list_changed` received during a call window marks
+//     the connection stale; the next tools read re-lists.
+//   - An unknown-tool protocol error (`-32602`, "Tool … not found") on
+//     `tools/call` means the catalog drifted: the call fails with a typed
+//     `mcp_tool_unknown` ToolResult and the catalog heals on the next read.
+//   - `tools/list` is paginated; discovery follows `nextCursor` to the end.
+//   - A failed listing (server unreachable) is non-authoritative: the
+//     previously persisted catalog is kept, not wiped.
+// ---------------------------------------------------------------------------
+
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Option, Schema } from "effect";
+import { HttpServerResponse } from "effect/unstable/http";
+
+import {
+  AuthTemplateSlug,
+  ConnectionName,
+  IntegrationSlug,
+  ToolAddress,
+  createExecutor,
+} from "@executor-js/sdk";
+import {
+  makeTestConfig,
+  memoryCredentialsPlugin,
+  serveTestHttpApp,
+} from "@executor-js/sdk/testing";
+
+import { mcpPlugin } from "./plugin";
+import { createMcpConnector } from "./connection";
+import { discoverTools } from "./discover";
+import { makeMutableCatalogMcpServer, serveMcpServer } from "../testing";
+
+const INTEG = IntegrationSlug.make("catalog_mcp");
+const CONNECTION = ConnectionName.make("main");
+const TEMPLATE = AuthTemplateSlug.make("none");
+
+const makeCatalogTestExecutor = (
+  serverUrl: string,
+  options?: { readonly toolsSyncTtlMs?: number | null },
+) =>
+  createExecutor({
+    ...makeTestConfig({ plugins: [memoryCredentialsPlugin(), mcpPlugin()] as const }),
+    ...(options?.toolsSyncTtlMs === undefined ? {} : { toolsSyncTtlMs: options.toolsSyncTtlMs }),
+  }).pipe(
+    Effect.tap((executor) =>
+      Effect.gen(function* () {
+        yield* executor.mcp.addServer({
+          name: "catalog-mcp",
+          endpoint: serverUrl,
+          slug: String(INTEG),
+        });
+        yield* executor.connections.create({
+          owner: "org",
+          name: CONNECTION,
+          integration: INTEG,
+          template: TEMPLATE,
+          value: "",
+        });
+      }),
+    ),
+  );
+
+const toolNames = (tools: readonly { readonly name: unknown }[]): readonly string[] =>
+  tools.map((tool) => String(tool.name)).sort();
+
+describe("MCP tool-catalog sync (end-to-end)", () => {
+  it.effect(
+    "tools/list_changed during a call marks the catalog stale and the next read re-lists",
+    () =>
+      Effect.gen(function* () {
+        const mutable = makeMutableCatalogMcpServer();
+        const server = yield* serveMcpServer(mutable.factory);
+        const executor = yield* makeCatalogTestExecutor(server.url);
+
+        expect(toolNames(yield* executor.tools.list())).toContain(mutable.initialToolName);
+
+        // `rename_greet` renames the greet tool mid-call; the SDK server sends
+        // `notifications/tools/list_changed` on the open connection, which the
+        // invoke path records and turns into a stale mark after the call.
+        const result = yield* executor.execute(
+          ToolAddress.make(`tools.${String(INTEG)}.org.main.rename_greet`),
+          {},
+        );
+        expect(result).toMatchObject({ ok: true });
+
+        // No manual refresh: the next tools read re-lists from the server.
+        const refreshed = toolNames(yield* executor.tools.list());
+        expect(refreshed).toContain(mutable.renamedToolName);
+        expect(refreshed).not.toContain(mutable.initialToolName);
+      }),
+  );
+
+  it.effect(
+    "unknown-tool rejection fails typed, marks stale, and the catalog heals on the next read",
+    () =>
+      Effect.gen(function* () {
+        const mutable = makeMutableCatalogMcpServer();
+        const server = yield* serveMcpServer(mutable.factory);
+        // TTL disabled: only the unknown-tool signal may trigger the re-list.
+        const executor = yield* makeCatalogTestExecutor(server.url, { toolsSyncTtlMs: null });
+
+        expect(toolNames(yield* executor.tools.list())).toContain(mutable.initialToolName);
+
+        // Mutate the server catalog outside any executor call window — the
+        // executor has no notification to react to and its catalog is drifted.
+        mutable.renameTool();
+
+        const staleAddress = ToolAddress.make(
+          `tools.${String(INTEG)}.org.main.${mutable.initialToolName}`,
+        );
+        const result = yield* executor.execute(staleAddress, { name: "world" });
+        expect(result).toMatchObject({
+          ok: false,
+          error: { code: "mcp_tool_unknown" },
+        });
+
+        // The failure marked the connection stale; the next read converges.
+        const healed = toolNames(yield* executor.tools.list());
+        expect(healed).toContain(mutable.renamedToolName);
+        expect(healed).not.toContain(mutable.initialToolName);
+      }),
+  );
+
+  it.effect("expired catalogs re-list on read once older than the freshness TTL", () =>
+    Effect.gen(function* () {
+      const mutable = makeMutableCatalogMcpServer();
+      const server = yield* serveMcpServer(mutable.factory);
+      // Everything is instantly stale — every tools read re-lists.
+      const executor = yield* makeCatalogTestExecutor(server.url, { toolsSyncTtlMs: 0 });
+
+      expect(toolNames(yield* executor.tools.list())).toContain(mutable.initialToolName);
+
+      // Server-side change with no notification and no executor signal at all.
+      mutable.renameTool();
+
+      const refreshed = toolNames(yield* executor.tools.list());
+      expect(refreshed).toContain(mutable.renamedToolName);
+      expect(refreshed).not.toContain(mutable.initialToolName);
+    }),
+  );
+
+  it.effect("a fresh catalog inside the TTL is served from the persisted rows", () =>
+    Effect.gen(function* () {
+      const mutable = makeMutableCatalogMcpServer();
+      const server = yield* serveMcpServer(mutable.factory);
+      const executor = yield* makeCatalogTestExecutor(server.url, {
+        toolsSyncTtlMs: 60 * 60 * 1000,
+      });
+
+      expect(toolNames(yield* executor.tools.list())).toContain(mutable.initialToolName);
+      const sessionsAfterFirstList = server.sessionCount();
+
+      mutable.renameTool();
+
+      // Within the TTL and with no stale signal, reads serve the persisted
+      // catalog without dialing the server.
+      expect(toolNames(yield* executor.tools.list())).toContain(mutable.initialToolName);
+      expect(server.sessionCount()).toBe(sessionsAfterFirstList);
+    }),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Pagination — discovery follows `nextCursor` across tools/list pages.
+// ---------------------------------------------------------------------------
+
+const JsonRpcId = Schema.Union([Schema.String, Schema.Number, Schema.Null]);
+const JsonRpcRequest = Schema.Struct({
+  id: Schema.optional(JsonRpcId),
+  method: Schema.String,
+  params: Schema.optional(Schema.Record(Schema.String, Schema.Unknown)),
+});
+type JsonRpcRequest = typeof JsonRpcRequest.Type;
+
+const decodeJsonRpcRequest = Schema.decodeUnknownOption(Schema.fromJsonString(JsonRpcRequest));
+
+const jsonRpcResult = (request: JsonRpcRequest, result: unknown) =>
+  HttpServerResponse.jsonUnsafe({ jsonrpc: "2.0", id: request.id ?? null, result });
+
+const pageTool = (name: string) => ({
+  name,
+  description: `Tool ${name}`,
+  inputSchema: { type: "object", properties: {} },
+});
+
+// A minimal paginated fixture: page1 → cursor "p2" → page2 → done.
+const servePaginatedListServer = () =>
+  serveTestHttpApp((request) =>
+    Effect.gen(function* () {
+      if (request.method === "GET") {
+        return HttpServerResponse.text("SSE disabled", { status: 405 });
+      }
+      const body = yield* request.text.pipe(Effect.orDie);
+      return Option.match(decodeJsonRpcRequest(body), {
+        onNone: () => HttpServerResponse.text("Invalid JSON-RPC fixture request", { status: 400 }),
+        onSome: (rpc) => {
+          if (rpc.method === "initialize") {
+            return jsonRpcResult(rpc, {
+              protocolVersion: "2025-06-18",
+              capabilities: { tools: { listChanged: true } },
+              serverInfo: { name: "paginated-fixture", version: "1.0.0" },
+            });
+          }
+          if (rpc.method === "notifications/initialized") {
+            return HttpServerResponse.text("", { status: 202 });
+          }
+          if (rpc.method === "tools/list") {
+            const cursor = rpc.params?.cursor;
+            if (cursor === undefined) {
+              return jsonRpcResult(rpc, {
+                tools: [pageTool("alpha"), pageTool("beta")],
+                nextCursor: "p2",
+              });
+            }
+            if (cursor === "p2") {
+              return jsonRpcResult(rpc, { tools: [pageTool("gamma")] });
+            }
+            return HttpServerResponse.text("Unknown cursor", { status: 400 });
+          }
+          return HttpServerResponse.text("Unexpected JSON-RPC method", { status: 400 });
+        },
+      });
+    }),
+  );
+
+describe("MCP tools/list pagination", () => {
+  it.effect("discoverTools follows nextCursor across every page", () =>
+    Effect.gen(function* () {
+      const server = yield* servePaginatedListServer();
+      const manifest = yield* discoverTools(
+        createMcpConnector({
+          transport: "remote",
+          endpoint: server.url("/mcp"),
+          remoteTransport: "streamable-http",
+        }),
+      );
+
+      expect(manifest.tools.map((tool) => tool.toolName).sort()).toEqual([
+        "alpha",
+        "beta",
+        "gamma",
+      ]);
+    }),
+  );
+});

--- a/packages/plugins/mcp/src/sdk/discover.ts
+++ b/packages/plugins/mcp/src/sdk/discover.ts
@@ -2,19 +2,70 @@
 // MCP tool discovery — connect to an MCP server and list its tools
 // ---------------------------------------------------------------------------
 
-import { Effect } from "effect";
+import { Effect, Option } from "effect";
 
-import type { McpConnector } from "./connection";
+import type { McpConnection, McpConnector } from "./connection";
 import { McpToolDiscoveryError } from "./errors";
 import {
+  decodeListToolsPage,
   extractManifestFromListToolsResult,
-  isListToolsResult,
   type McpToolManifest,
 } from "./manifest";
+
+// Backstop for a server that returns a cycling / never-terminating cursor.
+// The spec puts no bound on page count; a compliant server terminates by
+// omitting `nextCursor`, so any real catalog fits well inside this.
+const MAX_LIST_TOOLS_PAGES = 100;
 
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
+
+/**
+ * List every tool from an open MCP connection, following `nextCursor`
+ * pagination (spec: `tools/list` is a paginated operation — a single call
+ * returns one page, not the catalog).
+ */
+const listAllTools = (
+  connection: McpConnection,
+): Effect.Effect<McpToolManifest, McpToolDiscoveryError> =>
+  Effect.gen(function* () {
+    const tools: unknown[] = [];
+    let cursor: string | undefined = undefined;
+
+    for (let page = 0; page < MAX_LIST_TOOLS_PAGES; page++) {
+      const params: { cursor?: string } | undefined = cursor === undefined ? undefined : { cursor };
+      const listResult = yield* Effect.tryPromise({
+        try: () => connection.client.listTools(params),
+        catch: () =>
+          new McpToolDiscoveryError({
+            stage: "list_tools",
+            message: "Failed listing MCP tools",
+          }),
+      });
+
+      const decoded = decodeListToolsPage(listResult);
+      if (Option.isNone(decoded)) {
+        return yield* new McpToolDiscoveryError({
+          stage: "list_tools",
+          message: "MCP listTools response did not match the expected schema",
+        });
+      }
+
+      tools.push(...decoded.value.tools);
+      const nextCursor = decoded.value.nextCursor;
+      if (nextCursor == null || nextCursor === "") break;
+      cursor = nextCursor;
+    }
+
+    return extractManifestFromListToolsResult(
+      { tools },
+      {
+        serverInfo: connection.client.getServerVersion?.(),
+        instructions: connection.client.getInstructions?.(),
+      },
+    );
+  });
 
 /**
  * Connect to an MCP server and discover all available tools.
@@ -35,31 +86,9 @@ export const discoverTools = (
       ),
     );
 
-    // List tools
-    const listResult = yield* Effect.tryPromise({
-      try: () => connection.client.listTools(),
-      catch: () =>
-        new McpToolDiscoveryError({
-          stage: "list_tools",
-          message: "Failed listing MCP tools",
-        }),
-    });
-
-    if (!isListToolsResult(listResult)) {
-      yield* closeConnection(connection);
-      return yield* new McpToolDiscoveryError({
-        stage: "list_tools",
-        message: "MCP listTools response did not match the expected schema",
-      });
-    }
-
-    const manifest = extractManifestFromListToolsResult(listResult, {
-      serverInfo: connection.client.getServerVersion?.(),
-      instructions: connection.client.getInstructions?.(),
-    });
-
-    // Close the connection after discovery
-    yield* closeConnection(connection);
+    const manifest = yield* listAllTools(connection).pipe(
+      Effect.onExit(() => closeConnection(connection)),
+    );
 
     return manifest;
   });

--- a/packages/plugins/mcp/src/sdk/errors.ts
+++ b/packages/plugins/mcp/src/sdk/errors.ts
@@ -28,6 +28,9 @@ export class McpInvocationError extends Data.TaggedError("McpInvocationError")<{
   readonly toolName: string;
   readonly message: string;
   readonly status?: number;
+  /** The server rejected the call as an unknown tool (protocol error), which
+   *  means the persisted catalog has drifted from the server's live tool set. */
+  readonly unknownTool?: boolean;
 }> {}
 
 export class McpOAuthReauthorizationRequired extends Data.TaggedError(

--- a/packages/plugins/mcp/src/sdk/invoke.ts
+++ b/packages/plugins/mcp/src/sdk/invoke.ts
@@ -14,7 +14,12 @@
 import { Cause, Effect, Exit, Option, Predicate, Schema } from "effect";
 
 import { StreamableHTTPError } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
-import { ElicitRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import {
+  ElicitRequestSchema,
+  ErrorCode,
+  McpError,
+  ToolListChangedNotificationSchema,
+} from "@modelcontextprotocol/sdk/types.js";
 
 import {
   ElicitationId,
@@ -61,6 +66,31 @@ const statusFromStreamableHttpError = (cause: unknown): number | undefined => {
 
 const httpStatusFromCause = (cause: unknown): number | undefined =>
   statusFromStreamableHttpError(cause) ?? statusFromSsePostError(cause);
+
+// The spec answers `tools/call` for a tool the server no longer advertises
+// with a protocol error (`-32602 Invalid params`, example message
+// "Unknown tool: …"); the reference TypeScript SDK server instead catches that
+// error and returns it as an execution-error envelope (`isError: true`, text
+// "Tool <name> not found"). Both shapes mean the same thing — the persisted
+// catalog drifted — so both are detected, anchored to the exact tool name to
+// keep a domain error that merely mentions "not found" from matching. A miss
+// is benign (the catalog still heals via TTL or explicit refresh).
+const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+export const isUnknownToolMessage = (message: string, toolName: string): boolean => {
+  const name = escapeRegExp(toolName);
+  return new RegExp(
+    `(?:unknown tool:?\\s*"?${name}"?|tool\\s+"?${name}"?\\s+(?:not found|is not available|does not exist))`,
+    "i",
+  ).test(message);
+};
+
+const isUnknownToolCause = (cause: unknown, toolName: string): boolean =>
+  // oxlint-disable-next-line executor/no-instanceof-tagged-error -- boundary: MCP SDK surfaces JSON-RPC protocol errors as this Error subclass
+  cause instanceof McpError &&
+  (cause.code === ErrorCode.InvalidParams || cause.code === ErrorCode.MethodNotFound) &&
+  // oxlint-disable-next-line executor/no-unknown-error-message -- boundary: instanceof narrows to the SDK's McpError, whose message carries the only unknown-tool discriminator the protocol provides
+  isUnknownToolMessage(cause.message, toolName);
 
 // ---------------------------------------------------------------------------
 // Elicitation bridge — decode incoming MCP ElicitRequest, route through
@@ -128,7 +158,25 @@ const installElicitationHandler = (client: McpConnection["client"], elicit: Elic
 };
 
 // ---------------------------------------------------------------------------
-// Single tool call — install handler, callTool, return raw result
+// tools/list_changed bridge — while a connection is open (the call window),
+// listen for the spec's `notifications/tools/list_changed` and surface it to
+// the host so it can mark the persisted catalog stale. Registering the handler
+// is unconditional: it only fires if the server sends the notification, and a
+// server that never does costs nothing.
+// ---------------------------------------------------------------------------
+
+const installToolListChangedHandler = (
+  client: McpConnection["client"],
+  onToolListChanged: (() => void) | undefined,
+): void => {
+  if (!onToolListChanged) return;
+  client.setNotificationHandler(ToolListChangedNotificationSchema, () => {
+    onToolListChanged();
+  });
+};
+
+// ---------------------------------------------------------------------------
+// Single tool call — install handlers, callTool, return raw result
 // ---------------------------------------------------------------------------
 
 const useConnection = (
@@ -136,9 +184,11 @@ const useConnection = (
   toolName: string,
   args: Record<string, unknown>,
   elicit: Elicit,
+  onToolListChanged: (() => void) | undefined,
 ): Effect.Effect<unknown, McpInvocationError | McpOAuthReauthorizationRequired> =>
   Effect.gen(function* () {
     installElicitationHandler(connection.client, elicit);
+    installToolListChangedHandler(connection.client, onToolListChanged);
     return yield* Effect.tryPromise({
       try: () => connection.client.callTool({ name: toolName, arguments: args }),
       catch: (cause) => {
@@ -152,6 +202,7 @@ const useConnection = (
           toolName,
           message: `MCP tool call failed for ${toolName}`,
           ...(status === undefined ? {} : { status }),
+          ...(isUnknownToolCause(cause, toolName) ? { unknownTool: true } : {}),
         });
       },
     }).pipe(
@@ -174,6 +225,10 @@ export interface InvokeMcpToolInput {
   /** Dials a fresh connection. The connection is closed after the call. */
   readonly connector: McpConnector;
   readonly elicit: Elicit;
+  /** Fired when the server sends `notifications/tools/list_changed` during
+   *  the call window. Synchronous and non-throwing by contract; the caller
+   *  uses it to mark the persisted catalog stale. */
+  readonly onToolListChanged?: () => void;
 }
 
 export const invokeMcpTool = (
@@ -204,7 +259,13 @@ export const invokeMcpTool = (
         ),
     );
 
-    return yield* useConnection(connection, input.toolName, args, input.elicit);
+    return yield* useConnection(
+      connection,
+      input.toolName,
+      args,
+      input.elicit,
+      input.onToolListChanged,
+    );
   }).pipe(
     Effect.scoped,
     Effect.withSpan("plugin.mcp.invoke", {

--- a/packages/plugins/mcp/src/sdk/manifest.ts
+++ b/packages/plugins/mcp/src/sdk/manifest.ts
@@ -44,16 +44,30 @@ const ListToolsResult = Schema.Struct({
   tools: Schema.Array(ListedTool),
 });
 
+// One page of a paginated `tools/list` response. Entries stay opaque here so a
+// page with foreign tool shapes still pages correctly; per-entry decoding
+// happens in `extractManifestFromListToolsResult` over the merged list.
+const ListToolsPage = Schema.Struct({
+  tools: Schema.Array(Schema.Unknown),
+  nextCursor: Schema.optional(Schema.NullOr(Schema.String)),
+});
+
+export interface McpListToolsPage {
+  readonly tools: readonly unknown[];
+  readonly nextCursor?: string | null;
+}
+
 const ServerInfo = Schema.Struct({
   name: Schema.optional(Schema.String),
   version: Schema.optional(Schema.String),
 });
 
 const decodeListToolsResult = Schema.decodeUnknownOption(ListToolsResult);
+const decodeListToolsPageOption = Schema.decodeUnknownOption(ListToolsPage);
 const decodeServerInfo = Schema.decodeUnknownOption(ServerInfo);
 
-export const isListToolsResult = (value: unknown): boolean =>
-  Option.isSome(decodeListToolsResult(value));
+export const decodeListToolsPage = (value: unknown): Option.Option<McpListToolsPage> =>
+  decodeListToolsPageOption(value);
 
 // ---------------------------------------------------------------------------
 // Tool ID sanitization

--- a/packages/plugins/mcp/src/sdk/plugin.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.ts
@@ -45,7 +45,7 @@ import {
   McpOAuthReauthorizationRequired,
   McpToolDiscoveryError,
 } from "./errors";
-import { invokeMcpTool } from "./invoke";
+import { invokeMcpTool, isUnknownToolMessage } from "./invoke";
 import { deriveMcpNamespace, type McpToolManifestEntry } from "./manifest";
 import { mcpPresets } from "./presets";
 import { probeMcpEndpointShape, type McpShapeProbeResult } from "./probe-shape";
@@ -413,6 +413,22 @@ const extractMcpErrorMessage = (content: unknown): string => {
   return "MCP tool returned an error";
 };
 
+// The server no longer advertises this tool — the persisted catalog drifted.
+// Answered after marking the connection stale so the next tools read re-lists;
+// the message tells the caller to re-list instead of retrying blind.
+const unknownToolFailure = (
+  toolName: string,
+  credential: { readonly integration: unknown; readonly connection: unknown },
+) =>
+  ToolResult.fail({
+    code: "mcp_tool_unknown",
+    message: `The MCP server no longer provides tool "${toolName}". Its tool catalog changed; list tools again for the current set.`,
+    details: {
+      integration: String(credential.integration),
+      connection: String(credential.connection),
+    },
+  });
+
 /** Match `token` as a separator-bounded run inside a URL hostname or path,
  *  used as a low-confidence detection hint when wire-shape detection fails. */
 const urlMatchesToken = (url: URL, token: string): boolean => {
@@ -666,6 +682,9 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
   return {
     id: MCP_PLUGIN_ID,
     packageName: "@executor-js/plugin-mcp",
+    // MCP servers own their tool catalogs and change them server-side with no
+    // executor-visible signal — opt into core's freshness TTL re-listing.
+    remoteToolCatalog: true,
     integrationPresets: presetEntries,
     // Surfaced to the client bundle via the Vite plugin. The MCP `./client`
     // factory reads `allowStdio` and gates the stdio tab + presets.
@@ -1114,15 +1133,17 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
     // -----------------------------------------------------------------------
     // Per-connection tool production. Dial the server using the connection's
     // resolved value (rendered through the integration's auth template) and
-    // list its tools. The real MCP tool name + upstream annotations are
-    // stamped into each ToolDef's annotations so invokeTool can recover them.
-    // Discovery failures (auth not ready, server down) yield an empty tool set
-    // rather than failing — the connection still lands and can be refreshed.
+    // list its tools (following `nextCursor` pagination). The real MCP tool
+    // name + upstream annotations are stamped into each ToolDef's annotations
+    // so invokeTool can recover them. Discovery failures (auth not ready,
+    // server down) yield an `incomplete` empty result rather than failing —
+    // the connection still lands, and core keeps any previously persisted
+    // catalog instead of wiping it over a transient outage.
     // -----------------------------------------------------------------------
     resolveTools: ({ config, connection, template, getValues, httpClientLayer }) =>
       Effect.gen(function* () {
         const parsed = parseMcpIntegrationConfig(config);
-        if (!parsed) return { tools: [] as readonly ToolDef[] };
+        if (!parsed) return { tools: [] as readonly ToolDef[], incomplete: true };
 
         // Discovery tolerates unresolved credentials (an open server lists
         // tools unauthenticated; a bad value just yields zero tools).
@@ -1151,13 +1172,18 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
             )
           : { ok: false as const, manifest: null };
 
-        const entries = manifest.ok && manifest.manifest ? manifest.manifest.tools : [];
-        return { tools: entries.map(toToolDef) };
+        if (!manifest.ok || !manifest.manifest) {
+          return { tools: [] as readonly ToolDef[], incomplete: true };
+        }
+        return { tools: manifest.manifest.tools.map(toToolDef) };
       }).pipe(
         Effect.withSpan("mcp.plugin.resolve_tools", {
           attributes: { "mcp.connection.name": String(connection.name) },
         }),
-      ) as Effect.Effect<{ readonly tools: readonly ToolDef[] }, StorageFailure>,
+      ) as Effect.Effect<
+        { readonly tools: readonly ToolDef[]; readonly incomplete?: boolean },
+        StorageFailure
+      >,
 
     invokeTool: ({ ctx, toolRow, credential, args, elicit }) =>
       Effect.gen(function* () {
@@ -1207,6 +1233,19 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
           options?.httpClientLayer ?? ctx.httpClientLayer,
         ).pipe(Effect.map((ci) => createMcpConnector(ci)));
 
+        const connectionRef = {
+          owner: credential.owner,
+          integration: credential.integration,
+          name: credential.connection,
+        };
+
+        // Spec: a server whose tool list changed sends
+        // `notifications/tools/list_changed` on any open connection — the call
+        // window included. Record it here (the handler must be sync) and mark
+        // the persisted catalog stale after the call settles, so the next
+        // tools read re-lists instead of serving the drifted catalog.
+        let toolListChanged = false;
+
         const raw = yield* invokeMcpTool({
           toolId: String(toolRow.name),
           toolName: stamp.toolName,
@@ -1214,13 +1253,32 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
           transport,
           connector,
           elicit,
-        });
+          onToolListChanged: () => {
+            toolListChanged = true;
+          },
+        }).pipe(
+          Effect.onExit(() =>
+            toolListChanged
+              ? ctx.connections.markToolsStale(connectionRef).pipe(Effect.ignore)
+              : Effect.void,
+          ),
+        );
 
         const envelope = Option.getOrUndefined(decodeMcpToolCallEnvelope(raw));
         if (envelope?.isError === true) {
+          const errorMessage = extractMcpErrorMessage(envelope.content);
+          // The reference TS SDK server reports an unknown tool as an
+          // execution-error envelope ("Tool <name> not found") rather than the
+          // spec's protocol error. Same meaning: the persisted catalog
+          // drifted. Mark it stale and answer with the typed drift failure.
+          if (isUnknownToolMessage(errorMessage, stamp.toolName)) {
+            return yield* ctx.connections
+              .markToolsStale(connectionRef)
+              .pipe(Effect.ignore, Effect.as(unknownToolFailure(String(toolRow.name), credential)));
+          }
           return ToolResult.fail({
             code: "mcp_tool_error",
-            message: extractMcpErrorMessage(envelope.content),
+            message: errorMessage,
             details: { content: envelope.content },
           });
         }
@@ -1253,6 +1311,15 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
                 connection: String(credential.connection),
               }),
             );
+          }
+          if (error.unknownTool === true) {
+            return ctx.connections
+              .markToolsStale({
+                owner: credential.owner,
+                integration: credential.integration,
+                name: credential.connection,
+              })
+              .pipe(Effect.ignore, Effect.as(unknownToolFailure(String(toolRow.name), credential)));
           }
           return Effect.fail(error);
         }),

--- a/packages/plugins/mcp/src/testing/index.ts
+++ b/packages/plugins/mcp/src/testing/index.ts
@@ -8,6 +8,7 @@ export {
   makeElicitationMcpServer,
   makeGreetingMcpServer,
   makeImageMcpServer,
+  makeMutableCatalogMcpServer,
   serveMcpServer,
   serveMcpServerWithOAuth,
   type McpTestRequest,

--- a/packages/plugins/mcp/src/testing/server.ts
+++ b/packages/plugins/mcp/src/testing/server.ts
@@ -468,10 +468,12 @@ export const makeElicitationMcpServer = () => {
  */
 export const makeMutableCatalogMcpServer = (
   options: {
+    readonly name?: string;
     readonly initialToolName?: string;
     readonly renamedToolName?: string;
   } = {},
 ) => {
+  const serverName = options.name ?? "mutable-catalog-test-server";
   const initialToolName = options.initialToolName ?? "greet";
   const renamedToolName = options.renamedToolName ?? "greet_v2";
   const registrations = new Set<{ update: (updates: { name: string }) => void }>();
@@ -485,10 +487,7 @@ export const makeMutableCatalogMcpServer = (
   };
 
   const factory = () => {
-    const server = new McpServer(
-      { name: "mutable-catalog-test-server", version: "1.0.0" },
-      { capabilities: {} },
-    );
+    const server = new McpServer({ name: serverName, version: "1.0.0" }, { capabilities: {} });
     const registered = server.registerTool(
       currentToolName,
       {

--- a/packages/plugins/mcp/src/testing/server.ts
+++ b/packages/plugins/mcp/src/testing/server.ts
@@ -454,6 +454,66 @@ export const makeElicitationMcpServer = () => {
   return server;
 };
 
+/**
+ * A server whose tool catalog mutates at runtime. `renameTool` renames the
+ * advertised tool from `initialToolName` to `renamedToolName` via the SDK's
+ * `RegisteredTool.update`, which sends `notifications/tools/list_changed` to
+ * connected sessions. Calling the retired name afterwards yields the spec's
+ * unknown-tool protocol error. The rename applies to every live session and
+ * to sessions created after it (one shared name across the factory), so a
+ * mutation made during one client's call window is visible to the next
+ * connection's `tools/list`. The `rename_greet` tool performs the rename
+ * mid-call, so a client with an open connection receives the notification
+ * inside its own call window.
+ */
+export const makeMutableCatalogMcpServer = (
+  options: {
+    readonly initialToolName?: string;
+    readonly renamedToolName?: string;
+  } = {},
+) => {
+  const initialToolName = options.initialToolName ?? "greet";
+  const renamedToolName = options.renamedToolName ?? "greet_v2";
+  const registrations = new Set<{ update: (updates: { name: string }) => void }>();
+  let currentToolName = initialToolName;
+
+  const renameTool = () => {
+    currentToolName = renamedToolName;
+    for (const registered of registrations) {
+      registered.update({ name: renamedToolName });
+    }
+  };
+
+  const factory = () => {
+    const server = new McpServer(
+      { name: "mutable-catalog-test-server", version: "1.0.0" },
+      { capabilities: {} },
+    );
+    const registered = server.registerTool(
+      currentToolName,
+      {
+        description: "Greets the caller",
+        inputSchema: { name: z.string() },
+      },
+      async ({ name }: { name: string }) => ({
+        content: [{ type: "text" as const, text: `greeting:${name}` }],
+      }),
+    );
+    registrations.add(registered);
+    server.registerTool(
+      "rename_greet",
+      { description: "Renames the greet tool", inputSchema: {} },
+      async () => {
+        renameTool();
+        return { content: [{ type: "text" as const, text: "renamed" }] };
+      },
+    );
+    return server;
+  };
+
+  return { factory, renameTool, initialToolName, renamedToolName };
+};
+
 export const makeAnnotationsMcpServer = () => {
   const server = new McpServer(
     { name: "annotations-test-server", version: "1.0.0" },

--- a/packages/plugins/mcp/src/testing/server.ts
+++ b/packages/plugins/mcp/src/testing/server.ts
@@ -503,8 +503,15 @@ export const makeMutableCatalogMcpServer = (
     server.registerTool(
       "rename_greet",
       { description: "Renames the greet tool", inputSchema: {} },
-      async () => {
+      async (_args, extra) => {
         renameTool();
+        // `RegisteredTool.update` already emitted list_changed, but with no
+        // relatedRequestId the transport routes it to the standalone GET SSE
+        // stream, which a request-scoped client may never have open. Send it
+        // through the handler's `extra` too: that stamps the request id, so
+        // the notification rides THIS call's response stream and is
+        // guaranteed to reach the caller before the tool result.
+        await extra.sendNotification({ method: "notifications/tools/list_changed" });
         return { content: [{ type: "text" as const, text: "renamed" }] };
       },
     );


### PR DESCRIPTION
## Problem

An MCP connection's tool catalog was listed once at connection create and only re-listed on an executor-side config edit or a manual Refresh click. Server-side catalog changes (tools added, removed, renamed) were never picked up: stale tools kept failing invocations, and new tools never appeared.

Three spec gaps underneath:

- `tools/list` pagination was ignored — discovery called `listTools()` once and kept only the first page.
- `notifications/tools/list_changed` was not handled anywhere (no handler registered, no capability interest, and connections closed immediately after each call).
- Unknown-tool rejections on `tools/call` surfaced as generic errors with no self-healing.

There was also a latent data-loss bug: a transient outage during any re-list persisted an empty tool set, wiping working tools.

## Changes

**MCP plugin**
- Discovery follows `nextCursor` until exhausted (bounded at 100 pages against cycling cursors).
- Every invoke connection registers a `tools/list_changed` notification handler; a notification received during the call window marks the connection's persisted catalog stale, and the next tools read re-lists.
- Unknown-tool rejections are detected in both wire shapes — the spec's `-32602` protocol error and the reference TS SDK's `isError` envelope ("Tool X not found") — anchored to the exact tool name so domain errors can't false-positive. The call answers a typed `mcp_tool_unknown` failure telling the caller to re-list, and the catalog marks stale.
- Failed listings return `incomplete: true` instead of an empty catalog.

**Core SDK**
- New `ctx.connections.markToolsStale(ref)`: clears `tools_synced_at` so the next tools read re-produces the connection, without blocking the in-flight call.
- The stale-sync in `toolsList` now has three triggers: stale-marked (NULL stamp), config-revised (existing behavior), and TTL-expired — plugins that declare the new `remoteToolCatalog` flag (MCP does) are re-listed on read once older than `ExecutorConfig.toolsSyncTtlMs` (default 15 min, `null` disables). This covers servers that change tools without ever notifying. Steady state stays one indexed query returning nothing.
- `incomplete` results keep the previously persisted catalog rather than wiping it, and still stamp the sync time so a down server isn't re-dialed on every read.

## Scope note

Connections are dialed per-operation (Workers constraint), so `list_changed` notifications are only received during call windows; the TTL guarantees convergence for changes that land while no call is open. A persistent listener connection for long-running hosts would be a follow-up and can't work on Cloudflare, so this fix isn't coupled to it.

## Testing

New `catalog-sync.test.ts` covers all five behaviors end-to-end against a live MCP server whose catalog mutates at runtime (new `makeMutableCatalogMcpServer` fixture):

- `list_changed` during a call → stale mark → next read re-lists
- unknown-tool rejection → typed `mcp_tool_unknown` → catalog heals on next read
- TTL expiry re-lists on read
- fresh catalog inside the TTL serves persisted rows without dialing the server (asserted via session count)
- pagination across multiple `tools/list` pages

Full suite: 36/36 packages pass; format, lint, typecheck clean. Changeset included (`@executor-js/plugin-mcp` + `@executor-js/sdk` patch).