### PR TITLE
Carry the verified Principal into DO agent sessions

### DIFF
--- a/apps/cloud/src/mcp/agent-handler.ts
+++ b/apps/cloud/src/mcp/agent-handler.ts
@@ -105,6 +105,9 @@ const propsForPrincipal = (
         elicitationMode: readElicitationMode(request),
         resource,
         webOrigin: new URL(request.url).origin,
+        // The whole verified caller, so the session DO rebuilds its runtime
+        // with the same identity the in-memory store passes to buildServer.
+        principal,
       },
       propagation,
     };

--- a/apps/host-cloudflare/src/mcp/agent-handler.ts
+++ b/apps/host-cloudflare/src/mcp/agent-handler.ts
@@ -96,6 +96,9 @@ const propsForPrincipal = (
         // resource.
         resource: defaultMcpResource,
         webOrigin: new URL(request.url).origin,
+        // The whole verified caller, so the session DO rebuilds its runtime
+        // with the same identity the in-memory store passes to buildServer.
+        principal,
       },
       propagation,
     };

--- a/packages/hosts/cloudflare/src/mcp/agent-session-durable-object.ts
+++ b/packages/hosts/cloudflare/src/mcp/agent-session-durable-object.ts
@@ -14,7 +14,7 @@ import {
   PAUSED_APPROVAL_TIMEOUT_MS,
   type PausedExecutionHooks,
 } from "@executor-js/host-mcp/tool-server";
-import { defaultMcpResource, type McpResource } from "@executor-js/host-mcp";
+import { defaultMcpResource, type McpResource, type Principal } from "@executor-js/host-mcp";
 
 import type { IncomingPropagationHeaders, McpElicitationMode } from "./do-headers";
 import {
@@ -22,6 +22,7 @@ import {
   decideSessionAlarm,
   pausedLeaseExtensionLog,
 } from "./session-alarm-policy";
+import { carrySessionInit } from "./session-meta";
 
 export type IncomingTraceHeaders = IncomingPropagationHeaders;
 
@@ -33,6 +34,11 @@ export interface McpSessionInit {
    *  `/mcp/toolkits/<slug>` toolkit), so the tool catalog is scoped to it. */
   readonly resource: McpResource;
   readonly webOrigin?: string;
+  /** The verified caller, carried whole so the DO can rebuild its runtime with
+   *  the same identity the in-memory session store already passes to
+   *  `buildServer`. Optional and additive: unset changes no behavior, and
+   *  ownership validation stays keyed on userId + organizationId. */
+  readonly principal?: Principal;
 }
 
 export interface McpSessionProps extends Record<string, unknown> {
@@ -89,6 +95,12 @@ export interface SessionMeta {
    *  `buildMcpServer` scopes the tool catalog to it. */
   readonly resource: McpResource;
   readonly webOrigin?: string;
+  /** The verified caller (carried from {@link McpSessionInit}), persisted with
+   *  the meta so a cold isolate rebuilds the runtime with the same identity.
+   *  A snapshot at session mint, same lifetime semantics as userId and
+   *  organizationId (a session does not re-authenticate). Optional; ownership
+   *  validation still keys on userId + organizationId only. */
+  readonly principal?: Principal;
 }
 
 export interface BuiltMcpServer {
@@ -341,10 +353,7 @@ export abstract class McpAgentSessionDOBase<
     const self = this;
     return Effect.gen(function* () {
       const resolved = yield* self.resolveSessionMeta(token);
-      const sessionMeta: SessionMeta = {
-        ...resolved,
-        ...(token.webOrigin ? { webOrigin: token.webOrigin } : {}),
-      };
+      const sessionMeta = carrySessionInit(resolved, token);
       yield* Effect.promise(() => self.saveSessionMeta(sessionMeta)).pipe(
         Effect.withSpan("mcp.session.save_meta"),
       );

--- a/packages/hosts/cloudflare/src/mcp/session-meta.test.ts
+++ b/packages/hosts/cloudflare/src/mcp/session-meta.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import type { Principal } from "@executor-js/host-mcp";
+
+import type { SessionMeta } from "./agent-session-durable-object";
+import { carrySessionInit } from "./session-meta";
+
+const resolved: SessionMeta = {
+  organizationId: "org-1",
+  organizationName: "Org One",
+  userId: "acct-1",
+  elicitationMode: "model",
+  resource: { kind: "default" },
+};
+
+const principal: Principal = {
+  accountId: "acct-1",
+  organizationId: "org-1",
+  organizationName: "Org One",
+  email: "person@example.com",
+  name: "Person",
+  avatarUrl: null,
+  roles: ["admin"],
+};
+
+describe("carrySessionInit", () => {
+  it("carries the verified principal onto the stored meta", () => {
+    const meta = carrySessionInit(resolved, { principal });
+    expect(meta.principal).toEqual(principal);
+  });
+
+  it("carries webOrigin and principal together", () => {
+    const meta = carrySessionInit(resolved, {
+      webOrigin: "https://executor.example.com",
+      principal,
+    });
+    expect(meta.webOrigin).toBe("https://executor.example.com");
+    expect(meta.principal).toEqual(principal);
+  });
+
+  it("leaves both unset when the init carries neither", () => {
+    const meta = carrySessionInit(resolved, {});
+    expect(meta).toEqual(resolved);
+    expect("principal" in meta).toBe(false);
+    expect("webOrigin" in meta).toBe(false);
+  });
+
+  it("does not let carried fields clobber host-resolved meta", () => {
+    const meta = carrySessionInit(resolved, { principal });
+    expect(meta.organizationId).toBe("org-1");
+    expect(meta.userId).toBe("acct-1");
+    expect(meta.resource).toEqual({ kind: "default" });
+  });
+});

--- a/packages/hosts/cloudflare/src/mcp/session-meta.ts
+++ b/packages/hosts/cloudflare/src/mcp/session-meta.ts
@@ -1,0 +1,17 @@
+import type { McpSessionInit, SessionMeta } from "./agent-session-durable-object";
+
+/**
+ * Merge the host-resolved meta with the fields the base carries verbatim from
+ * `McpSessionInit`: `webOrigin` and the verified `principal`. Carrying them
+ * here (rather than in every host's `resolveSessionMeta`) keeps each host's
+ * resolver lossless without it knowing about either field, and mirrors what
+ * the in-memory session store gives `buildServer`: the whole principal.
+ */
+export const carrySessionInit = (
+  resolved: SessionMeta,
+  token: Pick<McpSessionInit, "webOrigin" | "principal">,
+): SessionMeta => ({
+  ...resolved,
+  ...(token.webOrigin ? { webOrigin: token.webOrigin } : {}),
+  ...(token.principal ? { principal: token.principal } : {}),
+});


### PR DESCRIPTION
## Problem

The two session stores give the host's server builder different views of the authenticated caller.

The in-memory store hands `buildServer` the full `Principal`:

```ts
// packages/hosts/mcp/src/in-memory-session-store.ts
return buildServer(principal, { ...buildOptionsFor(request, () => createdSessionId), resource })
```

The Durable Object bridge does not. `propsForPrincipal` in the cloud and host-cloudflare agent handlers builds `McpSessionInit` from just `principal.organizationId` and `principal.accountId`, and `SessionMeta` can never contain more than `McpSessionInit` carried in. Everything else the auth seam verified (email, name, avatarUrl, roles, organizationSlug) is discarded at that boundary, even though the worker had it in hand one call earlier.

So a host's `buildMcpServer` structurally cannot see the identity the request was authenticated with. A server builder that reads the principal (per-caller tool policies, audit attribution) behaves correctly on the in-memory store and silently loses identity on DO sessions.

## Change

Carry the principal whole across the DO boundary, the same way `webOrigin` is already carried:

- `McpSessionInit` and `SessionMeta` gain one optional `principal?: Principal` field. No new type: `Principal` is already the shared authenticated-caller noun on both sides of the seam.
- The base copies it onto the stored meta alongside `webOrigin`. That merge is extracted into a small pure `carrySessionInit` helper (`session-meta.ts`) so it is testable and so no host's `resolveSessionMeta` needs to know about either carried field.
- The cloud and host-cloudflare agent handlers add `principal` to the session props they already build from that same principal.

Optional and additive: unset changes no behavior, and ownership validation stays keyed on userId + organizationId only.

Two semantics made explicit on the field docs:

- **Snapshot at mint.** `SessionMeta` persists in DO storage, so the carried principal is frozen at session create, exactly like `userId` and `organizationId` today (a session does not re-authenticate). That matches the in-memory store, which also captures the principal at create.
- **PII at rest.** Email/name/avatarUrl land in DO storage for the session's lifetime (bounded by the session alarm). The in-memory store already holds the same data for the same lifetime, in process memory. The optional shape keeps this opt-in per host if that difference matters.

Context: we run the Cloudflare host with host-side plugins built per session in `buildMcpServer`; one enforces access grants matched on the caller's email and groups, which works against the in-memory store's contract and needed this carrier on the DO path.

## Testing

All run on this branch, all passing:

- `bun run --cwd packages/hosts/cloudflare test -- src/mcp/session-meta.test.ts`: new `carrySessionInit` test, 4/4 (carry-through, both fields, unset leaves no phantom keys, no clobbering of host-resolved meta)
- `bun run --cwd apps/host-cloudflare test -- src/worker.e2e.node.test.ts`: workerd/miniflare e2e through the real DO session path (initialize, cross-request survival, tools/call), 8/8
- `bun run --cwd apps/cloud test -- src/mcp-session.e2e.node.test.ts`: cloud session harness, 4/4
- Full suites of the touched packages: hosts/cloudflare 15/15, hosts/mcp 57/57, cloud 191/191
- `bunx turbo run typecheck` on the three touched packages (24/24), `bun run format:check` and `bun run lint` clean at the root
