### PR TITLE
test(host-selfhost): raise scope-isolation timeout to 120s

### DIFF
--- a/apps/host-selfhost/src/scope-isolation.test.ts
+++ b/apps/host-selfhost/src/scope-isolation.test.ts
@@ -135,7 +135,12 @@ test("concurrent requests with distinct identities get disjoint, correct executo
       expect(addresses.some((a) => a.includes(connectionNameForUser(other)))).toBe(false);
     }
   });
-}, 30_000);
+  // 120s, not the 30s this kept timing out at: seeding alone is 6 sequential
+  // addSpec calls, and each one is 0.5–15s under fork-pool CPU oversubscription
+  // (every test file boots a full app; all queries serialize through the one
+  // libSQL connection). The assertions are about isolation, not latency — a
+  // real regression fails on correctness, not the clock.
+}, 120_000);
 
 test("a request with no identity is rejected", async () => {
   const res = await handler(new Request("http://localhost/api/connections"));


### PR DESCRIPTION
## Summary

`scope-isolation.test.ts > concurrent requests with distinct identities get disjoint, correct executor bindings` has been timing out at the default 30s on recent CI runs — it failed the Test job on #1247's and #1248's runs (both unrelated changes) and reproduces on pristine main locally about 1 in 3 runs under CPU load.

## Where the time goes

Instrumented locally: the timeout is hit during **seeding**, before the concurrency under test even starts. Seeding is 6 sequential `addSpec` calls, and a single `addSpec` ranges from ~0.5s to **~15s** when the vitest fork pool oversubscribes the CPU — every host-selfhost test file boots a full app at import and all queries serialize through one libSQL connection. This is the same mechanism #1208 identified; that PR bounded the test's own concurrency (48-wide burst → 6) but left the default 30s ceiling, which the seeding phase alone can blow through. A passing run under load was observed at 58s wall clock.

## Fix

An explicit 120s timeout with a comment explaining why. The test asserts *isolation*, not latency — a real request-scoped-binding leak fails on correctness assertions immediately regardless of the clock, so a generous bound loses nothing.

Verified: 5 consecutive local runs pass (22–60s range under load), full host-selfhost suite green (72/72).