### PR TITLE
Log MCP session mode at info level instead of error

### DIFF
--- a/apps/local/src/mcp.ts
+++ b/apps/local/src/mcp.ts
@@ -1,4 +1,4 @@
-import { Effect, type Cause } from "effect";
+import { Effect, Logger, type Cause } from "effect";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
@@ -285,7 +285,9 @@ export const createMcpRequestHandler = (
 export const runMcpStdioServer = async (config: ExecutorMcpServerConfig): Promise<void> => {
   startIntegrationsRefresh();
 
-  const server = await Effect.runPromise(createExecutorMcpServer(config));
+  const server = await Effect.runPromise(
+    createExecutorMcpServer(config).pipe(Effect.provideService(Logger.LogToStderr, true)),
+  );
   const transport = new StdioServerTransport();
 
   const waitForExit = () =>

--- a/packages/hosts/mcp/src/tool-server.ts
+++ b/packages/hosts/mcp/src/tool-server.ts
@@ -1,4 +1,5 @@
 import { Duration, Effect, Match, Option, Schema } from "effect";
+import { MinimumLogLevel } from "effect/References";
 import * as Cause from "effect/Cause";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { ContentBlockSchema, type ContentBlock } from "@modelcontextprotocol/sdk/types.js";
@@ -576,10 +577,20 @@ const parseJsonContent = (raw: string): Record<string, unknown> | undefined => {
 // Server factory
 // ---------------------------------------------------------------------------
 
+const formatMcpDebugLine = (event: string, data: Record<string, unknown>): string => {
+  // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: debug logging must tolerate non-serializable SDK capability snapshots
+  try {
+    return `[executor:mcp] ${event} ${JSON.stringify(data)}`;
+  } catch {
+    return `[executor:mcp] ${event}`;
+  }
+};
+
 export const createExecutorMcpServer = <E extends Cause.YieldableError>(
   config: ExecutorMcpServerConfig<E>,
-): Effect.Effect<McpServer> =>
-  Effect.gen(function* () {
+): Effect.Effect<McpServer> => {
+  const debugEnabled = config.debug ?? readDebugDefault();
+  const program = Effect.gen(function* () {
     const engine = "engine" in config ? config.engine : createExecutionEngine(config);
     const description =
       config.description ??
@@ -592,15 +603,11 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
     // deferred past the outer Effect's await), so we use the runtime to
     // re-enter Effect-land at each callback edge.
     const context = yield* Effect.context<never>();
-    const debugEnabled = config.debug ?? readDebugDefault();
     const debugLog = (event: string, data: Record<string, unknown>) => {
       if (!debugEnabled) return;
-      // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: debug logging must tolerate non-serializable SDK capability snapshots
-      try {
-        console.error(`[executor:mcp] ${event} ${JSON.stringify(data)}`);
-      } catch {
-        console.error(`[executor:mcp] ${event}`, data);
-      }
+      Effect.runSync(
+        Effect.logDebug(formatMcpDebugLine(event, data)).pipe(Effect.provide(context)),
+      );
     };
     const elicitationMode =
       config.elicitationMode ??
@@ -897,22 +904,16 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
       }),
     );
 
-    yield* Effect.sync(() => {
-      console.error(
-        "[executor] MCP session mode",
-        JSON.stringify({
-          ...capabilitySnapshot(server),
-          elicitationMode: elicitationMode.mode,
-          resumeEnabled: elicitationMode.mode !== "native",
-        }),
-      );
-      debugLog("tool.visibility", {
-        clientCapabilities: server.server.getClientCapabilities() ?? null,
-        elicitationSupport: getElicitationSupport(server),
+    yield* Effect.logInfo(
+      `[executor] MCP session mode ${JSON.stringify({
+        ...capabilitySnapshot(server),
         elicitationMode: elicitationMode.mode,
         resumeEnabled: elicitationMode.mode !== "native",
-      });
-    }).pipe(Effect.withSpan("mcp.host.sync_tool_availability"));
+      })}`,
+    ).pipe(Effect.withSpan("mcp.host.sync_tool_availability"));
 
     return server;
   }).pipe(Effect.withSpan("mcp.host.create_executor_server"));
+
+  return debugEnabled ? program.pipe(Effect.provideService(MinimumLogLevel, "Debug")) : program;
+};


### PR DESCRIPTION
The MCP host logs a once-per-session capability snapshot (client capabilities, elicitation mode, resume support) right after a session initializes. It used console.error, which Cloudflare Workers Logs classifies as level=error, so every MCP session init in production showed up as a spurious error even though nothing was wrong.

This routes that log (and the debug-only debugLog helper) through Effect.logInfo / Effect.logDebug instead of console.error. The redundant debugLog("tool.visibility", ...) call right below it has been removed since it duplicated the same fields as the session-mode log.

The stdio MCP host now explicitly provides Logger.LogToStderr so Effect logs still go to stderr there, keeping stdout clear for the MCP protocol channel — stdio behavior is unchanged.