### PR TITLE
Add per-isolate SSE + OTel memory counters to cloud worker

### DIFF
--- a/apps/cloud/src/mcp/agent-handler.ts
+++ b/apps/cloud/src/mcp/agent-handler.ts
@@ -14,6 +14,7 @@ import {
 } from "@executor-js/cloudflare/mcp/do-headers";
 import type { McpSessionProps } from "@executor-js/cloudflare/mcp/agent-durable-object";
 
+import { wrapMcpSseResponse } from "../observability/memory-metrics";
 import { cloudMcpAuth } from "./auth-provider";
 import { McpSessionDOSqlite } from "./session-durable-object";
 
@@ -158,6 +159,7 @@ export const makeCloudMcpAgentHandler = () => {
       },
       resource,
     );
-    return serve.fetch(forwarded, env, ctx);
+    const response = await serve.fetch(forwarded, env, ctx);
+    return wrapMcpSseResponse(request, env, response);
   };
 };

--- a/apps/cloud/src/observability/memory-metrics.ts
+++ b/apps/cloud/src/observability/memory-metrics.ts
@@ -87,8 +87,10 @@ const scriptVersionFromEnv = (env: Env): string => {
   );
 };
 
+const utf8ByteCounter = new TextEncoder();
+
 const byteLengthOf = (chunk: unknown): number => {
-  if (typeof chunk === "string") return chunk.length;
+  if (typeof chunk === "string") return utf8ByteCounter.encode(chunk).length;
   if (chunk instanceof ArrayBuffer) return chunk.byteLength;
   if (ArrayBuffer.isView(chunk)) return chunk.byteLength;
   return 0;
@@ -197,7 +199,12 @@ const sseHeaders = (headers: Headers): Headers => {
 };
 
 export const wrapMcpSseResponse = (request: Request, env: Env, response: Response): Response => {
-  if (request.method !== "GET" || response.body === null) return response;
+  if (
+    request.method !== "GET" ||
+    response.body === null ||
+    !(response.headers.get("content-type") ?? "").includes("text/event-stream")
+  )
+    return response;
 
   const now = Date.now();
   const connection: SseConnection = {
@@ -302,10 +309,13 @@ export class CountingSpanProcessor implements SpanProcessor {
   onEnd(span: ReadableSpan): void {
     otelMetrics.spansEnded += 1;
     if (this.estimatedQueuedSpans >= this.maxQueueSize) {
+      // At the bound the inner processor would drop this span anyway; drop it
+      // here instead of forwarding, so a dropped span is never also counted as
+      // exported (which would double-count and inflate the drop signal).
       otelMetrics.spansDropped += 1;
-    } else {
-      this.estimatedQueuedSpans += 1;
+      return;
     }
+    this.estimatedQueuedSpans += 1;
     this.inner.onEnd(span);
   }
 

--- a/apps/cloud/src/observability/memory-metrics.ts
+++ b/apps/cloud/src/observability/memory-metrics.ts
@@ -1,0 +1,319 @@
+import type { Context } from "@opentelemetry/api";
+import type {
+  ReadableSpan,
+  Span,
+  SpanExporter,
+  SpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
+
+const LOG_PREFIX = "[executor:mem-metrics]";
+const PERIODIC_EMIT_INTERVAL_MS = 60_000;
+const STALLED_WRITE_MS = 30_000;
+const EXPORT_SUCCESS_CODE = 0;
+export const OTEL_MAX_SPAN_QUEUE_SIZE = 2_048;
+
+type CloseReason = "normal" | "cancel" | "error";
+
+type CfRequestMetadata = {
+  readonly colo?: string;
+};
+
+type VersionMetadataEnv = {
+  readonly VERSION_METADATA?: WorkerVersionMetadata;
+  readonly CF_VERSION_METADATA?: WorkerVersionMetadata;
+  readonly SCRIPT_VERSION?: string;
+};
+
+type SseConnection = {
+  readonly id: number;
+  readonly startedAt: number;
+  lastWriteAt: number;
+  chunks: number;
+  bytes: number;
+  closed: boolean;
+  colo: string;
+  scriptVersion: string;
+};
+
+type AgeBuckets = {
+  readonly lt1m: number;
+  readonly m1to5: number;
+  readonly m5to30: number;
+  readonly m30to60: number;
+  readonly gt60m: number;
+};
+
+type OtelMetricsSnapshot = {
+  readonly spansEnded: number;
+  readonly spansExported: number;
+  readonly spansDropped: number;
+  readonly spanExportFailures: number;
+  readonly forceFlushCalls: number;
+  readonly forceFlushFailures: number;
+  readonly forceFlushDurationMsTotal: number;
+  readonly forceFlushDurationMsLast: number;
+  readonly maxQueueSize: number;
+};
+
+const activeSse = new Map<number, SseConnection>();
+
+let nextConnectionId = 1;
+let totalBytesForwarded = 0;
+let lastSnapshotEmittedAt = 0;
+
+const otelMetrics = {
+  spansEnded: 0,
+  spansExported: 0,
+  spansDropped: 0,
+  spanExportFailures: 0,
+  forceFlushCalls: 0,
+  forceFlushFailures: 0,
+  forceFlushDurationMsTotal: 0,
+  forceFlushDurationMsLast: 0,
+};
+
+const requestWithCf = (request: Request): Request & { readonly cf?: CfRequestMetadata } =>
+  request as Request & { readonly cf?: CfRequestMetadata };
+
+const scriptVersionFromEnv = (env: Env): string => {
+  const metadataEnv = env as Env & VersionMetadataEnv;
+  return (
+    metadataEnv.VERSION_METADATA?.id ??
+    metadataEnv.VERSION_METADATA?.tag ??
+    metadataEnv.CF_VERSION_METADATA?.id ??
+    metadataEnv.CF_VERSION_METADATA?.tag ??
+    metadataEnv.SCRIPT_VERSION ??
+    ""
+  );
+};
+
+const byteLengthOf = (chunk: unknown): number => {
+  if (typeof chunk === "string") return chunk.length;
+  if (chunk instanceof ArrayBuffer) return chunk.byteLength;
+  if (ArrayBuffer.isView(chunk)) return chunk.byteLength;
+  return 0;
+};
+
+const emptyAgeBuckets = (): AgeBuckets => ({
+  lt1m: 0,
+  m1to5: 0,
+  m5to30: 0,
+  m30to60: 0,
+  gt60m: 0,
+});
+
+const bucketAge = (buckets: AgeBuckets, ageMs: number): AgeBuckets => {
+  const next = { ...buckets };
+  if (ageMs < 60_000) next.lt1m += 1;
+  else if (ageMs < 5 * 60_000) next.m1to5 += 1;
+  else if (ageMs < 30 * 60_000) next.m5to30 += 1;
+  else if (ageMs < 60 * 60_000) next.m30to60 += 1;
+  else next.gt60m += 1;
+  return next;
+};
+
+const otelSnapshot = (maxQueueSize: number): OtelMetricsSnapshot => ({
+  ...otelMetrics,
+  maxQueueSize,
+});
+
+const snapshot = (now: number, maxQueueSize: number) => {
+  let oldestConnectionAgeMs = 0;
+  let stalledConnections = 0;
+  let ageBuckets = emptyAgeBuckets();
+  const colos = new Set<string>();
+  const scriptVersions = new Set<string>();
+
+  for (const connection of activeSse.values()) {
+    const ageMs = now - connection.startedAt;
+    oldestConnectionAgeMs = Math.max(oldestConnectionAgeMs, ageMs);
+    if (now - connection.lastWriteAt > STALLED_WRITE_MS) stalledConnections += 1;
+    ageBuckets = bucketAge(ageBuckets, ageMs);
+    if (connection.colo) colos.add(connection.colo);
+    if (connection.scriptVersion) scriptVersions.add(connection.scriptVersion);
+  }
+  const sortedColos = Array.from(colos).sort();
+  const sortedScriptVersions = Array.from(scriptVersions).sort();
+
+  return {
+    activeSseConnections: activeSse.size,
+    ageBuckets,
+    oldestConnectionAgeMs,
+    totalBytesForwarded,
+    stalledConnections,
+    stalledWriteThresholdMs: STALLED_WRITE_MS,
+    colo: sortedColos[0] ?? "",
+    colos: sortedColos,
+    scriptVersion: sortedScriptVersions[0] ?? "",
+    scriptVersions: sortedScriptVersions,
+    otel: otelSnapshot(maxQueueSize),
+  };
+};
+
+const emitSnapshot = (event: string, now: number, maxQueueSize: number): void => {
+  lastSnapshotEmittedAt = now;
+  console.log(
+    `${LOG_PREFIX} ${JSON.stringify({
+      event,
+      ...snapshot(now, maxQueueSize),
+    })}`,
+  );
+};
+
+const maybeEmitPeriodicSnapshot = (now: number, maxQueueSize: number): void => {
+  if (now - lastSnapshotEmittedAt < PERIODIC_EMIT_INTERVAL_MS) return;
+  emitSnapshot("snapshot", now, maxQueueSize);
+};
+
+const closeConnection = (
+  connection: SseConnection,
+  reason: CloseReason,
+  maxQueueSize: number,
+): void => {
+  if (connection.closed) return;
+  connection.closed = true;
+  activeSse.delete(connection.id);
+  const now = Date.now();
+  console.log(
+    `${LOG_PREFIX} ${JSON.stringify({
+      event: "sse_close",
+      connectionId: connection.id,
+      reason,
+      ageMs: now - connection.startedAt,
+      bytesForwarded: connection.bytes,
+      chunksForwarded: connection.chunks,
+      lastWriteAgeMs: now - connection.lastWriteAt,
+      colo: connection.colo,
+      scriptVersion: connection.scriptVersion,
+    })}`,
+  );
+  maybeEmitPeriodicSnapshot(now, maxQueueSize);
+};
+
+const sseHeaders = (headers: Headers): Headers => {
+  const next = new Headers(headers);
+  next.delete("content-length");
+  return next;
+};
+
+export const wrapMcpSseResponse = (request: Request, env: Env, response: Response): Response => {
+  if (request.method !== "GET" || response.body === null) return response;
+
+  const now = Date.now();
+  const connection: SseConnection = {
+    id: nextConnectionId++,
+    startedAt: now,
+    lastWriteAt: now,
+    chunks: 0,
+    bytes: 0,
+    closed: false,
+    colo: requestWithCf(request).cf?.colo ?? "",
+    scriptVersion: scriptVersionFromEnv(env),
+  };
+  activeSse.set(connection.id, connection);
+  emitSnapshot("sse_open", now, OTEL_MAX_SPAN_QUEUE_SIZE);
+
+  const counting = new TransformStream<unknown, unknown>({
+    transform(chunk, controller) {
+      const written = byteLengthOf(chunk);
+      const writeAt = Date.now();
+      connection.chunks += 1;
+      connection.bytes += written;
+      connection.lastWriteAt = writeAt;
+      totalBytesForwarded += written;
+      maybeEmitPeriodicSnapshot(writeAt, OTEL_MAX_SPAN_QUEUE_SIZE);
+      controller.enqueue(chunk);
+    },
+    flush() {
+      closeConnection(connection, "normal", OTEL_MAX_SPAN_QUEUE_SIZE);
+    },
+    cancel(reason) {
+      closeConnection(
+        connection,
+        reason === undefined ? "cancel" : "error",
+        OTEL_MAX_SPAN_QUEUE_SIZE,
+      );
+    },
+  });
+
+  const body = response.body.pipeThrough(counting);
+  return new Response(body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: sseHeaders(response.headers),
+  });
+};
+
+export const recordForceFlush = (durationMs: number, failed: boolean): void => {
+  otelMetrics.forceFlushCalls += 1;
+  otelMetrics.forceFlushDurationMsLast = durationMs;
+  otelMetrics.forceFlushDurationMsTotal += durationMs;
+  if (failed) otelMetrics.forceFlushFailures += 1;
+};
+
+export class CountingSpanExporter implements SpanExporter {
+  constructor(
+    private readonly inner: SpanExporter,
+    private readonly onExportAttempt: (spans: number) => void,
+  ) {}
+
+  export(spans: ReadableSpan[], resultCallback: Parameters<SpanExporter["export"]>[1]): void {
+    this.onExportAttempt(spans.length);
+    this.inner.export(spans, (result) => {
+      if (result.code === EXPORT_SUCCESS_CODE) {
+        otelMetrics.spansExported += spans.length;
+      } else {
+        otelMetrics.spansDropped += spans.length;
+        otelMetrics.spanExportFailures += 1;
+      }
+      resultCallback(result);
+    });
+  }
+
+  shutdown(): Promise<void> {
+    return this.inner.shutdown();
+  }
+
+  forceFlush(): Promise<void> {
+    return this.inner.forceFlush?.() ?? Promise.resolve();
+  }
+}
+
+export class CountingSpanProcessor implements SpanProcessor {
+  private estimatedQueuedSpans = 0;
+
+  constructor(
+    private readonly inner: SpanProcessor,
+    private readonly maxQueueSize: number,
+  ) {}
+
+  forceFlush(): Promise<void> {
+    return this.inner.forceFlush();
+  }
+
+  onStart(span: Span, parentContext: Context): void {
+    this.inner.onStart(span, parentContext);
+  }
+
+  onEnding(span: Span): void {
+    this.inner.onEnding?.(span);
+  }
+
+  onEnd(span: ReadableSpan): void {
+    otelMetrics.spansEnded += 1;
+    if (this.estimatedQueuedSpans >= this.maxQueueSize) {
+      otelMetrics.spansDropped += 1;
+    } else {
+      this.estimatedQueuedSpans += 1;
+    }
+    this.inner.onEnd(span);
+  }
+
+  shutdown(): Promise<void> {
+    return this.inner.shutdown();
+  }
+
+  recordExportAttempt(spans: number): void {
+    this.estimatedQueuedSpans = Math.max(0, this.estimatedQueuedSpans - spans);
+  }
+}

--- a/apps/cloud/src/observability/telemetry.ts
+++ b/apps/cloud/src/observability/telemetry.ts
@@ -45,6 +45,13 @@ import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from "@opentelemetry/semantic
 import { env } from "cloudflare:workers";
 import { Effect, Layer } from "effect";
 
+import {
+  CountingSpanExporter,
+  CountingSpanProcessor,
+  OTEL_MAX_SPAN_QUEUE_SIZE,
+  recordForceFlush,
+} from "./memory-metrics";
+
 const SERVICE_NAME = "executor-cloud";
 const SERVICE_VERSION = "1.0.0";
 
@@ -60,14 +67,9 @@ const ensureGlobalTracerProvider = (): boolean => {
       [ATTR_SERVICE_NAME]: SERVICE_NAME,
       [ATTR_SERVICE_VERSION]: SERVICE_VERSION,
     }),
-    spanProcessors: [
-      // Batch, not Simple: SimpleSpanProcessor issues one synchronous fetch
-      // per span END — a busy MCP request emits dozens of spans, and the
-      // serialized export fetches add seconds of latency inside the request
-      // (enough to flip pause/resume timing in e2e). Batch buffers and
-      // ships on a timer; `ctx.waitUntil(flushTracerProvider())` at the end
-      // of each request still drains the buffer before the isolate exits.
-      new BatchSpanProcessor(
+    spanProcessors: (() => {
+      let countingProcessor: CountingSpanProcessor;
+      const exporter = new CountingSpanExporter(
         new OTLPTraceExporter({
           url: env.AXIOM_TRACES_URL ?? "https://api.axiom.co/v1/traces",
           headers: {
@@ -75,9 +77,24 @@ const ensureGlobalTracerProvider = (): boolean => {
             "X-Axiom-Dataset": env.AXIOM_DATASET ?? "executor-cloud",
           },
         }),
-        { scheduledDelayMillis: 1_000, maxExportBatchSize: 512 },
-      ),
-    ],
+        (spans) => countingProcessor.recordExportAttempt(spans),
+      );
+      // Batch, not Simple: SimpleSpanProcessor issues one synchronous fetch
+      // per span END — a busy MCP request emits dozens of spans, and the
+      // serialized export fetches add seconds of latency inside the request
+      // (enough to flip pause/resume timing in e2e). Batch buffers and
+      // ships on a timer; `ctx.waitUntil(flushTracerProvider())` at the end
+      // of each request still drains the buffer before the isolate exits.
+      countingProcessor = new CountingSpanProcessor(
+        new BatchSpanProcessor(exporter, {
+          scheduledDelayMillis: 1_000,
+          maxExportBatchSize: 512,
+          maxQueueSize: OTEL_MAX_SPAN_QUEUE_SIZE,
+        }),
+        OTEL_MAX_SPAN_QUEUE_SIZE,
+      );
+      return [countingProcessor];
+    })(),
   });
   // Skip `provider.register()` — its StackContextManager / W3C propagator
   // setup wires the global OTel context API, but Effect's tracer goes
@@ -92,8 +109,19 @@ const ensureGlobalTracerProvider = (): boolean => {
 // `ctx.waitUntil(flushTracerProvider())` so SimpleSpanProcessor exports
 // survive request termination.
 export const installTracerProvider = (): boolean => ensureGlobalTracerProvider();
-export const flushTracerProvider = (): Promise<void> =>
-  provider ? provider.forceFlush() : Promise.resolve();
+export const flushTracerProvider = async (): Promise<void> => {
+  if (!provider) return;
+  const startedAt = Date.now();
+  // oxlint-disable-next-line executor/no-try-catch-or-throw -- observability boundary; preserve forceFlush failure behavior while counting it
+  try {
+    await provider.forceFlush();
+    recordForceFlush(Date.now() - startedAt, false);
+  } catch (error) {
+    recordForceFlush(Date.now() - startedAt, true);
+    // oxlint-disable-next-line executor/no-try-catch-or-throw -- preserve original rejection for waitUntil diagnostics
+    throw error;
+  }
+};
 
 const makeTelemetryLive = (): Layer.Layer<never> =>
   Layer.unwrap(


### PR DESCRIPTION
## Summary

The stateless front worker (`apps/cloud`) OOMs 600-2500x/day at the 128MB Workers limit. The victims are long-lived `GET /<slug>/mcp` SSE streams (wall times up to 170 min, low CPU) that get caught in multi-tenant same-isolate memory cascades. We don't know yet which accumulator is responsible.

Workers has no `performance.memory`, so this adds telemetry-only counters to infer memory growth indirectly: no behavior change to request handling, auth, or what the MCP bridge returns (only the response body is wrapped for counting).

## What's added

`apps/cloud/src/observability/memory-metrics.ts` (new):
- Per-isolate active-SSE registry, populated by wrapping the bridge's returned `Response.body` in a counting `TransformStream` right after `serve.fetch()` in `apps/cloud/src/mcp/agent-handler.ts`. Tracks connection count, byte/chunk counts, and last-write time per connection without touching payload bytes.
- OTel counters via thin wrappers around the span exporter and span processor in `apps/cloud/src/observability/telemetry.ts`: spans ended vs exported vs dropped, force-flush call count/duration/failures.
- Sets an explicit `maxQueueSize: 2048` on the `BatchSpanProcessor`, which was previously unbounded.

## Log lines to grep in prod (Workers Observability / Axiom)

All lines are `console.log` (info level, not `console.error`) prefixed `[executor:mem-metrics]`:

- `event: "sse_open"` — emitted when a new GET SSE connection opens.
- `event: "snapshot"` — periodic registry snapshot (~60s cadence, piggybacked on connection activity, no new alarm/cron), fields: `activeSseConnections`, `ageBuckets` (`lt1m`/`m1to5`/`m5to30`/`m30to60`/`gt60m`), `oldestConnectionAgeMs`, `totalBytesForwarded`, `stalledConnections`, `stalledWriteThresholdMs`, `colo`, `colos`, `scriptVersion`, `scriptVersions`, and an `otel` object with `spansEnded`/`spansExported`/`spansDropped`/`spanExportFailures`/`forceFlushCalls`/`forceFlushFailures`/`forceFlushDurationMsTotal`/`forceFlushDurationMsLast`/`maxQueueSize`.
- `event: "sse_close"` — emitted per connection close, fields: `connectionId`, `reason` (`normal`/`cancel`/`error`), `ageMs`, `bytesForwarded`, `chunksForwarded`, `lastWriteAgeMs`, `colo`, `scriptVersion`.

## Test plan

- [x] `bun run typecheck` — 42/42 tasks green
- [x] `git diff --stat` confined to `apps/cloud/src/mcp/agent-handler.ts`, `apps/cloud/src/observability/telemetry.ts`, and the new `apps/cloud/src/observability/memory-metrics.ts`
- [ ] Deploy and confirm `[executor:mem-metrics]` lines land in Workers Observability