### PR TITLE
Drop the elicitInput fallback error log

### DIFF
--- a/packages/hosts/mcp/src/tool-server.ts
+++ b/packages/hosts/mcp/src/tool-server.ts
@@ -260,14 +260,6 @@ const makeMcpElicitationHandler =
           error,
           clientCapabilities: server.server.getClientCapabilities() ?? null,
         });
-        console.error(
-          "[executor] elicitInput failed - falling back to cancel.",
-          JSON.stringify({
-            error,
-            requestTag,
-            ...capabilitySnapshot(server),
-          }),
-        );
         return { action: "cancel" as const } as ElicitationResponse;
       }
     });


### PR DESCRIPTION
Removes the unconditional `console.error("[executor] elicitInput failed - falling back to cancel", ...)` in the MCP host's elicitation path.

Falling back to `cancel` is an expected outcome when a client doesn't support the elicitation the server asked for, so logging it at error level fires on normal traffic and shows up as an error in Cloudflare Workers Logs. The same information is already captured by the gated `debugLog("elicitation.error", ...)` immediately above it, which still fires when debug logging is enabled, so nothing is lost for actual debugging. Behavior is unchanged: the handler still returns `{ action: "cancel" }`.

Typecheck passes; MCP host tests (44, including the elicitation error-handling cases) pass.