### PR TITLE
Render loading skeletons and add Retry to failed list loads

### DIFF
--- a/packages/react/src/components/error-state.tsx
+++ b/packages/react/src/components/error-state.tsx
@@ -1,0 +1,22 @@
+import { Button } from "./button";
+import { cn } from "../lib/utils";
+
+export function ErrorState(props: {
+  readonly message: string;
+  readonly onRetry: () => void;
+  readonly className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-between gap-3 rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3",
+        props.className,
+      )}
+    >
+      <p className="text-sm text-destructive">{props.message}</p>
+      <Button type="button" variant="outline" size="sm" onClick={props.onRetry}>
+        Retry
+      </Button>
+    </div>
+  );
+}

--- a/packages/react/src/lib/async-result.test.ts
+++ b/packages/react/src/lib/async-result.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "@effect/vitest";
+import * as Cause from "effect/Cause";
+import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
+
+import { isAsyncResultLoading } from "./async-result";
+
+describe("isAsyncResultLoading", () => {
+  it("treats initial and waiting async results as loading", () => {
+    expect(isAsyncResultLoading(AsyncResult.initial())).toBe(true);
+    expect(isAsyncResultLoading(AsyncResult.initial(true))).toBe(true);
+    expect(isAsyncResultLoading(AsyncResult.success(["cached"], { waiting: true }))).toBe(true);
+  });
+
+  it("does not treat settled success or failure as loading", () => {
+    expect(isAsyncResultLoading(AsyncResult.success(["ready"]))).toBe(false);
+    expect(isAsyncResultLoading(AsyncResult.failure(Cause.fail("boom")))).toBe(false);
+  });
+});

--- a/packages/react/src/lib/async-result.ts
+++ b/packages/react/src/lib/async-result.ts
@@ -1,0 +1,5 @@
+import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
+
+export function isAsyncResultLoading<A, E>(result: AsyncResult.AsyncResult<A, E>): boolean {
+  return AsyncResult.isInitial(result) || AsyncResult.isWaiting(result);
+}

--- a/packages/react/src/pages/api-keys.tsx
+++ b/packages/react/src/pages/api-keys.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { Exit } from "effect";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
-import { useAtomSet, useAtomValue } from "@effect/atom-react";
+import { useAtomRefresh, useAtomSet, useAtomValue } from "@effect/atom-react";
 import { toast } from "sonner";
 import { apiKeyWriteKeys } from "../api/reactivity-keys";
 import { trackEvent } from "../api/analytics";
@@ -21,6 +21,8 @@ import {
 import { Input } from "../components/input";
 import { Label } from "../components/label";
 import { useExecutorDocumentTitle } from "../lib/document-title";
+import { ErrorState } from "../components/error-state";
+import { isAsyncResultLoading } from "../lib/async-result";
 
 // ---------------------------------------------------------------------------
 // Shared API-keys page. Reads/writes the provider-neutral `/account/api-keys`
@@ -61,6 +63,7 @@ const defaultApiKeyName = (): string =>
 export function ApiKeysPage() {
   useExecutorDocumentTitle("API keys");
   const result = useAtomValue(apiKeysAtom);
+  const refreshApiKeys = useAtomRefresh(apiKeysAtom);
   const doCreate = useAtomSet(createApiKey, { mode: "promiseExit" });
   const doRevoke = useAtomSet(revokeApiKey, { mode: "promiseExit" });
   const [createOpen, setCreateOpen] = useState(false);
@@ -134,65 +137,69 @@ export function ApiKeysPage() {
         </p>
       </PageHeader>
 
-      {AsyncResult.match(result, {
-        onInitial: () => (
-          <div className="rounded-md border border-border bg-card p-6 text-sm text-muted-foreground">
-            Loading API keys...
-          </div>
-        ),
-        onFailure: () => (
-          <div className="rounded-md border border-border bg-card p-6 text-sm text-destructive">
-            Failed to load API keys
-          </div>
-        ),
-        onSuccess: ({ value }) =>
-          value.apiKeys.length === 0 ? (
-            <div className="rounded-md border border-dashed border-border bg-card p-8">
-              <h2 className="text-base font-semibold text-foreground">No API keys</h2>
-              <p className="mt-2 max-w-xl text-sm leading-6 text-muted-foreground">
-                Create a key and send it in the Authorization Bearer header.
-              </p>
-            </div>
-          ) : (
-            <div className="overflow-hidden rounded-md border border-border bg-card">
-              <div className="grid grid-cols-[1fr_auto] gap-4 border-b border-border px-4 py-3 text-xs font-medium uppercase tracking-wider text-muted-foreground md:grid-cols-[1.4fr_1fr_1fr_auto]">
-                <span>Name</span>
-                <span className="hidden md:block">Created</span>
-                <span className="hidden md:block">Last used</span>
-                <span className="text-right">Actions</span>
-              </div>
-              {value.apiKeys.map((key: ApiKeySummary) => (
-                <div
-                  key={key.id}
-                  className="grid grid-cols-[1fr_auto] items-center gap-4 border-b border-border px-4 py-4 last:border-b-0 md:grid-cols-[1.4fr_1fr_1fr_auto]"
-                >
-                  <div className="min-w-0">
-                    <p className="truncate text-sm font-medium text-foreground">{key.name}</p>
-                    <p className="mt-1 font-mono text-xs text-muted-foreground">
-                      {key.obfuscatedValue}
-                    </p>
-                  </div>
-                  <p className="hidden text-sm text-muted-foreground md:block">
-                    {formatDate(key.createdAt)}
-                  </p>
-                  <p className="hidden text-sm text-muted-foreground md:block">
-                    {formatDate(key.lastUsedAt)}
-                  </p>
-                  <Button
-                    variant="ghost"
-                    size="icon-sm"
-                    onClick={() => handleRevoke(key)}
-                    disabled={revokingId === key.id}
-                    title={`Revoke ${key.name}`}
-                    className="text-muted-foreground hover:text-destructive"
-                  >
-                    <span aria-hidden="true">×</span>
-                  </Button>
-                </div>
-              ))}
+      {isAsyncResultLoading(result) ? (
+        <div className="rounded-md border border-border bg-card p-6 text-sm text-muted-foreground">
+          Loading API keys...
+        </div>
+      ) : (
+        AsyncResult.match(result, {
+          onInitial: () => (
+            <div className="rounded-md border border-border bg-card p-6 text-sm text-muted-foreground">
+              Loading API keys...
             </div>
           ),
-      })}
+          onFailure: () => (
+            <ErrorState message="Failed to load API keys" onRetry={refreshApiKeys} />
+          ),
+          onSuccess: ({ value }) =>
+            value.apiKeys.length === 0 ? (
+              <div className="rounded-md border border-dashed border-border bg-card p-8">
+                <h2 className="text-base font-semibold text-foreground">No API keys</h2>
+                <p className="mt-2 max-w-xl text-sm leading-6 text-muted-foreground">
+                  Create a key and send it in the Authorization Bearer header.
+                </p>
+              </div>
+            ) : (
+              <div className="overflow-hidden rounded-md border border-border bg-card">
+                <div className="grid grid-cols-[1fr_auto] gap-4 border-b border-border px-4 py-3 text-xs font-medium uppercase tracking-wider text-muted-foreground md:grid-cols-[1.4fr_1fr_1fr_auto]">
+                  <span>Name</span>
+                  <span className="hidden md:block">Created</span>
+                  <span className="hidden md:block">Last used</span>
+                  <span className="text-right">Actions</span>
+                </div>
+                {value.apiKeys.map((key: ApiKeySummary) => (
+                  <div
+                    key={key.id}
+                    className="grid grid-cols-[1fr_auto] items-center gap-4 border-b border-border px-4 py-4 last:border-b-0 md:grid-cols-[1.4fr_1fr_1fr_auto]"
+                  >
+                    <div className="min-w-0">
+                      <p className="truncate text-sm font-medium text-foreground">{key.name}</p>
+                      <p className="mt-1 font-mono text-xs text-muted-foreground">
+                        {key.obfuscatedValue}
+                      </p>
+                    </div>
+                    <p className="hidden text-sm text-muted-foreground md:block">
+                      {formatDate(key.createdAt)}
+                    </p>
+                    <p className="hidden text-sm text-muted-foreground md:block">
+                      {formatDate(key.lastUsedAt)}
+                    </p>
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      onClick={() => handleRevoke(key)}
+                      disabled={revokingId === key.id}
+                      title={`Revoke ${key.name}`}
+                      className="text-muted-foreground hover:text-destructive"
+                    >
+                      <span aria-hidden="true">×</span>
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            ),
+        })
+      )}
 
       <Dialog open={createOpen} onOpenChange={closeCreate}>
         <DialogContent className="sm:max-w-[480px]">

--- a/packages/react/src/pages/integration-detail.tsx
+++ b/packages/react/src/pages/integration-detail.tsx
@@ -34,6 +34,8 @@ import { useIntegrationPlugins, type IntegrationAccountHandoff } from "@executor
 import { Button } from "../components/button";
 import { Skeleton } from "../components/skeleton";
 import { useExecutorDocumentTitle } from "../lib/document-title";
+import { ErrorState } from "../components/error-state";
+import { isAsyncResultLoading } from "../lib/async-result";
 
 // v2: the route's `namespace` param is the integration slug. Tools belong to
 // the integration's per-owner connections; a tool's policy id is
@@ -138,7 +140,6 @@ export function IntegrationDetailPage(props: { namespace: string }) {
       ...(oauthClient !== undefined ? { oauthClient } : {}),
     };
   }, [locationSearch]);
-
   useEffect(() => {
     if (accountHandoff && !isBuiltInIntegration) {
       setActiveTab("accounts");
@@ -446,52 +447,58 @@ export function IntegrationDetailPage(props: { namespace: string }) {
           value="tools"
           className="flex min-h-0 flex-col overflow-hidden data-[state=inactive]:hidden"
         >
-          {AsyncResult.match(tools, {
-            onInitial: () => <IntegrationDetailSkeleton />,
-            onFailure: () => (
-              <div className="p-6 text-sm text-destructive">Failed to load tools</div>
-            ),
-            onSuccess: () => (
-              <div className="flex min-h-0 flex-1 overflow-hidden">
-                {/* Left: tool tree */}
-                <div className="flex w-72 shrink-0 flex-col border-r border-border/60 lg:w-80 xl:w-[22rem]">
-                  <ToolTree
-                    tools={integrationTools}
-                    selectedToolId={selectedToolId}
-                    onSelect={setSelectedToolId}
-                    onSetPolicy={(pattern, action) => void policyActions.set(pattern, action)}
-                    onClearPolicy={(pattern) => void policyActions.clear(pattern)}
-                    policies={sortedPolicies}
-                    groupByConnection={!isBuiltInIntegration}
-                  />
+          {isAsyncResultLoading(tools) ? (
+            <IntegrationDetailSkeleton />
+          ) : (
+            AsyncResult.match(tools, {
+              onInitial: () => <IntegrationDetailSkeleton />,
+              onFailure: () => (
+                <div className="p-6">
+                  <ErrorState message="Failed to load tools" onRetry={refreshTools} />
                 </div>
-
-                {/* Right: tool detail with Schema · TypeScript · Run tabs */}
-                <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
-                  {selectedTool && selectedAddress && selectedBareName ? (
-                    <ToolDetail
-                      address={selectedAddress}
-                      toolName={selectedTool.name}
-                      staticTool={selection?.static}
-                      policy={selectedTool.policy}
+              ),
+              onSuccess: () => (
+                <div className="flex min-h-0 flex-1 overflow-hidden">
+                  {/* Left: tool tree */}
+                  <div className="flex w-72 shrink-0 flex-col border-r border-border/60 lg:w-80 xl:w-[22rem]">
+                    <ToolTree
+                      tools={integrationTools}
+                      selectedToolId={selectedToolId}
+                      onSelect={setSelectedToolId}
                       onSetPolicy={(pattern, action) => void policyActions.set(pattern, action)}
                       onClearPolicy={(pattern) => void policyActions.clear(pattern)}
-                      {...(!selection?.static && selectedBareName
-                        ? {
-                            integration: slug,
-                            runToolName: selectedBareName,
-                            connections: integrationConnections,
-                            initialConnectionName: selection?.connection ?? null,
-                          }
-                        : {})}
+                      policies={sortedPolicies}
+                      groupByConnection={!isBuiltInIntegration}
                     />
-                  ) : (
-                    <ToolDetailEmpty hasTools={integrationTools.length > 0} />
-                  )}
+                  </div>
+
+                  {/* Right: tool detail with Schema · TypeScript · Run tabs */}
+                  <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+                    {selectedTool && selectedAddress && selectedBareName ? (
+                      <ToolDetail
+                        address={selectedAddress}
+                        toolName={selectedTool.name}
+                        staticTool={selection?.static}
+                        policy={selectedTool.policy}
+                        onSetPolicy={(pattern, action) => void policyActions.set(pattern, action)}
+                        onClearPolicy={(pattern) => void policyActions.clear(pattern)}
+                        {...(!selection?.static && selectedBareName
+                          ? {
+                              integration: slug,
+                              runToolName: selectedBareName,
+                              connections: integrationConnections,
+                              initialConnectionName: selection?.connection ?? null,
+                            }
+                          : {})}
+                      />
+                    ) : (
+                      <ToolDetailEmpty hasTools={integrationTools.length > 0} />
+                    )}
+                  </div>
                 </div>
-              </div>
-            ),
-          })}
+              ),
+            })
+          )}
         </TabsContent>
       </Tabs>
 

--- a/packages/react/src/pages/integrations.tsx
+++ b/packages/react/src/pages/integrations.tsx
@@ -1,6 +1,6 @@
 import { Suspense, useCallback, useMemo, useState } from "react";
 import { Link, useNavigate } from "@tanstack/react-router";
-import { useAtomSet, useAtomValue } from "@effect/atom-react";
+import { useAtomRefresh, useAtomSet, useAtomValue } from "@effect/atom-react";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 import * as Exit from "effect/Exit";
 import { PlusIcon } from "lucide-react";
@@ -41,6 +41,8 @@ import {
 import { IntegrationIconWithAccount } from "../components/integration-icon-with-account";
 import { Skeleton } from "../components/skeleton";
 import { useExecutorDocumentTitle } from "../lib/document-title";
+import { ErrorState } from "../components/error-state";
+import { isAsyncResultLoading } from "../lib/async-result";
 
 const KIND_TO_PLUGIN_KEY: Record<string, string> = {
   openapi: "openapi",
@@ -67,6 +69,7 @@ const bestDetection = (
 export function IntegrationsPage() {
   useExecutorDocumentTitle("Integrations");
   const integrations = useAtomValue(integrationsOptimisticAtom);
+  const refreshIntegrations = useAtomRefresh(integrationsOptimisticAtom);
   const [connectOpen, setConnectOpen] = useState(false);
 
   return (
@@ -95,28 +98,34 @@ export function IntegrationsPage() {
 
       <div className="mb-8 border-t border-border/50" />
 
-      {AsyncResult.match(integrations, {
-        onInitial: () => <IntegrationsGridSkeleton />,
-        onFailure: () => <p className="text-sm text-destructive">Failed to load integrations</p>,
-        onSuccess: ({ value }) => {
-          if (value.length === 0) {
-            return (
-              <EmptyIntegrations
-                onConnect={() => {
-                  setConnectOpen(true);
-                  trackEvent("integration_connect_dialog_opened");
-                }}
-              />
-            );
-          }
+      {isAsyncResultLoading(integrations) ? (
+        <IntegrationsGridSkeleton />
+      ) : (
+        AsyncResult.match(integrations, {
+          onInitial: () => <IntegrationsGridSkeleton />,
+          onFailure: () => (
+            <ErrorState message="Failed to load integrations" onRetry={refreshIntegrations} />
+          ),
+          onSuccess: ({ value }) => {
+            if (value.length === 0) {
+              return (
+                <EmptyIntegrations
+                  onConnect={() => {
+                    setConnectOpen(true);
+                    trackEvent("integration_connect_dialog_opened");
+                  }}
+                />
+              );
+            }
 
-          return (
-            <div className="mb-8 space-y-3">
-              <IntegrationGrid integrations={value} />
-            </div>
-          );
-        },
-      })}
+            return (
+              <div className="mb-8 space-y-3">
+                <IntegrationGrid integrations={value} />
+              </div>
+            );
+          },
+        })
+      )}
 
       <ConnectDialog open={connectOpen} onOpenChange={setConnectOpen} />
     </PageContainer>

--- a/packages/react/src/pages/org.tsx
+++ b/packages/react/src/pages/org.tsx
@@ -1,6 +1,6 @@
 import { useReducer, useState } from "react";
 import { Exit, Match } from "effect";
-import { useAtomValue, useAtomSet } from "@effect/atom-react";
+import { useAtomRefresh, useAtomValue, useAtomSet } from "@effect/atom-react";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 import { toast } from "sonner";
 import { trackEvent } from "../api/analytics";
@@ -47,6 +47,8 @@ import {
 import { useAuth } from "../multiplayer/auth-context";
 import { messageFromExit } from "../api/error-reporting";
 import { useExecutorDocumentTitle } from "../lib/document-title";
+import { ErrorState } from "../components/error-state";
+import { isAsyncResultLoading } from "../lib/async-result";
 
 // ---------------------------------------------------------------------------
 // Shared organization page — members + roles + invites + org name, over the
@@ -144,6 +146,7 @@ export function OrgPage(props: {
   const organizationName =
     auth.status === "authenticated" ? (auth.organization?.name ?? "Organization") : "Organization";
   const membersResult = useAtomValue(orgMembersAtom);
+  const refreshMembers = useAtomRefresh(orgMembersAtom);
   const rolesResult = useAtomValue(orgRolesAtom);
   const doRemove = useAtomSet(removeMember, { mode: "promiseExit" });
   const doUpdateRole = useAtomSet(updateMemberRole, { mode: "promiseExit" });
@@ -269,143 +272,149 @@ export function OrgPage(props: {
           className="mb-3 h-9 text-sm"
         />
 
-        {AsyncResult.match(membersResult, {
-          onInitial: () => (
-            <div className="space-y-2">
-              {[1, 2, 3].map((i) => (
-                <div key={i} className="h-14 animate-pulse rounded-lg bg-muted" />
-              ))}
-            </div>
-          ),
-          onFailure: () => (
-            <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3">
-              <p className="text-sm text-destructive">Failed to load members</p>
-            </div>
-          ),
-          onSuccess: ({ value }) => {
-            const members = value.members;
-            const filtered = search
-              ? members.filter(
-                  (m: MemberData) =>
-                    m.email.toLowerCase().includes(search.toLowerCase()) ||
-                    (m.name?.toLowerCase().includes(search.toLowerCase()) ?? false),
-                )
-              : members;
-
-            if (filtered.length === 0) {
-              return (
-                <p className="py-8 text-center text-sm text-muted-foreground">
-                  {search ? "No matching members" : "No members yet"}
-                </p>
-              );
-            }
-
-            return (
-              <div className="space-y-px">
-                {filtered.map((member: MemberData) => (
-                  <div
-                    key={member.id}
-                    className="group relative grid grid-cols-[2rem_1fr_6rem_5rem_2rem] items-center gap-3 rounded-lg border border-transparent px-4 py-3 transition-all hover:bg-muted/30"
-                  >
-                    {member.avatarUrl ? (
-                      <img src={member.avatarUrl} alt="" className="size-8 rounded-full" />
-                    ) : (
-                      <div className="flex size-8 items-center justify-center rounded-full bg-muted text-xs font-semibold text-muted-foreground">
-                        {member.name
-                          ? member.name
-                              .split(" ")
-                              .map((n: string) => n[0])
-                              .join("")
-                              .slice(0, 2)
-                              .toUpperCase()
-                          : member.email[0]!.toUpperCase()}
-                      </div>
-                    )}
-
-                    <div className="min-w-0">
-                      <div className="flex items-center gap-2">
-                        <p className="truncate text-sm font-medium text-foreground leading-none">
-                          {member.name ?? member.email}
-                        </p>
-                        {member.isCurrentUser && (
-                          <Badge className="bg-muted text-muted-foreground">You</Badge>
-                        )}
-                        {member.status === "pending" && (
-                          <Badge className="bg-muted text-muted-foreground">Invited</Badge>
-                        )}
-                      </div>
-                      {member.name && (
-                        <p className="mt-0.5 truncate text-xs text-muted-foreground leading-none">
-                          {member.email}
-                        </p>
-                      )}
-                    </div>
-
-                    <p className="text-sm text-muted-foreground capitalize leading-none">
-                      {member.role}
-                    </p>
-
-                    <p className="text-xs text-muted-foreground leading-none">
-                      {formatLastActive(member.lastActiveAt)}
-                    </p>
-
-                    {!member.isCurrentUser ? (
-                      <DropdownMenu>
-                        <DropdownMenuTrigger asChild>
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            className="size-7 opacity-0 group-hover:opacity-100 transition-opacity"
-                          >
-                            <svg viewBox="0 0 16 16" className="size-3">
-                              <circle cx="8" cy="3" r="1.2" fill="currentColor" />
-                              <circle cx="8" cy="8" r="1.2" fill="currentColor" />
-                              <circle cx="8" cy="13" r="1.2" fill="currentColor" />
-                            </svg>
-                          </Button>
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent align="end" className="w-44">
-                          {roles.length > 0 && (
-                            <>
-                              <DropdownMenuSub>
-                                <DropdownMenuSubTrigger className="text-xs">
-                                  Change role
-                                </DropdownMenuSubTrigger>
-                                <DropdownMenuSubContent>
-                                  {roles.map((role: RoleData) => (
-                                    <DropdownMenuItem
-                                      key={role.slug}
-                                      className="text-xs"
-                                      disabled={role.slug === member.role}
-                                      onClick={() =>
-                                        handleChangeRole(member.id, role.slug, role.name)
-                                      }
-                                    >
-                                      {role.name}
-                                    </DropdownMenuItem>
-                                  ))}
-                                </DropdownMenuSubContent>
-                              </DropdownMenuSub>
-                              <DropdownMenuSeparator />
-                            </>
-                          )}
-                          <DropdownMenuItem
-                            className="text-destructive focus:text-destructive text-sm"
-                            onClick={() => handleRemove(member.id, member.name ?? member.email)}
-                          >
-                            Remove member
-                          </DropdownMenuItem>
-                        </DropdownMenuContent>
-                      </DropdownMenu>
-                    ) : (
-                      <div />
-                    )}
-                  </div>
+        {isAsyncResultLoading(membersResult) ? (
+          <div className="space-y-2">
+            {[1, 2, 3].map((i) => (
+              <div key={i} className="h-14 animate-pulse rounded-lg bg-muted" />
+            ))}
+          </div>
+        ) : (
+          AsyncResult.match(membersResult, {
+            onInitial: () => (
+              <div className="space-y-2">
+                {[1, 2, 3].map((i) => (
+                  <div key={i} className="h-14 animate-pulse rounded-lg bg-muted" />
                 ))}
               </div>
-            );
-          },
-        })}
+            ),
+            onFailure: () => (
+              <ErrorState message="Failed to load members" onRetry={refreshMembers} />
+            ),
+            onSuccess: ({ value }) => {
+              const members = value.members;
+              const filtered = search
+                ? members.filter(
+                    (m: MemberData) =>
+                      m.email.toLowerCase().includes(search.toLowerCase()) ||
+                      (m.name?.toLowerCase().includes(search.toLowerCase()) ?? false),
+                  )
+                : members;
+
+              if (filtered.length === 0) {
+                return (
+                  <p className="py-8 text-center text-sm text-muted-foreground">
+                    {search ? "No matching members" : "No members yet"}
+                  </p>
+                );
+              }
+
+              return (
+                <div className="space-y-px">
+                  {filtered.map((member: MemberData) => (
+                    <div
+                      key={member.id}
+                      className="group relative grid grid-cols-[2rem_1fr_6rem_5rem_2rem] items-center gap-3 rounded-lg border border-transparent px-4 py-3 transition-all hover:bg-muted/30"
+                    >
+                      {member.avatarUrl ? (
+                        <img src={member.avatarUrl} alt="" className="size-8 rounded-full" />
+                      ) : (
+                        <div className="flex size-8 items-center justify-center rounded-full bg-muted text-xs font-semibold text-muted-foreground">
+                          {member.name
+                            ? member.name
+                                .split(" ")
+                                .map((n: string) => n[0])
+                                .join("")
+                                .slice(0, 2)
+                                .toUpperCase()
+                            : member.email[0]!.toUpperCase()}
+                        </div>
+                      )}
+
+                      <div className="min-w-0">
+                        <div className="flex items-center gap-2">
+                          <p className="truncate text-sm font-medium text-foreground leading-none">
+                            {member.name ?? member.email}
+                          </p>
+                          {member.isCurrentUser && (
+                            <Badge className="bg-muted text-muted-foreground">You</Badge>
+                          )}
+                          {member.status === "pending" && (
+                            <Badge className="bg-muted text-muted-foreground">Invited</Badge>
+                          )}
+                        </div>
+                        {member.name && (
+                          <p className="mt-0.5 truncate text-xs text-muted-foreground leading-none">
+                            {member.email}
+                          </p>
+                        )}
+                      </div>
+
+                      <p className="text-sm text-muted-foreground capitalize leading-none">
+                        {member.role}
+                      </p>
+
+                      <p className="text-xs text-muted-foreground leading-none">
+                        {formatLastActive(member.lastActiveAt)}
+                      </p>
+
+                      {!member.isCurrentUser ? (
+                        <DropdownMenu>
+                          <DropdownMenuTrigger asChild>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="size-7 opacity-0 group-hover:opacity-100 transition-opacity"
+                            >
+                              <svg viewBox="0 0 16 16" className="size-3">
+                                <circle cx="8" cy="3" r="1.2" fill="currentColor" />
+                                <circle cx="8" cy="8" r="1.2" fill="currentColor" />
+                                <circle cx="8" cy="13" r="1.2" fill="currentColor" />
+                              </svg>
+                            </Button>
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="end" className="w-44">
+                            {roles.length > 0 && (
+                              <>
+                                <DropdownMenuSub>
+                                  <DropdownMenuSubTrigger className="text-xs">
+                                    Change role
+                                  </DropdownMenuSubTrigger>
+                                  <DropdownMenuSubContent>
+                                    {roles.map((role: RoleData) => (
+                                      <DropdownMenuItem
+                                        key={role.slug}
+                                        className="text-xs"
+                                        disabled={role.slug === member.role}
+                                        onClick={() =>
+                                          handleChangeRole(member.id, role.slug, role.name)
+                                        }
+                                      >
+                                        {role.name}
+                                      </DropdownMenuItem>
+                                    ))}
+                                  </DropdownMenuSubContent>
+                                </DropdownMenuSub>
+                                <DropdownMenuSeparator />
+                              </>
+                            )}
+                            <DropdownMenuItem
+                              className="text-destructive focus:text-destructive text-sm"
+                              onClick={() => handleRemove(member.id, member.name ?? member.email)}
+                            >
+                              Remove member
+                            </DropdownMenuItem>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      ) : (
+                        <div />
+                      )}
+                    </div>
+                  ))}
+                </div>
+              );
+            },
+          })
+        )}
       </section>
 
       <InviteDialog open={inviteOpen} onOpenChange={setInviteOpen} roles={roles} />

--- a/packages/react/src/pages/policies.tsx
+++ b/packages/react/src/pages/policies.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useAtomSet, useAtomValue } from "@effect/atom-react";
+import { useAtomRefresh, useAtomSet, useAtomValue } from "@effect/atom-react";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 import * as Exit from "effect/Exit";
 import { trackEvent } from "../api/analytics";
@@ -57,6 +57,8 @@ import {
 } from "../components/select";
 import { Label } from "../components/label";
 import { useExecutorDocumentTitle } from "../lib/document-title";
+import { ErrorState } from "../components/error-state";
+import { isAsyncResultLoading } from "../lib/async-result";
 
 // Owner guardrail ordering: org rules are the outer guardrail (rank 0), user
 // rules are inner (rank 1). Mirrors server-side resolution where the most
@@ -284,6 +286,7 @@ function PolicyRow(props: {
 export function PoliciesPage() {
   useExecutorDocumentTitle("Policies");
   const policies = useAtomValue(policiesOptimisticAtom);
+  const refreshPolicies = useAtomRefresh(policiesOptimisticAtom);
   const doCreate = useAtomSet(createPolicyOptimistic, { mode: "promiseExit" });
   const doUpdate = useAtomSet(updatePolicyOptimistic, { mode: "promiseExit" });
   const doRemove = useAtomSet(removePolicyOptimistic, { mode: "promiseExit" });
@@ -374,114 +377,119 @@ export function PoliciesPage() {
         />
       </div>
 
-      {AsyncResult.match(policies, {
-        onInitial: () => (
-          <div className="flex items-center gap-2 py-8">
-            <div className="size-1.5 rounded-full bg-muted-foreground/30 animate-pulse" />
-            <p className="text-sm text-muted-foreground">Loading policies…</p>
-          </div>
-        ),
-        onFailure: () => (
-          <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3">
-            <p className="text-sm text-destructive">Failed to load policies</p>
-          </div>
-        ),
-        onSuccess: ({ value }) => {
-          // Sort by owner rank (org outer, user inner), then position (lex
-          // order on fractional-indexing keys), tiebreaking on id so
-          // identical positions don't swap on refetch and
-          // `generateKeyBetween` never sees duplicate neighbor keys (which
-          // would throw). Optimistic placeholders carry `position: ""` so
-          // they sort to the top of their owner group.
-          const sorted = [...value].sort((a, b) => {
-            const ownerOrder = ownerRank(a.owner) - ownerRank(b.owner);
-            return ownerOrder === 0
-              ? comparePolicy(a.position, a.id, b.position, b.id)
-              : ownerOrder;
-          });
-          // Reorder math runs against committed rows only — placeholder rows
-          // (empty `position`) aren't valid keys for `generateKeyBetween` and
-          // aren't reorderable until the server confirms.
-          const committedForOwner = (owner: Owner) =>
-            sorted.filter((p) => p.owner === owner && p.position !== "");
-          const committedIndex = (id: string, owner: Owner): number =>
-            committedForOwner(owner).findIndex((p) => p.id === id);
-          const positionAbove = (id: string, owner: Owner): string => {
-            const committed = committedForOwner(owner);
-            const j = committedIndex(id, owner);
-            if (j <= 0) return generateKeyBetween(null, committed[0]!.position);
-            return j === 1
-              ? generateKeyBetween(null, committed[0]!.position)
-              : generateKeyBetween(committed[j - 2]!.position, committed[j - 1]!.position);
-          };
-          const positionBelow = (id: string, owner: Owner): string => {
-            const committed = committedForOwner(owner);
-            const j = committedIndex(id, owner);
-            if (j === -1 || j >= committed.length - 1)
-              return generateKeyBetween(committed[committed.length - 1]!.position, null);
-            return j === committed.length - 2
-              ? generateKeyBetween(committed[committed.length - 1]!.position, null)
-              : generateKeyBetween(committed[j + 1]!.position, committed[j + 2]!.position);
-          };
-          return (
-            <CardStack>
-              <CardStackHeader>Active policies</CardStackHeader>
-              <CardStackContent>
-                {sorted.length === 0 ? (
-                  <CardStackEntry>
-                    <CardStackEntryContent>
-                      <CardStackEntryDescription>
-                        No policies yet. Tools fall back to their plugin's default approval
-                        behavior.
-                      </CardStackEntryDescription>
-                    </CardStackEntryContent>
-                  </CardStackEntry>
-                ) : (
-                  sorted.map((p) => {
-                    const committed = committedForOwner(p.owner);
-                    const j = committedIndex(p.id, p.owner);
-                    // Pending placeholder or only one committed row → no
-                    // reorder affordance.
-                    const reorderable = j !== -1 && committed.length > 1;
-                    return (
-                      <PolicyRow
-                        key={p.id}
-                        policy={{
-                          id: p.id,
-                          owner: p.owner,
-                          pattern: p.pattern,
-                          action: p.action,
-                        }}
-                        isFirst={!reorderable || j === 0}
-                        isLast={!reorderable || j === committed.length - 1}
-                        showOwnerLabel={ownerDisplay.showOwnerLabels}
-                        onRemove={() => handleRemove({ id: p.id, owner: p.owner })}
-                        onChangeAction={(action) =>
-                          handleUpdate({ id: p.id, owner: p.owner }, action)
-                        }
-                        onMoveUp={() =>
-                          handleMove(
-                            { id: p.id, owner: p.owner },
-                            positionAbove(p.id, p.owner),
-                            "up",
-                          )
-                        }
-                        onMoveDown={() =>
-                          handleMove(
-                            { id: p.id, owner: p.owner },
-                            positionBelow(p.id, p.owner),
-                            "down",
-                          )
-                        }
-                      />
-                    );
-                  })
-                )}
-              </CardStackContent>
-            </CardStack>
-          );
-        },
-      })}
+      {isAsyncResultLoading(policies) ? (
+        <div className="flex items-center gap-2 py-8">
+          <div className="size-1.5 animate-pulse rounded-full bg-muted-foreground/30" />
+          <p className="text-sm text-muted-foreground">Loading policies…</p>
+        </div>
+      ) : (
+        AsyncResult.match(policies, {
+          onInitial: () => (
+            <div className="flex items-center gap-2 py-8">
+              <div className="size-1.5 animate-pulse rounded-full bg-muted-foreground/30" />
+              <p className="text-sm text-muted-foreground">Loading policies…</p>
+            </div>
+          ),
+          onFailure: () => (
+            <ErrorState message="Failed to load policies" onRetry={refreshPolicies} />
+          ),
+          onSuccess: ({ value }) => {
+            // Sort by owner rank (org outer, user inner), then position (lex
+            // order on fractional-indexing keys), tiebreaking on id so
+            // identical positions don't swap on refetch and
+            // `generateKeyBetween` never sees duplicate neighbor keys (which
+            // would throw). Optimistic placeholders carry `position: ""` so
+            // they sort to the top of their owner group.
+            const sorted = [...value].sort((a, b) => {
+              const ownerOrder = ownerRank(a.owner) - ownerRank(b.owner);
+              return ownerOrder === 0
+                ? comparePolicy(a.position, a.id, b.position, b.id)
+                : ownerOrder;
+            });
+            // Reorder math runs against committed rows only — placeholder rows
+            // (empty `position`) aren't valid keys for `generateKeyBetween` and
+            // aren't reorderable until the server confirms.
+            const committedForOwner = (owner: Owner) =>
+              sorted.filter((p) => p.owner === owner && p.position !== "");
+            const committedIndex = (id: string, owner: Owner): number =>
+              committedForOwner(owner).findIndex((p) => p.id === id);
+            const positionAbove = (id: string, owner: Owner): string => {
+              const committed = committedForOwner(owner);
+              const j = committedIndex(id, owner);
+              if (j <= 0) return generateKeyBetween(null, committed[0]!.position);
+              return j === 1
+                ? generateKeyBetween(null, committed[0]!.position)
+                : generateKeyBetween(committed[j - 2]!.position, committed[j - 1]!.position);
+            };
+            const positionBelow = (id: string, owner: Owner): string => {
+              const committed = committedForOwner(owner);
+              const j = committedIndex(id, owner);
+              if (j === -1 || j >= committed.length - 1)
+                return generateKeyBetween(committed[committed.length - 1]!.position, null);
+              return j === committed.length - 2
+                ? generateKeyBetween(committed[committed.length - 1]!.position, null)
+                : generateKeyBetween(committed[j + 1]!.position, committed[j + 2]!.position);
+            };
+            return (
+              <CardStack>
+                <CardStackHeader>Active policies</CardStackHeader>
+                <CardStackContent>
+                  {sorted.length === 0 ? (
+                    <CardStackEntry>
+                      <CardStackEntryContent>
+                        <CardStackEntryDescription>
+                          No policies yet. Tools fall back to their plugin's default approval
+                          behavior.
+                        </CardStackEntryDescription>
+                      </CardStackEntryContent>
+                    </CardStackEntry>
+                  ) : (
+                    sorted.map((p) => {
+                      const committed = committedForOwner(p.owner);
+                      const j = committedIndex(p.id, p.owner);
+                      // Pending placeholder or only one committed row → no
+                      // reorder affordance.
+                      const reorderable = j !== -1 && committed.length > 1;
+                      return (
+                        <PolicyRow
+                          key={p.id}
+                          policy={{
+                            id: p.id,
+                            owner: p.owner,
+                            pattern: p.pattern,
+                            action: p.action,
+                          }}
+                          isFirst={!reorderable || j === 0}
+                          isLast={!reorderable || j === committed.length - 1}
+                          showOwnerLabel={ownerDisplay.showOwnerLabels}
+                          onRemove={() => handleRemove({ id: p.id, owner: p.owner })}
+                          onChangeAction={(action) =>
+                            handleUpdate({ id: p.id, owner: p.owner }, action)
+                          }
+                          onMoveUp={() =>
+                            handleMove(
+                              { id: p.id, owner: p.owner },
+                              positionAbove(p.id, p.owner),
+                              "up",
+                            )
+                          }
+                          onMoveDown={() =>
+                            handleMove(
+                              { id: p.id, owner: p.owner },
+                              positionBelow(p.id, p.owner),
+                              "down",
+                            )
+                          }
+                        />
+                      );
+                    })
+                  )}
+                </CardStackContent>
+              </CardStack>
+            );
+          },
+        })
+      )}
     </PageContainer>
   );
 }

--- a/packages/react/src/pages/secrets.tsx
+++ b/packages/react/src/pages/secrets.tsx
@@ -1,5 +1,5 @@
 import { Suspense } from "react";
-import { useAtomValue } from "@effect/atom-react";
+import { useAtomRefresh, useAtomValue } from "@effect/atom-react";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 import type { ProviderKey } from "@executor-js/sdk/shared";
 import { useSecretProviderPlugins } from "@executor-js/sdk/client";
@@ -18,6 +18,8 @@ import {
 import { Badge } from "../components/badge";
 import { PageContainer, PageHeader } from "../components/page";
 import { useExecutorDocumentTitle } from "../lib/document-title";
+import { ErrorState } from "../components/error-state";
+import { isAsyncResultLoading } from "../lib/async-result";
 
 // ---------------------------------------------------------------------------
 // Providers page (v2) — repurposed from the v1 Secrets page.
@@ -46,6 +48,7 @@ export function SecretsPage(props: { showProviderInfo?: boolean }) {
   const showProviderInfo = props.showProviderInfo ?? true;
   const secretProviderPlugins = useSecretProviderPlugins();
   const providers = useAtomValue(providersAtom);
+  const refreshProviders = useAtomRefresh(providersAtom);
 
   return (
     <PageContainer>
@@ -78,53 +81,58 @@ export function SecretsPage(props: { showProviderInfo?: boolean }) {
       )}
 
       {/* Registered providers */}
-      {AsyncResult.match(providers, {
-        onInitial: () => (
-          <div className="flex items-center gap-2 py-8">
-            <div className="size-1.5 rounded-full bg-muted-foreground/30 animate-pulse" />
-            <p className="text-sm text-muted-foreground">Loading providers…</p>
-          </div>
-        ),
-        onFailure: () => (
-          <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3">
-            <p className="text-sm text-destructive">Failed to load providers</p>
-          </div>
-        ),
-        onSuccess: ({ value }) => (
-          <CardStack>
-            <CardStackHeader>Available providers</CardStackHeader>
-            <CardStackContent>
-              {value.length === 0 ? (
-                <CardStackEntry>
-                  <CardStackEntryContent>
-                    <CardStackEntryDescription>
-                      No credential providers are registered.
-                    </CardStackEntryDescription>
-                  </CardStackEntryContent>
-                </CardStackEntry>
-              ) : (
-                value.map((key: ProviderKey) => (
-                  <CardStackEntry key={String(key)}>
+      {isAsyncResultLoading(providers) ? (
+        <div className="flex items-center gap-2 py-8">
+          <div className="size-1.5 animate-pulse rounded-full bg-muted-foreground/30" />
+          <p className="text-sm text-muted-foreground">Loading providers…</p>
+        </div>
+      ) : (
+        AsyncResult.match(providers, {
+          onInitial: () => (
+            <div className="flex items-center gap-2 py-8">
+              <div className="size-1.5 animate-pulse rounded-full bg-muted-foreground/30" />
+              <p className="text-sm text-muted-foreground">Loading providers…</p>
+            </div>
+          ),
+          onFailure: () => (
+            <ErrorState message="Failed to load providers" onRetry={refreshProviders} />
+          ),
+          onSuccess: ({ value }) => (
+            <CardStack>
+              <CardStackHeader>Available providers</CardStackHeader>
+              <CardStackContent>
+                {value.length === 0 ? (
+                  <CardStackEntry>
                     <CardStackEntryContent>
-                      <CardStackEntryTitle className="flex min-w-0 items-center gap-2">
-                        <span className="min-w-0 shrink truncate">
-                          {providerLabel(String(key))}
-                        </span>
-                        <span className="max-w-40 shrink truncate font-mono text-xs text-muted-foreground">
-                          {String(key)}
-                        </span>
-                      </CardStackEntryTitle>
+                      <CardStackEntryDescription>
+                        No credential providers are registered.
+                      </CardStackEntryDescription>
                     </CardStackEntryContent>
-                    <CardStackEntryActions>
-                      <Badge variant="secondary">provider</Badge>
-                    </CardStackEntryActions>
                   </CardStackEntry>
-                ))
-              )}
-            </CardStackContent>
-          </CardStack>
-        ),
-      })}
+                ) : (
+                  value.map((key: ProviderKey) => (
+                    <CardStackEntry key={String(key)}>
+                      <CardStackEntryContent>
+                        <CardStackEntryTitle className="flex min-w-0 items-center gap-2">
+                          <span className="min-w-0 shrink truncate">
+                            {providerLabel(String(key))}
+                          </span>
+                          <span className="max-w-40 shrink truncate font-mono text-xs text-muted-foreground">
+                            {String(key)}
+                          </span>
+                        </CardStackEntryTitle>
+                      </CardStackEntryContent>
+                      <CardStackEntryActions>
+                        <Badge variant="secondary">provider</Badge>
+                      </CardStackEntryActions>
+                    </CardStackEntry>
+                  ))
+                )}
+              </CardStackContent>
+            </CardStack>
+          ),
+        })
+      )}
     </PageContainer>
   );
 }

--- a/packages/react/src/pages/tools.tsx
+++ b/packages/react/src/pages/tools.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react";
 import { Link } from "@tanstack/react-router";
-import { useAtomValue } from "@effect/atom-react";
+import { useAtomRefresh, useAtomValue } from "@effect/atom-react";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 import { ToolAddress, effectivePolicyFromSorted } from "@executor-js/sdk/shared";
 
@@ -11,6 +11,8 @@ import { ToolDetail, ToolDetailEmpty } from "../components/tool-detail";
 import { Button } from "../components/button";
 import { Skeleton } from "../components/skeleton";
 import { useExecutorDocumentTitle } from "../lib/document-title";
+import { ErrorState } from "../components/error-state";
+import { isAsyncResultLoading } from "../lib/async-result";
 
 // Dynamic tool policy patterns are derived from the connection-aware address.
 // Static tools (for example Executor's own tools) use their address directly.
@@ -33,6 +35,7 @@ export function ToolsPage() {
   // Tools page is a flat policy tree, not an account-grouped view. Policy writes
   // still target a specific owner (Workspace default; see usePolicyActions).
   const tools = useAtomValue(toolsAllAtom);
+  const refreshTools = useAtomRefresh(toolsAllAtom);
   const policies = useAtomValue(policiesOptimisticAtom);
   const policyActions = usePolicyActions("org");
 
@@ -114,48 +117,56 @@ export function ToolsPage() {
         </div>
       </div>
 
-      {AsyncResult.match(tools, {
-        onInitial: () => <ToolsPageSkeleton />,
-        onFailure: () => <div className="p-6 text-sm text-destructive">Failed to load tools</div>,
-        onSuccess: () =>
-          summaries.length === 0 ? (
-            <div className="flex min-h-0 flex-1 items-center justify-center">
-              <div className="text-center">
-                <p className="text-sm font-medium text-foreground/70">No tools registered</p>
-                <p className="mt-1 text-sm text-muted-foreground">
-                  Add an integration to start discovering tools.
-                </p>
-              </div>
-            </div>
-          ) : (
-            <div className="flex min-h-0 flex-1 overflow-hidden">
-              <div className="flex w-72 shrink-0 flex-col border-r border-border/60 lg:w-80 xl:w-[22rem]">
-                <ToolTree
-                  tools={summaries}
-                  selectedToolId={selectedToolId}
-                  onSelect={setSelectedToolId}
-                  onSetPolicy={(pattern, action) => void policyActions.set(pattern, action)}
-                  onClearPolicy={(pattern) => void policyActions.clear(pattern)}
-                  policies={sortedPolicies}
-                />
-              </div>
-              <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
-                {selectedTool && selectedAddress ? (
-                  <ToolDetail
-                    address={selectedAddress}
-                    toolName={selectedTool.name}
-                    staticTool={selection?.static}
-                    policy={selectedTool.policy}
-                    onSetPolicy={(pattern, action) => void policyActions.set(pattern, action)}
-                    onClearPolicy={(pattern) => void policyActions.clear(pattern)}
-                  />
-                ) : (
-                  <ToolDetailEmpty hasTools={summaries.length > 0} />
-                )}
-              </div>
+      {isAsyncResultLoading(tools) ? (
+        <ToolsPageSkeleton />
+      ) : (
+        AsyncResult.match(tools, {
+          onInitial: () => <ToolsPageSkeleton />,
+          onFailure: () => (
+            <div className="p-6">
+              <ErrorState message="Failed to load tools" onRetry={refreshTools} />
             </div>
           ),
-      })}
+          onSuccess: () =>
+            summaries.length === 0 ? (
+              <div className="flex min-h-0 flex-1 items-center justify-center">
+                <div className="text-center">
+                  <p className="text-sm font-medium text-foreground/70">No tools registered</p>
+                  <p className="mt-1 text-sm text-muted-foreground">
+                    Add an integration to start discovering tools.
+                  </p>
+                </div>
+              </div>
+            ) : (
+              <div className="flex min-h-0 flex-1 overflow-hidden">
+                <div className="flex w-72 shrink-0 flex-col border-r border-border/60 lg:w-80 xl:w-[22rem]">
+                  <ToolTree
+                    tools={summaries}
+                    selectedToolId={selectedToolId}
+                    onSelect={setSelectedToolId}
+                    onSetPolicy={(pattern, action) => void policyActions.set(pattern, action)}
+                    onClearPolicy={(pattern) => void policyActions.clear(pattern)}
+                    policies={sortedPolicies}
+                  />
+                </div>
+                <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+                  {selectedTool && selectedAddress ? (
+                    <ToolDetail
+                      address={selectedAddress}
+                      toolName={selectedTool.name}
+                      staticTool={selection?.static}
+                      policy={selectedTool.policy}
+                      onSetPolicy={(pattern, action) => void policyActions.set(pattern, action)}
+                      onClearPolicy={(pattern) => void policyActions.clear(pattern)}
+                    />
+                  ) : (
+                    <ToolDetailEmpty hasTools={summaries.length > 0} />
+                  )}
+                </div>
+              </div>
+            ),
+        })
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Data-heavy pages painted blank white and then popped in: the skeleton components existed but never rendered, because pages only matched the query atom's Initial state while effect-atom queries actually pass through a waiting state. Failed loads rendered bare text (Failed to load integrations, Failed to load tools, ...) with no way to recover except a full reload.

A small async-result helper exposes the waiting state so the skeleton branches actually run, and a shared ErrorState component (message + Retry that refreshes the atom) replaces the bare failure strings on integrations, tools, API keys, providers, policies, members, and integration detail. The add-integration page also gets a real fallback instead of a null Suspense fallback that flashed blank.

Verified with a unit test for the async-result states and manual runs with an artificial delay to confirm skeletons render. Typecheck is green.

Stacked on #1261.