### PR TITLE
Copy and naming pass: providers, add flows, API keys, policies

### DIFF
--- a/packages/plugins/google/src/react/AddGoogleSource.tsx
+++ b/packages/plugins/google/src/react/AddGoogleSource.tsx
@@ -132,7 +132,7 @@ export default function AddGoogleSource(props: {
   return (
     <div className="flex flex-1 flex-col gap-6">
       <div>
-        <h1 className="text-xl font-semibold text-foreground">Add Google</h1>
+        <h1 className="text-xl font-semibold text-foreground">Add Google integration</h1>
         <p className="mt-1 text-[13px] text-muted-foreground">
           Bundle Google APIs into one integration with a shared OAuth consent.
         </p>

--- a/packages/plugins/graphql/src/react/AddGraphqlSource.tsx
+++ b/packages/plugins/graphql/src/react/AddGraphqlSource.tsx
@@ -130,7 +130,7 @@ export default function AddGraphqlSource(props: {
 
   return (
     <div className="flex flex-1 flex-col gap-6">
-      <h1 className="text-xl font-semibold text-foreground">Add GraphQL Source</h1>
+      <h1 className="text-xl font-semibold text-foreground">Add GraphQL integration</h1>
 
       <GraphqlSourceFields
         endpoint={endpoint}
@@ -143,8 +143,8 @@ export default function AddGraphqlSource(props: {
       <AuthMethodListEditor
         list={authMethodList}
         allowedKinds={["none", "apikey"]}
-        emptyHint="No authentication declared. Add a method, or add the source without auth and connect an account from the integration page later."
-        footerHint="Every method here is registered with the source. Connect an account from the integration page after adding."
+        emptyHint="No authentication declared. Add a method, or add the integration without auth and connect an account from the integration page later."
+        footerHint="Every method here is registered with the integration. Connect an account from the integration page after adding."
       />
 
       {slugAlreadyExists && !adding && <SlugCollisionAlert slug={resolvedSlug} />}
@@ -156,7 +156,7 @@ export default function AddGraphqlSource(props: {
           Cancel
         </Button>
         <Button onClick={() => void handleAdd()} disabled={!canAdd} loading={adding}>
-          Add source
+          Add integration
         </Button>
       </FloatActions>
     </div>

--- a/packages/plugins/mcp/src/react/AddMcpSource.tsx
+++ b/packages/plugins/mcp/src/react/AddMcpSource.tsx
@@ -380,7 +380,7 @@ export default function AddMcpSource(props: {
   return (
     <div className="flex flex-1 flex-col gap-6">
       <div>
-        <h1 className="text-xl font-semibold text-foreground">Add MCP Source</h1>
+        <h1 className="text-xl font-semibold text-foreground">Add MCP integration</h1>
         <p className="mt-1 text-[13px] text-muted-foreground">
           Connect to an MCP server to discover and use its tools.
         </p>
@@ -473,7 +473,7 @@ export default function AddMcpSource(props: {
             </Button>
             {(probe || isProbing) && (
               <Button type="button" onClick={handleAddRemote} disabled={!canAdd} loading={isAdding}>
-                Add source
+                Add integration
               </Button>
             )}
           </FloatActions>
@@ -542,7 +542,7 @@ export default function AddMcpSource(props: {
               disabled={!stdioCommand.trim() || stdioSlugExists}
               loading={stdioAdding}
             >
-              Add source
+              Add integration
             </Button>
           </FloatActions>
         </>

--- a/packages/plugins/microsoft/src/react/AddMicrosoftSource.tsx
+++ b/packages/plugins/microsoft/src/react/AddMicrosoftSource.tsx
@@ -108,7 +108,7 @@ export default function AddMicrosoftSource(props: {
   return (
     <div className="flex flex-1 flex-col gap-6">
       <div>
-        <h1 className="text-xl font-semibold text-foreground">Add Microsoft Graph</h1>
+        <h1 className="text-xl font-semibold text-foreground">Add Microsoft integration</h1>
         <p className="mt-1 text-[13px] text-muted-foreground">
           Pick Microsoft 365 workloads and connect them through one delegated OAuth consent.
         </p>

--- a/packages/react/src/pages/api-keys.tsx
+++ b/packages/react/src/pages/api-keys.tsx
@@ -133,7 +133,7 @@ export function ApiKeysPage() {
           <CopyButton value="Authorization: Bearer <api-key>" />
         </div>
         <p className="mt-2 max-w-2xl text-xs leading-5 text-muted-foreground">
-          API keys work as PATs and have full access to your account.
+          API keys work like personal access tokens and have full access to your account.
         </p>
       </PageHeader>
 

--- a/packages/react/src/pages/policies.tsx
+++ b/packages/react/src/pages/policies.tsx
@@ -365,7 +365,7 @@ export function PoliciesPage() {
     <PageContainer>
       <PageHeader
         title="Policies"
-        description="Override default approval behavior for tools. The most restrictive matched action wins. Blocked tools are hidden from agent search and fail at invoke."
+        description="Decide which tools run automatically, which ask for approval, and which are blocked. The most restrictive matching rule wins; blocked tools are hidden from agents."
       />
 
       <div className="mb-8">

--- a/packages/react/src/pages/secrets.tsx
+++ b/packages/react/src/pages/secrets.tsx
@@ -33,7 +33,7 @@ import { isAsyncResultLoading } from "../lib/async-result";
 // ---------------------------------------------------------------------------
 
 const PROVIDER_LABELS: Record<string, string> = {
-  default: "Default store",
+  encrypted: "Encrypted store",
   keychain: "Keychain",
   file: "Local file",
   memory: "Memory",
@@ -41,7 +41,13 @@ const PROVIDER_LABELS: Record<string, string> = {
   "workos-vault": "WorkOS Vault",
 };
 
-const providerLabel = (key: string): string => PROVIDER_LABELS[key] ?? key;
+const providerLabel = (key: string): string =>
+  PROVIDER_LABELS[key] ??
+  key
+    .split(/[-_]/g)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
 
 export function SecretsPage(props: { showProviderInfo?: boolean }) {
   useExecutorDocumentTitle("Providers");
@@ -117,13 +123,17 @@ export function SecretsPage(props: { showProviderInfo?: boolean }) {
                           <span className="min-w-0 shrink truncate">
                             {providerLabel(String(key))}
                           </span>
-                          <span className="max-w-40 shrink truncate font-mono text-xs text-muted-foreground">
-                            {String(key)}
-                          </span>
                         </CardStackEntryTitle>
+                        <CardStackEntryDescription>
+                          {String(key) === "encrypted"
+                            ? "Values you paste are encrypted and stored in this instance's database."
+                            : `${providerLabel(String(key))} credential provider.`}
+                        </CardStackEntryDescription>
                       </CardStackEntryContent>
                       <CardStackEntryActions>
-                        <Badge variant="secondary">provider</Badge>
+                        <Badge variant="secondary">
+                          {String(key) === "encrypted" ? "default" : "provider"}
+                        </Badge>
                       </CardStackEntryActions>
                     </CardStackEntry>
                   ))


### PR DESCRIPTION
Several copy problems surfaced in a first-run walkthrough. The Providers page rendered the built-in store as encrypted encrypted provider because the label map was keyed default while the runtime provider key is encrypted. Add flows disagreed on the noun (Add MCP Source, Add GraphQL Source, Add OpenAPI Integration). API keys copy explained one acronym with another (PATs). The policies description led with matching mechanics before saying what policies are for.

The built-in provider now renders as Encrypted store with a default badge and a plain-language description; add flows all say Add ... integration; PATs is now personal access tokens; the policies header leads with what the user decides (run automatically, ask for approval, block) before the precedence rule.

Verified in the browser on each page. Typecheck is green.

Stacked on #1266.