### PR TITLE
Dev: admin seeding requires EXECUTOR_DEV_SEED_ADMIN=1

### DIFF
--- a/RUNNING.md
+++ b/RUNNING.md
@@ -30,6 +30,9 @@ develop on its `main`, publish a bump, then bump the dependency here. The
 - Self-host boots standalone with just env vars — see
   `e2e/setup/selfhost.globalsetup.ts` for the canonical recipe (data dir,
   bootstrap admin email/password, base URL, `EXECUTOR_ALLOW_LOCAL_NETWORK`)
+- Self-host Vite dev shows first-run setup by default. Set
+  `EXECUTOR_DEV_SEED_ADMIN=1` to seed `admin@example.com` /
+  `executor-dev-admin` instead.
 - Cloud needs WorkOS + Autumn; for a no-.env boot, point it at emulators —
   see `e2e/setup/cloud.globalsetup.ts` for the canonical recipe (the real
   SDKs against emulated services, PGlite dev DB)

--- a/apps/host-selfhost/vite.config.ts
+++ b/apps/host-selfhost/vite.config.ts
@@ -34,8 +34,10 @@ const DEV_PORT = 5173;
 // via real env for anything you care about (esp. BETTER_AUTH_SECRET in prod).
 process.env.EXECUTOR_DATA_DIR ??= fileURLToPath(new URL("./.executor-dev/", import.meta.url));
 process.env.BETTER_AUTH_SECRET ??= "executor-selfhost-dev-secret-change-me-0123456789";
-process.env.EXECUTOR_BOOTSTRAP_ADMIN_EMAIL ??= "admin@example.com";
-process.env.EXECUTOR_BOOTSTRAP_ADMIN_PASSWORD ??= "executor-dev-admin";
+if (process.env.EXECUTOR_DEV_SEED_ADMIN === "1") {
+  process.env.EXECUTOR_BOOTSTRAP_ADMIN_EMAIL ??= "admin@example.com";
+  process.env.EXECUTOR_BOOTSTRAP_ADMIN_PASSWORD ??= "executor-dev-admin";
+}
 process.env.EXECUTOR_WEB_BASE_URL ??= `http://localhost:${DEV_PORT}`;
 
 // Dev-only: forward /api, /mcp, /docs to the self-host Effect handler in-process


### PR DESCRIPTION
bun run dev silently seeded admin@example.com into every dev instance, which means developers never see the real first-run setup flow. Several first-run problems survived unnoticed because the team literally could not reach the new-user path by default.

Seeding is now opt-in: set EXECUTOR_DEV_SEED_ADMIN=1 to get the previous behavior (same default credentials). RUNNING.md is updated.

Heads up on the behavior change: every dev server now boots into the real first-run setup unless the variable is exported. If you relied on the implicit admin, add the env var to your shell profile.

Verified by booting dev servers with and without the variable. Typecheck is green.

Stacked on #1268.