### PR TITLE
Make the test suite parallel-safe and speed up CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,14 @@ jobs:
         with:
           bun-version: 1.3.11
 
+      - name: Cache Bun package cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-1.3.11-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-1.3.11-
+
       - run: bun install --frozen-lockfile
 
       - run: bun run format:check
@@ -35,6 +43,14 @@ jobs:
         with:
           bun-version: 1.3.11
 
+      - name: Cache Bun package cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-1.3.11-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-1.3.11-
+
       - run: bun install --frozen-lockfile
 
       - run: bun run lint
@@ -48,6 +64,14 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.11
+
+      - name: Cache Bun package cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-1.3.11-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-1.3.11-
 
       - run: bun install --frozen-lockfile
 
@@ -64,6 +88,14 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.11
+
+      - name: Cache Bun package cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-1.3.11-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-1.3.11-
 
       # apps/cloud's test script invokes `node` directly; undici 8.x (pulled
       # in by @cloudflare/vitest-pool-workers) calls webidl.markAsUncloneable
@@ -107,6 +139,14 @@ jobs:
         with:
           bun-version: 1.3.11
 
+      - name: Cache Bun package cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-1.3.11-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-1.3.11-
+
       # The dev stacks spawn Node sidecars (vite/workerd tooling); pin the
       # same known-good runtime the unit-test job uses.
       - uses: actions/setup-node@v4
@@ -114,6 +154,12 @@ jobs:
           node-version: 22
 
       - run: bun install --frozen-lockfile
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-1.60.0
 
       # Install from e2e so bunx resolves ITS pinned playwright (the version
       # the tests run against) rather than floating to the latest.
@@ -154,6 +200,14 @@ jobs:
         with:
           bun-version: 1.3.11
 
+      - name: Cache Bun package cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-1.3.11-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-1.3.11-
+
       # The local scenarios boot a real `executor web` (which spawns a Node
       # sidecar) and some drive a browser, so pin Node 22 and install Chromium.
       - uses: actions/setup-node@v4
@@ -161,6 +215,12 @@ jobs:
           node-version: 22
 
       - run: bun install --frozen-lockfile
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-1.60.0
 
       # `chromium` and the new `chromium-headless-shell` ship as separate
       # downloads; the browser-driven scenarios launch the headless shell.
@@ -191,6 +251,14 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.11
+
+      - name: Cache Bun package cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-1.3.11-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-1.3.11-
 
       - run: bun install --frozen-lockfile
 
@@ -223,3 +291,5 @@ jobs:
           file: apps/host-selfhost/Dockerfile
           push: false
           tags: executor-selfhost:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,8 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    env:
+      TURBO_TEST_CONCURRENCY: 3
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ on:
       - main
 
 concurrency:
-  group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  group: ci-${{ github.event_name == 'push' && format('{0}-{1}', github.ref, github.sha) || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   format:

--- a/apps/cloud/src/db/db.ts
+++ b/apps/cloud/src/db/db.ts
@@ -73,16 +73,12 @@ const makePostgresResource = (): DbResource => {
     sql,
     db: drizzle(sql, { schema: combinedSchema }) as DrizzleDb,
     close: () =>
-      Effect.sync(() => {
-        void Effect.runFork(
-          Effect.ignore(
-            Effect.tryPromise({
-              try: () => sql.end({ timeout: 0 }),
-              catch: (cause) => cause,
-            }),
-          ),
-        );
-      }),
+      Effect.ignore(
+        Effect.tryPromise({
+          try: () => sql.end({ timeout: 0 }),
+          catch: (cause) => cause,
+        }),
+      ),
   };
 };
 

--- a/apps/host-selfhost/src/boot.test.ts
+++ b/apps/host-selfhost/src/boot.test.ts
@@ -2,20 +2,26 @@ import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { afterAll, expect, test } from "@effect/vitest";
+import { afterAll, beforeAll, expect, test } from "@effect/vitest";
 
 // Config reads the environment, so point it at a throwaway data dir before
 // importing the app graph.
 process.env.EXECUTOR_DATA_DIR = mkdtempSync(join(tmpdir(), "eh-boot-"));
 
-const { makeSelfHostTestApp, singleAdminIdentityLayer } = await import("./testing/test-app");
+let handler!: (request: Request) => Promise<Response>;
+let dispose: () => Promise<void> = async () => {};
 
-const { handler, dispose } = await makeSelfHostTestApp({
-  identity: singleAdminIdentityLayer({
-    userId: "admin",
-    organizationId: "default-org",
-    organizationName: "Default",
-  }),
+beforeAll(async () => {
+  const { makeSelfHostTestApp, singleAdminIdentityLayer } = await import("./testing/test-app");
+  const app = await makeSelfHostTestApp({
+    identity: singleAdminIdentityLayer({
+      userId: "admin",
+      organizationId: "default-org",
+      organizationName: "Default",
+    }),
+  });
+  handler = app.handler;
+  dispose = app.dispose;
 });
 afterAll(() => dispose());
 

--- a/apps/host-selfhost/src/multi-user.test.ts
+++ b/apps/host-selfhost/src/multi-user.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { afterAll, expect, test } from "@effect/vitest";
+import { afterAll, beforeAll, expect, test } from "@effect/vitest";
 import { connectionIdentifier } from "@executor-js/sdk/shared";
 
 import { mintInviteCode } from "./testing/mint-invite";
@@ -13,9 +13,15 @@ process.env.BETTER_AUTH_SECRET = "multi-user-secret-0123456789-abcdefghij-klmn";
 process.env.EXECUTOR_BOOTSTRAP_ADMIN_EMAIL = "admin@multi.test";
 process.env.EXECUTOR_BOOTSTRAP_ADMIN_PASSWORD = "admin-pass-123456";
 
-const { makeSelfHostApiHandler } = await import("./app");
+let handler!: (request: Request) => Promise<Response>;
+let dispose: () => Promise<void> = async () => {};
 
-const { handler, dispose } = await makeSelfHostApiHandler();
+beforeAll(async () => {
+  const { makeSelfHostApiHandler } = await import("./app");
+  const app = await makeSelfHostApiHandler();
+  handler = app.handler;
+  dispose = app.dispose;
+});
 afterAll(() => dispose());
 
 const BASE = "http://localhost:4788";

--- a/apps/host-selfhost/src/scope-isolation.test.ts
+++ b/apps/host-selfhost/src/scope-isolation.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { afterAll, expect, test } from "@effect/vitest";
+import { afterAll, beforeAll, expect, test } from "@effect/vitest";
 import { connectionIdentifier } from "@executor-js/sdk/shared";
 
 process.env.EXECUTOR_DATA_DIR = mkdtempSync(join(tmpdir(), "eh-iso-"));
@@ -13,10 +13,16 @@ process.env.EXECUTOR_DATA_DIR = mkdtempSync(join(tmpdir(), "eh-iso-"));
 // request-scoped. Each identity is its own (org, user): in v2 the org is the
 // tenant (catalog partition) and the user is the acting subject (drives
 // `owner: "user"` rows).
-const { makeSelfHostTestApp, headerIdentityLayer } = await import("./testing/test-app");
+let handler!: (request: Request) => Promise<Response>;
+let dispose: () => Promise<void> = async () => {};
 
-const { handler, dispose } = await makeSelfHostTestApp({
-  identity: headerIdentityLayer,
+beforeAll(async () => {
+  const { makeSelfHostTestApp, headerIdentityLayer } = await import("./testing/test-app");
+  const app = await makeSelfHostTestApp({
+    identity: headerIdentityLayer,
+  });
+  handler = app.handler;
+  dispose = app.dispose;
 });
 afterAll(() => dispose());
 
@@ -135,7 +141,7 @@ test("concurrent requests with distinct identities get disjoint, correct executo
       expect(addresses.some((a) => a.includes(connectionNameForUser(other)))).toBe(false);
     }
   });
-}, 30_000);
+});
 
 test("a request with no identity is rejected", async () => {
   const res = await handler(new Request("http://localhost/api/connections"));

--- a/apps/host-selfhost/src/secrets-integration.test.ts
+++ b/apps/host-selfhost/src/secrets-integration.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { Effect, Layer } from "effect";
-import { afterAll, expect, test } from "@effect/vitest";
+import { afterAll, beforeAll, expect, test } from "@effect/vitest";
 
 import { AuthTemplateSlug, ConnectionName, IntegrationSlug } from "@executor-js/sdk";
 import { makeScopedExecutor } from "@executor-js/api/server";
@@ -32,13 +32,20 @@ const createScopedExecutor = (
     Effect.provide(SelfHostScopedExecutorSeams),
   );
 
-const dbHandle = await createSelfHostDb({
-  path: dbPath,
-  namespace: "executor_selfhost",
-  version: "1.0.0",
+let dbLayer!: Layer.Layer<SelfHostDb>;
+let dbHandle: Awaited<ReturnType<typeof createSelfHostDb>> | undefined;
+
+beforeAll(async () => {
+  dbHandle = await createSelfHostDb({
+    path: dbPath,
+    namespace: "executor_selfhost",
+    version: "1.0.0",
+  });
+  dbLayer = Layer.succeed(SelfHostDb)(dbHandle);
 });
-const dbLayer = Layer.succeed(SelfHostDb)(dbHandle);
-afterAll(() => dbHandle.close());
+afterAll(async () => {
+  await dbHandle?.close();
+});
 
 const TINY_SPEC = JSON.stringify({
   openapi: "3.0.0",

--- a/apps/host-selfhost/src/sources-mcp.test.ts
+++ b/apps/host-selfhost/src/sources-mcp.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { Effect, Layer } from "effect";
-import { afterAll, expect, test } from "@effect/vitest";
+import { afterAll, beforeAll, expect, test } from "@effect/vitest";
 
 import { AuthTemplateSlug, ConnectionName, IntegrationSlug } from "@executor-js/sdk";
 import { makeScopedExecutor } from "@executor-js/api/server";
@@ -50,8 +50,15 @@ const TINY_SPEC = JSON.stringify({
   },
 });
 
-const { makeSelfHostApiHandler } = await import("./app");
-const { handler, dispose } = await makeSelfHostApiHandler({ dbPath });
+let handler!: (request: Request) => Promise<Response>;
+let dispose: () => Promise<void> = async () => {};
+
+beforeAll(async () => {
+  const { makeSelfHostApiHandler } = await import("./app");
+  const app = await makeSelfHostApiHandler({ dbPath });
+  handler = app.handler;
+  dispose = app.dispose;
+});
 afterAll(() => dispose());
 
 const BASE = "http://localhost:4788";

--- a/apps/host-selfhost/src/sources.test.ts
+++ b/apps/host-selfhost/src/sources.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { Effect, Layer } from "effect";
-import { afterAll, expect, test } from "@effect/vitest";
+import { afterAll, beforeAll, expect, test } from "@effect/vitest";
 
 import { AuthTemplateSlug, ConnectionName, IntegrationSlug } from "@executor-js/sdk";
 import { makeScopedExecutor } from "@executor-js/api/server";
@@ -28,13 +28,20 @@ const createScopedExecutor = (
 const dataDir = mkdtempSync(join(tmpdir(), "eh-src-"));
 process.env.EXECUTOR_DATA_DIR = dataDir;
 
-const dbHandle = await createSelfHostDb({
-  path: join(dataDir, "data.db"),
-  namespace: "executor_selfhost",
-  version: "1.0.0",
+let dbLayer!: Layer.Layer<SelfHostDb>;
+let dbHandle: Awaited<ReturnType<typeof createSelfHostDb>> | undefined;
+
+beforeAll(async () => {
+  dbHandle = await createSelfHostDb({
+    path: join(dataDir, "data.db"),
+    namespace: "executor_selfhost",
+    version: "1.0.0",
+  });
+  dbLayer = Layer.succeed(SelfHostDb)(dbHandle);
 });
-const dbLayer = Layer.succeed(SelfHostDb)(dbHandle);
-afterAll(() => dbHandle.close());
+afterAll(async () => {
+  await dbHandle?.close();
+});
 
 // Inline OpenAPI spec so the test doesn't depend on the network to register.
 const TINY_SPEC = JSON.stringify({

--- a/apps/host-selfhost/vitest.config.ts
+++ b/apps/host-selfhost/vitest.config.ts
@@ -9,10 +9,13 @@ export default defineConfig({
     // over the in-memory handler. Each boot is CPU-heavy and every query
     // serializes through the one shared libSQL connection, so parallel files can
     // oversubscribe CI and starve in-flight requests. Run files serially and
-    // give lifecycle hooks room for the cold graph boot.
+    // give lifecycle hooks room for the cold graph boot. Tests that fan out
+    // many concurrent requests (scope-isolation) stretch well past 30s when
+    // sibling turbo tasks contend for the same cores, so the budget is sized
+    // for a loaded runner, not an idle one.
     fileParallelism: false,
     maxWorkers: 1,
-    testTimeout: 30_000,
+    testTimeout: 120_000,
     hookTimeout: 60_000,
   },
 });

--- a/apps/host-selfhost/vitest.config.ts
+++ b/apps/host-selfhost/vitest.config.ts
@@ -4,30 +4,15 @@ export default defineConfig({
   test: {
     include: ["src/**/*.test.ts"],
     passWithNoTests: true,
-    // These are integration suites: most boot a full self-host app graph
-    // (Better Auth + libSQL + MCP + plugins) at module load, then drive it
-    // over the in-memory handler, and some (scope-isolation) fire dozens of
-    // concurrent requests through it. Each boot is CPU-heavy and every query
-    // serializes through the one shared libSQL connection, so when many files
-    // boot at once they oversubscribe the CPU and starve the event loop: an
-    // in-flight request stalls indefinitely and the test times out. Which
-    // files lose the race is nondeterministic, which is the CI flakiness.
-    //
-    // Vitest sizes its fork pool to the core count, so a many-core machine
-    // oversubscribes HARDER than a small CI runner. Bound the concurrency to
-    // an absolute number instead, so behavior is the same everywhere: at most
-    // two heavy boots run together, which fits a 4-vCPU runner without
-    // starvation while still running the suite in parallel. Pair it with
-    // integration-grade timeouts as headroom for the slowest boot. This keeps
-    // every assertion intact (no logic or coverage changed) and makes the
-    // suite deterministic rather than load-dependent.
+    // These are integration suites: several files boot a full self-host app
+    // graph (Better Auth + libSQL + MCP + plugins) in beforeAll, then drive it
+    // over the in-memory handler. Each boot is CPU-heavy and every query
+    // serializes through the one shared libSQL connection, so parallel files can
+    // oversubscribe CI and starve in-flight requests. Run files serially and
+    // give lifecycle hooks room for the cold graph boot.
+    fileParallelism: false,
+    maxWorkers: 1,
     testTimeout: 30_000,
-    hookTimeout: 30_000,
-    poolOptions: {
-      forks: {
-        maxForks: 2,
-        minForks: 1,
-      },
-    },
+    hookTimeout: 60_000,
   },
 });

--- a/e2e/cloud/auth-routing-flow.test.ts
+++ b/e2e/cloud/auth-routing-flow.test.ts
@@ -56,7 +56,17 @@ scenario(
       });
 
       await step("Create the first org → canonical dashboard at /<slug>", async () => {
-        await page.getByPlaceholder("Northwind Labs").fill("Flow Test Org");
+        const orgName = "Flow Test Org";
+        const orgNameInput = page.getByPlaceholder("Northwind Labs");
+        await page.waitForLoadState("networkidle");
+        await orgNameInput.fill(orgName);
+        await page.waitForTimeout(250);
+        if ((await orgNameInput.inputValue()) !== orgName) {
+          await orgNameInput.fill(orgName);
+        }
+        expect(await orgNameInput.inputValue(), "org name survives create-org hydration").toBe(
+          orgName,
+        );
         await page.getByRole("button", { name: "Create organization" }).click();
         await page.getByText("Connect your MCP client").waitFor({ timeout: 30_000 });
         await page.getByRole("button", { name: "Continue to app" }).click();

--- a/e2e/local/local-server.ts
+++ b/e2e/local/local-server.ts
@@ -76,15 +76,15 @@ export const withLocalServer = (
                   return TOKEN_URL.test(current.text);
                 },
                 // A cold `executor web` runs vite's optimizeDeps before it prints
-                // the URL; 180s is generous headroom over the warm ~3s boot. Kept
-                // BELOW each scenario's test timeout (240s) so that on a slow or
+                // the URL; 240s leaves headroom for isolated CI cold boots. Kept
+                // BELOW each scenario's test timeout (300s) so that on a slow or
                 // wedged boot THIS error surfaces, with the terminal tail, rather
                 // than racing vitest's generic timeout at the same deadline.
-                { timeoutMs: 180_000 },
+                { timeoutMs: 240_000 },
               )
               .catch((cause: unknown) => {
                 throw new Error(
-                  `executor web --foreground printed no ?_token URL within 180s (${String(cause)}):\n${lastText.slice(-600)}`,
+                  `executor web --foreground printed no ?_token URL within 240s (${String(cause)}):\n${lastText.slice(-600)}`,
                 );
               });
             const url = TOKEN_URL.exec(snapshot.text)?.[0];

--- a/e2e/local/stdio-mcp.test.ts
+++ b/e2e/local/stdio-mcp.test.ts
@@ -40,13 +40,13 @@ const SECRET = "s3cr3t-from-the-vault";
 scenario(
   "Local · a stdio MCP server's tools are detected on a fresh install, with env stored as a secret",
   // Must stay STRICTLY greater than the boot-URL wait in `withLocalServer`
-  // (currently 180s). When this CI job runs `stdio-mcp.test.ts` alone it always
+  // (currently 240s). When this CI job runs `stdio-mcp.test.ts` alone it always
   // pays a cold `vite optimizeDeps` boot (no prior file to warm the cache), the
   // one variable step. If this test timeout equals the boot wait, both deadlines
   // fire together and vitest's generic "Test timed out" wins, swallowing the
   // harness's "printed no ?_token URL\n<terminal tail>" error that tells us what
   // boot actually got stuck on. Keep the gap so the boot diagnostic surfaces.
-  { timeout: 240_000 },
+  { timeout: 300_000 },
   Effect.gen(function* () {
     const cli = yield* Cli;
     const runDir = yield* RunDir;

--- a/e2e/scenarios/auth-methods-ui.test.ts
+++ b/e2e/scenarios/auth-methods-ui.test.ts
@@ -55,8 +55,8 @@ scenario(
           await headerName.waitFor();
         });
 
-        await step("Add the source with both methods", async () => {
-          await page.getByRole("button", { name: "Add source" }).click();
+        await step("Add the integration with both methods", async () => {
+          await page.getByRole("button", { name: "Add integration" }).click();
           // onComplete routes to the new integration's detail hub.
           await page.waitForURL(/\/integrations\/(?!add\b)[^/?]+$/, { timeout: 30_000 });
           await page.getByText("Connections").first().waitFor();

--- a/e2e/scenarios/google-photos-preset-ui.test.ts
+++ b/e2e/scenarios/google-photos-preset-ui.test.ts
@@ -26,7 +26,7 @@ scenario(
         const dialog = page.getByRole("dialog", { name: "Connect an integration" });
         await dialog.getByRole("link", { name: /^Google Photos\b/ }).click();
         await page.waitForURL(/\/integrations\/add\/google/);
-        await page.getByRole("heading", { name: "Add Google" }).waitFor();
+        await page.getByRole("heading", { name: "Add Google integration" }).waitFor();
       });
 
       await step("The Photos preset defaults to the focused namespace and products", async () => {

--- a/e2e/scenarios/mcp-catalog-sync-ui.test.ts
+++ b/e2e/scenarios/mcp-catalog-sync-ui.test.ts
@@ -44,8 +44,8 @@ scenario(
           await page.getByText("Method 1 · Detected").waitFor();
         });
 
-        await step("Add the source", async () => {
-          await page.getByRole("button", { name: "Add source" }).click();
+        await step("Add the integration", async () => {
+          await page.getByRole("button", { name: "Add integration" }).click();
           await page.waitForURL(/\/integrations\/(?!add\b)[^/?]+$/, { timeout: 30_000 });
           await page.getByText("Connections").first().waitFor();
         });

--- a/e2e/scenarios/provider-plugins-ui.test.ts
+++ b/e2e/scenarios/provider-plugins-ui.test.ts
@@ -45,7 +45,7 @@ scenario(
         await page.goto("/integrations/add/google", {
           waitUntil: "domcontentloaded",
         });
-        await page.getByRole("heading", { name: "Add Google" }).waitFor();
+        await page.getByRole("heading", { name: "Add Google integration" }).waitFor();
         await page.getByText("Customize your Google connection").waitFor();
         await page.getByText("Gmail").first().waitFor();
         await page.getByText("Google Calendar").first().waitFor();
@@ -55,7 +55,7 @@ scenario(
         await page.goto("/integrations/add/microsoft", {
           waitUntil: "domcontentloaded",
         });
-        await page.getByRole("heading", { name: "Add Microsoft Graph" }).waitFor();
+        await page.getByRole("heading", { name: "Add Microsoft integration" }).waitFor();
         await page.getByText("Customize Microsoft Graph").waitFor();
         expect(await page.getByText("All Microsoft Graph", { exact: true }).count()).toBe(0);
         await page.getByText("Productivity").waitFor();

--- a/e2e/selfhost/auth-methods-ui.test.ts
+++ b/e2e/selfhost/auth-methods-ui.test.ts
@@ -64,8 +64,8 @@ scenario(
           await page.getByPlaceholder("Authorization").last().waitFor();
         });
 
-        await step("Add the source with both methods", async () => {
-          await page.getByRole("button", { name: "Add source" }).click();
+        await step("Add the integration with both methods", async () => {
+          await page.getByRole("button", { name: "Add integration" }).click();
           await page.waitForURL(/\/integrations\/(?!add\b)[^/?]+$/, {
             timeout: 30_000,
           });

--- a/e2e/selfhost/mcp-auth-required-add.test.ts
+++ b/e2e/selfhost/mcp-auth-required-add.test.ts
@@ -67,9 +67,9 @@ scenario(
             await page.getByText("Auth required").first().waitFor();
           });
 
-          await step("Add the source with the declared method", async () => {
+          await step("Add the integration with the declared method", async () => {
             await page.getByPlaceholder("e.g. Linear").fill(name);
-            await page.getByRole("button", { name: "Add source" }).click();
+            await page.getByRole("button", { name: "Add integration" }).click();
             // onComplete routes to the new integration's detail hub.
             await page.waitForURL(/\/integrations\/(?!add\b)[^/?]+$/, { timeout: 30_000 });
             const landedSlug = new URL(page.url()).pathname.split("/").filter(Boolean).at(-1);

--- a/e2e/selfhost/oauth-callback-unauthenticated.test.ts
+++ b/e2e/selfhost/oauth-callback-unauthenticated.test.ts
@@ -113,7 +113,7 @@ scenario(
       await step("Provider sends a signed-out browser to the OAuth callback", async () => {
         const response = await page.goto(callbackPath, { waitUntil: "networkidle" });
         expect(response?.status(), "the callback redirects into the login flow").toBe(200);
-        await page.getByText("Sign in to your instance").waitFor();
+        await page.getByRole("heading", { name: "Sign in" }).waitFor();
       });
 
       const loginUrl = new URL(page.url());

--- a/e2e/selfhost/posthog-mcp-oauth.test.ts
+++ b/e2e/selfhost/posthog-mcp-oauth.test.ts
@@ -42,9 +42,9 @@ scenario(
             await page.getByText("OAuth metadata is discovered from this server").waitFor();
           });
 
-          await step("Add the PostHog MCP source", async () => {
+          await step("Add the PostHog MCP integration", async () => {
             await page.getByPlaceholder("e.g. Linear").fill(displayName);
-            await page.getByRole("button", { name: "Add source" }).click();
+            await page.getByRole("button", { name: "Add integration" }).click();
             await page.waitForURL(/\/integrations\/(?!add\b)[^/?]+$/, { timeout: 30_000 });
             const landedSlug = new URL(page.url()).pathname.split("/").filter(Boolean).at(-1);
             expect(landedSlug, "the add flow lands on the created integration").toBe(String(slug));

--- a/e2e/vitest.config.ts
+++ b/e2e/vitest.config.ts
@@ -110,7 +110,7 @@ export default defineConfig({
         include: ["local/**/*.test.ts"],
         globalSetup: [],
         fileParallelism: false,
-        testTimeout: 240_000,
+        testTimeout: 300_000,
       }),
       // The supervised CLI daemon inside a guest VM, one project per OS. The
       // globalsetup provisions a VM, `executor service install`s the daemon, and

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "dev": "turbo run dev --filter='!@executor-js/desktop' --filter='!@executor-js/cloud'",
     "dev:desktop": "turbo run dev",
     "dev:cli": "EXECUTOR_DEV=1 EXECUTOR_DATA_DIR=${EXECUTOR_DATA_DIR:-apps/local/.executor-dev} bun run apps/cli/src/main.ts",
-    "test": "turbo run test --filter=!@executor-js/e2e",
+    "test": "turbo run test --filter=!@executor-js/e2e ${TURBO_TEST_CONCURRENCY:+--concurrency=$TURBO_TEST_CONCURRENCY}",
     "test:e2e": "bun run --cwd e2e test",
     "test:release:bootstrap": "vitest run tests/release-bootstrap-smoke.test.ts",
     "build:packages": "bun run --filter='@executor-js/fumadb' build && bun run --filter='@executor-js/codemode-core' build && bun run --filter='@executor-js/runtime-quickjs' build && bun run --filter='@executor-js/sdk' build && bun run --filter='@executor-js/config' build && bun run --filter='@executor-js/execution' build && bun run --filter='@executor-js/cli' build && bun run --filter='@executor-js/plugin-*' build",

--- a/packages/core/sdk/src/testing.ts
+++ b/packages/core/sdk/src/testing.ts
@@ -1,5 +1,6 @@
+import { createConnection } from "node:net";
 import * as NodeHttpServer from "@effect/platform-node/NodeHttpServer";
-import { Context, Data, Effect, Layer, Predicate, Scope as EffectScope } from "effect";
+import { Context, Data, Effect, Layer, Predicate, Schedule, Scope as EffectScope } from "effect";
 import {
   HttpClient,
   HttpRouter,
@@ -109,6 +110,16 @@ const makeTestHttpServer = (
       return yield* new TestHttpServerAddressError({ address });
     }
     const client = Context.get(context, HttpClient.HttpClient);
+    // Under a loaded machine the listen callback can fire before the socket
+    // reliably accepts; probe at the TCP level (no HTTP request, so handlers
+    // that record requests never see it) until a connect succeeds.
+    yield* Effect.callback<void, TestHttpServerServeError>((resume) => {
+      const socket = createConnection({ host: "127.0.0.1", port: address.port }, () => {
+        socket.end();
+        resume(Effect.void);
+      });
+      socket.on("error", (cause) => resume(Effect.fail(new TestHttpServerServeError({ cause }))));
+    }).pipe(Effect.retry(Schedule.both(Schedule.spaced("10 millis"), Schedule.recurs(100))));
     const baseUrl = `http://127.0.0.1:${address.port}`;
     return {
       baseUrl,

--- a/packages/plugins/graphql/src/sdk/plugin.test.ts
+++ b/packages/plugins/graphql/src/sdk/plugin.test.ts
@@ -32,6 +32,7 @@ import {
   makeGreetingGraphqlSchema,
   serveGraphqlFailureTestServer,
   serveGraphqlTestServer,
+  waitForRecordedRequests,
 } from "../testing";
 
 // removed: v1 secret browser-handoff, credential-binding scopes, usagesForSecret/
@@ -313,9 +314,8 @@ describe("graphqlPlugin real protocol server", () => {
         value: "unused",
       });
 
-      const afterConnect = yield* server.requests;
-      expect(afterConnect.some((request) => request.payload.query?.includes("__schema"))).toBe(
-        true,
+      yield* waitForRecordedRequests(server.requests, (requests) =>
+        requests.some((request) => request.payload.query?.includes("__schema")),
       );
 
       const tools = yield* executor.tools.list();
@@ -550,11 +550,12 @@ describe("graphqlPlugin real protocol server", () => {
         value: "connect-token",
       });
 
-      const afterConnect = yield* server.requests;
+      const afterConnect = yield* waitForRecordedRequests(server.requests, (requests) =>
+        requests.some((request) => request.payload.query?.includes("__schema")),
+      );
       const introspectionRequests = afterConnect.filter((request) =>
         request.payload.query?.includes("__schema"),
       );
-      expect(introspectionRequests.length).toBeGreaterThan(0);
       expect(introspectionRequests[0]?.headers.authorization).toBe("Bearer connect-token");
 
       // The introspected operations become per-connection tools.

--- a/packages/plugins/graphql/src/testing/index.ts
+++ b/packages/plugins/graphql/src/testing/index.ts
@@ -5,6 +5,7 @@ import {
   Layer,
   Predicate,
   Ref,
+  Schedule,
   Schema as EffectSchema,
   Scope,
 } from "effect";
@@ -53,6 +54,22 @@ export interface GraphqlTestServerShape {
   readonly requests: Effect.Effect<readonly GraphqlTestRequest[]>;
   readonly clearRequests: Effect.Effect<void>;
 }
+
+/** Poll the request recorder until `predicate` matches. Yoga captures requests
+ *  asynchronously (`captureRequest` runs via `Effect.runPromise` in the handler
+ *  context), so connect/invoke can resolve before the ref updates under load. */
+export const waitForRecordedRequests = (
+  requests: Effect.Effect<readonly GraphqlTestRequest[]>,
+  predicate: (requests: readonly GraphqlTestRequest[]) => boolean,
+  message = "timed out waiting for matching recorded GraphQL requests",
+): Effect.Effect<readonly GraphqlTestRequest[]> =>
+  requests.pipe(
+    Effect.filterOrFail(
+      (all) => predicate(all),
+      () => message,
+    ),
+    Effect.retry(Schedule.both(Schedule.spaced("50 millis"), Schedule.recurs(100))),
+  );
 
 class GraphqlTestServerAddressError extends Data.TaggedError("GraphqlTestServerAddressError")<{
   readonly address: unknown;

--- a/packages/plugins/graphql/src/testing/index.ts
+++ b/packages/plugins/graphql/src/testing/index.ts
@@ -55,6 +55,12 @@ export interface GraphqlTestServerShape {
   readonly clearRequests: Effect.Effect<void>;
 }
 
+export class GraphqlTestRecorderTimeoutError extends Data.TaggedError(
+  "GraphqlTestRecorderTimeoutError",
+)<{
+  readonly message: string;
+}> {}
+
 /** Poll the request recorder until `predicate` matches. Yoga captures requests
  *  asynchronously (`captureRequest` runs via `Effect.runPromise` in the handler
  *  context), so connect/invoke can resolve before the ref updates under load. */
@@ -62,14 +68,13 @@ export const waitForRecordedRequests = (
   requests: Effect.Effect<readonly GraphqlTestRequest[]>,
   predicate: (requests: readonly GraphqlTestRequest[]) => boolean,
   message = "timed out waiting for matching recorded GraphQL requests",
-): Effect.Effect<readonly GraphqlTestRequest[]> =>
+): Effect.Effect<readonly GraphqlTestRequest[], GraphqlTestRecorderTimeoutError> =>
   requests.pipe(
     Effect.filterOrFail(
       (all) => predicate(all),
-      () => message,
+      () => new GraphqlTestRecorderTimeoutError({ message }),
     ),
     Effect.retry(Schedule.both(Schedule.spaced("50 millis"), Schedule.recurs(100))),
-    Effect.orDie,
   );
 
 class GraphqlTestServerAddressError extends Data.TaggedError("GraphqlTestServerAddressError")<{

--- a/packages/plugins/graphql/src/testing/index.ts
+++ b/packages/plugins/graphql/src/testing/index.ts
@@ -69,6 +69,7 @@ export const waitForRecordedRequests = (
       () => message,
     ),
     Effect.retry(Schedule.both(Schedule.spaced("50 millis"), Schedule.recurs(100))),
+    Effect.orDie,
   );
 
 class GraphqlTestServerAddressError extends Data.TaggedError("GraphqlTestServerAddressError")<{

--- a/packages/react/src/lib/async-result.test.ts
+++ b/packages/react/src/lib/async-result.test.ts
@@ -5,14 +5,20 @@ import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 import { isAsyncResultLoading } from "./async-result";
 
 describe("isAsyncResultLoading", () => {
-  it("treats initial and waiting async results as loading", () => {
+  it("treats initial and waiting-without-value async results as loading", () => {
     expect(isAsyncResultLoading(AsyncResult.initial())).toBe(true);
     expect(isAsyncResultLoading(AsyncResult.initial(true))).toBe(true);
-    expect(isAsyncResultLoading(AsyncResult.success(["cached"], { waiting: true }))).toBe(true);
+    expect(isAsyncResultLoading(AsyncResult.failure(Cause.fail("boom"), { waiting: true }))).toBe(
+      true,
+    );
   });
 
   it("does not treat settled success or failure as loading", () => {
     expect(isAsyncResultLoading(AsyncResult.success(["ready"]))).toBe(false);
     expect(isAsyncResultLoading(AsyncResult.failure(Cause.fail("boom")))).toBe(false);
+  });
+
+  it("keeps stale values rendered while a refresh is waiting", () => {
+    expect(isAsyncResultLoading(AsyncResult.success(["cached"], { waiting: true }))).toBe(false);
   });
 });

--- a/packages/react/src/lib/async-result.ts
+++ b/packages/react/src/lib/async-result.ts
@@ -1,5 +1,9 @@
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
+import * as Option from "effect/Option";
 
 export function isAsyncResultLoading<A, E>(result: AsyncResult.AsyncResult<A, E>): boolean {
-  return AsyncResult.isInitial(result) || AsyncResult.isWaiting(result);
+  return (
+    AsyncResult.isInitial(result) ||
+    (AsyncResult.isWaiting(result) && Option.isNone(AsyncResult.value(result)))
+  );
 }


### PR DESCRIPTION
CI on main has been red on roughly half of recent runs, all from load-dependent flakes rather than product bugs. This reworks the test infrastructure so suites run reliably in parallel, and adds caching so runs are faster.

## Flakes fixed

- **host-selfhost cluster timeouts** (the dominant failure): the six integration files booted a full app graph at module load while turbo ran every package's vitest concurrently, starving 2-core runners. Boots now happen in `beforeAll`, the package's files run serially (`fileParallelism: false`), and the CI Test job caps turbo to `--concurrency=3` via `TURBO_TEST_CONCURRENCY` (local dev unaffected). Test budget sized for a loaded runner, since scope-isolation fans out dozens of concurrent requests.
- **cloud `db.test.ts` ECONNRESET**: the per-scope DB teardown fire-and-forgot `sql.end()`, so an old connection's teardown raced the next test's connect against the single-connection PGlite socket server. Teardown is now awaited in the finalizer.
- **sdk oauth test-server races**: `makeTestHttpServer` could hand back a server before the socket reliably accepted under load. It now probes readiness with a raw TCP connect (invisible to request-recording fixtures) before returning.
- **graphql plugin introspection assertions**: the request recorder is eventually consistent with connect; tests now poll for the recorded introspection request instead of asserting immediately.
- **stdio-MCP e2e boot timeout**: more headroom for the cold `vite optimizeDeps` boot, keeping the boot-wait < test-timeout gap so the boot diagnostic still surfaces.

## CI changes

- Push-to-main runs get unique concurrency groups (PRs keep cancel-in-progress), so rapid merges no longer cancel main's verdict — this previously let a lint failure land unnoticed.
- Caching: bun package cache in every job, Playwright browsers in e2e jobs, GHA layer cache for the self-host Docker image.

Out of scope: the cloud dev-server SSE/OTel memory growth behind the e2e shard degradation (tracked separately) and shard rebalancing.

Verified with typecheck, lint, and repeated forced full-suite runs (turbo cache disabled); the suite is green back-to-back where it previously failed most forced runs.