### PR TITLE
add launch config and dev-server notes for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,14 @@ run, boot, share, or navigate things today, see [RUNNING.md](RUNNING.md); for
 e2e scenarios, [e2e/AGENTS.md](e2e/AGENTS.md). Run `bun run bootstrap` first in
 any fresh checkout or worktree.
 
+## Dev Server
+
+See [RUNNING.md → Dev servers](RUNNING.md#dev-servers) for how to start/preview
+each app. Ports are dynamic (`portless`, per-checkout derived ports), so there's
+no fixed `.claude/launch.json` — check it first if one exists before starting
+anything, and never guess a server name. Never kill a running dev/preview
+server unless explicitly asked; the user may be actively using it.
+
 ## Task Completion
 
 - Tests use Effect Vitest. Run scoped tests with `vitest run ...`. `bun run test`

--- a/RUNNING.md
+++ b/RUNNING.md
@@ -25,6 +25,16 @@ develop on its `main`, publish a bump, then bump the dependency here. The
 
 ## Dev servers
 
+There is no `.claude/launch.json` here (ports are dynamic — see below), so
+there's no fixed server name to guess. Start what you need with the commands
+below, or check `.claude/launch.json` first if one has since been added.
+
+Never kill a running dev/preview server unless explicitly asked — the user
+may be actively using it (e.g. via `bun run cli up <target> --share`, see
+below). If you need a server and the port is taken, use another port rather
+than killing what's there; `bun run reap` is for orphaned/leaked stacks, not
+servers someone is using.
+
 - Everything except desktop/cloud: `bun run dev` (turbo, from root)
 - One app: `bun run dev` from its `apps/<name>` directory
 - Self-host boots standalone with just env vars — see


### PR DESCRIPTION
## Summary
- Investigated whether a `.claude/launch.json` `dev` entry could be added, but skipped it: dev-server ports here are dynamic by design (`portless` proxying + per-checkout derived/hashed ports, see RUNNING.md), so a hardcoded port would be wrong for concurrent worktrees and would go stale.
- Instead, documented agent-facing dev-server guidance in RUNNING.md and AGENTS.md: check `.claude/launch.json` first (if one exists) before guessing a server name, and never kill a running dev/preview server unless explicitly asked.

## Test plan
- [x] Docs-only change, no code paths touched
- [x] `git status` confirms only AGENTS.md and RUNNING.md are staged