### PR TITLE
Rotate long-lived MCP SSE streams after a max age to stop stalled-client memory buildup

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -664,6 +664,7 @@
         "@types/node": "catalog:",
         "bun-types": "catalog:",
         "typescript": "catalog:",
+        "urlpattern-polyfill": "^10.1.0",
         "vitest": "catalog:",
       },
     },

--- a/packages/hosts/cloudflare/package.json
+++ b/packages/hosts/cloudflare/package.json
@@ -37,6 +37,7 @@
     "@types/node": "catalog:",
     "bun-types": "catalog:",
     "typescript": "catalog:",
+    "urlpattern-polyfill": "^10.1.0",
     "vitest": "catalog:"
   }
 }

--- a/packages/hosts/cloudflare/src/mcp/agents-sse-max-age.test.ts
+++ b/packages/hosts/cloudflare/src/mcp/agents-sse-max-age.test.ts
@@ -1,0 +1,345 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "@effect/vitest";
+import { MAX_SSE_AGE_MS, McpAgent } from "agents/mcp";
+
+const KEEPALIVE_INTERVAL_MS = 25_000;
+const MAX_PENDING_SSE_BYTES = 8 * 1024 * 1024;
+
+type FakeWebSocket = EventTarget & {
+  accepted: boolean;
+  closeCode: number | undefined;
+  closeReason: string | undefined;
+  accept: () => void;
+  close: (code?: number, reason?: string) => void;
+};
+
+type FakeAgentStub = {
+  readonly setName: (name: string, props?: unknown) => Promise<void>;
+  readonly getInitializeRequest: () => Promise<unknown>;
+  readonly fetch: (request: Request) => Promise<{ readonly webSocket: FakeWebSocket }>;
+};
+
+type RotationLog = {
+  readonly event: "sse_max_age_close";
+  readonly sessionId: string;
+  readonly variant: "streamable-get" | "streamable-post" | "legacy-sse";
+  readonly ageMs: number;
+  readonly pendingBytes: number;
+};
+
+const encoder = new TextEncoder();
+
+const flushMicrotasks = async (): Promise<void> => {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+const waitFor = async (predicate: () => boolean): Promise<void> => {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    if (predicate()) return;
+    await flushMicrotasks();
+  }
+  throw new Error("Timed out waiting for test condition");
+};
+
+const drainResponse = (response: Response): Promise<void> => {
+  return (
+    response.body
+      ?.pipeTo(
+        new WritableStream<Uint8Array>({
+          write: () => {},
+        }),
+      )
+      .catch(() => {}) ?? Promise.resolve()
+  );
+};
+
+const installStallingTransformStream = () => {
+  let abortReason: unknown;
+  let writeCount = 0;
+  let stalledWriteStarted: (() => void) | undefined;
+  const stalledWrite = new Promise<void>((resolve) => {
+    stalledWriteStarted = resolve;
+  });
+  const writer = {
+    abort: (reason: unknown) => {
+      abortReason = reason;
+      return Promise.resolve();
+    },
+    close: () => Promise.resolve(),
+    write: () => {
+      writeCount += 1;
+      stalledWriteStarted?.();
+      return new Promise<void>(() => {});
+    },
+  };
+
+  vi.stubGlobal(
+    "TransformStream",
+    class {
+      readonly readable = new ReadableStream<Uint8Array>();
+      readonly writable = {
+        getWriter: () => writer,
+      };
+    },
+  );
+
+  return {
+    abortReason: () => abortReason,
+    stalledWrite,
+    writeCount: () => writeCount,
+  };
+};
+
+const makeExecutionContext = (): ExecutionContext =>
+  ({
+    passThroughOnException: () => {},
+    waitUntil: () => {},
+  }) as unknown as ExecutionContext;
+
+const makeWebSocket = (): FakeWebSocket => {
+  const ws = new EventTarget() as FakeWebSocket;
+  ws.accepted = false;
+  ws.closeCode = undefined;
+  ws.closeReason = undefined;
+  ws.accept = () => {
+    ws.accepted = true;
+  };
+  ws.close = (code?: number, reason?: string) => {
+    ws.closeCode = code;
+    ws.closeReason = reason;
+  };
+  return ws;
+};
+
+const makeAgentStub = (ws: FakeWebSocket): FakeAgentStub => ({
+  setName: async () => {},
+  getInitializeRequest: async () => ({}),
+  fetch: async () => ({ webSocket: ws }),
+});
+
+const makeNamespace = (agent: FakeAgentStub) => ({
+  newUniqueId: () => ({ toString: () => "generated-session" }),
+  idFromName: (name: string) => ({
+    equals: () => true,
+    name,
+    toString: () => name,
+  }),
+  get: () => agent,
+});
+
+const openSse = async () => {
+  const ws = makeWebSocket();
+  const agent = makeAgentStub(ws);
+  const namespace = makeNamespace(agent);
+  const handler = McpAgent.serve("/mcp", {
+    binding: "MCP_SESSION",
+    transport: "streamable-http",
+  });
+  const response = await handler.fetch(
+    new Request("https://executor.sh/mcp", {
+      headers: {
+        accept: "text/event-stream",
+        "mcp-session-id": "session-1",
+      },
+      method: "GET",
+    }),
+    { MCP_SESSION: namespace },
+    makeExecutionContext(),
+  );
+
+  expect(response.status).toBe(200);
+  expect(ws.accepted).toBe(true);
+  expect(response.body).toBeDefined();
+
+  return { response, ws };
+};
+
+const openPostSse = async () => {
+  const ws = makeWebSocket();
+  const agent = makeAgentStub(ws);
+  const namespace = makeNamespace(agent);
+  const handler = McpAgent.serve("/mcp", {
+    binding: "MCP_SESSION",
+    transport: "streamable-http",
+  });
+  const response = await handler.fetch(
+    new Request("https://executor.sh/mcp", {
+      body: JSON.stringify({
+        id: 1,
+        jsonrpc: "2.0",
+        method: "tools/call",
+        params: {
+          arguments: {},
+          name: "example",
+        },
+      }),
+      headers: {
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
+        "mcp-session-id": "session-1",
+      },
+      method: "POST",
+    }),
+    { MCP_SESSION: namespace },
+    makeExecutionContext(),
+  );
+
+  expect(response.status).toBe(200);
+  expect(ws.accepted).toBe(true);
+  expect(response.body).toBeDefined();
+
+  return { response, ws };
+};
+
+const emitAgentEvent = (ws: FakeWebSocket, event: string, close?: true): void => {
+  ws.dispatchEvent(
+    new MessageEvent("message", {
+      data: JSON.stringify({
+        close,
+        event,
+        type: "cf_mcp_agent_event",
+      }),
+    }),
+  );
+};
+
+const emitClose = (ws: FakeWebSocket): void => {
+  ws.dispatchEvent(new Event("close"));
+};
+
+const rotationLogs = (logs: ReadonlyArray<string>): ReadonlyArray<RotationLog> =>
+  logs
+    .map((line) => {
+      try {
+        return JSON.parse(line) as {
+          readonly event?: string;
+          readonly sessionId?: string;
+          readonly variant?: string;
+          readonly ageMs?: number;
+          readonly pendingBytes?: number;
+        };
+      } catch {
+        return null;
+      }
+    })
+    .filter(
+      (event): event is RotationLog =>
+        event?.event === "sse_max_age_close" &&
+        typeof event.sessionId === "string" &&
+        typeof event.variant === "string" &&
+        typeof event.ageMs === "number" &&
+        typeof event.pendingBytes === "number",
+    );
+
+describe("agents SSE max-age rotation", () => {
+  let errorLogs: string[] = [];
+
+  beforeEach(() => {
+    errorLogs = [];
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    vi.spyOn(console, "error").mockImplementation((line) => {
+      errorLogs.push(String(line));
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("closes a healthy draining SSE connection within one keepalive tick after max age", async () => {
+    const { response, ws } = await openSse();
+    const drained = drainResponse(response);
+
+    await vi.advanceTimersByTimeAsync(MAX_SSE_AGE_MS + KEEPALIVE_INTERVAL_MS);
+    await waitFor(() => ws.closeCode === 1013);
+
+    expect(ws.closeReason).toBe("SSE client not draining");
+    const [rotationLog] = rotationLogs(errorLogs);
+    expect(rotationLog?.event).toBe("sse_max_age_close");
+    expect(rotationLog?.ageMs).toBeGreaterThan(MAX_SSE_AGE_MS);
+    expect(rotationLog?.ageMs).toBeLessThanOrEqual(MAX_SSE_AGE_MS + KEEPALIVE_INTERVAL_MS);
+    expect(rotationLog?.pendingBytes).toBeGreaterThanOrEqual(0);
+    expect(vi.getTimerCount()).toBe(0);
+
+    await drained;
+  });
+
+  it("does not rotate an in-flight POST response past max age", async () => {
+    const { response, ws } = await openPostSse();
+    const drained = drainResponse(response);
+
+    emitAgentEvent(ws, `event: message\ndata: {"jsonrpc":"2.0","id":1,"result":{}}\n\n`);
+    await vi.advanceTimersByTimeAsync(MAX_SSE_AGE_MS + KEEPALIVE_INTERVAL_MS * 4);
+    await flushMicrotasks();
+
+    expect(ws.closeCode).toBeUndefined();
+    expect(ws.closeReason).toBeUndefined();
+    expect(rotationLogs(errorLogs)).toEqual([]);
+
+    emitAgentEvent(
+      ws,
+      `event: message\ndata: {"jsonrpc":"2.0","id":1,"result":{"ok":true}}\n\n`,
+      true,
+    );
+    await drained;
+
+    expect(ws.closeCode).toBeUndefined();
+    expect(ws.closeReason).toBeUndefined();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("leaves an SSE connection younger than max age untouched", async () => {
+    const { response, ws } = await openSse();
+    const drained = drainResponse(response);
+
+    await vi.advanceTimersByTimeAsync(MAX_SSE_AGE_MS - KEEPALIVE_INTERVAL_MS * 2);
+    await flushMicrotasks();
+
+    expect(ws.closeCode).toBeUndefined();
+    expect(rotationLogs(errorLogs)).toEqual([]);
+
+    emitClose(ws);
+    await drained;
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("still closes a stalled SSE writer at the byte cap without logging rotation", async () => {
+    const stalledFrame = `event: message\ndata: ${"x".repeat(2 * 1024 * 1024)}\n\n`;
+    const transform = installStallingTransformStream();
+    const { ws } = await openSse();
+
+    emitAgentEvent(ws, stalledFrame);
+    await transform.stalledWrite;
+    expect(transform.writeCount()).toBe(1);
+
+    const stalledFrameBytes = encoder.encode(stalledFrame).byteLength;
+    expect(stalledFrameBytes).toBeLessThan(MAX_PENDING_SSE_BYTES);
+
+    for (let attempt = 0; attempt < 8 && ws.closeCode === undefined; attempt += 1) {
+      emitAgentEvent(ws, stalledFrame);
+    }
+
+    expect(ws.closeCode).toBe(1013);
+    expect(ws.closeReason).toBe("SSE client not draining");
+    expect(transform.abortReason()).toBeInstanceOf(Error);
+    expect(rotationLogs(errorLogs)).toEqual([]);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("cleans up timers when the client closes before max age", async () => {
+    const { response, ws } = await openSse();
+    const drained = drainResponse(response);
+
+    await vi.advanceTimersByTimeAsync(KEEPALIVE_INTERVAL_MS);
+    emitClose(ws);
+    await drained;
+
+    expect(ws.closeCode).toBeUndefined();
+    expect(rotationLogs(errorLogs)).toEqual([]);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/packages/hosts/cloudflare/src/mcp/agents-sse-max-age.test.ts
+++ b/packages/hosts/cloudflare/src/mcp/agents-sse-max-age.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "@effect/vitest";
 import { MAX_SSE_AGE_MS, McpAgent } from "agents/mcp";
+import { Effect, Option, Schema } from "effect";
 
 const KEEPALIVE_INTERVAL_MS = 25_000;
 const MAX_PENDING_SSE_BYTES = 8 * 1024 * 1024;
@@ -27,6 +28,18 @@ type RotationLog = {
 };
 
 const encoder = new TextEncoder();
+const RotationLogEvent = Schema.Struct({
+  ageMs: Schema.Number,
+  event: Schema.Literal("sse_max_age_close"),
+  pendingBytes: Schema.Number,
+  sessionId: Schema.String,
+  variant: Schema.Union([
+    Schema.Literal("streamable-get"),
+    Schema.Literal("streamable-post"),
+    Schema.Literal("legacy-sse"),
+  ]),
+});
+const decodeRotationLogEvent = Schema.decodeUnknownOption(Schema.fromJsonString(RotationLogEvent));
 
 const flushMicrotasks = async (): Promise<void> => {
   await Promise.resolve();
@@ -39,18 +52,22 @@ const waitFor = async (predicate: () => boolean): Promise<void> => {
     if (predicate()) return;
     await flushMicrotasks();
   }
-  throw new Error("Timed out waiting for test condition");
+  expect(predicate()).toBe(true);
 };
 
 const drainResponse = (response: Response): Promise<void> => {
-  return (
-    response.body
-      ?.pipeTo(
-        new WritableStream<Uint8Array>({
-          write: () => {},
-        }),
-      )
-      .catch(() => {}) ?? Promise.resolve()
+  return Effect.runPromise(
+    Effect.ignore(
+      Effect.tryPromise({
+        try: () =>
+          response.body?.pipeTo(
+            new WritableStream<Uint8Array>({
+              write: () => {},
+            }),
+          ) ?? Promise.resolve(),
+        catch: () => undefined,
+      }),
+    ),
   );
 };
 
@@ -91,11 +108,11 @@ const installStallingTransformStream = () => {
   };
 };
 
-const makeExecutionContext = (): ExecutionContext =>
-  ({
-    passThroughOnException: () => {},
-    waitUntil: () => {},
-  }) as unknown as ExecutionContext;
+const makeExecutionContext = (): ExecutionContext => ({
+  passThroughOnException: () => {},
+  props: undefined,
+  waitUntil: () => {},
+});
 
 const makeWebSocket = (): FakeWebSocket => {
   const ws = new EventTarget() as FakeWebSocket;
@@ -209,28 +226,10 @@ const emitClose = (ws: FakeWebSocket): void => {
 };
 
 const rotationLogs = (logs: ReadonlyArray<string>): ReadonlyArray<RotationLog> =>
-  logs
-    .map((line) => {
-      try {
-        return JSON.parse(line) as {
-          readonly event?: string;
-          readonly sessionId?: string;
-          readonly variant?: string;
-          readonly ageMs?: number;
-          readonly pendingBytes?: number;
-        };
-      } catch {
-        return null;
-      }
-    })
-    .filter(
-      (event): event is RotationLog =>
-        event?.event === "sse_max_age_close" &&
-        typeof event.sessionId === "string" &&
-        typeof event.variant === "string" &&
-        typeof event.ageMs === "number" &&
-        typeof event.pendingBytes === "number",
-    );
+  logs.flatMap((line) => {
+    const decoded = decodeRotationLogEvent(line);
+    return Option.isSome(decoded) ? [decoded.value] : [];
+  });
 
 describe("agents SSE max-age rotation", () => {
   let errorLogs: string[] = [];

--- a/packages/hosts/cloudflare/src/test-setup.ts
+++ b/packages/hosts/cloudflare/src/test-setup.ts
@@ -1,0 +1,9 @@
+import { URLPattern } from "urlpattern-polyfill";
+
+type UrlPatternPolyfillGlobal = Omit<typeof globalThis, "URLPattern"> & {
+  URLPattern?: typeof URLPattern;
+};
+
+const globals = globalThis as UrlPatternPolyfillGlobal;
+
+globals.URLPattern ??= URLPattern;

--- a/packages/hosts/cloudflare/src/test-stubs/cloudflare-email.ts
+++ b/packages/hosts/cloudflare/src/test-stubs/cloudflare-email.ts
@@ -1,0 +1,7 @@
+export class EmailMessage {
+  constructor(
+    readonly from: string,
+    readonly to: string,
+    readonly raw: ReadableStream | string,
+  ) {}
+}

--- a/packages/hosts/cloudflare/src/test-stubs/cloudflare-workers.ts
+++ b/packages/hosts/cloudflare/src/test-stubs/cloudflare-workers.ts
@@ -1,0 +1,9 @@
+export const env: Record<string, unknown> = {};
+
+export class DurableObject {}
+
+export class RpcTarget {}
+
+export class WorkerEntrypoint {}
+
+export const exports: Record<string, unknown> = {};

--- a/packages/hosts/cloudflare/vitest.config.ts
+++ b/packages/hosts/cloudflare/vitest.config.ts
@@ -1,8 +1,23 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
 export default defineConfig({
+  resolve: {
+    alias: {
+      "cloudflare:email": resolve(__dirname, "./src/test-stubs/cloudflare-email.ts"),
+      "cloudflare:workers": resolve(__dirname, "./src/test-stubs/cloudflare-workers.ts"),
+    },
+  },
   test: {
     include: ["src/**/*.test.ts"],
     passWithNoTests: true,
+    server: {
+      deps: {
+        inline: ["agents", "partyserver"],
+      },
+    },
   },
 });

--- a/packages/hosts/cloudflare/vitest.config.ts
+++ b/packages/hosts/cloudflare/vitest.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
   test: {
     include: ["src/**/*.test.ts"],
     passWithNoTests: true,
+    setupFiles: ["./src/test-setup.ts"],
     server: {
       deps: {
         inline: ["agents", "partyserver"],

--- a/patches/agents@0.17.3.patch
+++ b/patches/agents@0.17.3.patch
@@ -1,8 +1,33 @@
+diff --git a/dist/mcp/index.d.ts b/dist/mcp/index.d.ts
+index c8fad44..439da01 100644
+--- a/dist/mcp/index.d.ts
++++ b/dist/mcp/index.d.ts
+@@ -29,6 +29,7 @@ import {
+   xt as MCPClientOAuthCallbackConfig,
+   zt as ElicitResult
+ } from "../agent-tool-types-CNyE1iz_.js";
++declare const MAX_SSE_AGE_MS = 300000;
+ export {
+   type ClearableEventStore,
+   type CreateMcpHandlerOptions,
+@@ -41,6 +42,7 @@ export {
+   type MCPConnectionResult,
+   type MCPDiscoverResult,
+   type MCPServerOptions,
++  MAX_SSE_AGE_MS,
+   MCP_SERVER_ID_MAX_LENGTH,
+   McpAgent,
+   type McpAuthContext,
 diff --git a/dist/mcp/index.js b/dist/mcp/index.js
-index 1edcf0c8..e65cd346 100644
+index 1edcf0c..707f1cf 100644
 --- a/dist/mcp/index.js
 +++ b/dist/mcp/index.js
-@@ -32,9 +32,9 @@ const KEEPALIVE_FRAME = ": keepalive\n\n";
+@@ -28,13 +28,14 @@ import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/
+ const KEEPALIVE_INTERVAL_MS = 25e3;
+ /** SSE comment frame the parser drops before any event dispatch. */
+ const KEEPALIVE_FRAME = ": keepalive\n\n";
++const MAX_SSE_AGE_MS = 300_000;
+ /**
  * Start an SSE keepalive on `writer`. Returns a `clearInterval` handle
  * that the stream cleanup must invoke when the stream closes.
  */
@@ -14,7 +39,7 @@ index 1edcf0c8..e65cd346 100644
  	}, KEEPALIVE_INTERVAL_MS);
  	return handle;
  }
-@@ -180,10 +180,15 @@ const createStreamingHttpHandler = (basePath, namespace, options = {}) => {
+@@ -180,10 +181,15 @@ const createStreamingHttpHandler = (basePath, namespace, options = {}) => {
  					});
  					return new Response(body, { status: 404 });
  				}
@@ -34,7 +59,7 @@ index 1edcf0c8..e65cd346 100644
  				request.headers.forEach((value, key) => {
  					existingHeaders[key] = value;
  				});
-@@ -206,45 +211,68 @@ const createStreamingHttpHandler = (basePath, namespace, options = {}) => {
+@@ -206,45 +212,71 @@ const createStreamingHttpHandler = (basePath, namespace, options = {}) => {
  						jsonrpc: "2.0"
  					});
  					return new Response(body, { status: 500 });
@@ -45,17 +70,20 @@ index 1edcf0c8..e65cd346 100644
 -					return new Response(null, {
 +					}
 +					ws.accept();
++					const __closeSse = () => {
++						__sseClosed = true;
++						try {
++							clearInterval(keepAlive);
++						} catch {}
++						try {
++							ws.close(1013, "SSE client not draining");
++						} catch {}
++						writer.abort(new Error("SSE client not draining")).catch(() => {});
++					};
 +					const __forwardSse = (frame) => {
 +						if (__sseClosed) return __writeChain;
 +						if (__pendingBytes + frame.byteLength > MAX_PENDING_SSE_BYTES) {
-+							__sseClosed = true;
-+							try {
-+								clearInterval(keepAlive);
-+							} catch {}
-+							try {
-+								ws.close(1013, "SSE client not draining");
-+							} catch {}
-+							writer.abort(new Error("SSE client not draining")).catch(() => {});
++							__closeSse();
 +							return Promise.resolve();
 +						}
 +						__pendingBytes += frame.byteLength;
@@ -129,7 +157,7 @@ index 1edcf0c8..e65cd346 100644
  					}
  					onClose().catch(console.error);
  				});
-@@ -279,10 +307,15 @@ const createStreamingHttpHandler = (basePath, namespace, options = {}) => {
+@@ -279,10 +311,16 @@ const createStreamingHttpHandler = (basePath, namespace, options = {}) => {
  					id: null,
  					jsonrpc: "2.0"
  				}), { status: 400 });
@@ -140,6 +168,7 @@ index 1edcf0c8..e65cd346 100644
 +					const { readable, writable } = new TransformStream();
 +					const writer = writable.getWriter();
 +					const encoder = new TextEncoder();
++					const __openedAt = Date.now();
 +					const MAX_PENDING_SSE_BYTES = 8 * 1024 * 1024;
 +					let __pendingBytes = 0;
 +					let __writeChain = Promise.resolve();
@@ -149,7 +178,7 @@ index 1edcf0c8..e65cd346 100644
  					props: ctx.props,
  					jurisdiction: options.jurisdiction
  				});
-@@ -306,27 +339,51 @@ const createStreamingHttpHandler = (basePath, namespace, options = {}) => {
+@@ -306,27 +344,66 @@ const createStreamingHttpHandler = (basePath, namespace, options = {}) => {
  				if (!ws) {
  					await writer.close();
  					return new Response("Failed to establish WS to DO", { status: 500 });
@@ -158,17 +187,32 @@ index 1edcf0c8..e65cd346 100644
 -				ws.addEventListener("message", (event) => {
 +					}
 +					ws.accept();
++					const __closeSse = () => {
++						__sseClosed = true;
++						try {
++							clearInterval(keepAlive);
++						} catch {}
++						try {
++							ws.close(1013, "SSE client not draining");
++						} catch {}
++						writer.abort(new Error("SSE client not draining")).catch(() => {});
++					};
 +					const __forwardSse = (frame) => {
 +						if (__sseClosed) return __writeChain;
++						const ageMs = Date.now() - __openedAt;
++						if (ageMs > MAX_SSE_AGE_MS) {
++							console.error(JSON.stringify({
++								event: "sse_max_age_close",
++								sessionId,
++								variant: "streamable-get",
++								ageMs,
++								pendingBytes: __pendingBytes
++							}));
++							__closeSse();
++							return Promise.resolve();
++						}
 +						if (__pendingBytes + frame.byteLength > MAX_PENDING_SSE_BYTES) {
-+							__sseClosed = true;
-+							try {
-+								clearInterval(keepAlive);
-+							} catch {}
-+							try {
-+								ws.close(1013, "SSE client not draining");
-+							} catch {}
-+							writer.abort(new Error("SSE client not draining")).catch(() => {});
++							__closeSse();
 +							return Promise.resolve();
 +						}
 +						__pendingBytes += frame.byteLength;
@@ -216,7 +260,7 @@ index 1edcf0c8..e65cd346 100644
  				return new Response(readable, {
  					headers: {
  						"Cache-Control": "no-cache",
-@@ -389,10 +446,15 @@ const createLegacySseHandler = (basePath, namespace, options = {}) => {
+@@ -389,10 +466,16 @@ const createLegacySseHandler = (basePath, namespace, options = {}) => {
  		const url = new URL(request.url);
  		if (request.method === "GET" && basePattern.test(url)) {
  			const sessionId = url.searchParams.get("sessionId") || namespace.newUniqueId().toString();
@@ -227,6 +271,7 @@ index 1edcf0c8..e65cd346 100644
 +				const { readable, writable } = new TransformStream();
 +				const writer = writable.getWriter();
 +				const encoder = new TextEncoder();
++				const __openedAt = Date.now();
 +				const MAX_PENDING_SSE_BYTES = 8 * 1024 * 1024;
 +				let __pendingBytes = 0;
 +				let __writeChain = Promise.resolve();
@@ -236,7 +281,7 @@ index 1edcf0c8..e65cd346 100644
  			endpointUrl.pathname = encodeURI(`${basePath}/message`);
  			endpointUrl.searchParams.set("sessionId", sessionId);
  			const endpointMessage = `event: endpoint\ndata: ${endpointUrl.pathname + endpointUrl.search + endpointUrl.hash}\n\n`;
-@@ -414,35 +476,59 @@ const createLegacySseHandler = (basePath, namespace, options = {}) => {
+@@ -414,35 +497,74 @@ const createLegacySseHandler = (basePath, namespace, options = {}) => {
  				console.error("Failed to establish WebSocket connection");
  				await writer.close();
  				return new Response("Failed to establish WebSocket connection", { status: 500 });
@@ -245,17 +290,32 @@ index 1edcf0c8..e65cd346 100644
 -			ws.addEventListener("message", (event) => {
 +				}
 +				ws.accept();
++				const __closeSse = () => {
++					__sseClosed = true;
++					try {
++						clearInterval(keepAlive);
++					} catch {}
++					try {
++						ws.close(1013, "SSE client not draining");
++					} catch {}
++					writer.abort(new Error("SSE client not draining")).catch(() => {});
++				};
 +				const __forwardSse = (frame) => {
 +					if (__sseClosed) return __writeChain;
++					const ageMs = Date.now() - __openedAt;
++					if (ageMs > MAX_SSE_AGE_MS) {
++						console.error(JSON.stringify({
++							event: "sse_max_age_close",
++							sessionId,
++							variant: "legacy-sse",
++							ageMs,
++							pendingBytes: __pendingBytes
++						}));
++						__closeSse();
++						return Promise.resolve();
++					}
 +					if (__pendingBytes + frame.byteLength > MAX_PENDING_SSE_BYTES) {
-+						__sseClosed = true;
-+						try {
-+							clearInterval(keepAlive);
-+						} catch {}
-+						try {
-+							ws.close(1013, "SSE client not draining");
-+						} catch {}
-+						writer.abort(new Error("SSE client not draining")).catch(() => {});
++						__closeSse();
 +						return Promise.resolve();
 +					}
 +					__pendingBytes += frame.byteLength;
@@ -314,9 +374,12 @@ index 1edcf0c8..e65cd346 100644
  						console.error("Error closing SSE connection:", error);
  					}
  				}
-@@ -1700,4 +1786,4 @@ McpAgent.STREAM_REQS_KEY_PREFIX = "__mcp_stream_reqs__:";
+@@ -1698,6 +1820,6 @@ var McpAgent = class McpAgent extends Agent {
+ };
+ McpAgent.STREAM_REQS_KEY_PREFIX = "__mcp_stream_reqs__:";
  //#endregion
- export { DurableObjectEventStore, ElicitRequestSchema, MCP_SERVER_ID_MAX_LENGTH, McpAgent, RPCClientTransport, RPCServerTransport, RPC_DO_PREFIX, SSEEdgeClientTransport, StreamableHTTPEdgeClientTransport, WorkerTransport, createMcpHandler, experimental_createMcpHandler, getMcpAuthContext, normalizeServerId };
+-export { DurableObjectEventStore, ElicitRequestSchema, MCP_SERVER_ID_MAX_LENGTH, McpAgent, RPCClientTransport, RPCServerTransport, RPC_DO_PREFIX, SSEEdgeClientTransport, StreamableHTTPEdgeClientTransport, WorkerTransport, createMcpHandler, experimental_createMcpHandler, getMcpAuthContext, normalizeServerId };
++export { DurableObjectEventStore, ElicitRequestSchema, MAX_SSE_AGE_MS, MCP_SERVER_ID_MAX_LENGTH, McpAgent, RPCClientTransport, RPCServerTransport, RPC_DO_PREFIX, SSEEdgeClientTransport, StreamableHTTPEdgeClientTransport, WorkerTransport, createMcpHandler, experimental_createMcpHandler, getMcpAuthContext, normalizeServerId };
  
 -//# sourceMappingURL=index.js.map
 \ No newline at end of file


### PR DESCRIPTION
## Problem

Cloud workers periodically die with `exceededMemory`, killing every MCP connection on the affected isolate at once (clients see `MCP error -32000: Connection closed` mid-request). The cause is stalled SSE clients: a client whose socket stays open but whose reader stops consuming. Buffered output for that connection accumulates inside the runtime until the isolate crosses the 128 MiB limit. Stalled connections were observed surviving 87-107 minutes in production.

## Why not detect the stall?

Two detection-based fixes were built and disproven on deployed workers:

- Keying on chunk transit through the counting wrapper: the runtime keeps pulling chunks for minutes after the client stalls, so the signal never fires.
- Keying on unresolved `writer.write()` promise age at the inner writer (this package patch): writes resolve promptly into internal runtime buffering even with the peer socket verifiably frozen; `IdentityTransformStream` behaves identically. There is no JS-observable backpressure signal on the write path at these payload sizes.

## Fix: bounded lifetime instead of detection

Close every **long-lived** SSE stream (streamable-http GET channel, legacy SSE) once it exceeds `MAX_SSE_AGE_MS` (5 minutes), checked on the existing 25s keepalive tick that already routes through the patched `__forwardSse` helper -- no new timers. The close path is the same one the existing 8 MB pending-bytes cap uses. Each rotation emits a structured `sse_max_age_close` log with session id and variant.

- Healthy clients recover transparently: the SDK reconnects with `Last-Event-ID` and the default DO-backed event store (events are persisted before the frame is written) replays anything in flight.
- Stalled clients stop accumulating: worst case is ~5 minutes of buffered output instead of unbounded growth.

The **POST response stream is deliberately not rotated**: those streams are finite (the DO closes them when the response completes) so they cannot leak unboundedly, and rotating one mid-response orphans the in-flight result -- the client SDK can only resume a stream that already delivered an event id, which an in-progress response may not have. A regression test asserts POST responses are never rotated. The 8 MB cap still bounds pathological POST readers.

## Validation (all on deployed workers, not just unit tests)

- Under a load profile that previously produced repeated `exceededMemory` isolate deaths (50 connections, half stalled via SIGSTOP), rotation ran 4+ cycles over 22 minutes with **zero** memory deaths, confirmed via runtime analytics.
- End-to-end with a real `@modelcontextprotocol/sdk` client against the actual patched package: GET-channel rotation survived two full cycles with zero client-visible transport errors; a server push notification fired 20s after a rotation was delivered in 27ms on the silently reconnected stream.
- The same e2e run demonstrated the POST hazard concretely (an in-flight call timing out after a forced POST rotation), which is why rotation is scoped to the long-lived channels.

## Changes

- `patches/agents@0.17.3.patch`: max-age rotation in the streamable-http GET and legacy SSE handlers; `MAX_SSE_AGE_MS` exported; existing 8 MB cap and keepalive routing preserved.
- `packages/hosts/cloudflare/src/mcp/agents-sse-max-age.test.ts`: five tests covering rotation timing, young connections untouched, byte-cap regression, clean-close cleanup, and the POST no-rotation guarantee.
- `packages/hosts/cloudflare/vitest.config.ts` + `src/test-stubs/`: aliases `cloudflare:workers`/`cloudflare:email` and inlines `agents`/`partyserver` so patched-package behavior is testable under vitest; existing package tests unaffected (15/15 pass).

## Update: same-run A/B against prod-state code

A follow-up experiment reproduced the production failure directly and demonstrated the fix in a single controlled run: two identical deployments of a real \`McpAgent\` worker built from this patched package -- one at current production state (byte cap, no rotation), one with this PR's rotation -- under identical load (10 rolling generations of 15 stalled GET-channel clients per arm, 150 total per arm, ~25 minutes).

| | prod state (control) | this PR (rotation) |
|---|---:|---:|
| \`exceededMemory\` | **57**, bursting with each connection-spike generation | **0** |
| rotation closes | 0 | 171, all within 146ms of the configured max age |
| healthy clients | n/a | clean reconnects, no errors |

The control arm's deaths arrived in the same burst pattern observed in production (each isolate death killing a batch of concurrent connections at once). The rotation arm absorbed the identical load with zero memory deaths.
