### PR TITLE
Show the daemon as "Executor" in Login Items instead of the developer name

### DIFF
--- a/apps/cli/src/service.test.ts
+++ b/apps/cli/src/service.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it } from "@effect/vitest";
+import { afterEach, describe, expect, it } from "@effect/vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 import {
   cmdSetValue,
@@ -11,6 +14,14 @@ import {
   parseNetstatListenerPids,
   parseSchtasksRunning,
 } from "./service";
+
+const tempDirs: Array<string> = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 describe("service unit generation", () => {
   const launchdInput = {
@@ -36,16 +47,49 @@ describe("service unit generation", () => {
     workingDirectory: "/Users/x/.executor",
   };
 
+  const makeExecutorBundle = (bundleIdentifier: string): string => {
+    const root = mkdtempSync(join(tmpdir(), "executor-launchd-bundle-"));
+    tempDirs.push(root);
+    const contentsDir = join(root, "Executor.app", "Contents");
+    const executableDir = join(contentsDir, "Resources", "executor");
+    mkdirSync(executableDir, { recursive: true });
+    writeFileSync(
+      join(contentsDir, "Info.plist"),
+      `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleIdentifier</key>
+  <string>${bundleIdentifier}</string>
+</dict>
+</plist>
+`,
+    );
+    return join(executableDir, "executor");
+  };
+
+  const expectLaunchdInvariants = (plist: string, input: typeof launchdInput): void => {
+    const programArguments = input.programArguments
+      .map((arg) => `    <string>${arg}</string>`)
+      .join("\n");
+
+    expect(plist).toContain("<key>Label</key>");
+    expect(plist).toContain(`<string>${input.label}</string>`);
+    expect(plist).toContain(
+      `  <key>ProgramArguments</key>\n  <array>\n${programArguments}\n  </array>`,
+    );
+    expect(plist).toMatch(/<key>RunAtLoad<\/key>\s*<true\/>/);
+    expect(plist).toMatch(
+      /<key>KeepAlive<\/key>\s*<dict>\s*<key>SuccessfulExit<\/key>\s*<false\/>\s*<\/dict>/,
+    );
+  };
+
   it("renders a launchd plist that restarts on crash but not clean stop", () => {
     const plist = generateLaunchdPlist(launchdInput);
+    expectLaunchdInvariants(plist, launchdInput);
     expect(plist).toContain('<plist version="1.0">');
-    expect(plist).toContain("<key>Label</key>");
-    expect(plist).toContain("<string>sh.executor.daemon</string>");
-    expect(plist).toMatch(/<key>RunAtLoad<\/key>\s*<true\/>/);
     // KeepAlive => restart only on non-zero/crash exit, not on a clean bootout.
-    expect(plist).toContain("<key>KeepAlive</key>");
     expect(plist).toContain("<key>SuccessfulExit</key>");
-    expect(plist).toMatch(/<key>SuccessfulExit<\/key>\s*<false\/>/);
     expect(plist).toContain("<key>ProcessType</key>");
     expect(plist).toContain("<string>Background</string>");
     expect(plist).toContain("--foreground");
@@ -57,6 +101,32 @@ describe("service unit generation", () => {
     const plist = generateLaunchdPlist(launchdInput);
     // No secret in the unit — the daemon reads the bearer from auth.json at boot.
     expect(plist).not.toContain("EXECUTOR_AUTH_PASSWORD");
+  });
+
+  it("associates an app-bundled launchd plist with the enclosing bundle identifier", () => {
+    const executablePath = makeExecutorBundle("sh.executor.desktop.test");
+    const input = {
+      ...launchdInput,
+      programArguments: [executablePath, ...launchdInput.programArguments.slice(1)],
+    };
+    const plist = generateLaunchdPlist(input);
+
+    expectLaunchdInvariants(plist, input);
+    expect(plist.match(/<key>AssociatedBundleIdentifiers<\/key>/g)).toHaveLength(1);
+    expect(plist).toMatch(
+      /<dict>\s*<key>Label<\/key>\s*<string>sh\.executor\.daemon<\/string>\s*<key>AssociatedBundleIdentifiers<\/key>\s*<array>\s*<string>sh\.executor\.desktop\.test<\/string>\s*<\/array>\s*<key>ProgramArguments<\/key>/,
+    );
+  });
+
+  it("omits app association for standalone launchd binaries", () => {
+    const input = {
+      ...launchdInput,
+      programArguments: ["/usr/local/bin/executor", ...launchdInput.programArguments.slice(1)],
+    };
+    const plist = generateLaunchdPlist(input);
+
+    expectLaunchdInvariants(plist, input);
+    expect(plist).not.toContain("AssociatedBundleIdentifiers");
   });
 
   it("xml-escapes environment values", () => {

--- a/apps/cli/src/service.ts
+++ b/apps/cli/src/service.ts
@@ -1,4 +1,5 @@
 import { execFile } from "node:child_process";
+import { readFileSync } from "node:fs";
 import { homedir, userInfo } from "node:os";
 import { FileSystem, Path } from "effect";
 import type { PlatformError } from "effect/PlatformError";
@@ -143,6 +144,14 @@ const xmlEscape = (value: string): string =>
     .replaceAll('"', "&quot;")
     .replaceAll("'", "&apos;");
 
+const xmlUnescape = (value: string): string =>
+  value
+    .replaceAll("&apos;", "'")
+    .replaceAll("&quot;", '"')
+    .replaceAll("&gt;", ">")
+    .replaceAll("&lt;", "<")
+    .replaceAll("&amp;", "&");
+
 // ---------------------------------------------------------------------------
 // Shared service environment + program args
 // ---------------------------------------------------------------------------
@@ -209,6 +218,36 @@ const launchdPlistPath = (path: Path.Path): string =>
 
 const serviceLogDir = (path: Path.Path): string => path.join(resolveExecutorDataDir(path), "logs");
 
+const DESKTOP_APP_BUNDLE_IDENTIFIER = "sh.executor.desktop";
+
+const enclosingAppBundlePath = (executablePath: string): string | null => {
+  const match = executablePath.match(/^(.*\.app)\/Contents\//);
+  return match?.[1] ?? null;
+};
+
+const readBundleIdentifier = (appBundlePath: string): string | null => {
+  try {
+    const plist = readFileSync(`${appBundlePath}/Contents/Info.plist`, "utf8");
+    const match = plist.match(/<key>\s*CFBundleIdentifier\s*<\/key>\s*<string>([^<]*)<\/string>/);
+    const bundleIdentifier = match ? xmlUnescape(match[1].trim()) : "";
+    return bundleIdentifier.length > 0 ? bundleIdentifier : null;
+  } catch {
+    return null;
+  }
+};
+
+const associatedBundleIdentifier = (programArguments: ReadonlyArray<string>): string | null => {
+  const executablePath = programArguments[0];
+  if (!executablePath) return null;
+  const appBundlePath = enclosingAppBundlePath(executablePath);
+  if (!appBundlePath) return null;
+  const bundleIdentifier = readBundleIdentifier(appBundlePath);
+  if (bundleIdentifier) return bundleIdentifier;
+  return /(?:^|\/)Executor\.app\/Contents\//.test(executablePath)
+    ? DESKTOP_APP_BUNDLE_IDENTIFIER
+    : null;
+};
+
 export interface LaunchdPlistOptions {
   readonly label: string;
   readonly programArguments: ReadonlyArray<string>;
@@ -219,7 +258,7 @@ export interface LaunchdPlistOptions {
 }
 
 /**
- * Render a user LaunchAgent plist. Pure (snapshot-tested). KeepAlive uses
+ * Render a user LaunchAgent plist. KeepAlive uses
  * `SuccessfulExit=false` so launchd restarts the daemon on a crash/non-zero
  * exit but leaves it stopped after a clean `bootout` (which sends SIGTERM →
  * the daemon exits 0). RunAtLoad starts it on login; ProcessType=Background
@@ -229,6 +268,10 @@ export const generateLaunchdPlist = (options: LaunchdPlistOptions): string => {
   const programArgs = options.programArguments
     .map((arg) => `    <string>${xmlEscape(arg)}</string>`)
     .join("\n");
+  const bundleIdentifier = associatedBundleIdentifier(options.programArguments);
+  const associatedBundleIdentifiers = bundleIdentifier
+    ? `  <key>AssociatedBundleIdentifiers</key>\n  <array>\n    <string>${xmlEscape(bundleIdentifier)}</string>\n  </array>\n`
+    : "";
   const envEntries = Object.entries(options.environment)
     .map(
       ([key, value]) =>
@@ -241,7 +284,7 @@ export const generateLaunchdPlist = (options: LaunchdPlistOptions): string => {
 <dict>
   <key>Label</key>
   <string>${xmlEscape(options.label)}</string>
-  <key>ProgramArguments</key>
+${associatedBundleIdentifiers}  <key>ProgramArguments</key>
   <array>
 ${programArgs}
   </array>


### PR DESCRIPTION
## Problem

macOS 13+ groups bare legacy LaunchAgents in System Settings → Login Items & Extensions under the **signing certificate developer name**. Executor installs its daemon as `~/Library/LaunchAgents/sh.executor.daemon.plist` with no app association, so every user sees a "Rhys Sullivan" login item (with a generic icon) instead of "Executor".

## Fix

`generateLaunchdPlist` now emits Apple's supported association key when (and only when) the service binary lives inside a macOS app bundle:

```xml
<key>AssociatedBundleIdentifiers</key>
<array>
  <string>sh.executor.desktop</string>
</array>
```

The bundle id is read from the enclosing bundle's `Contents/Info.plist` (with a constant fallback for `Executor.app` if the read fails). Standalone CLI installs (npm/homebrew, binary not inside a `.app`) produce a byte-identical plist to before. The app and daemon already share a Team ID (the daemon ships inside the bundle), which is what BTM requires to honor the association.

## Verification

| Before — plist without the key | After — plist with the key |
|---|---|
| ![Login Items grouping the daemon under "Rhys Sullivan" with a generic icon](https://raw.githubusercontent.com/RhysSullivan/executor/bd1de153a7065b832ea191b29d7cf78f05fb990b/login-items-before.jpg) | ![Login Items showing "Executor" with the app icon](https://raw.githubusercontent.com/RhysSullivan/executor/bd1de153a7065b832ea191b29d7cf78f05fb990b/login-items-after.jpg) |
| Grouped under the signing cert developer name — "Rhys Sullivan, 1 item", generic grid icon. | Same daemon attributed to **Executor** with the real app icon. |


Reproduced and proved in a disposable tart macOS VM (Sequoia) using the real Developer-ID-signed release bundle:

- **Before** (`sfltool dumpbtm`): daemon record `Type: legacy agent`, `Parent Identifier: Rhys Sullivan`; Login Items shows a "Rhys Sullivan / 1 item" entry with a generic icon.
- **After** adding the key and re-registering: daemon record gains `Assoc. Bundle IDs: [ sh.executor.desktop ]`, `Parent Identifier: 2.sh.executor.desktop`; Login Items shows **Executor** with the app icon.
- Existing installs self-heal on the first fresh BTM ingestion of the updated plist (the app reinstalls the service on upgrade, rewriting the plist); no `sfltool resetbtm` needed for new installs since first ingestion already carries the key.
- Unit tests cover both branches (association emitted from a fixture bundle's Info.plist; key absent for standalone paths) plus the pre-existing plist invariants. `bun run --cwd apps/cli test` 18/18, typecheck clean.
