### PR TITLE
Publish self-host image to legacy GHCR namespace during transition

### DIFF
--- a/.github/workflows/publish-selfhost-docker.yml
+++ b/.github/workflows/publish-selfhost-docker.yml
@@ -22,6 +22,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+    env:
+      HAS_LEGACY_TOKEN: ${{ secrets.GHCR_LEGACY_TOKEN != '' }}
 
     steps:
       - name: Checkout
@@ -57,6 +59,7 @@ jobs:
           version="${RELEASE_TAG#v}"
           owner="$(printf '%s' "$GITHUB_REPOSITORY_OWNER" | tr '[:upper:]' '[:lower:]')"
           image="ghcr.io/${owner}/executor-selfhost"
+          legacy_image="ghcr.io/rhyssullivan/executor-selfhost"
           revision="$(git rev-parse HEAD)"
 
           if [[ "$version" == *-* ]]; then
@@ -73,6 +76,11 @@ jobs:
             echo "${image}:${RELEASE_TAG}"
             echo "${image}:${version}"
             echo "${image}:${channel}"
+            echo "TAGS"
+            echo "legacy_tags<<TAGS"
+            echo "${legacy_image}:${RELEASE_TAG}"
+            echo "${legacy_image}:${version}"
+            echo "${legacy_image}:${channel}"
             echo "TAGS"
             echo "labels<<LABELS"
             echo "org.opencontainers.image.title=Executor self-host"
@@ -97,6 +105,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push self-host image
+        id: build
         uses: useblacksmith/build-push-action@v2
         with:
           context: .
@@ -105,3 +114,32 @@ jobs:
           push: true
           tags: ${{ steps.image.outputs.tags }}
           labels: ${{ steps.image.outputs.labels }}
+
+      - name: Skip legacy GHCR mirror (GHCR_LEGACY_TOKEN not configured)
+        if: env.HAS_LEGACY_TOKEN != 'true'
+        run: echo "GHCR_LEGACY_TOKEN is not configured; skipping legacy GHCR mirror."
+
+      - name: Log in to legacy GHCR namespace
+        if: env.HAS_LEGACY_TOKEN == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: rhyssullivan
+          password: ${{ secrets.GHCR_LEGACY_TOKEN }}
+
+      - name: Mirror self-host image to legacy GHCR namespace
+        if: env.HAS_LEGACY_TOKEN == 'true'
+        shell: bash
+        env:
+          SOURCE_IMAGE: ${{ steps.image.outputs.image }}@${{ steps.build.outputs.digest }}
+          LEGACY_TAGS: ${{ steps.image.outputs.legacy_tags }}
+        run: |
+          set -euo pipefail
+
+          tag_args=()
+          while IFS= read -r tag; do
+            [[ -n "$tag" ]] || continue
+            tag_args+=("-t" "$tag")
+          done <<< "$LEGACY_TAGS"
+
+          docker buildx imagetools create "${tag_args[@]}" "$SOURCE_IMAGE"


### PR DESCRIPTION
## Why

The repository moved from `RhysSullivan/executor` to `UsefulSoftwareCo/executor`, but GHCR packages do not redirect after an ownership transfer. Existing self-host deployments that still pull `ghcr.io/rhyssullivan/executor-selfhost` need a transition window where releases continue to update that legacy image.

## How

- Keep the current org image build and push to `ghcr.io/usefulsoftwareco/executor-selfhost`.
- Capture the build digest from the existing build step.
- When `GHCR_LEGACY_TOKEN` is configured, log in as `rhyssullivan` and mirror all release tags to `ghcr.io/rhyssullivan/executor-selfhost` with `docker buildx imagetools create` from the org image digest.
- When `GHCR_LEGACY_TOKEN` is absent, skip the legacy mirror with an explicit skip step so the release job still succeeds.

## Setup Required

Rhys needs to create a classic PAT on the `rhyssullivan` account with `write:packages`, then add it to this repository as the `GHCR_LEGACY_TOKEN` secret.

## Caveat

The legacy PAT identity needs to read the org image digest before it can create the legacy tags. If the org GHCR package is private on first publish, the mirror step may need package visibility or access adjusted. If the org package is public, the current flow should be fine.

## Removal

Remove the legacy mirror after a few releases, or once self-host install docs and known downstream deployments have moved to `ghcr.io/usefulsoftwareco/executor-selfhost`.

## Verification

- `bun run format:check`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest -ignore 'label "blacksmith-4vcpu-ubuntu-2404" is unknown' .github/workflows/publish-selfhost-docker.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish-selfhost-docker.yml"); puts "YAML parses"'`
