### PR TITLE
ci: run release + CLI publish jobs on ubuntu-latest

### DIFF
--- a/.github/workflows/publish-executor-package.yml
+++ b/.github/workflows/publish-executor-package.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   publish:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       actions: write
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   release:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       actions: write
       contents: write


### PR DESCRIPTION
The Blacksmith runner migration (#1286) broke npm trusted publishing. Blacksmith runners mint OIDC tokens from a different issuer than GitHub Actions, so npm rejects the provenance publish with a 404 (`PUT .../@executor-js%2fcodemode-core` → 404). This blocked the v1.5.28 release: the Version Packages PR (#1253) merged and bumped the version, but `prepare release` failed at the library-publish step before tagging or dispatching the CLI publish.

Move only the two publish jobs (`release.yml`, `publish-executor-package.yml`) back to `ubuntu-latest` so the OIDC issuer matches the trusted publishers configured on npm. The rest of the Blacksmith migration is untouched.

Last good release (v1.5.27, 2026-07-01) ran on `ubuntu-latest`; #1286 switched these jobs to Blacksmith on 2026-07-03, which is when publishing broke.