### PR TITLE
Revert "ci: run release + CLI publish jobs on ubuntu-latest"

### DIFF
--- a/.github/workflows/publish-executor-package.yml
+++ b/.github/workflows/publish-executor-package.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       actions: write
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       actions: write
       contents: write


### PR DESCRIPTION
Reverts #1291. That change moved the two publish jobs off Blacksmith on the theory that the runner broke npm trusted publishing — it did not. The actual cause of the v1.5.28 publish failures was a trusted-publisher workflow-filename mismatch on the `@executor-js/*` packages (configured for `publish-executor-package.yml`; the libraries publish from `release.yml`), now fixed on npm. GitHub issues the OIDC token based on the workflow/repo regardless of runner host, so Blacksmith works fine for trusted publishing. Restoring Blacksmith for consistency with #1286.