### PR TITLE
Stop wasted pkg-pr-new runs

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -59,6 +59,7 @@ jobs:
       # No prebuilt better-sqlite3 binary matches the Blacksmith Linux runner,
       # so `bun install` builds it from source via node-gyp, whose undici needs
       # Node 22.10+ (webidl.markAsUncloneable).
+
       - uses: actions/setup-node@v4
         if: runner.os == 'Linux'
         with:

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -6,6 +6,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: pkg-pr-new-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   # Per-platform matrix: build the executor binary, tar it, upload to R2.
   # The wrapper npm package is built later by the `publish` job which just
@@ -20,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: ubuntu-latest
+          - runner: blacksmith-4vcpu-ubuntu-2404
             target: executor-linux-x64
           - runner: macos-14
             target: executor-darwin-arm64
@@ -33,6 +37,24 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.11
+
+      - name: Cache Bun package cache
+        if: runner.os == 'Linux'
+        uses: useblacksmith/cache@v5
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-1.3.11-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-1.3.11-
+
+      - name: Cache Bun package cache
+        if: runner.os == 'macOS'
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-1.3.11-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-1.3.11-
 
       - run: bun install --frozen-lockfile
 
@@ -76,6 +98,14 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.11
+
+      - name: Cache Bun package cache
+        uses: useblacksmith/cache@v5
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-1.3.11-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-1.3.11-
 
       # No prebuilt better-sqlite3 binary matches this runner, so `bun install`
       # builds it from source via node-gyp, whose undici needs Node 22.10+

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -59,7 +59,6 @@ jobs:
       # No prebuilt better-sqlite3 binary matches the Blacksmith Linux runner,
       # so `bun install` builds it from source via node-gyp, whose undici needs
       # Node 22.10+ (webidl.markAsUncloneable).
-
       - uses: actions/setup-node@v4
         if: runner.os == 'Linux'
         with:

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -39,16 +39,6 @@ jobs:
           bun-version: 1.3.11
 
       - name: Cache Bun package cache
-        if: runner.os == 'Linux'
-        uses: useblacksmith/cache@v5
-        with:
-          path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-1.3.11-${{ hashFiles('bun.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-bun-1.3.11-
-
-      - name: Cache Bun package cache
-        if: runner.os == 'macOS'
         uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache
@@ -108,7 +98,7 @@ jobs:
           bun-version: 1.3.11
 
       - name: Cache Bun package cache
-        uses: useblacksmith/cache@v5
+        uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-1.3.11-${{ hashFiles('bun.lock') }}

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -56,6 +56,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-bun-1.3.11-
 
+      # No prebuilt better-sqlite3 binary matches the Blacksmith Linux runner,
+      # so `bun install` builds it from source via node-gyp, whose undici needs
+      # Node 22.10+ (webidl.markAsUncloneable).
+      - uses: actions/setup-node@v4
+        if: runner.os == 'Linux'
+        with:
+          node-version: 22
+
       - run: bun install --frozen-lockfile
 
       - name: Build executor preview tarball

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -35,6 +35,14 @@ jobs:
         with:
           bun-version: 1.3.11
 
+      - name: Cache Bun package cache
+        uses: useblacksmith/cache@v5
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-1.3.11-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-1.3.11-
+
       # No prebuilt better-sqlite3 binary matches this runner, so `bun install`
       # builds it from source via node-gyp, whose undici needs Node 22.10+
       # (webidl.markAsUncloneable). Pin the same runtime the CI jobs use.

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -36,7 +36,7 @@ jobs:
           bun-version: 1.3.11
 
       - name: Cache Bun package cache
-        uses: useblacksmith/cache@v5
+        uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-1.3.11-${{ hashFiles('bun.lock') }}


### PR DESCRIPTION
## Summary

- add per-PR cancellation to pkg-pr-new runs
- move the Linux pkg-pr-new binary build to Blacksmith while keeping macOS on GitHub-hosted runners
- add Bun package-cache steps for every bun install job in pkg-pr-new and preview
- pin Node 22 before bun install on the Blacksmith binary build leg so better-sqlite3 node-gyp fallback works

## Verification

- actionlint on .github/workflows/pkg-pr-new.yml and .github/workflows/preview.yml with blacksmith-4vcpu-ubuntu-2404 declared as a custom runner label
- Final Preview green: https://github.com/UsefulSoftwareCo/executor/actions/runs/28691747526
- Final Publish (pkg.pr.new) green: https://github.com/UsefulSoftwareCo/executor/actions/runs/28691747470
- Cancellation proof, superseded Preview cancelled: https://github.com/UsefulSoftwareCo/executor/actions/runs/28691734162
- Cancellation proof, superseded Publish (pkg.pr.new) cancelled: https://github.com/UsefulSoftwareCo/executor/actions/runs/28691734178
- Cache miss and save proof, first Preview Blacksmith cache: https://github.com/UsefulSoftwareCo/executor/actions/runs/28691558791
- Cache miss and save proof, first macOS pkg-pr-new cache: https://github.com/UsefulSoftwareCo/executor/actions/runs/28691558802
