### PR TITLE
Fix release publish workflow footguns

### DIFF
--- a/.github/workflows/publish-executor-package.yml
+++ b/.github/workflows/publish-executor-package.yml
@@ -2,6 +2,8 @@ name: Publish Executor
 run-name: "${{ format('publish executor {0}', github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name) }}"
 
 on:
+  # Release pushes a validated v* tag and lets this trigger handle automatic
+  # publishing. workflow_dispatch stays available for explicit repair runs.
   push:
     tags:
       - "v*"

--- a/.github/workflows/publish-selfhost-docker.yml
+++ b/.github/workflows/publish-selfhost-docker.yml
@@ -17,13 +17,16 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  publish:
+  metadata:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read
-      packages: write
-    env:
-      HAS_LEGACY_TOKEN: ${{ secrets.GHCR_LEGACY_TOKEN != '' }}
+    outputs:
+      release_tag: ${{ steps.validate.outputs.tag }}
+      image: ${{ steps.image.outputs.image }}
+      tags: ${{ steps.image.outputs.tags }}
+      legacy_tags: ${{ steps.image.outputs.legacy_tags }}
+      labels: ${{ steps.image.outputs.labels }}
 
     steps:
       - name: Checkout
@@ -38,9 +41,10 @@ jobs:
           bun-version: 1.3.11
 
       - name: Validate release tag
+        id: validate
         env:
           RAW_RELEASE_TAG: ${{ inputs.tag }}
-        run: bun run scripts/validate-release-ref.ts --tag-env RAW_RELEASE_TAG --write-env RELEASE_TAG
+        run: bun run scripts/validate-release-ref.ts --tag-env RAW_RELEASE_TAG --write-env RELEASE_TAG --output tag
 
       - name: Checkout release tag
         env:
@@ -91,8 +95,30 @@ jobs:
             echo "LABELS"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+  build:
+    needs: metadata
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: blacksmith-4vcpu-ubuntu-2404
+          - arch: arm64
+            platform: linux/arm64
+            runner: blacksmith-4vcpu-ubuntu-2404-arm
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.metadata.outputs.release_tag }}
+          fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Blacksmith Builder
         uses: useblacksmith/setup-docker-builder@v1
@@ -104,16 +130,94 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push self-host image
+      - name: Build and push self-host image by digest
         id: build
         uses: useblacksmith/build-push-action@v2
         with:
           context: .
           file: apps/host-selfhost/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.image.outputs.tags }}
-          labels: ${{ steps.image.outputs.labels }}
+          platforms: ${{ matrix.platform }}
+          labels: ${{ needs.metadata.outputs.labels }}
+          outputs: type=image,name=${{ needs.metadata.outputs.image }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export image digest
+        shell: bash
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "$DIGEST" ]; then
+            echo "Build did not return a digest."
+            exit 1
+          fi
+
+          mkdir -p "$RUNNER_TEMP/digests"
+          touch "$RUNNER_TEMP/digests/${DIGEST#sha256:}"
+
+      - name: Upload image digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    needs:
+      - metadata
+      - build
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      packages: write
+    env:
+      HAS_LEGACY_TOKEN: ${{ secrets.GHCR_LEGACY_TOKEN != '' }}
+
+    steps:
+      - name: Download image digests
+        uses: actions/download-artifact@v4
+        with:
+          pattern: digests-*
+          path: ${{ runner.temp }}/digests
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish multi-arch self-host image
+        shell: bash
+        env:
+          IMAGE: ${{ needs.metadata.outputs.image }}
+          TAGS: ${{ needs.metadata.outputs.tags }}
+        run: |
+          set -euo pipefail
+
+          sources=()
+          while IFS= read -r digest_file; do
+            digest="$(basename "$digest_file")"
+            [[ -n "$digest" ]] || continue
+            sources+=("${IMAGE}@sha256:${digest}")
+          done < <(find "$RUNNER_TEMP/digests" -maxdepth 1 -type f | sort)
+
+          if [ "${#sources[@]}" -eq 0 ]; then
+            echo "No image digests were downloaded."
+            exit 1
+          fi
+
+          tag_args=()
+          while IFS= read -r tag; do
+            [[ -n "$tag" ]] || continue
+            tag_args+=("-t" "$tag")
+          done <<< "$TAGS"
+
+          docker buildx imagetools create "${tag_args[@]}" "${sources[@]}"
 
       - name: Skip legacy GHCR mirror (GHCR_LEGACY_TOKEN not configured)
         if: env.HAS_LEGACY_TOKEN != 'true'
@@ -131,8 +235,8 @@ jobs:
         if: env.HAS_LEGACY_TOKEN == 'true'
         shell: bash
         env:
-          SOURCE_IMAGE: ${{ steps.image.outputs.image }}@${{ steps.build.outputs.digest }}
-          LEGACY_TAGS: ${{ steps.image.outputs.legacy_tags }}
+          SOURCE_IMAGE: ${{ needs.metadata.outputs.image }}:${{ needs.metadata.outputs.release_tag }}
+          LEGACY_TAGS: ${{ needs.metadata.outputs.legacy_tags }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
           # @changesets/changelog-github occasionally receives truncated
           # GitHub GraphQL responses. Retry only that transient failure mode.
           version: >-
-            bash -c 'for attempt in 1 2 3; do log="$(mktemp)"; if bun run changeset:version >"$log" 2>&1; then cat "$log"; rm -f "$log"; exit 0; fi; status=$?; cat "$log"; if ! grep -Eq "Failed to parse data from GitHub|Premature close" "$log" || [ "$attempt" -eq 3 ]; then rm -f "$log"; exit "$status"; fi; echo "::warning::changeset:version hit a transient GitHub GraphQL failure on attempt $attempt; resetting generated files before retry."; rm -f "$log"; git reset --hard HEAD; done'
+            bash -c 'for attempt in 1 2 3; do log="$(mktemp)"; if bun run changeset:version >"$log" 2>&1; then cat "$log"; rm -f "$log"; exit 0; else status=$?; fi; cat "$log"; if ! grep -Eq "Failed to parse data from GitHub|Premature close" "$log" || [ "$attempt" -eq 3 ]; then rm -f "$log"; exit "$status"; fi; echo "::warning::changeset:version hit a transient GitHub GraphQL failure on attempt $attempt; resetting generated files before retry."; rm -f "$log"; git reset --hard HEAD; git clean -fd -- .changeset apps packages examples e2e; done'
           commit: Version Packages
           title: Version Packages
           createGithubReleases: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,10 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          version: bun run changeset:version
+          # @changesets/changelog-github occasionally receives truncated
+          # GitHub GraphQL responses. Retry only that transient failure mode.
+          version: >-
+            bash -c 'for attempt in 1 2 3; do log="$(mktemp)"; if bun run changeset:version >"$log" 2>&1; then cat "$log"; rm -f "$log"; exit 0; fi; status=$?; cat "$log"; if ! grep -Eq "Failed to parse data from GitHub|Premature close" "$log" || [ "$attempt" -eq 3 ]; then rm -f "$log"; exit "$status"; fi; echo "::warning::changeset:version hit a transient GitHub GraphQL failure on attempt $attempt; resetting generated files before retry."; rm -f "$log"; git reset --hard HEAD; done'
           commit: Version Packages
           title: Version Packages
           createGithubReleases: false
@@ -124,13 +127,9 @@ jobs:
           git tag "$RELEASE_TAG"
           git push "$auth_remote" "$RELEASE_TAG"
 
-      - name: Trigger CLI publish
-        if: steps.changesets.outputs.hasChangesets == 'false' && steps.detect_release.outputs.changed == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ steps.validate_release.outputs.tag }}
-        run: |
-          gh workflow run publish-executor-package.yml --ref "$RELEASE_TAG" -f tag="$RELEASE_TAG"
+      # Publishing is intentionally tag-driven: pushing the validated v* tag
+      # triggers publish-executor-package.yml. A second workflow_dispatch path
+      # races a duplicate publish for the same release.
 
       # Desktop build downloads CLI binaries from the release, so it must
       # run after CLI publish completes. Trigger it from the CLI workflow


### PR DESCRIPTION
## What changed

- Retries `changeset:version` only when the changesets changelog step hits the transient GitHub GraphQL parse failures seen in Release logs.
- Removes the explicit `gh workflow run publish-executor-package.yml` dispatch from Release. The pushed `v*` tag is now the single automatic Publish Executor trigger, while `workflow_dispatch` remains for repair runs.
- Splits self-host Docker publishing into native amd64 and arm64 Blacksmith matrix builds, uploads per-arch digest artifacts, then creates the multi-arch manifest for both GHCR namespaces with `docker buildx imagetools create`.

## Release diagnosis

I inspected recent failed Release runs: `28686830716`, `28489661728`, `28411073545`, `28358855701`, `28355916948`, `28354166786`, `28353275594`, `28352320755`, `28351802611`, `28351073786`, and `28350205006`.

The current noisy changesets failure is not a non-fast-forward branch push or a permissions error. The relevant recent failures die while `@changesets/changelog-github` is fetching GitHub changelog data:

```text
Run 28489661728, 2026-07-01:
The following error was encountered while generating changelog entries
Error: Failed to parse data from GitHub
Invalid response body while trying to fetch https://api.github.com/graphql: Premature close
error: script "changeset:version" exited with code 1
```

```text
Run 28411073545, 2026-06-30:
The following error was encountered while generating changelog entries
Error: Failed to parse data from GitHub
Invalid response body while trying to fetch https://api.github.com/graphql: Premature close
error: script "changeset:version" exited with code 1
```

Several older failures were deterministic changeset authoring errors, for example:

```text
Run 28358855701, 2026-06-29:
Error: Found mixed changeset desktop-titlebar-polish
Found ignored packages: @executor-js/host-cloudflare
Found not ignored packages: @executor-js/desktop @executor-js/host-selfhost @executor-js/react
Mixed changesets that contain both ignored and not ignored packages are not allowed
```

Those should still fail. The wrapper exits immediately unless the log contains `Failed to parse data from GitHub` or `Premature close`, and it resets generated files before retrying the transient case. The Release workflow already had a non-cancelling branch concurrency group, and the sampled logs did not show a changeset branch push race.

The latest sampled failed Release run, `28686830716`, passed changesets and failed later in package publish with `npm error code E404` for `@executor-js/codemode-core@1.5.28`, so this PR does not claim to fix that separate npm permission or package availability issue.

## Publish trigger diagnosis

Publish Executor history showed paired automatic runs for the same tag, seconds apart:

- `v1.5.27`: `push` run `28490029741` and `workflow_dispatch` run `28490029285`, both successful.
- `v1.5.26`: `push` run `28411821883` and `workflow_dispatch` run `28411821591`, both successful.
- `v1.5.25`: `push` run `28393956665` and `workflow_dispatch` run `28393956319`, both successful.

The tag push path is reliable and directly tied to the validated release tag. Keeping it as the sole automatic path avoids duplicate publishes for the same release.

## Self-host Docker notes

The ARM runner label is from Blacksmith instance type docs: `blacksmith-4vcpu-ubuntu-2404-arm` at https://docs.blacksmith.sh/blacksmith-runners/overview.md.

The workflow still publishes the primary GHCR tags and, when `GHCR_LEGACY_TOKEN` is configured, mirrors the same tag set into `ghcr.io/rhyssullivan/executor-selfhost` during the org transition.

Because `publish-selfhost-docker.yml` is `workflow_dispatch` only, it still needs a post-merge manual dispatch against a real release tag to validate the full registry push and manifest merge path.

## Verification

- `bash /tmp/release-wrapper-review-test.sh`: covers attempt-1 success, deterministic non-transient failure without retry, transient `Premature close` failure across all configured attempts with a nonzero exit, and transient-once success. The transient-once case also creates an untracked package `CHANGELOG.md` and requires the retry cleanup to remove it before the successful attempt.
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest -config-file /tmp/actionlint-release-runner-label.yaml .github/workflows/release.yml`
- Local dry-run of digest artifact to `docker buildx imagetools create` argument construction.
