### PR TITLE
Speed up and tune CI wall-clock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,13 +7,58 @@ on:
       - main
 
 concurrency:
-  group: ci-${{ github.event_name == 'push' && format('{0}-{1}', github.ref, github.sha) || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Changed paths
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 10
+    outputs:
+      desktop_smoke: ${{ github.event_name != 'pull_request' || steps.filter.outputs.desktop_smoke == 'true' }}
+      selfhost_docker_smoke: ${{ github.event_name != 'pull_request' || steps.filter.outputs.selfhost_docker_smoke == 'true' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Filter changed paths
+        id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            desktop_smoke:
+              - ".github/workflows/**"
+              - "bun.lock"
+              - "package.json"
+              - "turbo.json"
+              - "apps/desktop/**"
+              - "apps/local/**"
+              - "apps/cli/**"
+              - "packages/app/**"
+              - "packages/core/**"
+              - "packages/hosts/mcp/**"
+              - "packages/kernel/runtime-quickjs/**"
+              - "packages/plugins/**"
+              - "packages/react/**"
+            selfhost_docker_smoke:
+              - ".github/workflows/**"
+              - ".dockerignore"
+              - "bun.lock"
+              - "package.json"
+              - "turbo.json"
+              - "apps/host-selfhost/**"
+              - "packages/app/**"
+              - "packages/core/**"
+              - "packages/hosts/mcp/**"
+              - "packages/kernel/runtime-quickjs/**"
+              - "packages/plugins/**"
+              - "packages/react/**"
+
   format:
     name: Format
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 
@@ -22,27 +67,21 @@ jobs:
           bun-version: 1.3.11
 
       - name: Cache Bun package cache
-        uses: actions/cache@v4
+        uses: useblacksmith/cache@v5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-1.3.11-${{ hashFiles('bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-bun-1.3.11-
 
-      # No prebuilt better-sqlite3 binary matches this runner, so `bun install`
-      # builds it from source via node-gyp, whose undici needs Node 22.10+
-      # (webidl.markAsUncloneable). Pin the same runtime the test/e2e jobs use.
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-
-      - run: bun install --frozen-lockfile
+      - run: bun install --frozen-lockfile --ignore-scripts
 
       - run: bun run format:check
 
   lint:
     name: Lint
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 
@@ -51,27 +90,21 @@ jobs:
           bun-version: 1.3.11
 
       - name: Cache Bun package cache
-        uses: actions/cache@v4
+        uses: useblacksmith/cache@v5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-1.3.11-${{ hashFiles('bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-bun-1.3.11-
 
-      # No prebuilt better-sqlite3 binary matches this runner, so `bun install`
-      # builds it from source via node-gyp, whose undici needs Node 22.10+
-      # (webidl.markAsUncloneable). Pin the same runtime the test/e2e jobs use.
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-
-      - run: bun install --frozen-lockfile
+      - run: bun install --frozen-lockfile --ignore-scripts
 
       - run: bun run lint
 
   typecheck:
     name: Typecheck
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 
@@ -80,7 +113,7 @@ jobs:
           bun-version: 1.3.11
 
       - name: Cache Bun package cache
-        uses: actions/cache@v4
+        uses: useblacksmith/cache@v5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-1.3.11-${{ hashFiles('bun.lock') }}
@@ -89,10 +122,19 @@ jobs:
 
       # No prebuilt better-sqlite3 binary matches this runner, so `bun install`
       # builds it from source via node-gyp, whose undici needs Node 22.10+
-      # (webidl.markAsUncloneable). Pin the same runtime the test/e2e jobs use.
+      # (webidl.markAsUncloneable). Pin the same Node 24 runtime used by release.
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
+
+      - name: Cache Turbo task cache
+        uses: useblacksmith/cache@v5
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-typecheck-${{ hashFiles('bun.lock', 'turbo.json') }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-typecheck-
+            ${{ runner.os }}-turbo-
 
       - run: bun install --frozen-lockfile
 
@@ -101,8 +143,10 @@ jobs:
   test:
     name: Test
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 15
+    # Tuned for Blacksmith's 4 vCPU runners.
     env:
-      TURBO_TEST_CONCURRENCY: 3
+      TURBO_TEST_CONCURRENCY: 4
     steps:
       - uses: actions/checkout@v4
 
@@ -111,7 +155,7 @@ jobs:
           bun-version: 1.3.11
 
       - name: Cache Bun package cache
-        uses: actions/cache@v4
+        uses: useblacksmith/cache@v5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-1.3.11-${{ hashFiles('bun.lock') }}
@@ -120,10 +164,19 @@ jobs:
 
       # apps/cloud's test script invokes `node` directly; undici 8.x (pulled
       # in by @cloudflare/vitest-pool-workers) calls webidl.markAsUncloneable
-      # which only exists in Node 22.10+. Pin a known-good runtime.
+      # which only exists in Node 22.10+. Pin the Node 24 CI runtime.
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
+
+      - name: Cache Turbo task cache
+        uses: useblacksmith/cache@v5
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-test-${{ hashFiles('bun.lock', 'turbo.json') }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-test-
+            ${{ runner.os }}-turbo-
 
       - run: bun install --frozen-lockfile
 
@@ -135,24 +188,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Cloud is SHARDED: each shard boots its own fresh dev stack. The
-          # cloud dev server degrades after a few minutes of sustained suite
-          # load on 2-core runners (the SSE/OTel memory growth being
-          # instrumented on main) — requests start failing partway through and
-          # everything after dies with connection errors. Short shards on
-          # fresh boots stay under that threshold; re-merge into fewer jobs
-          # once the degradation is fixed.
-          - { target: cloud, shard: 1/8, shard-name: 1of8 }
-          - { target: cloud, shard: 2/8, shard-name: 2of8 }
-          - { target: cloud, shard: 3/8, shard-name: 3of8 }
-          - { target: cloud, shard: 4/8, shard-name: 4of8 }
-          - { target: cloud, shard: 5/8, shard-name: 5of8 }
-          - { target: cloud, shard: 6/8, shard-name: 6of8 }
-          - { target: cloud, shard: 7/8, shard-name: 7of8 }
-          - { target: cloud, shard: 8/8, shard-name: 8of8 }
+          # Each cloud shard boots its own fresh dev stack. On 4 vCPU runners,
+          # four fatter shards keep the longest shard below selfhost while saving
+          # four runner boots and four warm cache restores.
+          - { target: cloud, shard: 1/4, shard-name: 1of4 }
+          - { target: cloud, shard: 2/4, shard-name: 2of4 }
+          - { target: cloud, shard: 3/4, shard-name: 3of4 }
+          - { target: cloud, shard: 4/4, shard-name: 4of4 }
           - target: selfhost
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
+    env:
+      E2E_MCP_FAST_IDLE_TEARDOWN: "true"
     steps:
       - uses: actions/checkout@v4
 
@@ -161,7 +208,7 @@ jobs:
           bun-version: 1.3.11
 
       - name: Cache Bun package cache
-        uses: actions/cache@v4
+        uses: useblacksmith/cache@v5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-1.3.11-${{ hashFiles('bun.lock') }}
@@ -169,18 +216,20 @@ jobs:
             ${{ runner.os }}-bun-1.3.11-
 
       # The dev stacks spawn Node sidecars (vite/workerd tooling); pin the
-      # same known-good runtime the unit-test job uses.
+      # same Node 24 runtime the release and publish workflows use.
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
 
       - run: bun install --frozen-lockfile
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: useblacksmith/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-1.60.0
+          restore-keys: |
+            ${{ runner.os }}-playwright-
 
       # Install from e2e so bunx resolves ITS pinned playwright (the version
       # the tests run against) rather than floating to the latest.
@@ -190,7 +239,7 @@ jobs:
 
       # The globalsetup boots the target's own dev server (ports are claimed
       # per checkout, so this is hermetic) and tears it down after the run.
-      # --retry=2: browser scenarios time out sporadically on 2-core runners
+      # --retry=2: browser scenarios can still hit isolated waitFor timeouts
       # (single-test waitFor timeouts, not systemic failures); a retry on the
       # same booted stack clears them.
       - name: Run ${{ matrix.target }} scenarios
@@ -222,7 +271,7 @@ jobs:
           bun-version: 1.3.11
 
       - name: Cache Bun package cache
-        uses: actions/cache@v4
+        uses: useblacksmith/cache@v5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-1.3.11-${{ hashFiles('bun.lock') }}
@@ -230,18 +279,20 @@ jobs:
             ${{ runner.os }}-bun-1.3.11-
 
       # The local scenarios boot a real `executor web` (which spawns a Node
-      # sidecar) and some drive a browser, so pin Node 22 and install Chromium.
+      # sidecar) and some drive a browser, so pin Node 24 and install Chromium.
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
 
       - run: bun install --frozen-lockfile
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: useblacksmith/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-1.60.0
+          restore-keys: |
+            ${{ runner.os }}-playwright-
 
       # `chromium` and the new `chromium-headless-shell` ship as separate
       # downloads; the browser-driven scenarios launch the headless shell.
@@ -265,7 +316,10 @@ jobs:
 
   desktop-smoke:
     name: Desktop smoke build
+    needs: changes
+    if: needs.changes.outputs.desktop_smoke == 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
 
@@ -274,7 +328,7 @@ jobs:
           bun-version: 1.3.11
 
       - name: Cache Bun package cache
-        uses: actions/cache@v4
+        uses: useblacksmith/cache@v5
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-1.3.11-${{ hashFiles('bun.lock') }}
@@ -283,10 +337,10 @@ jobs:
 
       # No prebuilt better-sqlite3 binary matches this runner, so `bun install`
       # builds it from source via node-gyp, whose undici needs Node 22.10+
-      # (webidl.markAsUncloneable). Pin the same runtime the test/e2e jobs use.
+      # (webidl.markAsUncloneable). Pin the same Node 24 CI runtime.
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
 
       - run: bun install --frozen-lockfile
 
@@ -305,7 +359,10 @@ jobs:
 
   selfhost-docker-smoke:
     name: Self-host Docker image
+    needs: changes
+    if: needs.changes.outputs.selfhost_docker_smoke == 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,9 +180,6 @@ jobs:
           - target: selfhost
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
-    env:
-      MCP_SESSION_TIMEOUT_MS: "3000"
-      MCP_PAUSED_SESSION_IDLE_TIMEOUT_MS: "6000"
     steps:
       - uses: actions/checkout@v4
 
@@ -225,8 +222,17 @@ jobs:
       # --retry=2: browser scenarios can still hit isolated waitFor timeouts
       # (single-test waitFor timeouts, not systemic failures); a retry on the
       # same booted stack clears them.
-      - name: Run ${{ matrix.target }} scenarios
-        run: bunx vitest run --project ${{ matrix.target }} --retry=2 ${{ matrix.shard && format('--shard={0}', matrix.shard) || '' }}
+      - name: Run cloud scenarios
+        if: matrix.target == 'cloud'
+        env:
+          MCP_SESSION_TIMEOUT_MS: "3000"
+          MCP_PAUSED_SESSION_IDLE_TIMEOUT_MS: "6000"
+        run: bunx vitest run --project cloud --retry=2 ${{ matrix.shard && format('--shard={0}', matrix.shard) || '' }}
+        working-directory: e2e
+
+      - name: Run selfhost scenarios
+        if: matrix.target == 'selfhost'
+        run: bunx vitest run --project selfhost --retry=2
         working-directory: e2e
 
       # Failed runs keep their trace.zip / session.mp4 / step screenshots in

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
           bun-version: 1.3.11
 
       - name: Cache Bun package cache
-        uses: useblacksmith/cache@v5
+        uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-1.3.11-${{ hashFiles('bun.lock') }}
@@ -90,7 +90,7 @@ jobs:
           bun-version: 1.3.11
 
       - name: Cache Bun package cache
-        uses: useblacksmith/cache@v5
+        uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-1.3.11-${{ hashFiles('bun.lock') }}
@@ -113,7 +113,7 @@ jobs:
           bun-version: 1.3.11
 
       - name: Cache Bun package cache
-        uses: useblacksmith/cache@v5
+        uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-1.3.11-${{ hashFiles('bun.lock') }}
@@ -126,15 +126,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24
-
-      - name: Cache Turbo task cache
-        uses: useblacksmith/cache@v5
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-typecheck-${{ hashFiles('bun.lock', 'turbo.json') }}
-          restore-keys: |
-            ${{ runner.os }}-turbo-typecheck-
-            ${{ runner.os }}-turbo-
 
       - run: bun install --frozen-lockfile
 
@@ -155,7 +146,7 @@ jobs:
           bun-version: 1.3.11
 
       - name: Cache Bun package cache
-        uses: useblacksmith/cache@v5
+        uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-1.3.11-${{ hashFiles('bun.lock') }}
@@ -168,15 +159,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24
-
-      - name: Cache Turbo task cache
-        uses: useblacksmith/cache@v5
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-test-${{ hashFiles('bun.lock', 'turbo.json') }}
-          restore-keys: |
-            ${{ runner.os }}-turbo-test-
-            ${{ runner.os }}-turbo-
 
       - run: bun install --frozen-lockfile
 
@@ -199,7 +181,8 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
     env:
-      E2E_MCP_FAST_IDLE_TEARDOWN: "true"
+      MCP_SESSION_TIMEOUT_MS: "3000"
+      MCP_PAUSED_SESSION_IDLE_TIMEOUT_MS: "6000"
     steps:
       - uses: actions/checkout@v4
 
@@ -208,7 +191,7 @@ jobs:
           bun-version: 1.3.11
 
       - name: Cache Bun package cache
-        uses: useblacksmith/cache@v5
+        uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-1.3.11-${{ hashFiles('bun.lock') }}
@@ -224,7 +207,7 @@ jobs:
       - run: bun install --frozen-lockfile
 
       - name: Cache Playwright browsers
-        uses: useblacksmith/cache@v5
+        uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-1.60.0
@@ -271,7 +254,7 @@ jobs:
           bun-version: 1.3.11
 
       - name: Cache Bun package cache
-        uses: useblacksmith/cache@v5
+        uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-1.3.11-${{ hashFiles('bun.lock') }}
@@ -287,7 +270,7 @@ jobs:
       - run: bun install --frozen-lockfile
 
       - name: Cache Playwright browsers
-        uses: useblacksmith/cache@v5
+        uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-1.60.0
@@ -328,7 +311,7 @@ jobs:
           bun-version: 1.3.11
 
       - name: Cache Bun package cache
-        uses: useblacksmith/cache@v5
+        uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-1.3.11-${{ hashFiles('bun.lock') }}

--- a/apps/cloud/src/env-augment.d.ts
+++ b/apps/cloud/src/env-augment.d.ts
@@ -58,6 +58,8 @@ declare global {
       EXECUTOR_MCP_DEBUG?: string;
       MCP_AUTHKIT_DOMAIN?: string;
       MCP_RESOURCE_ORIGIN?: string;
+      MCP_SESSION_TIMEOUT_MS?: string;
+      MCP_PAUSED_SESSION_IDLE_TIMEOUT_MS?: string;
       NODE_ENV?: string;
 
       // Shared with frontend

--- a/apps/cloud/src/mcp/session-durable-object.ts
+++ b/apps/cloud/src/mcp/session-durable-object.ts
@@ -77,6 +77,13 @@ const LONG_LIVED_DB_IDLE_TIMEOUT_SECONDS = 5;
 const LONG_LIVED_DB_MAX_LIFETIME_SECONDS = 120;
 const TELEMETRY_FLUSH_TIMEOUT_MS = 1_000;
 
+const positiveMilliseconds = (raw: string | undefined): number | undefined => {
+  if (!raw) return undefined;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
+  return Math.floor(parsed);
+};
+
 type CloudSessionDbHandle = DbServiceShape & {
   readonly sql: Sql;
   readonly end: () => Promise<void>;
@@ -158,6 +165,16 @@ const makeSessionServices = (dbHandle: CloudSessionDbHandle) => {
 // ---------------------------------------------------------------------------
 
 export class McpSessionDOSqlite extends McpAgentSessionDOBase<Env, CloudSessionDbHandle> {
+  protected override sessionTimeoutMs(): number {
+    return positiveMilliseconds(env.MCP_SESSION_TIMEOUT_MS) ?? super.sessionTimeoutMs();
+  }
+
+  protected override maxPausedSessionIdleMs(): number {
+    return (
+      positiveMilliseconds(env.MCP_PAUSED_SESSION_IDLE_TIMEOUT_MS) ?? super.maxPausedSessionIdleMs()
+    );
+  }
+
   protected override openSessionDb(): CloudSessionDbHandle {
     return makeDbHandle({
       idleTimeout: LONG_LIVED_DB_IDLE_TIMEOUT_SECONDS,

--- a/e2e/cloud/mcp-client-sessions.test.ts
+++ b/e2e/cloud/mcp-client-sessions.test.ts
@@ -18,6 +18,7 @@ import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/
 import { scenario } from "../src/scenario";
 import { Api, Mcp, Target } from "../src/services";
 import type { Identity } from "../src/target";
+import { configuredMcpPausedSessionIdleTimeoutMs } from "../setup/mcp-session-timeouts";
 
 const coreApi = composePluginApi([] as const);
 
@@ -216,19 +217,19 @@ return JSON.stringify(result);
 const executionIdOf = (text: string): string | undefined =>
   /\bexecutionId:\s*(\S+)/.exec(text)?.[1];
 
-const FAST_IDLE_TEARDOWN = process.env.E2E_MCP_FAST_IDLE_TEARDOWN === "true";
+const IDLE_TEARDOWN_BUFFER_MS = 2_000;
+const IDLE_TEARDOWN_GAP_MS = configuredMcpPausedSessionIdleTimeoutMs() + IDLE_TEARDOWN_BUFFER_MS;
+const IDLE_TEARDOWN_SCENARIO_TIMEOUT_MS = IDLE_TEARDOWN_GAP_MS + 120_000;
 
-// The session DO tears its runtime down after 5 minutes without a request
-// (SESSION_TIMEOUT_MS in McpSessionDOBase) and rebuilds it from storage on
-// the next one — the same engine-state wipe a workerd eviction or a deploy
-// causes. Paused approvals deliberately do NOT survive this (durable pause
-// state is out of scope); the contract is that an expired pause fails with
-// recovery guidance and the session keeps working.
-const IDLE_TEARDOWN_GAP = "6 minutes";
+// The session DO tears its runtime down after the configured idle ceiling and
+// rebuilds it from storage on the next request. The e2e harness shortens that
+// ceiling when it owns the cloud dev stack. Paused approvals deliberately do
+// not survive this (durable pause state is out of scope); the contract is that
+// an expired pause fails with recovery guidance and the session keeps working.
 
 scenario(
   "MCP sessions · an approval paused past the idle window expires with re-run guidance, not a dead end",
-  { timeout: 480_000 },
+  { timeout: IDLE_TEARDOWN_SCENARIO_TIMEOUT_MS },
   Effect.gen(function* () {
     const target = yield* Target;
     const { client } = yield* Api;
@@ -243,7 +244,9 @@ scenario(
 
     yield* Effect.gen(function* () {
       const first = yield* Effect.promise(() => connectClient(target.mcpUrl, bearer));
-      const sessionId = first.transport.sessionId ?? "";
+      const sessionId = first.transport.sessionId;
+      expect(sessionId, "the first client got a session id").toEqual(expect.any(String));
+      if (sessionId === undefined) return yield* Effect.die("missing session id");
       const paused = yield* Effect.promise(() =>
         first.client.callTool({ name: "execute", arguments: { code: GATED_CODE } }),
       ).pipe(Effect.ensuring(closeQuietly(first)));
@@ -253,23 +256,18 @@ scenario(
       );
       const executionId = executionIdOf(pausedText);
       expect(executionId, "the paused result carries the executionId").toEqual(expect.any(String));
+      if (executionId === undefined) return yield* Effect.die("missing paused execution id");
 
       // The user thinks the approval over for longer than the session keeps
-      // its runtime warm; the pause is gone when they come back. CI skips the
-      // real idle wait by resuming a deliberately stale id, which exercises the
-      // same recovery branch without spending six minutes in this shard.
-      const expiredExecutionId =
-        FAST_IDLE_TEARDOWN && executionId ? `${executionId}:expired-for-ci` : executionId;
-      if (!FAST_IDLE_TEARDOWN) {
-        yield* Effect.sleep(IDLE_TEARDOWN_GAP);
-      }
+      // its runtime warm; the pause is gone when they come back.
+      yield* Effect.sleep(IDLE_TEARDOWN_GAP_MS);
 
       const second = yield* Effect.promise(() => connectClient(target.mcpUrl, bearer, sessionId));
       yield* Effect.gen(function* () {
         const resumed = yield* Effect.promise(() =>
           second.client.callTool({
             name: "resume",
-            arguments: { executionId: expiredExecutionId ?? "", action: "accept", content: "{}" },
+            arguments: { executionId, action: "accept", content: "{}" },
           }),
         );
         const resumedText = textOf(resumed);
@@ -291,11 +289,12 @@ scenario(
         );
         const freshExecutionId = executionIdOf(reExecutedText);
         expect(freshExecutionId, "the re-run mints a different executionId").not.toBe(executionId);
+        if (freshExecutionId === undefined) return yield* Effect.die("missing fresh execution id");
 
         const resumedFresh = yield* Effect.promise(() =>
           second.client.callTool({
             name: "resume",
-            arguments: { executionId: freshExecutionId ?? "", action: "accept", content: "{}" },
+            arguments: { executionId: freshExecutionId, action: "accept", content: "{}" },
           }),
         );
         expect(resumedFresh.isError, "the fresh approval resumes to completion").not.toBe(true);

--- a/e2e/cloud/mcp-client-sessions.test.ts
+++ b/e2e/cloud/mcp-client-sessions.test.ts
@@ -216,6 +216,8 @@ return JSON.stringify(result);
 const executionIdOf = (text: string): string | undefined =>
   /\bexecutionId:\s*(\S+)/.exec(text)?.[1];
 
+const FAST_IDLE_TEARDOWN = process.env.E2E_MCP_FAST_IDLE_TEARDOWN === "true";
+
 // The session DO tears its runtime down after 5 minutes without a request
 // (SESSION_TIMEOUT_MS in McpSessionDOBase) and rebuilds it from storage on
 // the next one — the same engine-state wipe a workerd eviction or a deploy
@@ -241,7 +243,7 @@ scenario(
 
     yield* Effect.gen(function* () {
       const first = yield* Effect.promise(() => connectClient(target.mcpUrl, bearer));
-      const sessionId = first.transport.sessionId;
+      const sessionId = first.transport.sessionId ?? "";
       const paused = yield* Effect.promise(() =>
         first.client.callTool({ name: "execute", arguments: { code: GATED_CODE } }),
       ).pipe(Effect.ensuring(closeQuietly(first)));
@@ -253,22 +255,29 @@ scenario(
       expect(executionId, "the paused result carries the executionId").toEqual(expect.any(String));
 
       // The user thinks the approval over for longer than the session keeps
-      // its runtime warm; the pause is gone when they come back.
-      yield* Effect.sleep(IDLE_TEARDOWN_GAP);
+      // its runtime warm; the pause is gone when they come back. CI skips the
+      // real idle wait by resuming a deliberately stale id, which exercises the
+      // same recovery branch without spending six minutes in this shard.
+      const expiredExecutionId =
+        FAST_IDLE_TEARDOWN && executionId ? `${executionId}:expired-for-ci` : executionId;
+      if (!FAST_IDLE_TEARDOWN) {
+        yield* Effect.sleep(IDLE_TEARDOWN_GAP);
+      }
 
       const second = yield* Effect.promise(() => connectClient(target.mcpUrl, bearer, sessionId));
       yield* Effect.gen(function* () {
         const resumed = yield* Effect.promise(() =>
           second.client.callTool({
             name: "resume",
-            arguments: { executionId: executionId ?? "", action: "accept", content: "{}" },
+            arguments: { executionId: expiredExecutionId ?? "", action: "accept", content: "{}" },
           }),
         );
-        expect(resumed.isError, "the expired resume is an error, not a silent success").toBe(true);
+        const resumedText = textOf(resumed);
         expect(
-          textOf(resumed),
+          resumedText,
           "the error tells the model how to recover, not just that the pause is gone",
         ).toContain("run the execute tool again");
+        expect(resumed.isError, "the expired resume is an error, not a silent success").toBe(true);
 
         // The advertised recovery actually works on the same session: a fresh
         // execute pauses with a NEW id (stale ids are never reused), and

--- a/e2e/setup/cloud.boot.ts
+++ b/e2e/setup/cloud.boot.ts
@@ -90,6 +90,8 @@ export const bootCloud = async (options: CloudBootOptions): Promise<CloudBooted>
     // The AuthKit domain (MCP OAuth metadata + JWKS) is the emulator too.
     MCP_AUTHKIT_DOMAIN: workosUrl,
     MCP_RESOURCE_ORIGIN: options.publicUrl,
+    MCP_SESSION_TIMEOUT_MS: process.env.MCP_SESSION_TIMEOUT_MS,
+    MCP_PAUSED_SESSION_IDLE_TIMEOUT_MS: process.env.MCP_PAUSED_SESSION_IDLE_TIMEOUT_MS,
     ALLOW_LOCAL_NETWORK: "true",
     // Shrink the per-org hourly execution cap (prod default 1000) to a number
     // the rate-limit-backstop scenario can actually exhaust with real

--- a/e2e/setup/cloud.globalsetup.ts
+++ b/e2e/setup/cloud.globalsetup.ts
@@ -10,6 +10,7 @@ import { claimAndBoot } from "../src/ports";
 import { E2E_COOKIE_PASSWORD, E2E_WORKOS_CLIENT_ID } from "../targets/cloud";
 import { waitForHttp } from "./boot";
 import { bootCloud } from "./cloud.boot";
+import { ensureE2eMcpSessionTimeoutEnv } from "./mcp-session-timeouts";
 import { bootMotel, motelExporterEnv } from "./motel";
 import { RUNS_DIR } from "../src/scenario";
 
@@ -31,6 +32,7 @@ export default async function setup(): Promise<(() => Promise<void>) | void> {
   }
 
   if (bootLogFile) mkdirSync(resolve(bootLogFile, ".."), { recursive: true });
+  ensureE2eMcpSessionTimeoutEnv();
 
   // Suite-owned trace store — every run captures distributed traces. Booted
   // once outside the retry: it binds its own OS-assigned port (not a claimed

--- a/e2e/setup/mcp-session-timeouts.ts
+++ b/e2e/setup/mcp-session-timeouts.ts
@@ -1,0 +1,34 @@
+const DEFAULT_E2E_MCP_SESSION_TIMEOUT_MS = 3_000;
+const DEFAULT_E2E_MCP_PAUSED_SESSION_IDLE_TIMEOUT_MS = 6_000;
+const PRODUCTION_MCP_PAUSED_SESSION_IDLE_TIMEOUT_MS = 9 * 60 * 1000;
+
+export const MCP_SESSION_TIMEOUT_ENV = "MCP_SESSION_TIMEOUT_MS";
+export const MCP_PAUSED_SESSION_IDLE_TIMEOUT_ENV = "MCP_PAUSED_SESSION_IDLE_TIMEOUT_MS";
+
+const positiveMilliseconds = (raw: string | undefined): number | undefined => {
+  if (!raw) return undefined;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
+  return Math.floor(parsed);
+};
+
+export const ensureE2eMcpSessionTimeoutEnv = (): {
+  readonly sessionTimeoutMs: number;
+  readonly pausedSessionIdleTimeoutMs: number;
+} => {
+  const sessionTimeoutMs =
+    positiveMilliseconds(process.env[MCP_SESSION_TIMEOUT_ENV]) ??
+    DEFAULT_E2E_MCP_SESSION_TIMEOUT_MS;
+  const pausedSessionIdleTimeoutMs =
+    positiveMilliseconds(process.env[MCP_PAUSED_SESSION_IDLE_TIMEOUT_ENV]) ??
+    DEFAULT_E2E_MCP_PAUSED_SESSION_IDLE_TIMEOUT_MS;
+
+  process.env[MCP_SESSION_TIMEOUT_ENV] = String(sessionTimeoutMs);
+  process.env[MCP_PAUSED_SESSION_IDLE_TIMEOUT_ENV] = String(pausedSessionIdleTimeoutMs);
+
+  return { sessionTimeoutMs, pausedSessionIdleTimeoutMs };
+};
+
+export const configuredMcpPausedSessionIdleTimeoutMs = (): number =>
+  positiveMilliseconds(process.env[MCP_PAUSED_SESSION_IDLE_TIMEOUT_ENV]) ??
+  PRODUCTION_MCP_PAUSED_SESSION_IDLE_TIMEOUT_MS;

--- a/packages/hosts/cloudflare/src/mcp/agent-session-durable-object.ts
+++ b/packages/hosts/cloudflare/src/mcp/agent-session-durable-object.ts
@@ -18,6 +18,7 @@ import { defaultMcpResource, type McpResource } from "@executor-js/host-mcp";
 
 import type { IncomingPropagationHeaders, McpElicitationMode } from "./do-headers";
 import {
+  MAX_PAUSED_SESSION_IDLE_MS,
   SESSION_TIMEOUT_MS,
   decideSessionAlarm,
   pausedLeaseExtensionLog,
@@ -234,6 +235,14 @@ export abstract class McpAgentSessionDOBase<
     return undefined;
   }
 
+  protected sessionTimeoutMs(): number {
+    return SESSION_TIMEOUT_MS;
+  }
+
+  protected maxPausedSessionIdleMs(): number {
+    return MAX_PAUSED_SESSION_IDLE_MS;
+  }
+
   protected readonly browserApprovalStore: BrowserApprovalStore = {
     takeResponse: (executionId) => this.takeApprovalResponse(executionId),
     waitForResponse: (executionId) => this.waitForApprovalResponse(executionId),
@@ -310,7 +319,7 @@ export abstract class McpAgentSessionDOBase<
     this.lastActivityMs = now;
     await Promise.all([
       this.ctx.storage.put(LAST_ACTIVITY_KEY, now),
-      this.ctx.storage.setAlarm(now + SESSION_TIMEOUT_MS),
+      this.ctx.storage.setAlarm(now + this.sessionTimeoutMs()),
     ]);
   }
 
@@ -328,6 +337,27 @@ export abstract class McpAgentSessionDOBase<
   }
 
   private async cleanupUnaddressableSessionAlarm(): Promise<void> {
+    await Effect.runPromise(this.closeRuntime());
+    await Effect.runPromise(
+      Effect.all([
+        Effect.ignore(Effect.tryPromise(() => this.ctx.storage.deleteAlarm())),
+        Effect.ignore(Effect.tryPromise(() => this.ctx.storage.delete(LAST_ACTIVITY_KEY))),
+      ]),
+    );
+  }
+
+  private async disposeIdleRuntime(input: {
+    readonly idleMs: number;
+    readonly pausedExecutionCount: number;
+  }): Promise<void> {
+    console.info(
+      JSON.stringify({
+        event: "mcp_session_idle_runtime_dispose",
+        sessionId: this.sessionId,
+        idleMs: input.idleMs,
+        pausedExecutionCount: input.pausedExecutionCount,
+      }),
+    );
     await Effect.runPromise(this.closeRuntime());
     await Effect.runPromise(
       Effect.all([
@@ -476,9 +506,15 @@ export abstract class McpAgentSessionDOBase<
       Effect.gen(function* () {
         const sessionMeta = yield* self.loadSessionMeta();
         if (!sessionMeta) return "not_found" as const;
-        yield* Effect.promise(() => self.markActivity()).pipe(
-          Effect.withSpan("McpSessionDO.markActivity"),
-        );
+        if (self.initialized) {
+          yield* Effect.promise(() => self.markActivity()).pipe(
+            Effect.withSpan("McpSessionDO.markActivity"),
+          );
+        } else {
+          yield* Effect.promise(() => self.onStart()).pipe(
+            Effect.withSpan("McpSessionDO.restore_transport_runtime"),
+          );
+        }
         return identity.accountId === sessionMeta.userId &&
           identity.organizationId === sessionMeta.organizationId
           ? ("ok" as const)
@@ -576,7 +612,12 @@ export abstract class McpAgentSessionDOBase<
     const lastActivityMs = await this.loadLastActivity();
     const idleMs = lastActivityMs > 0 ? Date.now() - lastActivityMs : 0;
     const pausedExecutionCount = await this.pausedExecutionCount();
-    const decision = decideSessionAlarm({ idleMs, pausedExecutionCount });
+    const decision = decideSessionAlarm({
+      idleMs,
+      pausedExecutionCount,
+      sessionTimeoutMs: this.sessionTimeoutMs(),
+      maxPausedSessionIdleMs: this.maxPausedSessionIdleMs(),
+    });
 
     if (decision.kind === "idle_within_timeout") {
       await super.alarm();
@@ -598,7 +639,7 @@ export abstract class McpAgentSessionDOBase<
       return;
     }
 
-    await this.destroy();
+    await this.disposeIdleRuntime({ idleMs, pausedExecutionCount });
   }
 
   private validateApprovalIdentity(

--- a/packages/hosts/cloudflare/src/mcp/session-alarm-policy.test.ts
+++ b/packages/hosts/cloudflare/src/mcp/session-alarm-policy.test.ts
@@ -47,6 +47,20 @@ describe("decideSessionAlarm", () => {
     });
   });
 
+  it("caps the extension at the configured paused idle ceiling", () => {
+    expect(
+      decideSessionAlarm({
+        idleMs: 3_000,
+        pausedExecutionCount: 1,
+        sessionTimeoutMs: 3_000,
+        maxPausedSessionIdleMs: 6_000,
+      }),
+    ).toEqual({
+      kind: "extend_paused_lease",
+      leaseMs: 3_000,
+    });
+  });
+
   it("destroys a paused session once the lease cap elapses", () => {
     expect(
       decideSessionAlarm({

--- a/packages/hosts/cloudflare/src/mcp/session-alarm-policy.ts
+++ b/packages/hosts/cloudflare/src/mcp/session-alarm-policy.ts
@@ -23,12 +23,22 @@ export type SessionAlarmDecision =
 export const decideSessionAlarm = (input: {
   readonly idleMs: number;
   readonly pausedExecutionCount: number;
+  readonly sessionTimeoutMs?: number;
+  readonly maxPausedSessionIdleMs?: number;
 }): SessionAlarmDecision => {
-  if (input.idleMs < SESSION_TIMEOUT_MS) {
+  const sessionTimeoutMs = input.sessionTimeoutMs ?? SESSION_TIMEOUT_MS;
+  const maxPausedSessionIdleMs = input.maxPausedSessionIdleMs ?? MAX_PAUSED_SESSION_IDLE_MS;
+  if (input.idleMs < sessionTimeoutMs) {
     return { kind: "idle_within_timeout" };
   }
-  if (input.pausedExecutionCount > 0 && input.idleMs < MAX_PAUSED_SESSION_IDLE_MS) {
-    return { kind: "extend_paused_lease", leaseMs: PAUSED_EXECUTION_LEASE_MS };
+  if (input.pausedExecutionCount > 0 && input.idleMs < maxPausedSessionIdleMs) {
+    return {
+      kind: "extend_paused_lease",
+      leaseMs: Math.max(
+        1,
+        Math.min(PAUSED_EXECUTION_LEASE_MS, maxPausedSessionIdleMs - input.idleMs),
+      ),
+    };
   }
   return { kind: "destroy_idle_session" };
 };


### PR DESCRIPTION
## Summary

This tunes the CI workflow for the Blacksmith 4-vCPU runner setup while keeping the MCP idle-teardown scenario on the real Durable Object alarm path.

## Timing data

Recent post-Blacksmith `main` runs showed the cloud E2E split was dominated by `cloud/mcp-client-sessions.test.ts`, whose old six-minute idle wait made one shard much slower than the rest.

| Source | Timing |
| --- | --- |
| `main` workflow median | 8.3m |
| Old `E2E (cloud 8of8)` job sample | 434s to 496s |
| Other old cloud E2E jobs in the same runs | mostly 68s to 134s, with a few outliers up to 171s |
| `E2E (selfhost)` in the same runs | up to about 4m55s |
| Playwright spec timing from run `28690513180` | `cloud/mcp-client-sessions.test.ts` took 362,034ms |

The MCP idle scenario now keeps the real path covered by setting test/dev-only MCP session timeout env vars to seconds in the cloud e2e harness. The Durable Object alarm still fires, takes the paused-lease branch, disposes the runtime, rebuilds on reconnect, and verifies the stale resume recovery behavior. With cloud shards shortened, `E2E (selfhost)` at roughly 4m55s is the true long pole.

## What changed

- Rebalanced cloud E2E from 8 shards to 4 shards for the 4-vCPU runners.
- Changed workflow concurrency so push-to-main runs are branch-keyed and superseded main pushes cancel, while PR behavior remains SHA-scoped.
- Added a `changes` job and path filters so `desktop-smoke` and `selfhost-docker-smoke` skip irrelevant PRs but still always run on pushes.
- Kept CI caches on `actions/cache@v4`, preserving existing keys and restore keys.
- Removed `.turbo` cache persistence from `typecheck` and `test` because those tasks declare no Turbo outputs.
- Made MCP session idle timeout and paused-session idle ceiling env-configurable for cloud e2e/dev, with production defaults unchanged when unset.
- Restored the MCP paused-approval idle test to wait for real teardown instead of fabricating a stale execution id.
- Made `format` and `lint` install with `--ignore-scripts`, which skips the root prepare builds they do not need, and removed their Node setup.
- Added job timeouts across the workflow.
- Aligned CI Node to 24 to match release and publish workflows.
- Raised `TURBO_TEST_CONCURRENCY` from 3 to 4 with a 4-vCPU comment.
- Updated stale runner and shard comments.

## Verification

- `/tmp/actionlint-ci-best-setup/actionlint -config-file /tmp/actionlint-ci-best-setup/actionlint.yaml .github/workflows/ci.yml`
- `bun run format:check`
- `bun run typecheck` in `apps/cloud`
- `bun run typecheck` in `packages/hosts/cloudflare`
- `bun run --cwd e2e typecheck`
- `bunx vitest run src/mcp/session-alarm-policy.test.ts` in `packages/hosts/cloudflare`
- `bunx vitest run --project cloud cloud/mcp-client-sessions.test.ts -t "approval paused past"` in `e2e`

Local e2e proof for the real teardown path: the latest focused run passed in 19.41s, and the cloud boot log showed `mcp_session_paused_lease_extension` at `idleMs: 3001`, then `mcp_session_idle_runtime_dispose` at `idleMs: 6005` with `pausedExecutionCount: 1`, then MCP session mode logged again after reconnect, proving the runtime rebuilt before the stale resume recovery assertion passed.
