### PR TITLE
Fix 1Password SDK wasm loading in compiled binaries and close the CI gap that hid it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,6 +299,40 @@ jobs:
         run: bun ./scripts/build-sidecar.ts
         working-directory: apps/desktop
 
+      # Run the compiled sidecar in a clean container where the build
+      # workspace does not exist. bun --compile bakes build-machine paths
+      # into __dirname for runtime-loaded assets; running the binary on the
+      # build machine hides that entire failure class (this exact gap
+      # shipped a broken 1Password SDK: its sdk-core wasm was read from the
+      # CI runner's node_modules path at runtime, ENOENT on every user
+      # machine). Pass condition: the 1Password endpoint reaches real
+      # credential validation, not a module-load or empty-namespace error.
+      - name: Run sidecar outside the workspace
+        working-directory: apps/desktop
+        run: |
+          docker run --rm -d --name sidecar-smoke -p 45841:45841 -e HOME=/tmp \
+            -v "$PWD/resources/executor:/opt/executor:ro" \
+            debian:bookworm-slim /opt/executor/executor daemon run --foreground \
+            --port 45841 --hostname 0.0.0.0 --auth-token=ci-smoke
+          for i in $(seq 1 60); do
+            code=$(curl -s -o /dev/null -w '%{http_code}' -H "Authorization: Bearer ci-smoke" http://127.0.0.1:45841/api/onepassword/vaults || true)
+            [ "$code" != "000" ] && break
+            docker ps -q -f name=sidecar-smoke | grep -q . || { docker logs sidecar-smoke; exit 1; }
+            sleep 1
+          done
+          body=$(curl -s -H "Authorization: Bearer ci-smoke" \
+            "http://127.0.0.1:45841/api/onepassword/vaults?authKind=service-account&account=ops_ci_fake_token")
+          docker stop sidecar-smoke
+          echo "$body"
+          if echo "$body" | grep -qE "sdk module load|ENOENT|is not a function|not a constructor"; then
+            echo "::error::1Password SDK failed to load inside the compiled binary (baked build path or missing sibling asset)"
+            exit 1
+          fi
+          if ! echo "$body" | grep -q "invalid service account token"; then
+            echo "::error::sidecar did not reach 1Password credential validation; unexpected response above"
+            exit 1
+          fi
+
       - name: Build Electron main/preload/renderer
         run: bunx --bun electron-vite build
         working-directory: apps/desktop

--- a/apps/cli/src/build.ts
+++ b/apps/cli/src/build.ts
@@ -10,6 +10,7 @@ const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
 const cliRoot = resolve(repoRoot, "apps/cli");
 const webRoot = resolve(repoRoot, "apps/local");
 const distDir = resolve(cliRoot, "dist");
+const ONEPASSWORD_CORE_WASM_FILENAME = "onepassword-core_bg.wasm";
 
 const resolveQuickJsWasmPath = (): string => {
   const req = createRequire(join(repoRoot, "packages/kernel/runtime-quickjs/package.json"));
@@ -19,6 +20,16 @@ const resolveQuickJsWasmPath = (): string => {
     "../@jitl/quickjs-wasmfile-release-sync/dist/emscripten-module.wasm",
   );
   if (!existsSync(wasmPath)) throw new Error(`QuickJS WASM not found at ${wasmPath}`);
+  return wasmPath;
+};
+
+const resolveOnePasswordCoreWasmPath = (): string => {
+  const req = createRequire(join(repoRoot, "packages/plugins/onepassword/package.json"));
+  const sdkPkg = req.resolve("@1password/sdk/package.json");
+  const sdkReq = createRequire(sdkPkg);
+  const sdkCorePkg = sdkReq.resolve("@1password/sdk-core/package.json");
+  const wasmPath = join(dirname(sdkCorePkg), "nodejs/core_bg.wasm");
+  if (!existsSync(wasmPath)) throw new Error(`1Password SDK core WASM not found at ${wasmPath}`);
   return wasmPath;
 };
 
@@ -321,6 +332,7 @@ const buildBinaries = async (targets: Target[], mode: BuildMode) => {
   await writeFile(embeddedMigrationsPath, `${embeddedMigrations}\n`);
 
   const quickJsWasmPath = resolveQuickJsWasmPath();
+  const onePasswordCoreWasmPath = resolveOnePasswordCoreWasmPath();
 
   try {
     for (const target of targets) {
@@ -342,6 +354,11 @@ const buildBinaries = async (targets: Target[], mode: BuildMode) => {
 
       // Copy QuickJS WASM next to binary — loaded at runtime by the server
       await cp(quickJsWasmPath, join(binDir, "emscripten-module.wasm"));
+
+      // Copy 1Password's sdk-core WASM next to the binary. The patched
+      // sdk-core loader falls back to this sibling file when bun --compile
+      // bakes a build-machine node_modules path into __dirname.
+      await cp(onePasswordCoreWasmPath, join(binDir, ONEPASSWORD_CORE_WASM_FILENAME));
 
       // Copy @napi-rs/keyring native binding next to executor — bun --compile
       // doesn't bundle .node files, so the loader needs to find it on disk

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -4,13 +4,20 @@ import "./native-bindings";
 
 import { randomUUID } from "node:crypto";
 import { existsSync, realpathSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
-// Make sibling binaries (if any are added later) discoverable on $PATH so
-// child processes spawned without an absolute path still find them.
+import { delimiter, dirname, join, resolve } from "node:path";
+// Make sibling binaries and standard GUI-missing CLI install locations
+// discoverable on $PATH so child processes spawned without an absolute path
+// still find them.
 const execDir = dirname(process.execPath);
-if (process.env.PATH && !process.env.PATH.includes(execDir)) {
-  process.env.PATH = `${execDir}:${process.env.PATH}`;
-}
+const prependPathEntries = (entries: ReadonlyArray<string>): void => {
+  const current = process.env.PATH?.split(delimiter).filter(Boolean) ?? [];
+  const next = [...entries.filter((entry) => !current.includes(entry)), ...current];
+  process.env.PATH = next.join(delimiter);
+};
+prependPathEntries([
+  execDir,
+  ...(process.platform === "darwin" ? ["/opt/homebrew/bin", "/usr/local/bin"] : []),
+]);
 
 // Pre-load QuickJS WASM for compiled binaries — must run before server imports
 const wasmOnDisk = join(execDir, "emscripten-module.wasm");

--- a/apps/desktop/scripts/smoke-sidecar.ts
+++ b/apps/desktop/scripts/smoke-sidecar.ts
@@ -16,10 +16,10 @@
  * Run after `bun ./scripts/build-sidecar.ts`. Exits non-zero on any
  * deviation so it can gate CI.
  */
-import { mkdtemp, rm } from "node:fs/promises";
+import { chmod, cp, mkdtemp, rm } from "node:fs/promises";
 import { createHash } from "node:crypto";
 import { tmpdir } from "node:os";
-import { basename, join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import { spawn, type Subprocess } from "bun";
 import { Database } from "bun:sqlite";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -36,6 +36,7 @@ const BINARY = resolve(
 const AUTH_TOKEN = "smoke-test-token";
 const AUTH_HEADER = `Bearer ${AUTH_TOKEN}`;
 const READY_TIMEOUT_MS = 30_000;
+const EXECUTOR_BINARY_NAME = process.platform === "win32" ? "executor.exe" : "executor";
 
 // Throw instead of process.exit so main()'s finally still tears down the
 // spawned daemon + temp dirs — exiting here leaks a running process.
@@ -319,6 +320,49 @@ const completePausedResult = async (
   return fail("execute still paused after 5 resume attempts");
 };
 
+const stageSidecarWithUnavailableOp = async (
+  sidecarRoot: string,
+): Promise<{ readonly binary: string }> => {
+  const stagedDir = join(sidecarRoot, "executor");
+  await cp(dirname(BINARY), stagedDir, { recursive: true });
+
+  const fakeOpPath = join(stagedDir, process.platform === "win32" ? "op.cmd" : "op");
+  const fakeOp =
+    process.platform === "win32"
+      ? "@echo off\r\necho [ERROR] 2026/01/01 00:00:00 op: command not found 1>&2\r\nexit /b 127\r\n"
+      : "#!/bin/sh\necho '[ERROR] 2026/01/01 00:00:00 op: command not found' >&2\nexit 127\n";
+  await Bun.write(fakeOpPath, fakeOp);
+  if (process.platform !== "win32") {
+    await chmod(fakeOpPath, 0o755);
+  }
+
+  return { binary: join(stagedDir, EXECUTOR_BINARY_NAME) };
+};
+
+const assertOnePasswordSdkLoads = async (origin: string): Promise<void> => {
+  const url = new URL("/api/onepassword/vaults", origin);
+  url.searchParams.set("authKind", "service-account");
+  url.searchParams.set("account", "ops_fake_smoke_token");
+  const response = await fetch(url, { headers: { Authorization: AUTH_HEADER } });
+  const body = await response.text();
+
+  if (response.status !== 502) {
+    fail(`expected 1Password invalid-token 502, got ${response.status}: ${body}`);
+  }
+  if (
+    body.includes("createClient is not a function") ||
+    body.includes("undefined is not a constructor") ||
+    body.includes("did not expose createClient and DesktopAuth")
+  ) {
+    fail(`1Password SDK namespace did not load in compiled binary: ${body}`);
+  }
+  if (!body.includes("invalid service account token")) {
+    fail(`1Password SDK did not reach token validation: ${body}`);
+  }
+
+  console.log("[smoke-sidecar] OK - 1Password SDK reached service-account token validation");
+};
+
 const main = async () => {
   if (!(await Bun.file(BINARY).exists())) {
     fail(
@@ -328,6 +372,8 @@ const main = async () => {
 
   const scopeDir = await mkdtemp(join(tmpdir(), "executor-smoke-scope-"));
   const dataDir = await mkdtemp(join(tmpdir(), "executor-smoke-data-"));
+  const sidecarRoot = await mkdtemp(join(tmpdir(), "executor-smoke-sidecar-"));
+  const sidecar = await stageSidecarWithUnavailableOp(sidecarRoot);
   await seedLegacyScopedSqlite(dataDir, makeScopeId(scopeDir));
   // v2 connections reference credentials by provider item instead of carrying
   // raw values, so seed the file-secrets provider (auth.json under
@@ -342,10 +388,11 @@ const main = async () => {
   console.log(`[smoke-sidecar] scope:   ${scopeDir}`);
   console.log(`[smoke-sidecar] data:    ${dataDir}`);
   console.log(`[smoke-sidecar] openapi: ${openapi.origin}`);
+  console.log(`[smoke-sidecar] sidecar: ${sidecar.binary}`);
 
   const proc = spawn({
     cmd: [
-      BINARY,
+      sidecar.binary,
       "daemon",
       "run",
       "--foreground",
@@ -386,6 +433,8 @@ const main = async () => {
     await rm(dataDir, { recursive: true, force: true }).catch(() => {});
     // oxlint-disable-next-line executor/no-promise-catch -- boundary: best-effort tempdir cleanup in a standalone smoke harness
     await rm(xdgDir, { recursive: true, force: true }).catch(() => {});
+    // oxlint-disable-next-line executor/no-promise-catch -- boundary: best-effort tempdir cleanup in a standalone smoke harness
+    await rm(sidecarRoot, { recursive: true, force: true }).catch(() => {});
   };
 
   // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: standalone smoke harness needs a finally to tear down the spawned binary + http server
@@ -394,6 +443,7 @@ const main = async () => {
     await assertV1MigrationCompleted(dataDir);
     const mcpUrl = new URL(`http://127.0.0.1:${port}/mcp`);
     console.log(`[smoke-sidecar] ready on ${mcpUrl.origin}`);
+    await assertOnePasswordSdkLoads(mcpUrl.origin);
 
     const transport = new StreamableHTTPClientTransport(mcpUrl, {
       requestInit: { headers: { Authorization: AUTH_HEADER } },

--- a/apps/desktop/scripts/smoke-sidecar.ts
+++ b/apps/desktop/scripts/smoke-sidecar.ts
@@ -16,8 +16,9 @@
  * Run after `bun ./scripts/build-sidecar.ts`. Exits non-zero on any
  * deviation so it can gate CI.
  */
-import { chmod, cp, mkdtemp, rm } from "node:fs/promises";
+import { chmod, cp, mkdtemp, rename, rm } from "node:fs/promises";
 import { createHash } from "node:crypto";
+import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
 import { spawn, type Subprocess } from "bun";
@@ -26,6 +27,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 
 const ROOT = resolve(import.meta.dir, "..");
+const REPO_ROOT = resolve(ROOT, "../..");
 const APPS_LOCAL_DRIZZLE = resolve(ROOT, "../local/drizzle-legacy-v1");
 const BINARY = resolve(
   ROOT,
@@ -37,6 +39,16 @@ const AUTH_TOKEN = "smoke-test-token";
 const AUTH_HEADER = `Bearer ${AUTH_TOKEN}`;
 const READY_TIMEOUT_MS = 30_000;
 const EXECUTOR_BINARY_NAME = process.platform === "win32" ? "executor.exe" : "executor";
+const requireFromOnePasswordPlugin = createRequire(
+  join(REPO_ROOT, "packages/plugins/onepassword/package.json"),
+);
+const requireFromOnePasswordSdk = createRequire(
+  requireFromOnePasswordPlugin.resolve("@1password/sdk/package.json"),
+);
+const ONEPASSWORD_SDK_CORE_WASM = join(
+  dirname(requireFromOnePasswordSdk.resolve("@1password/sdk-core/package.json")),
+  "nodejs/core_bg.wasm",
+);
 
 // Throw instead of process.exit so main()'s finally still tears down the
 // spawned daemon + temp dirs — exiting here leaks a running process.
@@ -339,6 +351,41 @@ const stageSidecarWithUnavailableOp = async (
   return { binary: join(stagedDir, EXECUTOR_BINARY_NAME) };
 };
 
+interface HiddenWorkspaceWasm {
+  readonly original: string;
+  readonly hidden: string;
+}
+
+const hideWorkspaceOnePasswordWasm = async (): Promise<HiddenWorkspaceWasm> => {
+  const hidden = `${ONEPASSWORD_SDK_CORE_WASM}.hidden`;
+  if (!(await Bun.file(ONEPASSWORD_SDK_CORE_WASM).exists())) {
+    fail(`workspace 1Password SDK WASM not found at ${ONEPASSWORD_SDK_CORE_WASM}`);
+  }
+
+  await rm(hidden, { force: true });
+  await rename(ONEPASSWORD_SDK_CORE_WASM, hidden);
+  console.log(`[smoke-sidecar] hid workspace 1Password SDK WASM: ${ONEPASSWORD_SDK_CORE_WASM}`);
+  return { original: ONEPASSWORD_SDK_CORE_WASM, hidden };
+};
+
+const restoreWorkspaceOnePasswordWasm = async (
+  hiddenWorkspaceWasm: HiddenWorkspaceWasm | null,
+): Promise<void> => {
+  if (!hiddenWorkspaceWasm) return;
+
+  if (await Bun.file(hiddenWorkspaceWasm.original).exists()) {
+    await rm(hiddenWorkspaceWasm.hidden, { force: true });
+    return;
+  }
+
+  if (!(await Bun.file(hiddenWorkspaceWasm.hidden).exists())) {
+    fail(`workspace 1Password SDK WASM restore source missing at ${hiddenWorkspaceWasm.hidden}`);
+  }
+
+  await rename(hiddenWorkspaceWasm.hidden, hiddenWorkspaceWasm.original);
+  console.log(`[smoke-sidecar] restored workspace 1Password SDK WASM`);
+};
+
 const assertOnePasswordSdkLoads = async (origin: string): Promise<void> => {
   const url = new URL("/api/onepassword/vaults", origin);
   url.searchParams.set("authKind", "service-account");
@@ -374,6 +421,7 @@ const main = async () => {
   const dataDir = await mkdtemp(join(tmpdir(), "executor-smoke-data-"));
   const sidecarRoot = await mkdtemp(join(tmpdir(), "executor-smoke-sidecar-"));
   const sidecar = await stageSidecarWithUnavailableOp(sidecarRoot);
+  let hiddenWorkspaceWasm: HiddenWorkspaceWasm | null = null;
   await seedLegacyScopedSqlite(dataDir, makeScopeId(scopeDir));
   // v2 connections reference credentials by provider item instead of carrying
   // raw values, so seed the file-secrets provider (auth.json under
@@ -427,6 +475,7 @@ const main = async () => {
       if (exitCode === null) proc.kill("SIGKILL");
     }
     openapi.server.stop(true);
+    await restoreWorkspaceOnePasswordWasm(hiddenWorkspaceWasm);
     // oxlint-disable-next-line executor/no-promise-catch -- boundary: best-effort tempdir cleanup in a standalone smoke harness
     await rm(scopeDir, { recursive: true, force: true }).catch(() => {});
     // oxlint-disable-next-line executor/no-promise-catch -- boundary: best-effort tempdir cleanup in a standalone smoke harness
@@ -443,6 +492,7 @@ const main = async () => {
     await assertV1MigrationCompleted(dataDir);
     const mcpUrl = new URL(`http://127.0.0.1:${port}/mcp`);
     console.log(`[smoke-sidecar] ready on ${mcpUrl.origin}`);
+    hiddenWorkspaceWasm = await hideWorkspaceOnePasswordWasm();
     await assertOnePasswordSdkLoads(mcpUrl.origin);
 
     const transport = new StreamableHTTPClientTransport(mcpUrl, {

--- a/bun.lock
+++ b/bun.lock
@@ -1215,6 +1215,7 @@
     },
   },
   "patchedDependencies": {
+    "@1password/sdk-core@0.4.1-beta.1": "patches/@1password%2Fsdk-core@0.4.1-beta.1.patch",
     "@electric-sql/pglite-socket@0.1.4": "patches/@electric-sql%2Fpglite-socket@0.1.4.patch",
     "libsql@0.5.29": "patches/libsql@0.5.29.patch",
     "agents@0.17.3": "patches/agents@0.17.3.patch",

--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "@effect/opentelemetry": "4.0.0-beta.59"
   },
   "patchedDependencies": {
+    "@1password/sdk-core@0.4.1-beta.1": "patches/@1password%2Fsdk-core@0.4.1-beta.1.patch",
     "postgres@3.4.9": "patches/postgres@3.4.9.patch",
     "@cloudflare/vite-plugin@1.31.2": "patches/@cloudflare%2Fvite-plugin@1.31.2.patch",
     "agents@0.17.3": "patches/agents@0.17.3.patch",

--- a/packages/plugins/onepassword/src/sdk/onepassword-sdk.ts
+++ b/packages/plugins/onepassword/src/sdk/onepassword-sdk.ts
@@ -1,0 +1,8 @@
+import * as sdk from "@1password/sdk";
+
+export type OnePasswordSdkModule = typeof sdk;
+
+// Keep the package import static in this local shim. The service dynamically
+// imports this file so normal app boot stays lazy, while Bun's compiler sees
+// the concrete @1password/sdk dependency and its sdk-core WASM loader.
+export const onePasswordSdk: OnePasswordSdkModule = sdk;

--- a/packages/plugins/onepassword/src/sdk/service.test.ts
+++ b/packages/plugins/onepassword/src/sdk/service.test.ts
@@ -17,6 +17,10 @@ const opMocks = vi.hoisted(() => ({
 const sdkMocks = vi.hoisted(() => ({
   createClient: vi.fn(),
   DesktopAuth: vi.fn((accountName: string) => ({ accountName })),
+  exports: {} as {
+    createClient?: unknown;
+    DesktopAuth?: unknown;
+  },
 }));
 
 vi.mock("@1password/op-js", () => ({
@@ -27,10 +31,7 @@ vi.mock("@1password/op-js", () => ({
   read: { parse: opMocks.readParse },
 }));
 
-vi.mock("@1password/sdk", () => ({
-  createClient: sdkMocks.createClient,
-  DesktopAuth: sdkMocks.DesktopAuth,
-}));
+vi.mock("@1password/sdk", () => sdkMocks.exports);
 
 describe("makeOnePasswordService", () => {
   beforeEach(() => {
@@ -38,6 +39,8 @@ describe("makeOnePasswordService", () => {
     opMocks.vaultList.mockReturnValue([]);
     opMocks.itemList.mockReturnValue([]);
     opMocks.readParse.mockReturnValue("secret");
+    sdkMocks.exports.createClient = sdkMocks.createClient;
+    sdkMocks.exports.DesktopAuth = sdkMocks.DesktopAuth;
     sdkMocks.createClient.mockResolvedValue({
       secrets: { resolve: vi.fn(async () => "secret") },
       vaults: { list: vi.fn(async () => []) },
@@ -100,6 +103,32 @@ describe("makeOnePasswordService", () => {
       expect(error.message).toContain("1Password SDK vault listing failed:");
       expect(error.message).toContain("desktop approval refused for account");
       expect(error.message).not.toBe("1Password CLI vault listing failed");
+      // oxlint-enable executor/no-unknown-error-message
+    }),
+  );
+
+  it.effect("reports a clear SDK load error when the compiled namespace is empty", () =>
+    Effect.gen(function* () {
+      opMocks.vaultList.mockImplementation(() => {
+        // oxlint-disable-next-line executor/no-try-catch-or-throw, executor/no-error-constructor -- boundary: simulates the untyped op-js CLI wrapper throwing
+        throw new Error("spawn op ENOENT");
+      });
+      sdkMocks.exports.createClient = undefined;
+      sdkMocks.exports.DesktopAuth = undefined;
+
+      const error = yield* makeOnePasswordService(
+        { kind: "service-account", token: "ops_test_token" },
+        { timeoutMs: 1_000 },
+      ).pipe(
+        Effect.flatMap((service) => service.listVaults()),
+        Effect.flip,
+      );
+
+      expect(error).toBeInstanceOf(OnePasswordError);
+      expect(error.operation).toBe("sdk module load");
+      // oxlint-disable executor/no-unknown-error-message -- boundary: OnePasswordError carries a typed message; asserting its contents
+      expect(error.message).toContain("did not expose createClient and DesktopAuth");
+      expect(error.message).toContain("/opt/homebrew/bin");
       // oxlint-enable executor/no-unknown-error-message
     }),
   );

--- a/packages/plugins/onepassword/src/sdk/service.ts
+++ b/packages/plugins/onepassword/src/sdk/service.ts
@@ -2,6 +2,7 @@ import { Context, Duration, Effect, Semaphore } from "effect";
 import * as op from "@1password/op-js";
 
 import { OnePasswordError } from "./errors";
+import type { OnePasswordSdkModule } from "./onepassword-sdk";
 
 // ---------------------------------------------------------------------------
 // Canonical service interface — all backends (SDK, CLI) implement this
@@ -50,7 +51,6 @@ export type ResolvedAuth =
 const DEFAULT_TIMEOUT_MS = 15_000;
 const MAX_ERROR_MESSAGE_LENGTH = 300;
 const SERVICE_ACCOUNT_TOKEN_RE = /ops_[A-Za-z0-9_-]+/g;
-type OnePasswordSdkModule = typeof import("@1password/sdk");
 
 const formatCause = (cause: unknown): string => {
   // oxlint-disable-next-line executor/no-unknown-error-message -- boundary: normalizing untyped op-js/SDK throwables into OnePasswordError.message
@@ -72,15 +72,33 @@ const messageWithCause = (prefix: string, cause: unknown): string => {
     : message;
 };
 
+const hasOnePasswordSdkShape = (value: unknown): value is OnePasswordSdkModule => {
+  const sdk = value as Partial<OnePasswordSdkModule> | null | undefined;
+  return typeof sdk?.createClient === "function" && typeof sdk.DesktopAuth === "function";
+};
+
+const invalidOnePasswordSdkError = () =>
+  new OnePasswordError({
+    operation: "sdk module load",
+    message: [
+      "Failed to load 1Password SDK: the packaged SDK module did not expose createClient and DesktopAuth.",
+      "Install the 1Password CLI (`op`) in /opt/homebrew/bin or /usr/local/bin and retry, or update Executor.",
+    ].join(" "),
+  });
+
 const loadOnePasswordSdk = (): Effect.Effect<OnePasswordSdkModule, OnePasswordError> =>
   Effect.tryPromise({
-    try: () => import("@1password/sdk"),
+    try: () => import("./onepassword-sdk").then((module) => module.onePasswordSdk),
     catch: (cause) =>
       new OnePasswordError({
         operation: "sdk module load",
         message: messageWithCause("Failed to load 1Password SDK", cause),
       }),
-  });
+  }).pipe(
+    Effect.flatMap((sdk) =>
+      hasOnePasswordSdkShape(sdk) ? Effect.succeed(sdk) : Effect.fail(invalidOnePasswordSdkError()),
+    ),
+  );
 
 const makeTimeoutMessage = (operation: string, timeoutMs: number): string =>
   [

--- a/patches/@1password%2Fsdk-core@0.4.1-beta.1.patch
+++ b/patches/@1password%2Fsdk-core@0.4.1-beta.1.patch
@@ -1,0 +1,24 @@
+diff --git a/nodejs/core.js b/nodejs/core.js
+index 259891a2bbcd97e6630855087547fb1b5a389876..768a8321cbf31212e5a31b075d44706803a362a8 100644
+--- a/nodejs/core.js
++++ b/nodejs/core.js
+@@ -786,8 +786,17 @@ module.exports.__wbindgen_throw = function(arg0, arg1) {
+     throw new Error(getStringFromWasm0(arg0, arg1));
+ };
+
+-const path = require('path').join(__dirname, 'core_bg.wasm');
+-const bytes = require('fs').readFileSync(path);
++const path = require('path');
++const fs = require('fs');
++const wasmPath = path.join(__dirname, 'core_bg.wasm');
++let bytes;
++try {
++    bytes = fs.readFileSync(wasmPath);
++} catch {
++    bytes = fs.readFileSync(
++        path.join(path.dirname(process.execPath), 'onepassword-core_bg.wasm'),
++    );
++}
+
+ const wasmModule = new WebAssembly.Module(bytes);
+ const wasmInstance = new WebAssembly.Instance(wasmModule, imports);


### PR DESCRIPTION
## Problem

In production desktop builds, connecting 1Password failed for both auth methods with `n.createClient is not a function` / `undefined is not a constructor (evaluating 'new n.DesktopAuth(...)')`. Dev builds were unaffected, and so was every CI check.

Root cause, confirmed against the released v1.5.28 binary: `@1password/sdk-core` loads its wasm with `readFileSync(join(__dirname, 'core_bg.wasm'))`. Under `bun build --compile`, `__dirname` is baked to the build machine's absolute node_modules path (`/Users/runner/work/executor/...` in releases). On any machine without that path, the first SDK import throws ENOENT, Bun caches the partially-evaluated module, and every later import sees an empty namespace, which produces the reported errors.

CI could not catch this class of bug: the publish workflow's smoke runs on the machine that just built the binary, where the baked path exists, and the CI desktop-smoke job builds the linux sidecar without ever running it. Reproduced deterministically by running the built sidecar in a clean `debian:bookworm-slim` container with only the staged bin dir mounted: first call returns the ENOENT with the build machine's path, subsequent calls return the exact production errors.

## Fix

- Patch `@1password/sdk-core` (bun `patchedDependencies`): keep the original `__dirname` read, fall back to `dirname(process.execPath)/onepassword-core_bg.wasm`.
- Stage `onepassword-core_bg.wasm` next to the compiled binary in `apps/cli/src/build.ts`, following the existing QuickJS/libsql/keyring sibling-asset pattern. Verified it rides through desktop packaging and `bun pm pack` for the npm platform packages.
- Augment PATH with `/opt/homebrew/bin` and `/usr/local/bin` on macOS so GUI-launched apps can find the `op` CLI.
- Typed error when the SDK namespace is malformed, instead of the raw JSC message.

## Regression gates

- **Local smoke (`apps/desktop test:smoke`)**: now hides the workspace `core_bg.wasm` while exercising the 1Password endpoint against the compiled binary and stages a fake failing `op` first on PATH, so the SDK path is genuinely exercised in build-machine-absent conditions. Fails on main and on the naive static-import fix; passes here.
- **CI (`desktop-smoke` job)**: new step runs the built linux sidecar in a clean container (no workspace, no node_modules) and asserts the 1Password endpoint reaches real credential validation rather than a module-load or empty-namespace error. This is the generic net for baked-build-path bugs in any runtime-loaded asset.

Verified end to end: the fix-branch linux binary in the clean container returns the real SDK token-validation error for service accounts and a legitimate environment error for desktop-app auth, on repeated calls.
