### PR TITLE
Wire Turbo remote cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,12 +67,10 @@ jobs:
           bun-version: 1.3.11
 
       - name: Cache Bun package cache
-        uses: actions/cache@v4
+        uses: useblacksmith/stickydisk@v1
         with:
+          key: ${{ github.repository }}-bun-cache
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-1.3.11-${{ hashFiles('bun.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-bun-1.3.11-
 
       - run: bun install --frozen-lockfile --ignore-scripts
 
@@ -90,12 +88,10 @@ jobs:
           bun-version: 1.3.11
 
       - name: Cache Bun package cache
-        uses: actions/cache@v4
+        uses: useblacksmith/stickydisk@v1
         with:
+          key: ${{ github.repository }}-bun-cache
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-1.3.11-${{ hashFiles('bun.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-bun-1.3.11-
 
       - run: bun install --frozen-lockfile --ignore-scripts
 
@@ -105,6 +101,11 @@ jobs:
     name: Typecheck
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 15
+    env:
+      TURBO_API: ${{ vars.TURBO_API }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_REMOTE_CACHE_SIGNATURE_KEY: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
     steps:
       - uses: actions/checkout@v4
 
@@ -113,12 +114,10 @@ jobs:
           bun-version: 1.3.11
 
       - name: Cache Bun package cache
-        uses: actions/cache@v4
+        uses: useblacksmith/stickydisk@v1
         with:
+          key: ${{ github.repository }}-bun-cache
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-1.3.11-${{ hashFiles('bun.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-bun-1.3.11-
 
       # No prebuilt better-sqlite3 binary matches this runner, so `bun install`
       # builds it from source via node-gyp, whose undici needs Node 22.10+
@@ -137,6 +136,10 @@ jobs:
     timeout-minutes: 15
     # Tuned for Blacksmith's 4 vCPU runners.
     env:
+      TURBO_API: ${{ vars.TURBO_API }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_REMOTE_CACHE_SIGNATURE_KEY: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
       TURBO_TEST_CONCURRENCY: 4
     steps:
       - uses: actions/checkout@v4
@@ -146,12 +149,10 @@ jobs:
           bun-version: 1.3.11
 
       - name: Cache Bun package cache
-        uses: actions/cache@v4
+        uses: useblacksmith/stickydisk@v1
         with:
+          key: ${{ github.repository }}-bun-cache
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-1.3.11-${{ hashFiles('bun.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-bun-1.3.11-
 
       # apps/cloud's test script invokes `node` directly; undici 8.x (pulled
       # in by @cloudflare/vitest-pool-workers) calls webidl.markAsUncloneable
@@ -188,12 +189,10 @@ jobs:
           bun-version: 1.3.11
 
       - name: Cache Bun package cache
-        uses: actions/cache@v4
+        uses: useblacksmith/stickydisk@v1
         with:
+          key: ${{ github.repository }}-bun-cache
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-1.3.11-${{ hashFiles('bun.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-bun-1.3.11-
 
       # The dev stacks spawn Node sidecars (vite/workerd tooling); pin the
       # same Node 24 runtime the release and publish workflows use.
@@ -204,12 +203,10 @@ jobs:
       - run: bun install --frozen-lockfile
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: useblacksmith/stickydisk@v1
         with:
+          key: ${{ github.repository }}-playwright-cache
           path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-1.60.0
-          restore-keys: |
-            ${{ runner.os }}-playwright-
 
       # Install from e2e so bunx resolves ITS pinned playwright (the version
       # the tests run against) rather than floating to the latest.
@@ -260,12 +257,10 @@ jobs:
           bun-version: 1.3.11
 
       - name: Cache Bun package cache
-        uses: actions/cache@v4
+        uses: useblacksmith/stickydisk@v1
         with:
+          key: ${{ github.repository }}-bun-cache
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-1.3.11-${{ hashFiles('bun.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-bun-1.3.11-
 
       # The local scenarios boot a real `executor web` (which spawns a Node
       # sidecar) and some drive a browser, so pin Node 24 and install Chromium.
@@ -276,12 +271,10 @@ jobs:
       - run: bun install --frozen-lockfile
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: useblacksmith/stickydisk@v1
         with:
+          key: ${{ github.repository }}-playwright-cache
           path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-1.60.0
-          restore-keys: |
-            ${{ runner.os }}-playwright-
 
       # `chromium` and the new `chromium-headless-shell` ship as separate
       # downloads; the browser-driven scenarios launch the headless shell.
@@ -317,12 +310,10 @@ jobs:
           bun-version: 1.3.11
 
       - name: Cache Bun package cache
-        uses: actions/cache@v4
+        uses: useblacksmith/stickydisk@v1
         with:
+          key: ${{ github.repository }}-bun-cache
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-1.3.11-${{ hashFiles('bun.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-bun-1.3.11-
 
       # No prebuilt better-sqlite3 binary matches this runner, so `bun install`
       # builds it from source via node-gyp, whose undici needs Node 22.10+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,10 +67,12 @@ jobs:
           bun-version: 1.3.11
 
       - name: Cache Bun package cache
-        uses: useblacksmith/stickydisk@v1
+        uses: actions/cache@v4
         with:
-          key: ${{ github.repository }}-bun-cache
           path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-1.3.11-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-1.3.11-
 
       - run: bun install --frozen-lockfile --ignore-scripts
 
@@ -88,10 +90,12 @@ jobs:
           bun-version: 1.3.11
 
       - name: Cache Bun package cache
-        uses: useblacksmith/stickydisk@v1
+        uses: actions/cache@v4
         with:
-          key: ${{ github.repository }}-bun-cache
           path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-1.3.11-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-1.3.11-
 
       - run: bun install --frozen-lockfile --ignore-scripts
 
@@ -114,10 +118,12 @@ jobs:
           bun-version: 1.3.11
 
       - name: Cache Bun package cache
-        uses: useblacksmith/stickydisk@v1
+        uses: actions/cache@v4
         with:
-          key: ${{ github.repository }}-bun-cache
           path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-1.3.11-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-1.3.11-
 
       # No prebuilt better-sqlite3 binary matches this runner, so `bun install`
       # builds it from source via node-gyp, whose undici needs Node 22.10+
@@ -149,10 +155,12 @@ jobs:
           bun-version: 1.3.11
 
       - name: Cache Bun package cache
-        uses: useblacksmith/stickydisk@v1
+        uses: actions/cache@v4
         with:
-          key: ${{ github.repository }}-bun-cache
           path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-1.3.11-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-1.3.11-
 
       # apps/cloud's test script invokes `node` directly; undici 8.x (pulled
       # in by @cloudflare/vitest-pool-workers) calls webidl.markAsUncloneable
@@ -189,10 +197,12 @@ jobs:
           bun-version: 1.3.11
 
       - name: Cache Bun package cache
-        uses: useblacksmith/stickydisk@v1
+        uses: actions/cache@v4
         with:
-          key: ${{ github.repository }}-bun-cache
           path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-1.3.11-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-1.3.11-
 
       # The dev stacks spawn Node sidecars (vite/workerd tooling); pin the
       # same Node 24 runtime the release and publish workflows use.
@@ -203,10 +213,12 @@ jobs:
       - run: bun install --frozen-lockfile
 
       - name: Cache Playwright browsers
-        uses: useblacksmith/stickydisk@v1
+        uses: actions/cache@v4
         with:
-          key: ${{ github.repository }}-playwright-cache
           path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-1.60.0
+          restore-keys: |
+            ${{ runner.os }}-playwright-
 
       # Install from e2e so bunx resolves ITS pinned playwright (the version
       # the tests run against) rather than floating to the latest.
@@ -257,10 +269,12 @@ jobs:
           bun-version: 1.3.11
 
       - name: Cache Bun package cache
-        uses: useblacksmith/stickydisk@v1
+        uses: actions/cache@v4
         with:
-          key: ${{ github.repository }}-bun-cache
           path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-1.3.11-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-1.3.11-
 
       # The local scenarios boot a real `executor web` (which spawns a Node
       # sidecar) and some drive a browser, so pin Node 24 and install Chromium.
@@ -271,10 +285,12 @@ jobs:
       - run: bun install --frozen-lockfile
 
       - name: Cache Playwright browsers
-        uses: useblacksmith/stickydisk@v1
+        uses: actions/cache@v4
         with:
-          key: ${{ github.repository }}-playwright-cache
           path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-1.60.0
+          restore-keys: |
+            ${{ runner.os }}-playwright-
 
       # `chromium` and the new `chromium-headless-shell` ship as separate
       # downloads; the browser-driven scenarios launch the headless shell.
@@ -310,10 +326,12 @@ jobs:
           bun-version: 1.3.11
 
       - name: Cache Bun package cache
-        uses: useblacksmith/stickydisk@v1
+        uses: actions/cache@v4
         with:
-          key: ${{ github.repository }}-bun-cache
           path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-1.3.11-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-1.3.11-
 
       # No prebuilt better-sqlite3 binary matches this runner, so `bun install`
       # builds it from source via node-gyp, whose undici needs Node 22.10+

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "remoteCache": {
+    "signature": true
+  },
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Summary

- Wire Turbo remote cache environment variables into CI typecheck and test jobs.
- Enable Turbo remote cache signature verification.
- Keep the existing GitHub Actions dependency caches after the sticky-disk trial failed the warm-install timing gate.

## Validation

- `bun run format`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest -config-file <temp config> .github/workflows/ci.yml`
- `TURBO_API=... TURBO_TEAM=team_executor TURBO_TOKEN=dummy-token TURBO_REMOTE_CACHE_SIGNATURE_KEY=<dummy 64 hex> bunx turbo run typecheck --dry-run=json`
- `env -u TURBO_API -u TURBO_TEAM -u TURBO_TOKEN -u TURBO_REMOTE_CACHE_SIGNATURE_KEY bun run typecheck` twice
- PR CI runs on this branch
