### PR TITLE
Make paused-execution resume survive MCP session changes

### DIFF
--- a/apps/cloud/src/env-augment.d.ts
+++ b/apps/cloud/src/env-augment.d.ts
@@ -38,6 +38,7 @@ declare global {
       // workers and older local setups run without the binding, and the
       // limiter degrades to disabled when absent.
       EXECUTION_RATE_LIMITER?: import("@cloudflare/workers-types").DurableObjectNamespace;
+      MCP_EXECUTION_OWNER?: import("@cloudflare/workers-types").DurableObjectNamespace;
 
       // Optional per-org hourly execution rate-limit override, parsed as an
       // integer (defaults to EXECUTIONS_PER_ORG_PER_HOUR = 1000 when unset or

--- a/apps/cloud/src/mcp/agent-handler.ts
+++ b/apps/cloud/src/mcp/agent-handler.ts
@@ -13,6 +13,7 @@ import {
   withVerifiedIdentityHeaders,
 } from "@executor-js/cloudflare/mcp/do-headers";
 import type { McpSessionProps } from "@executor-js/cloudflare/mcp/agent-durable-object";
+import { mcpSessionDurableObjectName } from "@executor-js/cloudflare/mcp/execution-owner-directory";
 
 import { wrapMcpSseResponse } from "../observability/memory-metrics";
 import { cloudMcpAuth } from "./auth-provider";
@@ -70,7 +71,7 @@ const renderAuthError = (
 const sessionStub = (env: Env, sessionId: string): McpAgentSessionStub =>
   // oxlint-disable-next-line executor/no-double-cast -- boundary: Workers types expose only DurableObjectStub, but RPC methods are generated from the bound DO class.
   env.MCP_SESSION.get(
-    env.MCP_SESSION.idFromName(`streamable-http:${sessionId}`),
+    env.MCP_SESSION.idFromName(mcpSessionDurableObjectName(sessionId)),
   ) as unknown as McpAgentSessionStub;
 
 const authenticate = (request: Request) =>

--- a/apps/cloud/src/mcp/session-durable-object.ts
+++ b/apps/cloud/src/mcp/session-durable-object.ts
@@ -36,6 +36,7 @@ import {
   type SessionMeta,
 } from "@executor-js/cloudflare/mcp/agent-durable-object";
 import {
+  mcpSessionDurableObjectName,
   mcpExecutionOwnerDirectoryFromNamespace,
   type McpExecutionOwnerDirectory,
   type McpExecutionOwnerRoute,
@@ -212,7 +213,7 @@ export class McpSessionDOSqlite extends McpAgentSessionDOBase<Env, CloudSessionD
       try: () =>
         (
           env.MCP_SESSION.get(
-            env.MCP_SESSION.idFromString(owner.sessionId),
+            env.MCP_SESSION.idFromName(mcpSessionDurableObjectName(owner.sessionId)),
           ) as unknown as McpModelResumeStub
         ).resumeExecutionForModel(executionId, identity, response),
       catch: (cause) => new McpModelResumeForwardError({ cause }),

--- a/apps/cloud/src/mcp/session-durable-object.ts
+++ b/apps/cloud/src/mcp/session-durable-object.ts
@@ -21,16 +21,26 @@ import * as OtelTracer from "@effect/opentelemetry/Tracer";
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres, { type Sql } from "postgres";
 
-import { createExecutorMcpServer } from "@executor-js/host-mcp/tool-server";
+import {
+  PAUSED_APPROVAL_TIMEOUT_MS,
+  createExecutorMcpServer,
+} from "@executor-js/host-mcp/tool-server";
 import { buildResumeApprovalUrl } from "@executor-js/host-mcp/browser-approval";
 import {
   McpAgentSessionDOBase,
   type BuiltMcpServer,
   type IncomingTraceHeaders,
+  type McpApprovalOwner,
+  type McpSessionModelResumeResult,
   type McpSessionInit,
   type SessionMeta,
 } from "@executor-js/cloudflare/mcp/agent-durable-object";
-import { buildExecuteDescription } from "@executor-js/execution";
+import {
+  mcpExecutionOwnerDirectoryFromNamespace,
+  type McpExecutionOwnerDirectory,
+  type McpExecutionOwnerRoute,
+} from "@executor-js/cloudflare/mcp/execution-owner-directory";
+import { buildExecuteDescription, type ResumeResponse } from "@executor-js/execution";
 
 // The DO meters executions just like the HTTP `/api/*` plane: it builds its
 // engine with `CloudMeteredExecutionStackLayer`, so every MCP execution is
@@ -64,6 +74,7 @@ import { captureCause as reportCause } from "../observability";
 export type {
   McpApprovalOwner,
   McpSessionApprovalResult,
+  McpSessionModelResumeResult,
   McpSessionResumeApprovalResult,
   McpSessionInit,
   IncomingTraceHeaders,
@@ -89,8 +100,20 @@ type CloudSessionDbHandle = DbServiceShape & {
   readonly end: () => Promise<void>;
 };
 
+interface McpModelResumeStub {
+  readonly resumeExecutionForModel: (
+    executionId: string,
+    identity: McpApprovalOwner,
+    response: ResumeResponse,
+  ) => Promise<McpSessionModelResumeResult>;
+}
+
 class OrganizationNotFoundError extends Data.TaggedError("OrganizationNotFoundError")<{
   readonly organizationId: string;
+}> {}
+
+class McpModelResumeForwardError extends Data.TaggedError("McpModelResumeForwardError")<{
+  readonly cause: unknown;
 }> {}
 
 // W3C propagation across the worker→DO boundary. The worker injects its
@@ -175,6 +198,27 @@ export class McpSessionDOSqlite extends McpAgentSessionDOBase<Env, CloudSessionD
     );
   }
 
+  protected override executionOwnerDirectory(): McpExecutionOwnerDirectory | null {
+    return mcpExecutionOwnerDirectoryFromNamespace(env.MCP_EXECUTION_OWNER);
+  }
+
+  protected override forwardModelResumeToOwner(
+    owner: McpExecutionOwnerRoute,
+    identity: McpApprovalOwner,
+    executionId: string,
+    response: ResumeResponse,
+  ): Effect.Effect<McpSessionModelResumeResult, unknown> {
+    return Effect.tryPromise({
+      try: () =>
+        (
+          env.MCP_SESSION.get(
+            env.MCP_SESSION.idFromString(owner.sessionId),
+          ) as unknown as McpModelResumeStub
+        ).resumeExecutionForModel(executionId, identity, response),
+      catch: (cause) => new McpModelResumeForwardError({ cause }),
+    });
+  }
+
   protected override openSessionDb(): CloudSessionDbHandle {
     return makeDbHandle({
       idleTimeout: LONG_LIVED_DB_IDLE_TIMEOUT_SECONDS,
@@ -239,6 +283,8 @@ export class McpSessionDOSqlite extends McpAgentSessionDOBase<Env, CloudSessionD
         debug: env.EXECUTOR_MCP_DEBUG === "true",
         browserApprovalStore: self.browserApprovalStore,
         pausedExecutionHooks: self.pausedExecutionHooks,
+        pausedExecutionLeaseMs: PAUSED_APPROVAL_TIMEOUT_MS,
+        resumeFallback: self.modelResumeFallback,
         elicitationMode:
           sessionElicitationMode === "browser"
             ? {

--- a/apps/cloud/src/mcp/session-durable-object.ts
+++ b/apps/cloud/src/mcp/session-durable-object.ts
@@ -109,6 +109,8 @@ interface McpModelResumeStub {
   ) => Promise<McpSessionModelResumeResult>;
 }
 
+const toMcpModelResumeStub = (stub: unknown): McpModelResumeStub => stub as McpModelResumeStub;
+
 class OrganizationNotFoundError extends Data.TaggedError("OrganizationNotFoundError")<{
   readonly organizationId: string;
 }> {}
@@ -211,10 +213,10 @@ export class McpSessionDOSqlite extends McpAgentSessionDOBase<Env, CloudSessionD
   ): Effect.Effect<McpSessionModelResumeResult, unknown> {
     return Effect.tryPromise({
       try: () =>
-        (
+        toMcpModelResumeStub(
           env.MCP_SESSION.get(
             env.MCP_SESSION.idFromName(mcpSessionDurableObjectName(owner.sessionId)),
-          ) as unknown as McpModelResumeStub
+          ),
         ).resumeExecutionForModel(executionId, identity, response),
       catch: (cause) => new McpModelResumeForwardError({ cause }),
     });

--- a/apps/cloud/src/server.ts
+++ b/apps/cloud/src/server.ts
@@ -60,6 +60,8 @@ export class McpSessionDO extends DurableObject {}
 // its callers already fail open and report errors themselves.
 export { ExecutionRateLimiterDO } from "./engine/execution-rate-limit";
 
+export { McpExecutionOwnerDirectoryDO } from "@executor-js/cloudflare/mcp/execution-owner-directory";
+
 // ---------------------------------------------------------------------------
 // Worker fetch handler
 //

--- a/apps/cloud/wrangler.jsonc
+++ b/apps/cloud/wrangler.jsonc
@@ -22,6 +22,10 @@
         "name": "MCP_SESSION",
         "class_name": "McpSessionDOSqlite",
       },
+      {
+        "name": "MCP_EXECUTION_OWNER",
+        "class_name": "McpExecutionOwnerDirectoryDO",
+      },
       // Per-org execution rate-limit counter (abuse backstop). One instance
       // per organization via idFromName(orgId); a single { windowId, count }
       // record per instance, purged by alarm after inactivity.
@@ -52,6 +56,10 @@
     {
       "tag": "v3",
       "new_sqlite_classes": ["ExecutionRateLimiterDO"],
+    },
+    {
+      "tag": "v4",
+      "new_sqlite_classes": ["McpExecutionOwnerDirectoryDO"],
     },
   ],
   "services": [

--- a/apps/host-cloudflare/src/config.ts
+++ b/apps/host-cloudflare/src/config.ts
@@ -25,6 +25,7 @@ export interface CloudflareEnv {
    *  session (the DO id IS the session id), so a session survives across the
    *  Worker's stateless isolates. */
   readonly MCP_SESSION: DurableObjectNamespace;
+  readonly MCP_EXECUTION_OWNER?: DurableObjectNamespace;
   /** Zero Trust team domain, e.g. `your-team.cloudflareaccess.com`. */
   readonly ACCESS_TEAM_DOMAIN: string;
   /** The Access application's AUD tag (the JWT audience to verify). */

--- a/apps/host-cloudflare/src/mcp/agent-handler.ts
+++ b/apps/host-cloudflare/src/mcp/agent-handler.ts
@@ -13,6 +13,7 @@ import {
   withVerifiedIdentityHeaders,
 } from "@executor-js/cloudflare/mcp/do-headers";
 import type { McpSessionProps } from "@executor-js/cloudflare/mcp/agent-durable-object";
+import { mcpSessionDurableObjectName } from "@executor-js/cloudflare/mcp/execution-owner-directory";
 
 import type { CloudflareConfig, CloudflareEnv } from "../config";
 import { cloudflareAccessMcpAuth } from "./auth";
@@ -70,7 +71,7 @@ const renderAuthError = (
 const sessionStub = (env: CloudflareEnv, sessionId: string): McpAgentSessionStub =>
   // oxlint-disable-next-line executor/no-double-cast -- boundary: Workers types expose only DurableObjectStub, but RPC methods are generated from the bound DO class.
   env.MCP_SESSION.get(
-    env.MCP_SESSION.idFromName(`streamable-http:${sessionId}`),
+    env.MCP_SESSION.idFromName(mcpSessionDurableObjectName(sessionId)),
   ) as unknown as McpAgentSessionStub;
 
 const authenticate = (request: Request, config: CloudflareConfig) =>

--- a/apps/host-cloudflare/src/mcp/index.ts
+++ b/apps/host-cloudflare/src/mcp/index.ts
@@ -13,6 +13,7 @@ import { makeAccessVerifier } from "../auth/cloudflare-access";
 
 export { cloudflareAccessMcpAuth } from "./auth";
 export { McpSessionDO } from "./session-durable-object";
+export { McpExecutionOwnerDirectoryDO } from "@executor-js/cloudflare/mcp/execution-owner-directory";
 
 const toApprovalStub = (stub: unknown): McpApprovalStub => stub as McpApprovalStub;
 

--- a/apps/host-cloudflare/src/mcp/index.ts
+++ b/apps/host-cloudflare/src/mcp/index.ts
@@ -6,6 +6,7 @@ import type {
   McpSessionApprovalResult,
   McpSessionResumeApprovalResult,
 } from "@executor-js/cloudflare/mcp/agent-durable-object";
+import { mcpSessionDurableObjectName } from "@executor-js/cloudflare/mcp/execution-owner-directory";
 import type { ResumeResponse } from "@executor-js/execution";
 
 import type { CloudflareConfig, CloudflareEnv } from "../config";
@@ -41,7 +42,9 @@ export const makeCloudflareApprovalHandler = (
 ): ((request: Request) => Promise<Response>) => {
   const { verify } = makeAccessVerifier(config);
   const stubFor = (sessionId: string): McpApprovalStub =>
-    toApprovalStub(env.MCP_SESSION.get(env.MCP_SESSION.idFromName(`streamable-http:${sessionId}`)));
+    toApprovalStub(
+      env.MCP_SESSION.get(env.MCP_SESSION.idFromName(mcpSessionDurableObjectName(sessionId))),
+    );
 
   return async (request) => {
     const principal = await Effect.runPromise(verify(request));

--- a/apps/host-cloudflare/src/mcp/session-durable-object.ts
+++ b/apps/host-cloudflare/src/mcp/session-durable-object.ts
@@ -55,6 +55,8 @@ interface McpModelResumeStub {
   ) => Promise<McpSessionModelResumeResult>;
 }
 
+const toMcpModelResumeStub = (stub: unknown): McpModelResumeStub => stub as McpModelResumeStub;
+
 class McpModelResumeForwardError extends Data.TaggedError("McpModelResumeForwardError")<{
   readonly cause: unknown;
 }> {}
@@ -84,10 +86,10 @@ export class McpSessionDO extends McpAgentSessionDOBase<CloudflareEnv, CfSession
   ): Effect.Effect<McpSessionModelResumeResult, unknown> {
     return Effect.tryPromise({
       try: () =>
-        (
+        toMcpModelResumeStub(
           this.cfEnv.MCP_SESSION.get(
             this.cfEnv.MCP_SESSION.idFromName(mcpSessionDurableObjectName(owner.sessionId)),
-          ) as unknown as McpModelResumeStub
+          ),
         ).resumeExecutionForModel(executionId, identity, response),
       catch: (cause) => new McpModelResumeForwardError({ cause }),
     });

--- a/apps/host-cloudflare/src/mcp/session-durable-object.ts
+++ b/apps/host-cloudflare/src/mcp/session-durable-object.ts
@@ -15,6 +15,7 @@ import {
   type SessionMeta,
 } from "@executor-js/cloudflare/mcp/agent-durable-object";
 import {
+  mcpSessionDurableObjectName,
   mcpExecutionOwnerDirectoryFromNamespace,
   type McpExecutionOwnerDirectory,
   type McpExecutionOwnerRoute,
@@ -85,7 +86,7 @@ export class McpSessionDO extends McpAgentSessionDOBase<CloudflareEnv, CfSession
       try: () =>
         (
           this.cfEnv.MCP_SESSION.get(
-            this.cfEnv.MCP_SESSION.idFromName(`streamable-http:${owner.sessionId}`),
+            this.cfEnv.MCP_SESSION.idFromName(mcpSessionDurableObjectName(owner.sessionId)),
           ) as unknown as McpModelResumeStub
         ).resumeExecutionForModel(executionId, identity, response),
       catch: (cause) => new McpModelResumeForwardError({ cause }),

--- a/apps/host-cloudflare/src/mcp/session-durable-object.ts
+++ b/apps/host-cloudflare/src/mcp/session-durable-object.ts
@@ -1,14 +1,25 @@
-import { Effect } from "effect";
+import { Data, Effect } from "effect";
 
-import { createExecutorMcpServer } from "@executor-js/host-mcp/tool-server";
+import {
+  PAUSED_APPROVAL_TIMEOUT_MS,
+  createExecutorMcpServer,
+} from "@executor-js/host-mcp/tool-server";
 import { buildResumeApprovalUrl } from "@executor-js/host-mcp/browser-approval";
 import type { ExecutorDbHandle } from "@executor-js/api/server";
 import {
   McpAgentSessionDOBase,
   type BuiltMcpServer,
+  type McpApprovalOwner,
+  type McpSessionModelResumeResult,
   type McpSessionInit,
   type SessionMeta,
 } from "@executor-js/cloudflare/mcp/agent-durable-object";
+import {
+  mcpExecutionOwnerDirectoryFromNamespace,
+  type McpExecutionOwnerDirectory,
+  type McpExecutionOwnerRoute,
+} from "@executor-js/cloudflare/mcp/execution-owner-directory";
+import type { ResumeResponse } from "@executor-js/execution";
 
 import { loadConfig, type CloudflareConfig, type CloudflareEnv } from "../config";
 import { createD1ExecutorDb } from "../db/d1";
@@ -35,6 +46,18 @@ import { preloadQuickJs } from "../quickjs";
 // own lifecycle (the binding is the connection), so `end` is `close` — a no-op.
 type CfSessionDbHandle = ExecutorDbHandle & { readonly end: () => Promise<void> };
 
+interface McpModelResumeStub {
+  readonly resumeExecutionForModel: (
+    executionId: string,
+    identity: McpApprovalOwner,
+    response: ResumeResponse,
+  ) => Promise<McpSessionModelResumeResult>;
+}
+
+class McpModelResumeForwardError extends Data.TaggedError("McpModelResumeForwardError")<{
+  readonly cause: unknown;
+}> {}
+
 export class McpSessionDO extends McpAgentSessionDOBase<CloudflareEnv, CfSessionDbHandle> {
   private readonly cfEnv: CloudflareEnv;
   private readonly cfConfig: CloudflareConfig;
@@ -46,6 +69,27 @@ export class McpSessionDO extends McpAgentSessionDOBase<CloudflareEnv, CfSession
     super(ctx, env);
     this.cfEnv = env;
     this.cfConfig = loadConfig(env);
+  }
+
+  protected override executionOwnerDirectory(): McpExecutionOwnerDirectory | null {
+    return mcpExecutionOwnerDirectoryFromNamespace(this.cfEnv.MCP_EXECUTION_OWNER);
+  }
+
+  protected override forwardModelResumeToOwner(
+    owner: McpExecutionOwnerRoute,
+    identity: McpApprovalOwner,
+    executionId: string,
+    response: ResumeResponse,
+  ): Effect.Effect<McpSessionModelResumeResult, unknown> {
+    return Effect.tryPromise({
+      try: () =>
+        (
+          this.cfEnv.MCP_SESSION.get(
+            this.cfEnv.MCP_SESSION.idFromName(`streamable-http:${owner.sessionId}`),
+          ) as unknown as McpModelResumeStub
+        ).resumeExecutionForModel(executionId, identity, response),
+      catch: (cause) => new McpModelResumeForwardError({ cause }),
+    });
   }
 
   protected override async openSessionDb(): Promise<CfSessionDbHandle> {
@@ -91,6 +135,8 @@ export class McpSessionDO extends McpAgentSessionDOBase<CloudflareEnv, CfSession
         engine,
         browserApprovalStore: self.browserApprovalStore,
         pausedExecutionHooks: self.pausedExecutionHooks,
+        pausedExecutionLeaseMs: PAUSED_APPROVAL_TIMEOUT_MS,
+        resumeFallback: self.modelResumeFallback,
         elicitationMode:
           elicitationMode === "browser"
             ? {

--- a/apps/host-cloudflare/src/worker.ts
+++ b/apps/host-cloudflare/src/worker.ts
@@ -1,9 +1,9 @@
 import { makeCloudflareApp } from "./app";
 import type { CloudflareEnv } from "./config";
 
-// The MCP session Durable Object class, bound as `MCP_SESSION` in wrangler.jsonc.
-// Must be exported at the Worker entry module scope for the runtime to find it.
-export { McpSessionDO } from "./mcp";
+// The MCP Durable Object classes, bound in wrangler.jsonc. They must be exported
+// at the Worker entry module scope for the runtime to find them.
+export { McpExecutionOwnerDirectoryDO, McpSessionDO } from "./mcp";
 
 // ---------------------------------------------------------------------------
 // The Worker fetch entry. Most requests go to `ExecutorApp.make`'s Effect web

--- a/apps/host-cloudflare/wrangler.jsonc
+++ b/apps/host-cloudflare/wrangler.jsonc
@@ -40,9 +40,15 @@
   // isolate that never saw the session ("Not connected"). `new_sqlite_classes`
   // is the free-tier-eligible SQLite-backed DO storage.
   "durable_objects": {
-    "bindings": [{ "name": "MCP_SESSION", "class_name": "McpSessionDO" }],
+    "bindings": [
+      { "name": "MCP_SESSION", "class_name": "McpSessionDO" },
+      { "name": "MCP_EXECUTION_OWNER", "class_name": "McpExecutionOwnerDirectoryDO" },
+    ],
   },
-  "migrations": [{ "tag": "v1", "new_sqlite_classes": ["McpSessionDO"] }],
+  "migrations": [
+    { "tag": "v1", "new_sqlite_classes": ["McpSessionDO"] },
+    { "tag": "v2", "new_sqlite_classes": ["McpExecutionOwnerDirectoryDO"] },
+  ],
   // Cloudflare Access is the entire auth layer: the Worker validates the
   // Cf-Access-Jwt-Assertion JWT against the team JWKS. Set these to your Zero
   // Trust team domain + the Access application's AUD tag. EXECUTOR_SECRET_KEY

--- a/packages/core/execution/src/engine.ts
+++ b/packages/core/execution/src/engine.ts
@@ -41,6 +41,11 @@ export type PausedExecution = {
   readonly elicitationContext: ElicitationContext;
 };
 
+export type PausedExecutionDeadline = {
+  readonly expiresAt: string;
+  readonly ttlMs: number;
+};
+
 /** Internal representation with Effect runtime state for pause/resume. */
 type InternalPausedExecution<E> = PausedExecution & {
   readonly response: Deferred.Deferred<typeof ElicitationResponse.Type>;
@@ -127,22 +132,28 @@ export const formatExecuteResult = (
 
 export const formatPausedExecution = (
   paused: PausedExecution,
+  options?: { readonly deadline?: PausedExecutionDeadline },
 ): {
   text: string;
   structured: Record<string, unknown>;
 } => {
   const req = paused.elicitationContext.request;
   const lines: string[] = [`Execution paused: ${req.message}`];
+  const deadline = options?.deadline;
   const isUrlElicitation = Predicate.isTagged(req, "UrlElicitation");
   const isFormElicitation = Predicate.isTagged(req, "FormElicitation");
   const requestedSchema = isFormElicitation ? req.requestedSchema : undefined;
   const hasRequestedSchema =
     requestedSchema !== undefined && Object.keys(requestedSchema).length > 0;
-  const instructions = isUrlElicitation
+  const baseInstructions = isUrlElicitation
     ? `The user needs to open this URL in a browser and complete the flow. After the user finishes, call the resume tool with executionId "${paused.id}" and action "accept".`
     : hasRequestedSchema
       ? `Ask the user for values matching requestedSchema. Then call the resume tool with executionId "${paused.id}", action "accept", and content matching requestedSchema. If the user declines, call resume with action "decline" or "cancel".`
       : `This is a model-side confirmation gate; there is no browser form to open. Ask the user whether to approve the paused tool call. If the user approves, call the resume tool with executionId "${paused.id}" and action "accept". If the user declines, call resume with action "decline" or "cancel".`;
+  const deadlineInstructions = deadline
+    ? ` Resume before ${deadline.expiresAt}; this approval window lasts ${formatTtlDuration(deadline.ttlMs)}.`
+    : "";
+  const instructions = `${baseInstructions}${deadlineInstructions}`;
 
   if (isUrlElicitation) {
     lines.push(`\nOpen this URL in a browser:\n${req.url}`);
@@ -159,6 +170,11 @@ export const formatPausedExecution = (
   }
 
   lines.push(`\nexecutionId: ${paused.id}`);
+  if (deadline) {
+    lines.push(
+      `\nresumeDeadline: ${deadline.expiresAt} (${formatTtlDuration(deadline.ttlMs)} approval window)`,
+    );
+  }
   lines.push(`\ninstructions: ${instructions}`);
 
   return {
@@ -166,6 +182,7 @@ export const formatPausedExecution = (
     structured: {
       status: "waiting_for_interaction",
       executionId: paused.id,
+      ...(deadline ? { expiresAt: deadline.expiresAt, ttlMs: deadline.ttlMs } : {}),
       interaction: {
         kind: isUrlElicitation ? "url" : "form",
         message: req.message,
@@ -177,6 +194,15 @@ export const formatPausedExecution = (
       },
     },
   };
+};
+
+const formatTtlDuration = (ttlMs: number): string => {
+  const seconds = Math.max(1, Math.round(ttlMs / 1000));
+  if (seconds % 60 === 0) {
+    const minutes = seconds / 60;
+    return `${minutes} minute${minutes === 1 ? "" : "s"}`;
+  }
+  return `${seconds} second${seconds === 1 ? "" : "s"}`;
 };
 
 // ---------------------------------------------------------------------------
@@ -396,6 +422,12 @@ export type ExecutionEngine<E extends Cause.YieldableError = CodeExecutionError>
   ) => Effect.Effect<ExecutionResult | null, E>;
 
   /**
+   * True when the engine remembers that an executionId has already settled, even
+   * if the replayed outcome has rolled out of the bounded resume cache.
+   */
+  readonly isExecutionSettled?: (executionId: string) => Effect.Effect<boolean>;
+
+  /**
    * Inspect a paused execution without resuming it. Returns null if the id is
    * unknown or has already been resumed.
    */
@@ -426,6 +458,8 @@ export const createExecutionEngine = <E extends Cause.YieldableError = CodeExecu
   // volume is tiny (human approvals), so a small window is plenty.
   const settledOutcomes = new Map<string, Exit.Exit<ExecutionResult, E>>();
   const SETTLED_OUTCOME_LIMIT = 64;
+  const settledExecutionIds = new Set<string>();
+  const SETTLED_EXECUTION_ID_LIMIT = 1024;
   // Resumes whose outcome is still being computed, so a concurrent duplicate
   // awaits the same result instead of missing the (already-consumed) pause.
   const pendingResumes = new Map<string, Deferred.Deferred<ExecutionResult, E>>();
@@ -434,6 +468,12 @@ export const createExecutionEngine = <E extends Cause.YieldableError = CodeExecu
   // typed channel — hosts render engine failures opaquely, and a replay must
   // not bypass that by flattening the cause into result text.
   const recordSettledOutcome = (executionId: string, exit: Exit.Exit<ExecutionResult, E>): void => {
+    settledExecutionIds.add(executionId);
+    while (settledExecutionIds.size > SETTLED_EXECUTION_ID_LIMIT) {
+      const oldest = settledExecutionIds.keys().next().value;
+      if (oldest === undefined) break;
+      settledExecutionIds.delete(oldest);
+    }
     settledOutcomes.set(executionId, exit);
     while (settledOutcomes.size > SETTLED_OUTCOME_LIMIT) {
       const oldest = settledOutcomes.keys().next().value;
@@ -637,6 +677,7 @@ export const createExecutionEngine = <E extends Cause.YieldableError = CodeExecu
     execute: runInlineExecution,
     executeWithPause: startPausableExecution,
     resume: resumeExecution,
+    isExecutionSettled: (executionId) => Effect.sync(() => settledExecutionIds.has(executionId)),
     getPausedExecution: (executionId) =>
       Effect.sync(() => pausedExecutions.get(executionId) ?? null),
     pausedExecutionCount: () => Effect.sync(() => pausedExecutions.size),

--- a/packages/core/execution/src/engine.ts
+++ b/packages/core/execution/src/engine.ts
@@ -196,7 +196,7 @@ export const formatPausedExecution = (
   };
 };
 
-const formatTtlDuration = (ttlMs: number): string => {
+export const formatTtlDuration = (ttlMs: number): string => {
   const seconds = Math.max(1, Math.round(ttlMs / 1000));
   if (seconds % 60 === 0) {
     const minutes = seconds / 60;

--- a/packages/core/execution/src/index.ts
+++ b/packages/core/execution/src/index.ts
@@ -6,6 +6,7 @@ export {
   type ExecutionEngineConfig,
   type ExecutionResult,
   type PausedExecution,
+  type PausedExecutionDeadline,
   type ResumeResponse,
 } from "./engine";
 

--- a/packages/core/execution/src/index.ts
+++ b/packages/core/execution/src/index.ts
@@ -2,6 +2,7 @@ export {
   createExecutionEngine,
   formatExecuteResult,
   formatPausedExecution,
+  formatTtlDuration,
   type ExecutionEngine,
   type ExecutionEngineConfig,
   type ExecutionResult,

--- a/packages/hosts/cloudflare/package.json
+++ b/packages/hosts/cloudflare/package.json
@@ -15,6 +15,10 @@
     "./mcp/agent-durable-object": {
       "types": "./src/mcp/agent-session-durable-object.ts",
       "default": "./src/mcp/agent-session-durable-object.ts"
+    },
+    "./mcp/execution-owner-directory": {
+      "types": "./src/mcp/execution-owner-directory.ts",
+      "default": "./src/mcp/execution-owner-directory.ts"
     }
   },
   "scripts": {

--- a/packages/hosts/cloudflare/src/mcp/agent-session-durable-object.ts
+++ b/packages/hosts/cloudflare/src/mcp/agent-session-durable-object.ts
@@ -120,6 +120,7 @@ const MCP_HTTP_METHOD_HEADER = "cf-mcp-method";
 const MCP_MESSAGE_HEADER = "cf-mcp-message";
 const ACTIVE_POST_RESPONSE_WAIT_POLL_MS = 25;
 const ACTIVE_POST_RESPONSE_WAIT_MAX_MS = PAUSED_APPROVAL_TIMEOUT_MS + 30_000;
+const MODEL_RESUME_FORWARD_TIMEOUT_MS = 10_000;
 const approvalResponseKey = (executionId: string) => `approval-response:${executionId}`;
 
 type JsonRpcRequestId = string | number;
@@ -889,6 +890,11 @@ export abstract class McpAgentSessionDOBase<
       const forwarded = yield* self
         .forwardModelResumeToOwner(record.owner, identity, executionId, response)
         .pipe(
+          Effect.timeoutOrElse({
+            duration: `${MODEL_RESUME_FORWARD_TIMEOUT_MS} millis`,
+            orElse: () =>
+              Effect.succeed({ status: "execution_expired" as const, ttlMs: record.ttlMs }),
+          }),
           Effect.catchCause(() =>
             Effect.succeed({ status: "execution_expired" as const, ttlMs: record.ttlMs }),
           ),

--- a/packages/hosts/cloudflare/src/mcp/agent-session-durable-object.ts
+++ b/packages/hosts/cloudflare/src/mcp/agent-session-durable-object.ts
@@ -8,15 +8,24 @@ import { RequestOrgSlug, RequestWebOrigin } from "@executor-js/api/server";
 import {
   formatPausedExecution,
   type ExecutionEngine,
+  type ExecutionResult,
+  type PausedExecutionDeadline,
   type ResumeResponse,
 } from "@executor-js/execution";
 import {
   PAUSED_APPROVAL_TIMEOUT_MS,
+  formatMcpExecutionOutcome,
   type PausedExecutionHooks,
+  type ResumeFallbackOutcome,
 } from "@executor-js/host-mcp/tool-server";
 import { defaultMcpResource, type McpResource } from "@executor-js/host-mcp";
 
 import type { IncomingPropagationHeaders, McpElicitationMode } from "./do-headers";
+import type {
+  McpExecutionOwnerDirectory,
+  McpExecutionOwnerRecord,
+  McpExecutionOwnerRoute,
+} from "./execution-owner-directory";
 import {
   MAX_PAUSED_SESSION_IDLE_MS,
   SESSION_TIMEOUT_MS,
@@ -73,6 +82,8 @@ export type McpSessionResumeApprovalResult =
       readonly isError?: boolean;
     }
   | McpSessionApprovalErrorResult;
+
+export type McpSessionModelResumeResult = ResumeFallbackOutcome;
 
 export interface SessionDbHandle {
   readonly end: () => Promise<void> | void;
@@ -244,15 +255,45 @@ export abstract class McpAgentSessionDOBase<
     return MAX_PAUSED_SESSION_IDLE_MS;
   }
 
+  protected executionOwnerDirectory(): McpExecutionOwnerDirectory | null {
+    return null;
+  }
+
+  protected executionOwnerRoute(): McpExecutionOwnerRoute {
+    return { sessionId: this.sessionId };
+  }
+
+  protected sameExecutionOwnerRoute(a: McpExecutionOwnerRoute, b: McpExecutionOwnerRoute): boolean {
+    return a.sessionId === b.sessionId;
+  }
+
+  protected forwardModelResumeToOwner(
+    _owner: McpExecutionOwnerRoute,
+    _identity: McpApprovalOwner,
+    _executionId: string,
+    _response: ResumeResponse,
+  ): Effect.Effect<McpSessionModelResumeResult, unknown> {
+    return Effect.succeed({
+      status: "execution_expired",
+      ttlMs: PAUSED_APPROVAL_TIMEOUT_MS,
+    });
+  }
+
   protected readonly browserApprovalStore: BrowserApprovalStore = {
     takeResponse: (executionId) => this.takeApprovalResponse(executionId),
     waitForResponse: (executionId) => this.waitForApprovalResponse(executionId),
   };
 
+  protected readonly modelResumeFallback = (
+    executionId: string,
+    response: ResumeResponse,
+  ): Effect.Effect<ResumeFallbackOutcome | null> =>
+    this.resumeFromExecutionOwnerDirectory(executionId, response);
+
   protected readonly pausedExecutionHooks: PausedExecutionHooks = {
-    onExecutionPaused: (executionId) =>
+    onExecutionPaused: (executionId, deadline) =>
       Effect.sync(() => {
-        this.queuePendingApprovalLeaseStart(executionId);
+        this.queuePendingApprovalLeaseStart(executionId, deadline);
       }),
     onResumeStarted: (executionId) => this.beginPendingApprovalResume(executionId),
     onResumeSettled: (executionId) => this.finishPendingApprovalResume(executionId),
@@ -584,7 +625,8 @@ export abstract class McpAgentSessionDOBase<
         const paused = yield* self.engine.getPausedExecution(executionId);
         if (!paused) return { status: "not_found" } as const;
 
-        const formatted = formatPausedExecution(paused);
+        const deadline = yield* self.deadlineForExecution(executionId);
+        const formatted = formatPausedExecution(paused, { deadline });
         return {
           status: "ok" as const,
           text: formatted.text,
@@ -592,6 +634,63 @@ export abstract class McpAgentSessionDOBase<
         };
       }).pipe(
         Effect.withSpan("McpSessionDO.getPausedExecutionForApproval", {
+          attributes: { "mcp.execution.id": executionId },
+        }),
+        (eff) => this.withTelemetry(eff, incoming),
+        // oxlint-disable-next-line executor/no-effect-escape-hatch -- boundary: DO RPC exposes Promise results
+        Effect.orDie,
+        (eff) => self.withSpanFlush(eff),
+      ),
+    );
+  }
+
+  async resumeExecutionForModel(
+    executionId: string,
+    identity: McpApprovalOwner,
+    response: ResumeResponse,
+    incoming?: IncomingTraceHeaders,
+  ): Promise<McpSessionModelResumeResult> {
+    const self = this;
+    return Effect.runPromise(
+      Effect.gen(function* () {
+        const owner = yield* self.validateApprovalIdentity(identity);
+        if (owner === "forbidden") return { status: "execution_forbidden" } as const;
+        if (owner === "not_found") {
+          return { status: "execution_expired" as const, ttlMs: PAUSED_APPROVAL_TIMEOUT_MS };
+        }
+
+        const restored = yield* self.ensureRuntimeForApproval();
+        if (!restored || !self.engine) {
+          yield* self.deleteExecutionOwnerEntry(executionId);
+          return { status: "execution_expired" as const, ttlMs: PAUSED_APPROVAL_TIMEOUT_MS };
+        }
+
+        const outcome = yield* self.resumeEngineWithLifecycle(executionId, response);
+        if (!outcome) {
+          const alreadySettled = self.engine.isExecutionSettled
+            ? yield* self.engine.isExecutionSettled(executionId)
+            : false;
+          yield* self.deleteExecutionOwnerEntry(executionId);
+          return alreadySettled
+            ? ({ status: "execution_already_settled" } as const)
+            : ({ status: "execution_expired", ttlMs: PAUSED_APPROVAL_TIMEOUT_MS } as const);
+        }
+
+        if (outcome.status === "paused") {
+          const deadline = self.approvalDeadline();
+          yield* self.startPendingApprovalLease(outcome.execution.id, deadline);
+          return {
+            status: "result" as const,
+            result: formatMcpExecutionOutcome(outcome, { pausedDeadline: deadline }),
+          };
+        }
+
+        return {
+          status: "result" as const,
+          result: formatMcpExecutionOutcome(outcome),
+        };
+      }).pipe(
+        Effect.withSpan("McpSessionDO.resumeExecutionForModel", {
           attributes: { "mcp.execution.id": executionId },
         }),
         (eff) => this.withTelemetry(eff, incoming),
@@ -696,7 +795,121 @@ export abstract class McpAgentSessionDOBase<
     }).pipe(Effect.withSpan("mcp.session.validate_approval_identity"));
   }
 
-  private startPendingApprovalLease(executionId: string): Effect.Effect<void> {
+  private approvalDeadline(now = Date.now()): PausedExecutionDeadline {
+    return {
+      ttlMs: PAUSED_APPROVAL_TIMEOUT_MS,
+      expiresAt: new Date(now + PAUSED_APPROVAL_TIMEOUT_MS).toISOString(),
+    };
+  }
+
+  private deadlineForExecution(
+    executionId: string,
+  ): Effect.Effect<PausedExecutionDeadline | undefined> {
+    const directory = this.executionOwnerDirectory();
+    const noDeadline = Effect.sync((): PausedExecutionDeadline | undefined => undefined);
+    if (!directory) return noDeadline;
+    return directory.get(executionId).pipe(
+      Effect.map((record) =>
+        record ? { expiresAt: record.expiresAt, ttlMs: record.ttlMs } : undefined,
+      ),
+      Effect.catchCause(() => noDeadline),
+    );
+  }
+
+  private writeExecutionOwnerEntry(
+    executionId: string,
+    deadline: PausedExecutionDeadline | undefined,
+  ): Effect.Effect<void> {
+    const directory = this.executionOwnerDirectory();
+    if (!directory || !deadline) return Effect.void;
+    const self = this;
+    return Effect.gen(function* () {
+      const sessionMeta = yield* self.loadSessionMeta();
+      if (!sessionMeta) return;
+      const record: McpExecutionOwnerRecord = {
+        executionId,
+        owner: self.executionOwnerRoute(),
+        accountId: sessionMeta.userId,
+        organizationId: sessionMeta.organizationId,
+        expiresAt: deadline.expiresAt,
+        ttlMs: deadline.ttlMs,
+      };
+      yield* directory.put(record);
+    }).pipe(Effect.ignore);
+  }
+
+  private deleteExecutionOwnerEntry(executionId: string): Effect.Effect<void> {
+    const directory = this.executionOwnerDirectory();
+    return directory?.delete(executionId).pipe(Effect.ignore) ?? Effect.void;
+  }
+
+  private resumeEngineWithLifecycle(
+    executionId: string,
+    response: ResumeResponse,
+  ): Effect.Effect<ExecutionResult | null, Cause.YieldableError> {
+    const self = this;
+    return Effect.gen(function* () {
+      if (!self.engine) return null;
+      yield* self.beginPendingApprovalResume(executionId);
+      return yield* self.engine.resume(executionId, response);
+    }).pipe(Effect.ensuring(self.finishPendingApprovalResume(executionId)));
+  }
+
+  private resumeFromExecutionOwnerDirectory(
+    executionId: string,
+    response: ResumeResponse,
+  ): Effect.Effect<ResumeFallbackOutcome | null> {
+    const directory = this.executionOwnerDirectory();
+    if (!directory) return Effect.succeed(null);
+    const self = this;
+    return Effect.gen(function* () {
+      const record = yield* directory
+        .get(executionId)
+        .pipe(Effect.catchCause(() => Effect.succeed(null)));
+      if (!record) return null;
+
+      const sessionMeta = yield* self.loadSessionMeta();
+      if (!sessionMeta) return { status: "execution_forbidden" } as const;
+      const identity: McpApprovalOwner = {
+        accountId: sessionMeta.userId,
+        organizationId: sessionMeta.organizationId,
+      };
+      if (
+        identity.accountId !== record.accountId ||
+        identity.organizationId !== record.organizationId
+      ) {
+        return { status: "execution_forbidden" } as const;
+      }
+
+      if (self.sameExecutionOwnerRoute(record.owner, self.executionOwnerRoute())) {
+        yield* self.deleteExecutionOwnerEntry(executionId);
+        return { status: "execution_expired", ttlMs: record.ttlMs } as const;
+      }
+
+      const forwarded = yield* self
+        .forwardModelResumeToOwner(record.owner, identity, executionId, response)
+        .pipe(
+          Effect.catchCause(() =>
+            Effect.succeed({ status: "execution_expired" as const, ttlMs: record.ttlMs }),
+          ),
+        );
+      if (
+        forwarded.status === "execution_expired" ||
+        forwarded.status === "execution_not_found" ||
+        forwarded.status === "execution_already_settled"
+      ) {
+        yield* self.deleteExecutionOwnerEntry(executionId);
+      }
+      return forwarded.status === "execution_not_found"
+        ? ({ status: "execution_expired", ttlMs: record.ttlMs } as const)
+        : forwarded;
+    });
+  }
+
+  private startPendingApprovalLease(
+    executionId: string,
+    deadline: PausedExecutionDeadline | undefined,
+  ): Effect.Effect<void> {
     const self = this;
     return Effect.gen(function* () {
       if (self.pendingApprovalLeases.has(executionId)) return;
@@ -709,6 +922,7 @@ export abstract class McpAgentSessionDOBase<
         self.queuePendingApprovalLeaseExpiration(executionId);
       }, PAUSED_APPROVAL_TIMEOUT_MS);
       self.pendingApprovalLeases.set(executionId, { disposeKeepAlive, timeout, expiring: false });
+      yield* self.writeExecutionOwnerEntry(executionId, deadline);
     }).pipe(
       Effect.withSpan("McpSessionDO.pending_approval_lease.start", {
         attributes: { "mcp.execution.id": executionId },
@@ -723,8 +937,11 @@ export abstract class McpAgentSessionDOBase<
     );
   }
 
-  private queuePendingApprovalLeaseStart(executionId: string): void {
-    this.ctx.waitUntil(Effect.runPromise(this.startPendingApprovalLease(executionId)));
+  private queuePendingApprovalLeaseStart(
+    executionId: string,
+    deadline: PausedExecutionDeadline | undefined,
+  ): void {
+    this.ctx.waitUntil(Effect.runPromise(this.startPendingApprovalLease(executionId, deadline)));
   }
 
   private queuePendingApprovalLeaseExpiration(executionId: string): void {
@@ -768,24 +985,36 @@ export abstract class McpAgentSessionDOBase<
   }
 
   private releasePendingApprovalLease(executionId: string): Effect.Effect<void> {
-    return Effect.sync(() => {
-      const lease = this.pendingApprovalLeases.get(executionId);
-      if (!lease) return;
+    const self = this;
+    return Effect.gen(function* () {
+      const lease = self.pendingApprovalLeases.get(executionId);
+      if (!lease) {
+        yield* self.deleteExecutionOwnerEntry(executionId);
+        return;
+      }
       if (lease.timeout) clearTimeout(lease.timeout);
-      this.pendingApprovalLeases.delete(executionId);
+      self.pendingApprovalLeases.delete(executionId);
       lease.disposeKeepAlive();
+      yield* self.deleteExecutionOwnerEntry(executionId);
     });
   }
 
   private releaseAllPendingApprovalLeases(): Effect.Effect<void> {
-    return Effect.sync(() => {
-      for (const executionId of this.pendingApprovalLeases.keys()) {
-        const lease = this.pendingApprovalLeases.get(executionId);
-        if (!lease) continue;
-        if (lease.timeout) clearTimeout(lease.timeout);
-        lease.disposeKeepAlive();
+    const self = this;
+    return Effect.gen(function* () {
+      const executionIds = Array.from(self.pendingApprovalLeases.keys());
+      yield* Effect.sync(() => {
+        for (const executionId of executionIds) {
+          const lease = self.pendingApprovalLeases.get(executionId);
+          if (!lease) continue;
+          if (lease.timeout) clearTimeout(lease.timeout);
+          lease.disposeKeepAlive();
+        }
+        self.pendingApprovalLeases.clear();
+      });
+      for (const executionId of executionIds) {
+        yield* self.deleteExecutionOwnerEntry(executionId);
       }
-      this.pendingApprovalLeases.clear();
     });
   }
 

--- a/packages/hosts/cloudflare/src/mcp/agent-session-model-resume.test.ts
+++ b/packages/hosts/cloudflare/src/mcp/agent-session-model-resume.test.ts
@@ -67,20 +67,80 @@ vi.mock("agents/mcp", () => ({
   },
 }));
 
-class FakeStorage {
+class FakeStorage implements DurableObjectStorage {
   private readonly values = new Map<string, unknown>();
+  readonly sql = {} as DurableObjectStorage["sql"];
+  readonly kv = {} as DurableObjectStorage["kv"];
   alarmAt: number | null = null;
 
-  async get<T>(key: string): Promise<T | undefined> {
-    return this.values.get(key) as T | undefined;
+  async get<T>(key: string): Promise<T | undefined>;
+  async get<T>(keys: string[]): Promise<Map<string, T>>;
+  async get<T>(keyOrKeys: string | string[]): Promise<T | undefined | Map<string, T>> {
+    if (Array.isArray(keyOrKeys)) {
+      return new Map(keyOrKeys.map((key) => [key, this.values.get(key) as T]));
+    }
+    return this.values.get(keyOrKeys) as T | undefined;
   }
 
-  async put<T>(key: string, value: T): Promise<void> {
-    this.values.set(key, value);
+  async put<T>(key: string, value: T): Promise<void>;
+  async put<T>(entries: Record<string, T> | Map<string, T>): Promise<void>;
+  async put<T>(
+    keyOrEntries: string | Record<string, T> | Map<string, T>,
+    value?: T,
+  ): Promise<void> {
+    if (typeof keyOrEntries === "string") {
+      this.values.set(keyOrEntries, value);
+      return;
+    }
+    const entries =
+      keyOrEntries instanceof Map ? keyOrEntries.entries() : Object.entries(keyOrEntries);
+    for (const [key, entry] of entries) this.values.set(key, entry);
   }
 
-  async delete(key: string): Promise<boolean> {
-    return this.values.delete(key);
+  async delete(key: string): Promise<boolean>;
+  async delete(keys: string[]): Promise<number>;
+  async delete(keyOrKeys: string | string[]): Promise<boolean | number> {
+    if (!Array.isArray(keyOrKeys)) return this.values.delete(keyOrKeys);
+    let deleted = 0;
+    for (const key of keyOrKeys) {
+      if (this.values.delete(key)) deleted += 1;
+    }
+    return deleted;
+  }
+
+  async list<T = unknown>(): Promise<Map<string, T>> {
+    return new Map([...this.values.entries()].map(([key, value]) => [key, value as T]));
+  }
+
+  async deleteAll(): Promise<void> {
+    this.values.clear();
+    this.alarmAt = null;
+  }
+
+  transaction<T>(_closure: (txn: DurableObjectTransaction) => Promise<T>): Promise<T> {
+    return Promise.resolve(undefined as T);
+  }
+
+  transactionSync<T>(_closure: () => T): T {
+    return undefined as T;
+  }
+
+  async sync(): Promise<void> {}
+
+  async getAlarm(): Promise<number | null> {
+    return this.alarmAt;
+  }
+
+  async getCurrentBookmark(): Promise<string> {
+    return "test-bookmark";
+  }
+
+  async getBookmarkForTime(_timestamp: number | Date): Promise<string> {
+    return "test-bookmark";
+  }
+
+  onNextSessionRestoreBookmark(_bookmark: string): Promise<string> {
+    return Promise.resolve("test-bookmark");
   }
 
   async setAlarm(scheduledTime: number | Date): Promise<void> {
@@ -92,18 +152,21 @@ class FakeStorage {
   }
 }
 
-class FakeDurableObjectState {
+class FakeDurableObjectState implements DurableObjectState {
   readonly storage = new FakeStorage();
   readonly id: DurableObjectId;
+  readonly props: unknown = undefined;
+  readonly facets = {} as DurableObjectState["facets"];
   readonly ctx = this;
   private waitUntilPromises: Promise<unknown>[] = [];
 
   constructor(name: string) {
-    this.id = {
+    const id: Pick<DurableObjectId, "equals" | "name" | "toString"> = {
       equals: (other: DurableObjectId) => other.toString() === name,
       name,
       toString: () => name,
-    } as unknown as DurableObjectId;
+    };
+    this.id = id as DurableObjectId;
   }
 
   waitUntil(promise: Promise<unknown>): void {
@@ -120,6 +183,34 @@ class FakeDurableObjectState {
   blockConcurrencyWhile<T>(callback: () => Promise<T>): Promise<T> {
     return callback();
   }
+
+  acceptWebSocket(_ws: WebSocket, _tags?: string[]): void {}
+
+  getWebSockets(_tag?: string): WebSocket[] {
+    return [];
+  }
+
+  getTags(_ws: WebSocket): string[] {
+    return [];
+  }
+
+  setWebSocketAutoResponse(_pair?: WebSocketRequestResponsePair): void {}
+
+  getWebSocketAutoResponse(): WebSocketRequestResponsePair | null {
+    return null;
+  }
+
+  getWebSocketAutoResponseTimestamp(_ws: WebSocket): Date | null {
+    return null;
+  }
+
+  setHibernatableWebSocketEventTimeout(_timeoutMs?: number): void {}
+
+  getHibernatableWebSocketEventTimeout(): number | null {
+    return null;
+  }
+
+  abort(_reason?: string): void {}
 }
 
 class InMemoryExecutionOwnerDirectoryNamespace implements McpExecutionOwnerDirectoryNamespace<string> {
@@ -134,7 +225,7 @@ class InMemoryExecutionOwnerDirectoryNamespace implements McpExecutionOwnerDirec
     if (!directory) {
       directory = new McpExecutionOwnerDirectoryDO({
         storage: new FakeStorage(),
-      } as unknown as DurableObjectState);
+      });
       this.directories.set(id, directory);
     }
     return directory;
@@ -200,13 +291,6 @@ type PendingApprovalLeaseSnapshot = {
   readonly timeout: ReturnType<typeof setTimeout> | null;
 };
 
-type PrivateRuntimeState = {
-  engine: ExecutionEngine<Cause.YieldableError> | null;
-  dbHandle: TestDbHandle | null;
-  initialized: boolean;
-  pendingApprovalLeases: Map<string, PendingApprovalLeaseSnapshot>;
-};
-
 class HarnessSession extends McpAgentSessionDOBase<Cloudflare.Env, TestDbHandle> {
   private readonly meta: SessionMeta;
   private readonly fakeState: FakeDurableObjectState;
@@ -227,7 +311,7 @@ class HarnessSession extends McpAgentSessionDOBase<Cloudflare.Env, TestDbHandle>
     readonly forwardModelResumeToOwner?: HarnessSession["modelResumeForward"];
   }) {
     const state = new FakeDurableObjectState(input.sessionId);
-    super(state as unknown as DurableObjectState, {} as Cloudflare.Env);
+    super(state, {} as Cloudflare.Env);
     this.fakeState = state;
     this.meta = input.meta ?? sessionMeta();
     this.directory = mcpExecutionOwnerDirectoryFromNamespace(input.directoryNamespace);
@@ -269,10 +353,9 @@ class HarnessSession extends McpAgentSessionDOBase<Cloudflare.Env, TestDbHandle>
   }
 
   protected override buildMcpServer(): Effect.Effect<BuiltMcpServer> {
-    const runtime = this.runtimeState();
     return Effect.succeed({
       mcpServer: new McpServer({ name: "test", version: "1.0.0" }),
-      engine: runtime.engine!,
+      engine: this["engine"]!,
     });
   }
 
@@ -298,31 +381,24 @@ class HarnessSession extends McpAgentSessionDOBase<Cloudflare.Env, TestDbHandle>
     executionId: string,
     response: ResumeResponse,
   ): Promise<McpSessionModelResumeResult | null> {
-    const local = await Effect.runPromise(
-      this.runtimeState().engine!.resume(executionId, response),
-    );
+    const local = await Effect.runPromise(this["engine"]!.resume(executionId, response));
     if (local) return { status: "result", result: formatMcpExecutionOutcome(local) };
     return Effect.runPromise(this.modelResumeFallback(executionId, response));
   }
 
   pendingLease(executionId: string): PendingApprovalLeaseSnapshot | undefined {
-    return this.runtimeState().pendingApprovalLeases.get(executionId);
+    return this["pendingApprovalLeases"].get(executionId);
   }
 
   pendingLeaseCount(): number {
-    return this.runtimeState().pendingApprovalLeases.size;
+    return this["pendingApprovalLeases"].size;
   }
 
   private installRuntime(engine: ExecutionEngine<Cause.YieldableError>): void {
-    const runtime = this.runtimeState();
-    runtime.engine = engine;
-    runtime.dbHandle = { end: () => undefined };
-    runtime.initialized = true;
+    this["engine"] = engine;
+    this["dbHandle"] = { end: () => undefined };
+    this["initialized"] = true;
     this.server = new McpServer({ name: "test", version: "1.0.0" });
-  }
-
-  private runtimeState(): PrivateRuntimeState {
-    return this as unknown as PrivateRuntimeState;
   }
 }
 

--- a/packages/hosts/cloudflare/src/mcp/agent-session-model-resume.test.ts
+++ b/packages/hosts/cloudflare/src/mcp/agent-session-model-resume.test.ts
@@ -1,0 +1,559 @@
+import { afterEach, beforeEach, describe, expect, it } from "@effect/vitest";
+// oxlint-disable-next-line executor/no-vitest-import -- boundary: vi.mock must come from vitest itself for mock hoisting to resolve
+import { vi } from "vitest";
+import { Cause, Effect } from "effect";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { defaultMcpResource } from "@executor-js/host-mcp";
+import {
+  PAUSED_APPROVAL_TIMEOUT_MS,
+  formatMcpExecutionOutcome,
+} from "@executor-js/host-mcp/tool-server";
+import type {
+  ExecutionEngine,
+  ExecutionResult,
+  PausedExecutionDeadline,
+  ResumeResponse,
+} from "@executor-js/execution";
+
+import {
+  McpAgentSessionDOBase,
+  type BuiltMcpServer,
+  type McpApprovalOwner,
+  type McpSessionInit,
+  type McpSessionModelResumeResult,
+  type SessionMeta,
+} from "./agent-session-durable-object";
+import {
+  McpExecutionOwnerDirectoryDO,
+  mcpExecutionOwnerDirectoryFromNamespace,
+  mcpSessionDurableObjectName,
+  type McpExecutionOwnerDirectory,
+  type McpExecutionOwnerDirectoryNamespace,
+  type McpExecutionOwnerRecord,
+  type McpExecutionOwnerRoute,
+} from "./execution-owner-directory";
+
+vi.mock("agents/mcp", () => ({
+  McpAgent: class {
+    protected readonly ctx: DurableObjectState;
+
+    constructor(ctx: DurableObjectState) {
+      this.ctx = ctx;
+    }
+
+    getSessionId(): string {
+      return this.ctx.id.toString();
+    }
+
+    keepAlive(): Promise<() => void> {
+      return Promise.resolve(() => undefined);
+    }
+
+    getStreamRequestIds(): Promise<readonly (string | number)[]> {
+      return Promise.resolve([]);
+    }
+
+    onConnect(): Promise<void> {
+      return Promise.resolve();
+    }
+
+    alarm(): Promise<void> {
+      return Promise.resolve();
+    }
+
+    destroy(): Promise<void> {
+      return Promise.resolve();
+    }
+  },
+}));
+
+class FakeStorage {
+  private readonly values = new Map<string, unknown>();
+  alarmAt: number | null = null;
+
+  async get<T>(key: string): Promise<T | undefined> {
+    return this.values.get(key) as T | undefined;
+  }
+
+  async put<T>(key: string, value: T): Promise<void> {
+    this.values.set(key, value);
+  }
+
+  async delete(key: string): Promise<boolean> {
+    return this.values.delete(key);
+  }
+
+  async setAlarm(scheduledTime: number | Date): Promise<void> {
+    this.alarmAt = scheduledTime instanceof Date ? scheduledTime.getTime() : scheduledTime;
+  }
+
+  async deleteAlarm(): Promise<void> {
+    this.alarmAt = null;
+  }
+}
+
+class FakeDurableObjectState {
+  readonly storage = new FakeStorage();
+  readonly id: DurableObjectId;
+  readonly ctx = this;
+  private waitUntilPromises: Promise<unknown>[] = [];
+
+  constructor(name: string) {
+    this.id = {
+      equals: (other: DurableObjectId) => other.toString() === name,
+      name,
+      toString: () => name,
+    } as unknown as DurableObjectId;
+  }
+
+  waitUntil(promise: Promise<unknown>): void {
+    this.waitUntilPromises.push(promise);
+  }
+
+  async flushWaitUntil(): Promise<void> {
+    while (this.waitUntilPromises.length > 0) {
+      const pending = this.waitUntilPromises.splice(0);
+      await Promise.all(pending);
+    }
+  }
+
+  blockConcurrencyWhile<T>(callback: () => Promise<T>): Promise<T> {
+    return callback();
+  }
+}
+
+class InMemoryExecutionOwnerDirectoryNamespace implements McpExecutionOwnerDirectoryNamespace<string> {
+  private readonly directories = new Map<string, McpExecutionOwnerDirectoryDO>();
+
+  idFromName(name: string): string {
+    return name;
+  }
+
+  get(id: string): McpExecutionOwnerDirectoryDO {
+    let directory = this.directories.get(id);
+    if (!directory) {
+      directory = new McpExecutionOwnerDirectoryDO({
+        storage: new FakeStorage(),
+      } as unknown as DurableObjectState);
+      this.directories.set(id, directory);
+    }
+    return directory;
+  }
+}
+
+type TestDbHandle = {
+  readonly end: () => void;
+};
+
+type ResumeCall = {
+  readonly executionId: string;
+  readonly response: ResumeResponse;
+};
+
+const completed = (result: unknown): ExecutionResult => ({
+  status: "completed",
+  result: { result },
+});
+
+const makeEngine = (
+  resultForResume: (executionId: string, response: ResumeResponse) => ExecutionResult | null,
+) => {
+  const calls: ResumeCall[] = [];
+  const resume = vi.fn((executionId: string, response: ResumeResponse) =>
+    Effect.sync(() => {
+      calls.push({ executionId, response });
+      return resultForResume(executionId, response);
+    }),
+  );
+  const engine: ExecutionEngine<Cause.YieldableError> = {
+    execute: () => Effect.succeed({ result: "execute-result" }),
+    executeWithPause: () => Effect.succeed(completed("execute-result")),
+    resume,
+    getPausedExecution: () => Effect.succeed(null),
+    pausedExecutionCount: () => Effect.succeed(0),
+    hasPausedExecutions: () => Effect.succeed(false),
+    getDescription: Effect.succeed("test engine"),
+  };
+  return { calls, engine, resume };
+};
+
+const sessionMeta = (input?: Partial<SessionMeta>): SessionMeta => ({
+  organizationId: "org_1",
+  organizationName: "Test Org",
+  userId: "acct_1",
+  elicitationMode: "model",
+  resource: defaultMcpResource,
+  ...input,
+});
+
+const deadline = (): PausedExecutionDeadline => ({
+  expiresAt: new Date(Date.now() + PAUSED_APPROVAL_TIMEOUT_MS).toISOString(),
+  ttlMs: PAUSED_APPROVAL_TIMEOUT_MS,
+});
+
+const approval = {
+  action: "accept",
+  content: { approved: true },
+} satisfies ResumeResponse;
+
+type PendingApprovalLeaseSnapshot = {
+  readonly timeout: ReturnType<typeof setTimeout> | null;
+};
+
+type PrivateRuntimeState = {
+  engine: ExecutionEngine<Cause.YieldableError> | null;
+  dbHandle: TestDbHandle | null;
+  initialized: boolean;
+  pendingApprovalLeases: Map<string, PendingApprovalLeaseSnapshot>;
+};
+
+class HarnessSession extends McpAgentSessionDOBase<Cloudflare.Env, TestDbHandle> {
+  private readonly meta: SessionMeta;
+  private readonly fakeState: FakeDurableObjectState;
+  private readonly directory: McpExecutionOwnerDirectory | null;
+  private readonly modelResumeForward: (
+    owner: McpExecutionOwnerRoute,
+    identity: McpApprovalOwner,
+    executionId: string,
+    response: ResumeResponse,
+  ) => Effect.Effect<McpSessionModelResumeResult, unknown>;
+  activeKeepAlives = 0;
+
+  constructor(input: {
+    readonly sessionId: string;
+    readonly meta?: SessionMeta;
+    readonly engine: ExecutionEngine<Cause.YieldableError>;
+    readonly directoryNamespace: McpExecutionOwnerDirectoryNamespace<string>;
+    readonly forwardModelResumeToOwner?: HarnessSession["modelResumeForward"];
+  }) {
+    const state = new FakeDurableObjectState(input.sessionId);
+    super(state as unknown as DurableObjectState, {} as Cloudflare.Env);
+    this.fakeState = state;
+    this.meta = input.meta ?? sessionMeta();
+    this.directory = mcpExecutionOwnerDirectoryFromNamespace(input.directoryNamespace);
+    this.modelResumeForward =
+      input.forwardModelResumeToOwner ??
+      (() =>
+        Effect.succeed({
+          status: "execution_expired",
+          ttlMs: PAUSED_APPROVAL_TIMEOUT_MS,
+        }));
+    this.installRuntime(input.engine);
+  }
+
+  protected override get sessionId(): string {
+    return this.fakeState.id.toString();
+  }
+
+  protected override executionOwnerDirectory(): McpExecutionOwnerDirectory | null {
+    return this.directory;
+  }
+
+  protected override forwardModelResumeToOwner(
+    owner: McpExecutionOwnerRoute,
+    identity: McpApprovalOwner,
+    executionId: string,
+    response: ResumeResponse,
+  ): Effect.Effect<McpSessionModelResumeResult, unknown> {
+    return this.modelResumeForward(owner, identity, executionId, response);
+  }
+
+  protected override openSessionDb(): TestDbHandle {
+    return { end: () => undefined };
+  }
+
+  protected override resolveSessionMeta(token: McpSessionInit): Effect.Effect<SessionMeta> {
+    return Effect.succeed(
+      sessionMeta({ organizationId: token.organizationId, userId: token.userId }),
+    );
+  }
+
+  protected override buildMcpServer(): Effect.Effect<BuiltMcpServer> {
+    const runtime = this.runtimeState();
+    return Effect.succeed({
+      mcpServer: new McpServer({ name: "test", version: "1.0.0" }),
+      engine: runtime.engine!,
+    });
+  }
+
+  override keepAlive(): Promise<() => void> {
+    this.activeKeepAlives += 1;
+    return Promise.resolve(() => {
+      this.activeKeepAlives -= 1;
+    });
+  }
+
+  async storeSessionMeta(): Promise<void> {
+    await this.fakeState.storage.put("session-meta", this.meta);
+  }
+
+  async startPause(executionId: string): Promise<void> {
+    await Effect.runPromise(
+      this.pausedExecutionHooks.onExecutionPaused?.(executionId, deadline()) ?? Effect.void,
+    );
+    await this.fakeState.flushWaitUntil();
+  }
+
+  async resumeViaModelTool(
+    executionId: string,
+    response: ResumeResponse,
+  ): Promise<McpSessionModelResumeResult | null> {
+    const local = await Effect.runPromise(
+      this.runtimeState().engine!.resume(executionId, response),
+    );
+    if (local) return { status: "result", result: formatMcpExecutionOutcome(local) };
+    return Effect.runPromise(this.modelResumeFallback(executionId, response));
+  }
+
+  pendingLease(executionId: string): PendingApprovalLeaseSnapshot | undefined {
+    return this.runtimeState().pendingApprovalLeases.get(executionId);
+  }
+
+  pendingLeaseCount(): number {
+    return this.runtimeState().pendingApprovalLeases.size;
+  }
+
+  private installRuntime(engine: ExecutionEngine<Cause.YieldableError>): void {
+    const runtime = this.runtimeState();
+    runtime.engine = engine;
+    runtime.dbHandle = { end: () => undefined };
+    runtime.initialized = true;
+    this.server = new McpServer({ name: "test", version: "1.0.0" });
+  }
+
+  private runtimeState(): PrivateRuntimeState {
+    return this as unknown as PrivateRuntimeState;
+  }
+}
+
+const makeDirectory = () => {
+  const namespace = new InMemoryExecutionOwnerDirectoryNamespace();
+  const directory = mcpExecutionOwnerDirectoryFromNamespace(namespace);
+  expect(directory).not.toBeNull();
+  return { directory: directory!, namespace };
+};
+
+const putOwnerRecord = (
+  directory: McpExecutionOwnerDirectory,
+  input: Partial<McpExecutionOwnerRecord>,
+) =>
+  Effect.runPromise(
+    directory.put({
+      executionId: "exec_1",
+      owner: { sessionId: "session-a" },
+      accountId: "acct_1",
+      organizationId: "org_1",
+      expiresAt: new Date(Date.now() + PAUSED_APPROVAL_TIMEOUT_MS).toISOString(),
+      ttlMs: PAUSED_APPROVAL_TIMEOUT_MS,
+      ...input,
+    }),
+  );
+
+const flushMicrotasks = async (): Promise<void> => {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+describe("mcpSessionDurableObjectName", () => {
+  it("uses the Agents streamable-http durable object name", () => {
+    expect(mcpSessionDurableObjectName("session_123")).toBe("streamable-http:session_123");
+  });
+});
+
+describe("McpAgentSessionDOBase cross-session model resume", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("routes a session B resume through the real directory path to session A and releases A's lease", async () => {
+    const { directory, namespace } = makeDirectory();
+    const ownerEngine = makeEngine((executionId, response) =>
+      executionId === "exec_owner" && response.action === "accept"
+        ? completed("owner-result")
+        : null,
+    );
+    const requesterEngine = makeEngine(() => null);
+    const sessions = new Map<string, HarnessSession>();
+    const sessionNamespace = {
+      idFromName: (name: string) => name,
+      get: (id: string) => sessions.get(id),
+    };
+    const forward = vi.fn(
+      (
+        owner: McpExecutionOwnerRoute,
+        identity: McpApprovalOwner,
+        executionId: string,
+        response: ResumeResponse,
+      ) =>
+        Effect.promise(async () => {
+          const session = sessionNamespace.get(
+            sessionNamespace.idFromName(mcpSessionDurableObjectName(owner.sessionId)),
+          );
+          return session
+            ? session.resumeExecutionForModel(executionId, identity, response)
+            : {
+                status: "execution_expired" as const,
+                ttlMs: PAUSED_APPROVAL_TIMEOUT_MS,
+              };
+        }),
+    );
+
+    const sessionA = new HarnessSession({
+      sessionId: "session-a",
+      engine: ownerEngine.engine,
+      directoryNamespace: namespace,
+    });
+    const sessionB = new HarnessSession({
+      sessionId: "session-b",
+      engine: requesterEngine.engine,
+      directoryNamespace: namespace,
+      forwardModelResumeToOwner: forward,
+    });
+    sessions.set(mcpSessionDurableObjectName("session-a"), sessionA);
+    await sessionA.storeSessionMeta();
+    await sessionB.storeSessionMeta();
+
+    await sessionA.startPause("exec_owner");
+
+    expect(await Effect.runPromise(directory.get("exec_owner"))).toMatchObject({
+      executionId: "exec_owner",
+      owner: { sessionId: "session-a" },
+      accountId: "acct_1",
+      organizationId: "org_1",
+    });
+    expect(sessionA.pendingLeaseCount()).toBe(1);
+    expect(sessionA.pendingLease("exec_owner")?.timeout).not.toBeNull();
+    expect(vi.getTimerCount()).toBe(1);
+
+    const outcome = await sessionB.resumeViaModelTool("exec_owner", approval);
+    await flushMicrotasks();
+
+    expect(outcome).toMatchObject({
+      status: "result",
+      result: {
+        structuredContent: {
+          status: "completed",
+          result: "owner-result",
+        },
+      },
+    });
+    expect(forward).toHaveBeenCalledTimes(1);
+    expect(requesterEngine.resume).toHaveBeenCalledTimes(1);
+    expect(ownerEngine.resume).toHaveBeenCalledTimes(1);
+    expect(ownerEngine.calls).toEqual([{ executionId: "exec_owner", response: approval }]);
+    expect(sessionA.pendingLeaseCount()).toBe(0);
+    expect(sessionA.activeKeepAlives).toBe(0);
+    expect(vi.getTimerCount()).toBe(0);
+    expect(await Effect.runPromise(directory.get("exec_owner"))).toBeNull();
+
+    await vi.advanceTimersByTimeAsync(PAUSED_APPROVAL_TIMEOUT_MS + 1);
+    await flushMicrotasks();
+
+    expect(ownerEngine.resume).toHaveBeenCalledTimes(1);
+    expect(ownerEngine.calls).toEqual([{ executionId: "exec_owner", response: approval }]);
+  });
+
+  it("rejects identity mismatch without invoking the owning session engine", async () => {
+    const { directory, namespace } = makeDirectory();
+    const ownerEngine = makeEngine(() => completed("should-not-run"));
+    const requesterEngine = makeEngine(() => null);
+    const forward = vi.fn(() =>
+      Effect.succeed({
+        status: "execution_expired" as const,
+        ttlMs: PAUSED_APPROVAL_TIMEOUT_MS,
+      }),
+    );
+    const sessionA = new HarnessSession({
+      sessionId: "session-a",
+      engine: ownerEngine.engine,
+      directoryNamespace: namespace,
+    });
+    const sessionB = new HarnessSession({
+      sessionId: "session-b",
+      meta: sessionMeta({ organizationId: "org_other" }),
+      engine: requesterEngine.engine,
+      directoryNamespace: namespace,
+      forwardModelResumeToOwner: forward,
+    });
+    await sessionA.storeSessionMeta();
+    await sessionB.storeSessionMeta();
+    await sessionA.startPause("exec_forbidden");
+
+    const outcome = await sessionB.resumeViaModelTool("exec_forbidden", approval);
+
+    expect(outcome).toEqual({ status: "execution_forbidden" });
+    expect(forward).not.toHaveBeenCalled();
+    expect(ownerEngine.resume).not.toHaveBeenCalled();
+    expect(sessionA.pendingLeaseCount()).toBe(1);
+    expect(await Effect.runPromise(directory.get("exec_forbidden"))).toMatchObject({
+      executionId: "exec_forbidden",
+      owner: { sessionId: "session-a" },
+    });
+  });
+
+  it("times out a wedged owner session forward as execution_expired", async () => {
+    const { directory, namespace } = makeDirectory();
+    const requesterEngine = makeEngine(() => null);
+    const forward = vi.fn(() => Effect.never);
+    const sessionB = new HarnessSession({
+      sessionId: "session-b",
+      engine: requesterEngine.engine,
+      directoryNamespace: namespace,
+      forwardModelResumeToOwner: forward,
+    });
+    await sessionB.storeSessionMeta();
+    await putOwnerRecord(directory, {
+      executionId: "exec_timeout",
+      owner: { sessionId: "session-a" },
+    });
+
+    const pending = sessionB.resumeViaModelTool("exec_timeout", approval);
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    await expect(pending).resolves.toEqual({
+      status: "execution_expired",
+      ttlMs: PAUSED_APPROVAL_TIMEOUT_MS,
+    });
+    expect(forward).toHaveBeenCalledTimes(1);
+    expect(await Effect.runPromise(directory.get("exec_timeout"))).toBeNull();
+  });
+
+  it("does not recurse when the directory maps a local miss back to the same session", async () => {
+    const { directory, namespace } = makeDirectory();
+    const engine = makeEngine(() => null);
+    const forward = vi.fn(() =>
+      Effect.succeed({
+        status: "result" as const,
+        result: formatMcpExecutionOutcome(completed("should-not-forward")),
+      }),
+    );
+    const sessionB = new HarnessSession({
+      sessionId: "session-b",
+      engine: engine.engine,
+      directoryNamespace: namespace,
+      forwardModelResumeToOwner: forward,
+    });
+    await sessionB.storeSessionMeta();
+    await putOwnerRecord(directory, {
+      executionId: "exec_self",
+      owner: { sessionId: "session-b" },
+    });
+
+    const outcome = await sessionB.resumeViaModelTool("exec_self", approval);
+
+    expect(outcome).toEqual({
+      status: "execution_expired",
+      ttlMs: PAUSED_APPROVAL_TIMEOUT_MS,
+    });
+    expect(engine.resume).toHaveBeenCalledTimes(1);
+    expect(forward).not.toHaveBeenCalled();
+    expect(await Effect.runPromise(directory.get("exec_self"))).toBeNull();
+  });
+});

--- a/packages/hosts/cloudflare/src/mcp/execution-owner-directory.test.ts
+++ b/packages/hosts/cloudflare/src/mcp/execution-owner-directory.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import {
+  McpExecutionOwnerDirectoryDO,
+  type McpExecutionOwnerRecord,
+} from "./execution-owner-directory";
+
+class FakeStorage {
+  private readonly values = new Map<string, unknown>();
+  alarmAt: number | null = null;
+
+  async get<T>(key: string): Promise<T | undefined> {
+    return this.values.get(key) as T | undefined;
+  }
+
+  async put<T>(key: string, value: T): Promise<void> {
+    this.values.set(key, value);
+  }
+
+  async delete(key: string): Promise<boolean> {
+    return this.values.delete(key);
+  }
+
+  async setAlarm(scheduledTime: number | Date): Promise<void> {
+    this.alarmAt = scheduledTime instanceof Date ? scheduledTime.getTime() : scheduledTime;
+  }
+
+  async deleteAlarm(): Promise<void> {
+    this.alarmAt = null;
+  }
+}
+
+const makeDirectory = () => {
+  const storage = new FakeStorage();
+  const directory = new McpExecutionOwnerDirectoryDO({
+    storage,
+  } as unknown as DurableObjectState);
+  return { directory, storage };
+};
+
+const record = (input?: Partial<McpExecutionOwnerRecord>): McpExecutionOwnerRecord => ({
+  executionId: "exec_1",
+  owner: { sessionId: "session_a" },
+  accountId: "acct_1",
+  organizationId: "org_1",
+  expiresAt: new Date(Date.now() + 60_000).toISOString(),
+  ttlMs: 60_000,
+  ...input,
+});
+
+describe("McpExecutionOwnerDirectoryDO", () => {
+  it("stores and reads an unexpired execution owner record", async () => {
+    const { directory, storage } = makeDirectory();
+    const entry = record();
+
+    await directory.put(entry);
+
+    expect(await directory.get("exec_1")).toEqual(entry);
+    expect(storage.alarmAt).toBe(Date.parse(entry.expiresAt));
+  });
+
+  it("treats expired records as absent and deletes them", async () => {
+    const { directory, storage } = makeDirectory();
+    const entry = record({
+      expiresAt: new Date(Date.now() - 1_000).toISOString(),
+    });
+
+    await directory.put(entry);
+
+    expect(await directory.get("exec_1")).toBeNull();
+    expect(await storage.get("owner")).toBeUndefined();
+    expect(storage.alarmAt).toBeNull();
+  });
+
+  it("alarm deletes the owner record", async () => {
+    const { directory, storage } = makeDirectory();
+    await directory.put(record());
+
+    await directory.alarm();
+
+    expect(await storage.get("owner")).toBeUndefined();
+    expect(storage.alarmAt).toBeNull();
+  });
+});

--- a/packages/hosts/cloudflare/src/mcp/execution-owner-directory.test.ts
+++ b/packages/hosts/cloudflare/src/mcp/execution-owner-directory.test.ts
@@ -34,7 +34,7 @@ const makeDirectory = () => {
   const storage = new FakeStorage();
   const directory = new McpExecutionOwnerDirectoryDO({
     storage,
-  } as unknown as DurableObjectState);
+  });
   return { directory, storage };
 };
 

--- a/packages/hosts/cloudflare/src/mcp/execution-owner-directory.ts
+++ b/packages/hosts/cloudflare/src/mcp/execution-owner-directory.ts
@@ -30,6 +30,21 @@ export interface McpExecutionOwnerDirectoryNamespace<Id> {
   readonly get: (id: Id) => unknown;
 }
 
+interface McpExecutionOwnerDirectoryStorage {
+  readonly get: <T>(key: string) => Promise<T | undefined>;
+  readonly put: <T>(key: string, value: T) => Promise<void>;
+  readonly delete: (key: string) => Promise<boolean>;
+  readonly setAlarm: (scheduledTime: number | Date) => Promise<void>;
+  readonly deleteAlarm: () => Promise<void>;
+}
+
+interface McpExecutionOwnerDirectoryState {
+  readonly storage: McpExecutionOwnerDirectoryStorage;
+}
+
+const toMcpExecutionOwnerDirectoryStub = (stub: unknown): McpExecutionOwnerDirectoryStub =>
+  stub as McpExecutionOwnerDirectoryStub;
+
 export const mcpSessionDurableObjectName = (sessionId: string): string =>
   `streamable-http:${sessionId}`;
 
@@ -59,9 +74,9 @@ const isOwnerRecord = (value: unknown): value is McpExecutionOwnerRecord =>
 const expiryMs = (record: McpExecutionOwnerRecord): number => Date.parse(record.expiresAt);
 
 export class McpExecutionOwnerDirectoryDO {
-  private readonly storage: DurableObjectStorage;
+  private readonly storage: McpExecutionOwnerDirectoryStorage;
 
-  constructor(ctx: DurableObjectState) {
+  constructor(ctx: McpExecutionOwnerDirectoryState) {
     this.storage = ctx.storage;
   }
 
@@ -99,7 +114,7 @@ export const mcpExecutionOwnerDirectoryFromNamespace = <Id>(
 ): McpExecutionOwnerDirectory | null => {
   if (!namespace) return null;
   const stubFor = (executionId: string): McpExecutionOwnerDirectoryStub =>
-    namespace.get(namespace.idFromName(executionId)) as unknown as McpExecutionOwnerDirectoryStub;
+    toMcpExecutionOwnerDirectoryStub(namespace.get(namespace.idFromName(executionId)));
   return {
     put: (record) =>
       Effect.tryPromise({

--- a/packages/hosts/cloudflare/src/mcp/execution-owner-directory.ts
+++ b/packages/hosts/cloudflare/src/mcp/execution-owner-directory.ts
@@ -1,0 +1,117 @@
+import { Data, Effect } from "effect";
+
+export type McpExecutionOwnerRoute = {
+  readonly sessionId: string;
+};
+
+export type McpExecutionOwnerRecord = {
+  readonly executionId: string;
+  readonly owner: McpExecutionOwnerRoute;
+  readonly accountId: string;
+  readonly organizationId: string;
+  readonly expiresAt: string;
+  readonly ttlMs: number;
+};
+
+export interface McpExecutionOwnerDirectory {
+  readonly put: (record: McpExecutionOwnerRecord) => Effect.Effect<void, unknown>;
+  readonly get: (executionId: string) => Effect.Effect<McpExecutionOwnerRecord | null, unknown>;
+  readonly delete: (executionId: string) => Effect.Effect<void, unknown>;
+}
+
+export interface McpExecutionOwnerDirectoryStub {
+  readonly put: (record: McpExecutionOwnerRecord) => Promise<void>;
+  readonly get: (executionId: string) => Promise<McpExecutionOwnerRecord | null>;
+  readonly delete: (executionId: string) => Promise<void>;
+}
+
+export interface McpExecutionOwnerDirectoryNamespace<Id> {
+  readonly idFromName: (name: string) => Id;
+  readonly get: (id: Id) => unknown;
+}
+
+class McpExecutionOwnerDirectoryRpcError extends Data.TaggedError(
+  "McpExecutionOwnerDirectoryRpcError",
+)<{
+  readonly cause: unknown;
+}> {}
+
+const RECORD_KEY = "owner";
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const isOwnerRoute = (value: unknown): value is McpExecutionOwnerRoute =>
+  isRecord(value) && typeof value.sessionId === "string";
+
+const isOwnerRecord = (value: unknown): value is McpExecutionOwnerRecord =>
+  isRecord(value) &&
+  typeof value.executionId === "string" &&
+  isOwnerRoute(value.owner) &&
+  typeof value.accountId === "string" &&
+  typeof value.organizationId === "string" &&
+  typeof value.expiresAt === "string" &&
+  typeof value.ttlMs === "number";
+
+const expiryMs = (record: McpExecutionOwnerRecord): number => Date.parse(record.expiresAt);
+
+export class McpExecutionOwnerDirectoryDO {
+  private readonly storage: DurableObjectStorage;
+
+  constructor(ctx: DurableObjectState) {
+    this.storage = ctx.storage;
+  }
+
+  async put(record: McpExecutionOwnerRecord): Promise<void> {
+    const expiresAtMs = expiryMs(record);
+    if (!Number.isFinite(expiresAtMs)) return;
+    await this.storage.put(RECORD_KEY, record);
+    await this.storage.setAlarm(expiresAtMs);
+  }
+
+  async get(executionId: string): Promise<McpExecutionOwnerRecord | null> {
+    const stored = await this.storage.get<unknown>(RECORD_KEY);
+    if (!isOwnerRecord(stored) || stored.executionId !== executionId) return null;
+    const expiresAtMs = expiryMs(stored);
+    if (!Number.isFinite(expiresAtMs) || expiresAtMs <= Date.now()) {
+      await this.delete(executionId);
+      return null;
+    }
+    return stored;
+  }
+
+  async delete(executionId: string): Promise<void> {
+    const stored = await this.storage.get<unknown>(RECORD_KEY);
+    if (isOwnerRecord(stored) && stored.executionId !== executionId) return;
+    await Promise.all([this.storage.delete(RECORD_KEY), this.storage.deleteAlarm()]);
+  }
+
+  async alarm(): Promise<void> {
+    await Promise.all([this.storage.delete(RECORD_KEY), this.storage.deleteAlarm()]);
+  }
+}
+
+export const mcpExecutionOwnerDirectoryFromNamespace = <Id>(
+  namespace: McpExecutionOwnerDirectoryNamespace<Id> | undefined,
+): McpExecutionOwnerDirectory | null => {
+  if (!namespace) return null;
+  const stubFor = (executionId: string): McpExecutionOwnerDirectoryStub =>
+    namespace.get(namespace.idFromName(executionId)) as unknown as McpExecutionOwnerDirectoryStub;
+  return {
+    put: (record) =>
+      Effect.tryPromise({
+        try: () => stubFor(record.executionId).put(record),
+        catch: (cause) => new McpExecutionOwnerDirectoryRpcError({ cause }),
+      }),
+    get: (executionId) =>
+      Effect.tryPromise({
+        try: () => stubFor(executionId).get(executionId),
+        catch: (cause) => new McpExecutionOwnerDirectoryRpcError({ cause }),
+      }),
+    delete: (executionId) =>
+      Effect.tryPromise({
+        try: () => stubFor(executionId).delete(executionId),
+        catch: (cause) => new McpExecutionOwnerDirectoryRpcError({ cause }),
+      }),
+  };
+};

--- a/packages/hosts/cloudflare/src/mcp/execution-owner-directory.ts
+++ b/packages/hosts/cloudflare/src/mcp/execution-owner-directory.ts
@@ -30,6 +30,9 @@ export interface McpExecutionOwnerDirectoryNamespace<Id> {
   readonly get: (id: Id) => unknown;
 }
 
+export const mcpSessionDurableObjectName = (sessionId: string): string =>
+  `streamable-http:${sessionId}`;
+
 class McpExecutionOwnerDirectoryRpcError extends Data.TaggedError(
   "McpExecutionOwnerDirectoryRpcError",
 )<{

--- a/packages/hosts/mcp/src/tool-server.test.ts
+++ b/packages/hosts/mcp/src/tool-server.test.ts
@@ -16,7 +16,11 @@ import {
 import type { ToolFileValue } from "@executor-js/sdk";
 import type { ExecutionEngine, ExecutionResult } from "@executor-js/execution";
 
-import { createExecutorMcpServer, type ExecutorMcpServerConfig } from "./tool-server";
+import {
+  createExecutorMcpServer,
+  formatMcpExecutionOutcome,
+  type ExecutorMcpServerConfig,
+} from "./tool-server";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -30,6 +34,7 @@ const makeStubEngine = <E extends Cause.YieldableError = never>(overrides: {
   execute?: ExecutionEngine<E>["execute"];
   executeWithPause?: ExecutionEngine<E>["executeWithPause"];
   resume?: ExecutionEngine<E>["resume"];
+  isExecutionSettled?: ExecutionEngine<E>["isExecutionSettled"];
   description?: string;
 }): ExecutionEngine<E> => ({
   execute: overrides.execute ?? (() => Effect.succeed({ result: "default" })),
@@ -37,6 +42,7 @@ const makeStubEngine = <E extends Cause.YieldableError = never>(overrides: {
     overrides.executeWithPause ??
     (() => Effect.succeed({ status: "completed", result: { result: "default" } })),
   resume: overrides.resume ?? (() => Effect.succeed(null)),
+  isExecutionSettled: overrides.isExecutionSettled,
   getPausedExecution: () => Effect.succeed(null),
   pausedExecutionCount: () => Effect.succeed(0),
   hasPausedExecutions: () => Effect.succeed(false),
@@ -50,7 +56,12 @@ const withClient = async <E extends Cause.YieldableError>(
   fn: (client: Client) => Promise<void>,
   config?: Pick<
     ExecutorMcpServerConfig<E>,
-    "debug" | "elicitationMode" | "browserApprovalStore" | "pausedExecutionHooks"
+    | "debug"
+    | "elicitationMode"
+    | "browserApprovalStore"
+    | "pausedExecutionHooks"
+    | "pausedExecutionLeaseMs"
+    | "resumeFallback"
   >,
 ) => {
   const mcpServer = await Effect.runPromise(createExecutorMcpServer({ engine, ...config }));
@@ -1100,6 +1111,7 @@ describe("MCP host server — client without elicitation (pause/resume)", () => 
   });
 
   it("resume tool completes a paused execution when model resume is explicitly enabled", async () => {
+    let fallbackCalled = false;
     const engine = makeStubEngine({
       resume: (executionId, response) =>
         Effect.succeed(
@@ -1119,8 +1131,97 @@ describe("MCP host server — client without elicitation (pause/resume)", () => 
         });
         expect(result.content).toEqual([{ type: "text", text: "resumed-ok" }]);
         expect(result.isError).toBeFalsy();
+        expect(fallbackCalled).toBe(false);
       },
-      { elicitationMode: { mode: "model" } },
+      {
+        elicitationMode: { mode: "model" },
+        resumeFallback: () =>
+          Effect.sync(() => {
+            fallbackCalled = true;
+            return null;
+          }),
+      },
+    );
+  });
+
+  it("model resume can fall back to an owning session and return its resumed result", async () => {
+    const ownerEvents: string[] = [];
+    const ownerEngine = makeStubEngine({
+      resume: (executionId, response) =>
+        Effect.succeed(
+          executionId === "exec_owner" && response.action === "accept"
+            ? { status: "completed", result: { result: "owner-resumed" } }
+            : null,
+        ),
+    });
+    const engine = makeStubEngine({ resume: () => Effect.succeed(null) });
+
+    await withClient(
+      engine,
+      NO_CAPS,
+      async (client) => {
+        const result = await client.callTool({
+          name: "resume",
+          arguments: { executionId: "exec_owner", action: "accept", content: "{}" },
+        });
+
+        expect(result.content).toEqual([{ type: "text", text: "owner-resumed" }]);
+        expect(result.structuredContent).toMatchObject({
+          status: "completed",
+          result: "owner-resumed",
+        });
+        expect(result.isError).toBeFalsy();
+        expect(ownerEvents).toEqual(["resume-start:exec_owner", "resume-settle:exec_owner"]);
+      },
+      {
+        elicitationMode: { mode: "model" },
+        resumeFallback: (executionId, response) =>
+          Effect.gen(function* () {
+            ownerEvents.push(`resume-start:${executionId}`);
+            const outcome = yield* ownerEngine
+              .resume(executionId, response)
+              .pipe(
+                Effect.ensuring(
+                  Effect.sync(() => ownerEvents.push(`resume-settle:${executionId}`)),
+                ),
+              );
+            return outcome
+              ? { status: "result" as const, result: formatMcpExecutionOutcome(outcome) }
+              : { status: "execution_expired" as const, ttlMs: 240_000 };
+          }),
+      },
+    );
+  });
+
+  it("cross-session identity mismatch returns execution_forbidden and leaves owner pause untouched", async () => {
+    let ownerResumeCalled = false;
+    const engine = makeStubEngine({ resume: () => Effect.succeed(null) });
+
+    await withClient(
+      engine,
+      NO_CAPS,
+      async (client) => {
+        const result = await client.callTool({
+          name: "resume",
+          arguments: { executionId: "exec_owner", action: "accept", content: "{}" },
+        });
+
+        expect(result.isError).toBe(true);
+        expect(result.structuredContent).toMatchObject({
+          status: "execution_forbidden",
+          executionId: "exec_owner",
+        });
+        expect(textOf(result)).toContain("same account and organization");
+        expect(ownerResumeCalled).toBe(false);
+      },
+      {
+        elicitationMode: { mode: "model" },
+        resumeFallback: () =>
+          Effect.sync(() => {
+            ownerResumeCalled = false;
+            return { status: "execution_forbidden" as const };
+          }),
+      },
     );
   });
 
@@ -1236,8 +1337,160 @@ describe("MCP host server — client without elicitation (pause/resume)", () => 
         });
         expect(result.isError).toBe(true);
         expect(textOf(result)).toContain("does-not-exist");
+        expect(result.structuredContent).toMatchObject({
+          status: "execution_not_found",
+          executionId: "does-not-exist",
+        });
       },
       { elicitationMode: { mode: "model" } },
+    );
+  });
+
+  it("directory entry with a lost owner pause returns execution_expired", async () => {
+    const engine = makeStubEngine({ resume: () => Effect.succeed(null) });
+
+    await withClient(
+      engine,
+      NO_CAPS,
+      async (client) => {
+        const result = await client.callTool({
+          name: "resume",
+          arguments: { executionId: "exec_lost", action: "accept", content: "{}" },
+        });
+
+        expect(result.isError).toBe(true);
+        expect(result.structuredContent).toMatchObject({
+          status: "execution_expired",
+          executionId: "exec_lost",
+          ttlMs: 240_000,
+        });
+        expect(textOf(result)).toContain("Approval windows last 4 minutes");
+      },
+      {
+        elicitationMode: { mode: "model" },
+        resumeFallback: () =>
+          Effect.succeed({ status: "execution_expired" as const, ttlMs: 240_000 }),
+      },
+    );
+  });
+
+  it("directory mapping to the current session plus local miss returns execution_expired once", async () => {
+    let fallbackCalls = 0;
+    const engine = makeStubEngine({ resume: () => Effect.succeed(null) });
+
+    await withClient(
+      engine,
+      NO_CAPS,
+      async (client) => {
+        const result = await client.callTool({
+          name: "resume",
+          arguments: { executionId: "exec_current_lost", action: "accept", content: "{}" },
+        });
+
+        expect(result.isError).toBe(true);
+        expect(result.structuredContent).toMatchObject({
+          status: "execution_expired",
+          executionId: "exec_current_lost",
+        });
+        expect(fallbackCalls).toBe(1);
+      },
+      {
+        elicitationMode: { mode: "model" },
+        resumeFallback: () =>
+          Effect.sync(() => {
+            fallbackCalls += 1;
+            return { status: "execution_expired" as const, ttlMs: 240_000 };
+          }),
+      },
+    );
+  });
+
+  it("directory read failure degrades to execution_not_found", async () => {
+    const engine = makeStubEngine({ resume: () => Effect.succeed(null) });
+
+    await withClient(
+      engine,
+      NO_CAPS,
+      async (client) => {
+        const result = await client.callTool({
+          name: "resume",
+          arguments: { executionId: "exec_directory_down", action: "accept", content: "{}" },
+        });
+
+        expect(result.isError).toBe(true);
+        expect(result.structuredContent).toMatchObject({
+          status: "execution_not_found",
+          executionId: "exec_directory_down",
+        });
+      },
+      {
+        elicitationMode: { mode: "model" },
+        resumeFallback: () => Effect.fail("directory unavailable"),
+      },
+    );
+  });
+
+  it("local miss for a settled execution with no replay returns execution_already_settled", async () => {
+    const engine = makeStubEngine({
+      resume: () => Effect.succeed(null),
+      isExecutionSettled: () => Effect.succeed(true),
+    });
+
+    await withClient(
+      engine,
+      NO_CAPS,
+      async (client) => {
+        const result = await client.callTool({
+          name: "resume",
+          arguments: { executionId: "exec_settled", action: "accept", content: "{}" },
+        });
+
+        expect(result.isError).toBe(true);
+        expect(result.structuredContent).toMatchObject({
+          status: "execution_already_settled",
+          executionId: "exec_settled",
+        });
+        expect(textOf(result)).toContain("already settled");
+      },
+      { elicitationMode: { mode: "model" } },
+    );
+  });
+
+  it("pause payload includes expiresAt and ttlMs when the host supplies a lease duration", async () => {
+    const engine = makeStubEngine({
+      executeWithPause: () =>
+        Effect.succeed(
+          makePausedResult(
+            "exec_deadline",
+            FormElicitation.make({ message: "Approve soon", requestedSchema: {} }),
+          ),
+        ),
+    });
+
+    await withClient(
+      engine,
+      NO_CAPS,
+      async (client) => {
+        const before = Date.now();
+        const result = await client.callTool({
+          name: "execute",
+          arguments: { code: "pause-with-deadline" },
+        });
+        const after = Date.now();
+        const structured = result.structuredContent as Record<string, unknown>;
+        const expiresAt = structured.expiresAt as string;
+
+        expect(structured.ttlMs).toBe(60_000);
+        expect(typeof expiresAt).toBe("string");
+        const expiresAtMs = Date.parse(expiresAt);
+        expect(expiresAtMs).toBeGreaterThanOrEqual(before + 60_000);
+        expect(expiresAtMs).toBeLessThanOrEqual(after + 60_000);
+        expect(textOf(result)).toContain("resumeDeadline");
+        expect(textOf(result)).toContain("1 minute approval window");
+        const interaction = structured.interaction as Record<string, unknown>;
+        expect(interaction.instructions).toContain("Resume before");
+      },
+      { elicitationMode: { mode: "model" }, pausedExecutionLeaseMs: 60_000 },
     );
   });
 

--- a/packages/hosts/mcp/src/tool-server.test.ts
+++ b/packages/hosts/mcp/src/tool-server.test.ts
@@ -30,6 +30,10 @@ class TestExecutionError extends Data.TaggedError("TestExecutionError")<{
   readonly message: string;
 }> {}
 
+const expectString: (value: unknown) => asserts value is string = (value) => {
+  expect(typeof value).toBe("string");
+};
+
 const makeStubEngine = <E extends Cause.YieldableError = never>(overrides: {
   execute?: ExecutionEngine<E>["execute"];
   executeWithPause?: ExecutionEngine<E>["executeWithPause"];
@@ -1478,10 +1482,10 @@ describe("MCP host server — client without elicitation (pause/resume)", () => 
         });
         const after = Date.now();
         const structured = result.structuredContent as Record<string, unknown>;
-        const expiresAt = structured.expiresAt as string;
+        const expiresAt = structured.expiresAt;
 
         expect(structured.ttlMs).toBe(60_000);
-        expect(typeof expiresAt).toBe("string");
+        expectString(expiresAt);
         const expiresAtMs = Date.parse(expiresAt);
         expect(expiresAtMs).toBeGreaterThanOrEqual(before + 60_000);
         expect(expiresAtMs).toBeLessThanOrEqual(after + 60_000);

--- a/packages/hosts/mcp/src/tool-server.ts
+++ b/packages/hosts/mcp/src/tool-server.ts
@@ -23,6 +23,7 @@ import {
   createExecutionEngine,
   formatExecuteResult,
   formatPausedExecution,
+  formatTtlDuration,
   findSkill,
   renderSkillsIndex,
   EXECUTE_SKILL,
@@ -537,19 +538,6 @@ const toMcpFailureResult = (cause: Cause.Cause<unknown>): McpToolResult => {
     structuredContent: { status: "error", error: text },
     isError: true,
   };
-};
-
-// A paused execution lives in the session runtime's memory: it expires when
-// the user takes too long to answer, and dies early when the runtime is
-// rebuilt (host restart, redeploy). Either way the recovery is the same and
-// the model should be told it, not just handed a miss.
-const formatTtlDuration = (ttlMs: number): string => {
-  const seconds = Math.max(1, Math.round(ttlMs / 1000));
-  if (seconds % 60 === 0) {
-    const minutes = seconds / 60;
-    return `${minutes} minute${minutes === 1 ? "" : "s"}`;
-  }
-  return `${seconds} second${seconds === 1 ? "" : "s"}`;
 };
 
 const recoveryText =

--- a/packages/hosts/mcp/src/tool-server.ts
+++ b/packages/hosts/mcp/src/tool-server.ts
@@ -116,7 +116,7 @@ type SharedMcpServerConfig = {
   readonly resumeFallback?: (
     executionId: string,
     response: ResumeResponse,
-  ) => Effect.Effect<ResumeFallbackOutcome | null>;
+  ) => Effect.Effect<ResumeFallbackOutcome | null, unknown>;
 };
 
 export type ExecutorMcpServerConfig<E extends Cause.YieldableError = Cause.YieldableError> =

--- a/packages/hosts/mcp/src/tool-server.ts
+++ b/packages/hosts/mcp/src/tool-server.ts
@@ -30,6 +30,9 @@ import {
   type ExecutionEngine,
   type ExecutionEngineConfig,
   type ResumeResponse,
+  type ExecutionResult,
+  type PausedExecution,
+  type PausedExecutionDeadline,
 } from "@executor-js/execution";
 
 // ---------------------------------------------------------------------------
@@ -101,6 +104,19 @@ type SharedMcpServerConfig = {
    * wait, durable record, or no-op.
    */
   readonly pausedExecutionHooks?: PausedExecutionHooks;
+  /**
+   * Host-provided approval lease duration. When present, paused payloads carry
+   * an absolute deadline and hooks receive the same deadline.
+   */
+  readonly pausedExecutionLeaseMs?: number;
+  /**
+   * Optional host-owned model resume fallback. Used by Cloudflare session
+   * Durable Objects to route a resume miss to the session that owns the pause.
+   */
+  readonly resumeFallback?: (
+    executionId: string,
+    response: ResumeResponse,
+  ) => Effect.Effect<ResumeFallbackOutcome | null>;
 };
 
 export type ExecutorMcpServerConfig<E extends Cause.YieldableError = Cause.YieldableError> =
@@ -118,10 +134,32 @@ export const PAUSED_APPROVAL_TIMEOUT_MS = 4 * 60 * 1000;
 const BROWSER_APPROVAL_WAIT_TIMEOUT_MS = PAUSED_APPROVAL_TIMEOUT_MS + 1000;
 
 export type PausedExecutionHooks = {
-  readonly onExecutionPaused?: (executionId: string) => Effect.Effect<void>;
+  readonly onExecutionPaused?: (
+    executionId: string,
+    deadline: PausedExecutionDeadline | undefined,
+  ) => Effect.Effect<void>;
   readonly onResumeStarted?: (executionId: string) => Effect.Effect<void>;
   readonly onResumeSettled?: (executionId: string) => Effect.Effect<void>;
 };
+
+export type ResumeUnavailableStatus =
+  | "execution_not_found"
+  | "execution_expired"
+  | "execution_forbidden"
+  | "execution_already_settled";
+
+export type ResumeFallbackOutcome =
+  | {
+      readonly status: "result";
+      readonly result: McpToolResult;
+    }
+  | {
+      readonly status: Exclude<ResumeUnavailableStatus, "execution_not_found">;
+      readonly ttlMs?: number;
+    }
+  | {
+      readonly status: "execution_not_found";
+    };
 
 // ---------------------------------------------------------------------------
 // Elicitation bridge
@@ -276,7 +314,7 @@ const formatBoundaryError = (err: unknown): { name?: string; message: string; st
 // MCP result formatting
 // ---------------------------------------------------------------------------
 
-type McpToolResult = {
+export type McpToolResult = {
   content: ContentBlock[];
   structuredContent?: Record<string, unknown>;
   isError?: boolean;
@@ -430,6 +468,16 @@ const toMcpPausedResult = (formatted: ReturnType<typeof formatPausedExecution>):
   structuredContent: formatted.structured,
 });
 
+export const formatMcpExecutionOutcome = (
+  outcome: ExecutionResult,
+  options?: { readonly pausedDeadline?: PausedExecutionDeadline },
+): McpToolResult =>
+  outcome.status === "completed"
+    ? toMcpResult(outcome.result)
+    : toMcpPausedResult(
+        formatPausedExecution(outcome.execution, { deadline: options?.pausedDeadline }),
+      );
+
 // `execute` failures reaching the MCP host are infra defects — domain
 // failures from tools are now expressed as `ToolResult` values (success
 // channel) and flow through `formatExecuteResult`. Emit an opaque
@@ -495,24 +543,80 @@ const toMcpFailureResult = (cause: Cause.Cause<unknown>): McpToolResult => {
 // the user takes too long to answer, and dies early when the runtime is
 // rebuilt (host restart, redeploy). Either way the recovery is the same and
 // the model should be told it, not just handed a miss.
-const missingExecutionResult = (executionId: string): McpToolResult => ({
-  content: [
-    {
-      type: "text" as const,
-      text: [
-        `No paused execution: ${executionId}.`,
-        "The paused execution expired or was lost when its session was restarted — paused executions only stay resumable for a few minutes.",
-        "To recover, run the execute tool again with the original code; if it pauses, a fresh executionId will be issued.",
-      ].join(" "),
+const formatTtlDuration = (ttlMs: number): string => {
+  const seconds = Math.max(1, Math.round(ttlMs / 1000));
+  if (seconds % 60 === 0) {
+    const minutes = seconds / 60;
+    return `${minutes} minute${minutes === 1 ? "" : "s"}`;
+  }
+  return `${seconds} second${seconds === 1 ? "" : "s"}`;
+};
+
+const recoveryText =
+  "To recover, run the execute tool again with the original code; if it pauses, a fresh executionId will be issued.";
+
+const resumeUnavailableResult = (input: {
+  readonly status: ResumeUnavailableStatus;
+  readonly executionId: string;
+  readonly ttlMs?: number;
+}): McpToolResult => {
+  const windowMs = input.ttlMs ?? PAUSED_APPROVAL_TIMEOUT_MS;
+  const approvalWindow = formatTtlDuration(windowMs);
+  const textByStatus: Record<ResumeUnavailableStatus, string[]> = {
+    execution_not_found: [
+      `Paused execution is unknown: ${input.executionId}.`,
+      `Paused executions are only resumable for a limited window; this id may have expired or never existed.`,
+      recoveryText,
+    ],
+    execution_expired: [
+      `Paused execution expired: ${input.executionId}.`,
+      `Approval windows last ${approvalWindow}; the owning session no longer has a live pause for this executionId.`,
+      recoveryText,
+    ],
+    execution_forbidden: [
+      `Paused execution cannot be resumed by this authenticated identity: ${input.executionId}.`,
+      "Resume must be called by the same account and organization that owns the paused session.",
+    ],
+    execution_already_settled: [
+      `Paused execution has already settled: ${input.executionId}.`,
+      "The resume result is no longer available for replay.",
+      "Run execute again only if the result is still needed.",
+    ],
+  };
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: textByStatus[input.status].join(" "),
+      },
+    ],
+    structuredContent: {
+      status: input.status,
+      executionId: input.executionId,
+      ...(input.status === "execution_expired" ? { ttlMs: windowMs } : {}),
+      ...(input.status === "execution_forbidden" ? {} : { recovery: "re_execute" }),
     },
-  ],
-  structuredContent: {
-    status: "execution_not_found",
+    isError: true,
+  };
+};
+
+const missingExecutionResult = (executionId: string): McpToolResult =>
+  resumeUnavailableResult({ status: "execution_not_found", executionId });
+
+const alreadySettledResult = (executionId: string): McpToolResult =>
+  resumeUnavailableResult({ status: "execution_already_settled", executionId });
+
+const fallbackOutcomeResult = (
+  executionId: string,
+  outcome: ResumeFallbackOutcome,
+): McpToolResult => {
+  if (outcome.status === "result") return outcome.result;
+  return resumeUnavailableResult({
+    status: outcome.status,
     executionId,
-    recovery: "re_execute",
-  },
-  isError: true,
-});
+    ttlMs: "ttlMs" in outcome ? outcome.ttlMs : undefined,
+  });
+};
 
 // The `skills` tool serves named, static how-to docs (see the execution
 // package's skills registry). No name -> the index; a known name -> that
@@ -599,8 +703,17 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
       ({
         mode: "model",
       } as const);
-    const onExecutionPaused = (executionId: string): Effect.Effect<void> =>
-      config.pausedExecutionHooks?.onExecutionPaused?.(executionId) ?? Effect.void;
+    const pauseDeadline = (): PausedExecutionDeadline | undefined => {
+      const ttlMs = config.pausedExecutionLeaseMs;
+      return ttlMs === undefined || ttlMs <= 0
+        ? undefined
+        : { ttlMs, expiresAt: new Date(Date.now() + ttlMs).toISOString() };
+    };
+    const onExecutionPaused = (
+      executionId: string,
+      deadline: PausedExecutionDeadline | undefined,
+    ): Effect.Effect<void> =>
+      config.pausedExecutionHooks?.onExecutionPaused?.(executionId, deadline) ?? Effect.void;
     const onResumeStarted = (executionId: string): Effect.Effect<void> =>
       config.pausedExecutionHooks?.onResumeStarted?.(executionId) ?? Effect.void;
     const onResumeSettled = (executionId: string): Effect.Effect<void> =>
@@ -610,6 +723,32 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
         yield* onResumeStarted(executionId);
         return yield* engine.resume(executionId, response);
       }).pipe(Effect.ensuring(onResumeSettled(executionId)));
+
+    const localExecutionAlreadySettled = (executionId: string): Effect.Effect<boolean> =>
+      engine.isExecutionSettled?.(executionId) ?? Effect.succeed(false);
+
+    const resumeFallback = (
+      executionId: string,
+      response: ResumeResponse,
+    ): Effect.Effect<ResumeFallbackOutcome | null> =>
+      config
+        .resumeFallback?.(executionId, response)
+        .pipe(Effect.catchCause(() => Effect.succeed(null))) ?? Effect.succeed(null);
+
+    const formatPausedModelResult = (
+      execution: PausedExecution,
+      source: "execute" | "resume" | "browser_resume",
+    ): Effect.Effect<McpToolResult> =>
+      Effect.gen(function* () {
+        const deadline = pauseDeadline();
+        yield* Effect.annotateCurrentSpan({
+          "mcp.execute.paused": true,
+          "mcp.execute.paused_execution_id": execution.id,
+          "mcp.execute.pause_source": source,
+        });
+        yield* onExecutionPaused(execution.id, deadline);
+        return toMcpPausedResult(formatPausedExecution(execution, { deadline }));
+      });
 
     const resolveParentSpan = (): Tracer.AnySpan | undefined => {
       const ps = config.parentSpan;
@@ -661,18 +800,18 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
               : undefined,
         });
         if (outcome.status === "paused") {
+          const deadline = pauseDeadline();
           yield* Effect.annotateCurrentSpan({
             "mcp.execute.paused": true,
             "mcp.execute.paused_execution_id": outcome.execution.id,
             "mcp.execute.pause_source": "execute",
           });
-          yield* onExecutionPaused(outcome.execution.id);
-        }
-        return outcome.status === "completed"
-          ? toMcpResult(outcome.result)
-          : elicitationMode.mode === "browser"
+          yield* onExecutionPaused(outcome.execution.id, deadline);
+          return elicitationMode.mode === "browser"
             ? yield* requireUserResumeApproval(outcome.execution.id)
-            : toMcpPausedResult(formatPausedExecution(outcome.execution));
+            : toMcpPausedResult(formatPausedExecution(outcome.execution, { deadline }));
+        }
+        return toMcpResult(outcome.result);
       }).pipe(
         Effect.withSpan("mcp.host.tool.execute", {
           attributes: {
@@ -697,6 +836,14 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
         const outcome = yield* resumeWithLifecycle(executionId, { action, content });
         if (!outcome) {
           debugLog("resume.missing_execution", { executionId });
+          if (yield* localExecutionAlreadySettled(executionId)) {
+            return alreadySettledResult(executionId);
+          }
+          const fallback = yield* resumeFallback(executionId, { action, content });
+          if (fallback) {
+            debugLog("resume.fallback_result", { executionId, status: fallback.status });
+            return fallbackOutcomeResult(executionId, fallback);
+          }
           return missingExecutionResult(executionId);
         }
         debugLog("resume.result", {
@@ -709,16 +856,9 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
               : undefined,
         });
         if (outcome.status === "paused") {
-          yield* Effect.annotateCurrentSpan({
-            "mcp.execute.paused": true,
-            "mcp.execute.paused_execution_id": outcome.execution.id,
-            "mcp.execute.pause_source": "resume",
-          });
-          yield* onExecutionPaused(outcome.execution.id);
+          return yield* formatPausedModelResult(outcome.execution, "resume");
         }
-        return outcome.status === "completed"
-          ? toMcpResult(outcome.result)
-          : toMcpPausedResult(formatPausedExecution(outcome.execution));
+        return toMcpResult(outcome.result);
       }).pipe(
         Effect.withSpan("mcp.host.tool.resume", {
           attributes: {
@@ -780,12 +920,13 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
           return missingExecutionResult(executionId);
         }
         if (outcome.status === "paused") {
+          const deadline = pauseDeadline();
           yield* Effect.annotateCurrentSpan({
             "mcp.execute.paused": true,
             "mcp.execute.paused_execution_id": outcome.execution.id,
             "mcp.execute.pause_source": "browser_resume",
           });
-          yield* onExecutionPaused(outcome.execution.id);
+          yield* onExecutionPaused(outcome.execution.id, deadline);
         }
         return outcome.status === "completed"
           ? toMcpResult(outcome.result)


### PR DESCRIPTION
## Problem

When a paused execution's `resume` call arrives on a different MCP session than the one that created the pause (clients like Cursor recycle their MCP session between requests), the resume lands on a fresh session DO whose engine has no knowledge of the executionId. The client gets a generic "execution not found / may have expired" error — even seconds after the pause — and the original pause later auto-declines via the 4-minute pending-approval lease. Agents mis-diagnose this as a too-short expiry window and guess-and-retry.

Confirmed in production traces: pause at 17:07:09, new `McpSessionDO.init` at 17:07:18, resume miss 9 seconds after the pause, orphaned `Tool approval declined` (duration exactly 4m0s) at 17:11.

## Fix

Make model-mode `resume` session-portable:

- **Execution-owner directory**: a small DO (`McpExecutionOwnerDirectoryDO`, addressed `idFromName(executionId)`) records `{ owner session route, accountId, organizationId, expiresAt }` when a pause starts its pending-approval lease. Entries expire via alarm; expired reads are treated as absent. All directory reads/writes degrade gracefully — an unavailable directory never fails an execute/pause/resume.
- **Cross-session forward**: on a local resume miss, the tool-server's new optional `resumeFallback` hook looks up the owner and calls a new non-forwarding `resumeExecutionForModel` RPC on the owning session DO. That RPC re-validates the caller identity (account + organization from session meta, never client-supplied), runs the normal resume lifecycle — clearing the 4-minute lease so no later `approval_timeout` decline fires — and returns the continued execution result synchronously. A 10s deadline on the forward maps a wedged owner to `execution_expired`. Recursion-safe: an owner route pointing at the current session short-circuits.
- **Honest errors**: the generic miss result is replaced by distinct statuses — `execution_not_found`, `execution_expired`, `execution_forbidden`, `execution_already_settled` — with text that states the approval window (derived from the lease constant, not hardcoded).
- **Plannable deadlines**: paused payloads now carry `expiresAt`/`ttlMs` (threaded from the host lease duration) and mention the deadline in the pause text, so agents can schedule the resume instead of guessing.

Hosts that don't wire the fallback (local/selfhost stdio) keep exactly today's behavior. No timer values changed.

## Tests

- Two-session routing exercised through the real `resumeFromExecutionOwnerDirectory` → `resumeExecutionForModel` paths (forwarding stubbed only at the transport boundary): cross-session resume returns the owner's result, the owner's lease is released with no later auto-decline, identity mismatch is rejected without touching the owner engine, no recursion.
- Shared `mcpSessionDurableObjectName` helper test covers the DO-name derivation used by both apps (mutation-checked: breaking the derivation fails the suite).
- Directory DO unit tests (put/get/expiry/alarm), distinct-error-status coverage, same-session resume regression coverage.
- `bun run typecheck` 42/42; hosts/mcp 64 tests; hosts/cloudflare 24 tests.

## Deploy notes

New DO class `McpExecutionOwnerDirectoryDO` with additive `new_sqlite_classes` migrations in both apps (cloud `v4`, host-cloudflare `v2`); binding `MCP_EXECUTION_OWNER` is optional in code, so deploy order is safe for existing sessions.
