### PR TITLE
Publish .blockmap assets for differential desktop updates

### DIFF
--- a/.github/workflows/publish-desktop.yml
+++ b/.github/workflows/publish-desktop.yml
@@ -172,6 +172,7 @@ jobs:
             apps/desktop/dist/*.AppImage
             apps/desktop/dist/*.deb
             apps/desktop/dist/*.rpm
+            apps/desktop/dist/*.blockmap
             apps/desktop/dist/latest*.yml
           if-no-files-found: warn
 
@@ -223,6 +224,7 @@ jobs:
           done < <(find artifacts -type f \
             \( -name "*.dmg" -o -name "*.zip" -o -name "*.exe" \
             -o -name "*.AppImage" -o -name "*.deb" -o -name "*.rpm" \
+            -o -name "*.blockmap" \
             -o -name "latest*.yml" \))
 
       # Flip draft → published only after every desktop asset is uploaded —


### PR DESCRIPTION
## Problem

Desktop auto-updates use electron-updater against GitHub releases. electron-builder emits `.blockmap` files next to update artifacts, but the publish workflow only uploaded installer artifacts and `latest*.yml` metadata.

Clients currently hit:

```text
Cannot download differentially, fallback to full download: Error: Cannot download "https://github.com/UsefulSoftwareCo/executor/releases/download/v1.5.28/executor-desktop-mac-arm64.zip.blockmap", status 404
```

When the `.blockmap` URL 404s, electron-updater falls back to the full bundle, about 160 MB per update today.

## Change

Inter-job artifact upload before:

```text
apps/desktop/dist/*.dmg
apps/desktop/dist/*.zip
apps/desktop/dist/*.exe
apps/desktop/dist/*.AppImage
apps/desktop/dist/*.deb
apps/desktop/dist/*.rpm
apps/desktop/dist/latest*.yml
```

Inter-job artifact upload after:

```text
apps/desktop/dist/*.dmg
apps/desktop/dist/*.zip
apps/desktop/dist/*.exe
apps/desktop/dist/*.AppImage
apps/desktop/dist/*.deb
apps/desktop/dist/*.rpm
apps/desktop/dist/*.blockmap
apps/desktop/dist/latest*.yml
```

Release asset upload before:

```text
find artifacts -type f \
  \( -name "*.dmg" -o -name "*.zip" -o -name "*.exe" \
  -o -name "*.AppImage" -o -name "*.deb" -o -name "*.rpm" \
  -o -name "latest*.yml" \)
```

Release asset upload after:

```text
find artifacts -type f \
  \( -name "*.dmg" -o -name "*.zip" -o -name "*.exe" \
  -o -name "*.AppImage" -o -name "*.deb" -o -name "*.rpm" \
  -o -name "*.blockmap" \
  -o -name "latest*.yml" \)
```

This keeps the workflow structure unchanged and uploads whatever `.blockmap` files electron-builder emits.

## Caveat

The first release with blockmaps can still full-download when updating from an older release, because the old-version blockmap was never uploaded. Differential updates should work from the next release pair onward.

## Verification

- YAML parses.
- actionlint passes with the repo existing Blacksmith runner label diagnostic ignored.
- `bun run format:check` passes.
- Local `electron-builder --mac zip --arm64 --publish never` emitted `executor-desktop-mac-arm64.zip.blockmap`.
