### PR TITLE
Fix MCP session transport restore after idle teardown

### DIFF
--- a/e2e/cloud/mcp-client-sessions.test.ts
+++ b/e2e/cloud/mcp-client-sessions.test.ts
@@ -18,7 +18,10 @@ import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/
 import { scenario } from "../src/scenario";
 import { Api, Mcp, Target } from "../src/services";
 import type { Identity } from "../src/target";
-import { configuredMcpPausedSessionIdleTimeoutMs } from "../setup/mcp-session-timeouts";
+import {
+  configuredMcpPausedSessionIdleTimeoutMs,
+  configuredMcpSessionTimeoutMs,
+} from "../setup/mcp-session-timeouts";
 
 const coreApi = composePluginApi([] as const);
 
@@ -130,6 +133,45 @@ scenario(
       );
       expect(after.isError, "the resumed session executes code").not.toBe(true);
       expect(textOf(after), "the resumed session returns results").toContain("after");
+    }).pipe(Effect.ensuring(closeQuietly(second)));
+  }),
+);
+
+const IDLE_RUNTIME_DISPOSE_BUFFER_MS = 2_000;
+const IDLE_RUNTIME_DISPOSE_GAP_MS =
+  configuredMcpSessionTimeoutMs() + IDLE_RUNTIME_DISPOSE_BUFFER_MS;
+const IDLE_RUNTIME_DISPOSE_SCENARIO_TIMEOUT_MS = IDLE_RUNTIME_DISPOSE_GAP_MS + 120_000;
+
+scenario(
+  "MCP sessions · a resumed session after idle runtime disposal restores cleanly",
+  { timeout: IDLE_RUNTIME_DISPOSE_SCENARIO_TIMEOUT_MS },
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const mcp = yield* Mcp;
+    const identity = yield* target.newIdentity();
+    const bearer = yield* mcp.mintBearer(emailOf(identity));
+
+    const first = yield* Effect.promise(() => connectClient(target.mcpUrl, bearer));
+    const sessionId = first.transport.sessionId;
+    expect(sessionId, "the client got a session id").toEqual(expect.any(String));
+    if (sessionId === undefined) return yield* Effect.die("missing session id");
+
+    const before = yield* Effect.promise(() =>
+      first.client.callTool({ name: "execute", arguments: { code: 'return "before-idle";' } }),
+    ).pipe(Effect.ensuring(closeQuietly(first)));
+    expect(before.isError, "the pre-idle call succeeds").not.toBe(true);
+    expect(textOf(before), "the pre-idle call returns results").toContain("before-idle");
+
+    yield* Effect.sleep(IDLE_RUNTIME_DISPOSE_GAP_MS);
+
+    const second = yield* Effect.promise(() => connectClient(target.mcpUrl, bearer, sessionId));
+    yield* Effect.gen(function* () {
+      expect(second.transport.sessionId, "the session id is preserved").toBe(sessionId);
+      const after = yield* Effect.promise(() =>
+        second.client.callTool({ name: "execute", arguments: { code: 'return "after-idle";' } }),
+      );
+      expect(after.isError, "the post-idle call succeeds").not.toBe(true);
+      expect(textOf(after), "the post-idle call returns results").toContain("after-idle");
     }).pipe(Effect.ensuring(closeQuietly(second)));
   }),
 );

--- a/e2e/setup/mcp-session-timeouts.ts
+++ b/e2e/setup/mcp-session-timeouts.ts
@@ -1,5 +1,6 @@
 const DEFAULT_E2E_MCP_SESSION_TIMEOUT_MS = 3_000;
 const DEFAULT_E2E_MCP_PAUSED_SESSION_IDLE_TIMEOUT_MS = 6_000;
+const PRODUCTION_MCP_SESSION_TIMEOUT_MS = 5 * 60 * 1000;
 const PRODUCTION_MCP_PAUSED_SESSION_IDLE_TIMEOUT_MS = 9 * 60 * 1000;
 
 export const MCP_SESSION_TIMEOUT_ENV = "MCP_SESSION_TIMEOUT_MS";
@@ -32,3 +33,6 @@ export const ensureE2eMcpSessionTimeoutEnv = (): {
 export const configuredMcpPausedSessionIdleTimeoutMs = (): number =>
   positiveMilliseconds(process.env[MCP_PAUSED_SESSION_IDLE_TIMEOUT_ENV]) ??
   PRODUCTION_MCP_PAUSED_SESSION_IDLE_TIMEOUT_MS;
+
+export const configuredMcpSessionTimeoutMs = (): number =>
+  positiveMilliseconds(process.env[MCP_SESSION_TIMEOUT_ENV]) ?? PRODUCTION_MCP_SESSION_TIMEOUT_MS;

--- a/packages/hosts/cloudflare/src/mcp/agent-session-durable-object.test.ts
+++ b/packages/hosts/cloudflare/src/mcp/agent-session-durable-object.test.ts
@@ -122,6 +122,14 @@ class RestoredTransport implements Transport {
 
 const makeServer = () => new McpServer({ name: "executor-test", version: "1.0.0" });
 
+const makeDeferred = (): { readonly promise: Promise<void>; readonly resolve: () => void } => {
+  let resolve: () => void = () => undefined;
+  const promise = new Promise<void>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+};
+
 const makeHarnessSession = async (): Promise<HarnessSession> => {
   const sessionId = "session-reconnect";
   const sessionMeta: SessionMeta = {
@@ -166,5 +174,43 @@ describe("McpAgentSessionDOBase transport restore", () => {
     await expect(
       session.validateMcpSessionOwner({ accountId: "user-1", organizationId: "org-1" }),
     ).resolves.toBe("ok");
+  });
+
+  it("single-flights concurrent same-session restore after idle disposal", async () => {
+    const session = await makeHarnessSession();
+    const firstRestoreEntered = makeDeferred();
+    const finishRestore = makeDeferred();
+    let onStartCalls = 0;
+    let restoredServer: McpServer | undefined;
+
+    session.onStart = async () => {
+      onStartCalls += 1;
+      const restored = session.server ?? makeServer();
+      restoredServer ??= restored;
+      session.server = restored;
+      firstRestoreEntered.resolve();
+      await finishRestore.promise;
+      await restored.connect(new RestoredTransport());
+      session.initialized = true;
+    };
+
+    await session.alarm();
+
+    const first = session.validateMcpSessionOwner({
+      accountId: "user-1",
+      organizationId: "org-1",
+    });
+    const second = session.validateMcpSessionOwner({
+      accountId: "user-1",
+      organizationId: "org-1",
+    });
+
+    await firstRestoreEntered.promise;
+    await Promise.resolve();
+    finishRestore.resolve();
+
+    await expect(Promise.all([first, second])).resolves.toEqual(["ok", "ok"]);
+    expect(onStartCalls).toBe(1);
+    expect(session.server).toBe(restoredServer);
   });
 });

--- a/packages/hosts/cloudflare/src/mcp/agent-session-durable-object.test.ts
+++ b/packages/hosts/cloudflare/src/mcp/agent-session-durable-object.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import type { JSONRPCMessage, MessageExtraInfo } from "@modelcontextprotocol/sdk/types.js";
+
+import { defaultMcpResource } from "@executor-js/host-mcp";
+
+import { McpAgentSessionDOBase, type SessionMeta } from "./agent-session-durable-object";
+
+class MemoryStorage {
+  private readonly data = new Map<string, unknown>();
+  alarm: number | undefined;
+
+  readonly sql = {
+    exec: () => [],
+  };
+
+  async get<T>(key: string): Promise<T | undefined> {
+    return this.data.get(key) as T | undefined;
+  }
+
+  async put(key: string, value: unknown): Promise<void> {
+    this.data.set(key, value);
+  }
+
+  async setAlarm(time: number | Date): Promise<void> {
+    this.alarm = typeof time === "number" ? time : time.getTime();
+  }
+
+  async deleteAlarm(): Promise<void> {
+    this.alarm = undefined;
+  }
+
+  async delete(key: string | readonly string[]): Promise<void> {
+    if (typeof key === "string") {
+      this.data.delete(key);
+      return;
+    }
+    for (const entry of key) {
+      this.data.delete(entry);
+    }
+  }
+
+  async deleteAll(): Promise<void> {
+    this.data.clear();
+  }
+
+  async list<T>(
+    options: { readonly prefix?: string; readonly limit?: number } = {},
+  ): Promise<Map<string, T>> {
+    const rows = new Map<string, T>();
+    for (const [key, value] of this.data) {
+      if (options.prefix && !key.startsWith(options.prefix)) continue;
+      rows.set(key, value as T);
+      if (options.limit && rows.size >= options.limit) break;
+    }
+    return rows;
+  }
+
+  async blockConcurrencyWhile<T>(callback: () => T | Promise<T>): Promise<T> {
+    return callback();
+  }
+
+  get id(): { readonly name: string } {
+    return { name: "streamable-http:session-reconnect" };
+  }
+
+  get storage(): MemoryStorage {
+    return this;
+  }
+
+  waitUntil(_promise: Promise<unknown>): void {}
+}
+
+type HarnessSession = {
+  alarm: () => Promise<void>;
+  ctx: MemoryStorage;
+  dbHandle: { readonly end: () => void } | null;
+  engine: { readonly pausedExecutionCount: () => Effect.Effect<number> } | null;
+  getSessionId: () => string;
+  initialized: boolean;
+  lastActivityMs: number;
+  maxPausedSessionIdleMs: () => number;
+  onStart: () => Promise<void>;
+  pendingApprovalLeases: Map<string, never>;
+  props: Record<string, unknown>;
+  server?: McpServer;
+  sessionMeta: SessionMeta;
+  sessionTimeoutMs: () => number;
+  validateMcpSessionOwner: (identity: {
+    readonly accountId: string;
+    readonly organizationId: string;
+  }) => Promise<"ok" | "not_found" | "forbidden">;
+};
+
+class StaleCloseTransport implements Transport {
+  onclose?: () => void;
+  onerror?: (error: Error) => void;
+  onmessage?: (message: JSONRPCMessage, extra?: MessageExtraInfo) => void;
+
+  async start(): Promise<void> {}
+
+  async close(): Promise<void> {}
+
+  async send(_message: JSONRPCMessage): Promise<void> {}
+}
+
+class RestoredTransport implements Transport {
+  onclose?: () => void;
+  onerror?: (error: Error) => void;
+  onmessage?: (message: JSONRPCMessage, extra?: MessageExtraInfo) => void;
+
+  async start(): Promise<void> {}
+
+  async close(): Promise<void> {
+    this.onclose?.();
+  }
+
+  async send(_message: JSONRPCMessage): Promise<void> {}
+}
+
+const makeServer = () => new McpServer({ name: "executor-test", version: "1.0.0" });
+
+const makeHarnessSession = async (): Promise<HarnessSession> => {
+  const sessionId = "session-reconnect";
+  const sessionMeta: SessionMeta = {
+    organizationId: "org-1",
+    organizationName: "Org 1",
+    userId: "user-1",
+    resource: defaultMcpResource,
+  };
+  const storage = new MemoryStorage();
+  const server = makeServer();
+  await server.connect(new StaleCloseTransport());
+
+  const session = Object.create(McpAgentSessionDOBase.prototype) as HarnessSession;
+  session.ctx = storage;
+  session.dbHandle = { end: () => undefined };
+  session.engine = { pausedExecutionCount: () => Effect.succeed(0) };
+  session.getSessionId = () => sessionId;
+  session.initialized = true;
+  session.lastActivityMs = Date.now() - 10;
+  session.maxPausedSessionIdleMs = () => 1_000;
+  session.pendingApprovalLeases = new Map<string, never>();
+  session.props = {};
+  session.server = server;
+  session.sessionMeta = sessionMeta;
+  session.sessionTimeoutMs = () => 1;
+  session.onStart = async () => {
+    const restored = session.server ?? makeServer();
+    session.server = restored;
+    await restored.connect(new RestoredTransport());
+    session.initialized = true;
+  };
+
+  return session;
+};
+
+describe("McpAgentSessionDOBase transport restore", () => {
+  it("restores a same-session request after idle disposal leaves a stale server transport", async () => {
+    const session = await makeHarnessSession();
+
+    await session.alarm();
+
+    await expect(
+      session.validateMcpSessionOwner({ accountId: "user-1", organizationId: "org-1" }),
+    ).resolves.toBe("ok");
+  });
+});

--- a/packages/hosts/cloudflare/src/mcp/agent-session-durable-object.ts
+++ b/packages/hosts/cloudflare/src/mcp/agent-session-durable-object.ts
@@ -200,6 +200,7 @@ export abstract class McpAgentSessionDOBase<
   private dbHandle: TDbHandle | null = null;
   private sessionMeta: SessionMeta | null = null;
   private initialized = false;
+  private restoreTransportRuntimePromise: Promise<void> | null = null;
   private lastActivityMs = 0;
   private approvalResponses = new Map<string, ResumeResponse>();
   private approvalWaiters = new Map<string, Deferred.Deferred<ResumeResponse>>();
@@ -451,7 +452,7 @@ export abstract class McpAgentSessionDOBase<
     }).pipe(Effect.withSpan("McpSessionDO.ensure_runtime_for_approval"));
   }
 
-  private restoreTransportRuntime(): Effect.Effect<void> {
+  private restoreTransportRuntimeOnce(): Effect.Effect<void> {
     const self = this;
     return Effect.gen(function* () {
       yield* self.closeRuntime();
@@ -460,6 +461,31 @@ export abstract class McpAgentSessionDOBase<
         yield* self.closeRuntime();
         return yield* Effect.failCause(restored.cause);
       }
+    });
+  }
+
+  private restoreTransportRuntime(): Effect.Effect<void> {
+    const self = this;
+    return Effect.promise(() => {
+      if (self.restoreTransportRuntimePromise) return self.restoreTransportRuntimePromise;
+
+      const restoring = Promise.resolve().then(() =>
+        Effect.runPromise(self.restoreTransportRuntimeOnce()),
+      );
+      self.restoreTransportRuntimePromise = restoring;
+      restoring.then(
+        () => {
+          if (self.restoreTransportRuntimePromise === restoring) {
+            self.restoreTransportRuntimePromise = null;
+          }
+        },
+        () => {
+          if (self.restoreTransportRuntimePromise === restoring) {
+            self.restoreTransportRuntimePromise = null;
+          }
+        },
+      );
+      return restoring;
     });
   }
 

--- a/packages/hosts/cloudflare/src/mcp/agent-session-durable-object.ts
+++ b/packages/hosts/cloudflare/src/mcp/agent-session-durable-object.ts
@@ -415,8 +415,10 @@ export abstract class McpAgentSessionDOBase<
       yield* self.releaseAllPendingApprovalLeases();
       if (self.server) {
         const server = self.server;
+        delete (self as { server?: McpServer }).server;
         yield* Effect.promise(() => server.close()).pipe(Effect.ignore);
       }
+      Reflect.set(self, "_transport", undefined);
       self.engine = null;
       if (self.dbHandle) {
         const dbHandle = self.dbHandle;
@@ -447,6 +449,18 @@ export abstract class McpAgentSessionDOBase<
       );
       return true;
     }).pipe(Effect.withSpan("McpSessionDO.ensure_runtime_for_approval"));
+  }
+
+  private restoreTransportRuntime(): Effect.Effect<void> {
+    const self = this;
+    return Effect.gen(function* () {
+      yield* self.closeRuntime();
+      const restored = yield* Effect.exit(Effect.promise(() => self.onStart()));
+      if (Exit.isFailure(restored)) {
+        yield* self.closeRuntime();
+        return yield* Effect.failCause(restored.cause);
+      }
+    });
   }
 
   async init(): Promise<void> {
@@ -511,9 +525,9 @@ export abstract class McpAgentSessionDOBase<
             Effect.withSpan("McpSessionDO.markActivity"),
           );
         } else {
-          yield* Effect.promise(() => self.onStart()).pipe(
-            Effect.withSpan("McpSessionDO.restore_transport_runtime"),
-          );
+          yield* self
+            .restoreTransportRuntime()
+            .pipe(Effect.withSpan("McpSessionDO.restore_transport_runtime"));
         }
         return identity.accountId === sessionMeta.userId &&
           identity.organizationId === sessionMeta.organizationId


### PR DESCRIPTION
## Problem

#1296 changed the session DO idle path from `destroy()` to `disposeIdleRuntime()`, which tears down the runtime but leaves the DO instance alive with the McpServer transport still attached. The restore branch it added (`onStart()` when `!initialized`) then calls `McpServer.connect()` on a server whose `_transport` is still set, and the MCP SDK throws:

> Already connected to a transport. Call close() before connecting to a new transport

Once thrown, the session is permanently bricked — every subsequent request on that session id fails the same way until the client abandons it. Sentry: NODE-CLOUDFLARE-WORKERS-4C / 4E, first seen ~90s after the #1296 deploy, still accruing. The SSE max-age rotation (#1279) makes idle-dispose→restore a hot path, so aged sessions hit this steadily.

## Fix

- `closeRuntime()` now genuinely severs the MCP server: drops the `server` field, best-effort closes it, and clears the agents-SDK `_transport` reference — so a later restore connects a fresh server cleanly. (The agents SDK's `onStart` always creates and connects a new transport; the MCP SDK only clears `_transport` via the transport's `onclose`, which `server.close()` alone doesn't guarantee — reset-before-reconnect is the only viable shape.)
- The restore branch goes through a new `restoreTransportRuntime()`: cleanup before `onStart()`, and cleanup again if `onStart()` fails so a failed restore no longer bricks the session — the next request retries fresh.

## Tests

- DO-level regression test with a real `McpServer` + real SDK transports encoding the prod sequence: alarm-driven idle-dispose, then a same-session request, asserting it succeeds. Fails on main with the exact prod error (verified by stash/revert).
- e2e scenario with a real StreamableHTTP client: execute → idle past the session timeout → reconnect on the same session id → execute again.

## Follow-up landing on this branch

A review pass found the restore path isn't serialized: two concurrent same-session requests (SSE listen GET + POST) can both enter restore and the second can tear down the first's mid-connect server. A second commit serializing restore (single-flight) + a concurrency regression test is in progress and will land here before this leaves draft.