### PR TITLE
[codex] Wire Azure Trusted Signing for desktop releases

### DIFF
--- a/.github/workflows/publish-desktop.yml
+++ b/.github/workflows/publish-desktop.yml
@@ -130,6 +130,36 @@ jobs:
           printf '%s' "$APPLE_API_KEY" > "${RUNNER_TEMP}/private_keys/AuthKey.p8"
           echo "APPLE_API_KEY_PATH=${RUNNER_TEMP}/private_keys/AuthKey.p8" >> "$GITHUB_ENV"
 
+      - name: Verify Azure Trusted Signing configuration
+        if: matrix.platform == 'win'
+        shell: bash
+        env:
+          AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          AZURE_TRUSTED_SIGNING_ENDPOINT: ${{ vars.AZURE_TRUSTED_SIGNING_ENDPOINT }}
+          AZURE_TRUSTED_SIGNING_ACCOUNT: ${{ vars.AZURE_TRUSTED_SIGNING_ACCOUNT }}
+          AZURE_TRUSTED_SIGNING_CERT_PROFILE: ${{ vars.AZURE_TRUSTED_SIGNING_CERT_PROFILE }}
+          AZURE_TRUSTED_SIGNING_PUBLISHER_NAME: ${{ vars.AZURE_TRUSTED_SIGNING_PUBLISHER_NAME }}
+        run: |
+          set -euo pipefail
+          missing=0
+          for name in \
+            AZURE_TENANT_ID \
+            AZURE_CLIENT_ID \
+            AZURE_CLIENT_SECRET \
+            AZURE_TRUSTED_SIGNING_ENDPOINT \
+            AZURE_TRUSTED_SIGNING_ACCOUNT \
+            AZURE_TRUSTED_SIGNING_CERT_PROFILE \
+            AZURE_TRUSTED_SIGNING_PUBLISHER_NAME
+          do
+            if [[ -z "${!name:-}" ]]; then
+              echo "::error::$name is required for Windows Trusted Signing"
+              missing=1
+            fi
+          done
+          exit "$missing"
+
       - name: Build desktop distributables
         env:
           # electron-builder reads GH_TOKEN for the publish step. We use
@@ -148,6 +178,16 @@ jobs:
           APPLE_API_KEY: ${{ env.APPLE_API_KEY_PATH }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          # Windows Azure Trusted Signing. electron-builder 26 invokes the
+          # TrustedSigning PowerShell module and authenticates through Azure
+          # Identity environment credentials.
+          AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          AZURE_TRUSTED_SIGNING_ENDPOINT: ${{ vars.AZURE_TRUSTED_SIGNING_ENDPOINT }}
+          AZURE_TRUSTED_SIGNING_ACCOUNT: ${{ vars.AZURE_TRUSTED_SIGNING_ACCOUNT }}
+          AZURE_TRUSTED_SIGNING_CERT_PROFILE: ${{ vars.AZURE_TRUSTED_SIGNING_CERT_PROFILE }}
+          AZURE_TRUSTED_SIGNING_PUBLISHER_NAME: ${{ vars.AZURE_TRUSTED_SIGNING_PUBLISHER_NAME }}
         run: bunx --bun electron-builder --${{ matrix.platform }} --${{ matrix.arch }} --publish never --config electron-builder.config.ts
         working-directory: apps/desktop
 

--- a/apps/desktop/electron-builder.config.ts
+++ b/apps/desktop/electron-builder.config.ts
@@ -1,5 +1,29 @@
 import type { Configuration } from "electron-builder";
 
+type AzureTrustedSigningOptions = NonNullable<
+  NonNullable<Configuration["win"]>["azureSignOptions"]
+>;
+
+function getAzureTrustedSigningOptions(): AzureTrustedSigningOptions | undefined {
+  const endpoint = process.env.AZURE_TRUSTED_SIGNING_ENDPOINT;
+  const certificateProfileName = process.env.AZURE_TRUSTED_SIGNING_CERT_PROFILE;
+  const codeSigningAccountName = process.env.AZURE_TRUSTED_SIGNING_ACCOUNT;
+  const publisherName = process.env.AZURE_TRUSTED_SIGNING_PUBLISHER_NAME;
+
+  if (!endpoint || !certificateProfileName || !codeSigningAccountName || !publisherName) {
+    return undefined;
+  }
+
+  return {
+    endpoint,
+    certificateProfileName,
+    codeSigningAccountName,
+    publisherName,
+  };
+}
+
+const azureTrustedSigningOptions = getAzureTrustedSigningOptions();
+
 const config: Configuration = {
   appId: "sh.executor.desktop",
   productName: "Executor",
@@ -46,6 +70,7 @@ const config: Configuration = {
   // artifact only exists once a leg stages an arm64 executor for it.
   win: {
     target: ["nsis"],
+    ...(azureTrustedSigningOptions ? { azureSignOptions: azureTrustedSigningOptions } : {}),
   },
   nsis: {
     oneClick: true,

--- a/apps/desktop/electron-builder.e2e.config.ts
+++ b/apps/desktop/electron-builder.e2e.config.ts
@@ -28,6 +28,9 @@ const config: Configuration = {
   },
   win: {
     ...base.win,
+    // E2E packages must stay unsigned even if a developer shell exports the
+    // Azure Trusted Signing env vars used by the release workflow.
+    azureSignOptions: null,
     target: ["dir"],
   },
   linux: {


### PR DESCRIPTION
## What changed

- Adds conditional `win.azureSignOptions` to the desktop Electron builder config.
- Wires Azure Trusted Signing environment variables into the Windows desktop publish leg.
- Adds a Windows-only fail-fast check so release builds do not silently publish unsigned Windows installers when signing config is incomplete.
- Keeps e2e Windows packages explicitly unsigned even if a developer shell has Azure signing env vars set.

## Validation

- `bun run --filter @executor-js/desktop typecheck`
- `bun run typecheck`
- Imported the builder config with and without signing env vars to verify conditional behavior.
- Parsed `.github/workflows/publish-desktop.yml` as YAML.
