### PR TITLE
Desktop updater: keep checking after a declined update, surface errors, fix install-on-quit leak

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -61,6 +61,14 @@ import {
   UPDATE_STATUS_CHANNEL,
   UPDATE_STATUS_GET_CHANNEL,
 } from "../shared/update";
+import {
+  planCompletedUpdateCheck,
+  planDownloadedUpdate,
+  planFatalAutoInstallOnQuit,
+  planUpdateCheck,
+  statusAfterUpdateError,
+  type UpdateCheckTrigger,
+} from "./updater-state";
 
 // Pin userData to a friendly app-name-scoped dir BEFORE app.ready so every
 // Electron-side consumer (electron-store, electron-log, window-state) lands
@@ -741,7 +749,9 @@ const registerIpcHandlers = () => {
   // Crash-screen escape hatch: a recurring sidecar crash may already be
   // fixed upstream. Reuses the menu flow — staged updates prompt to install,
   // "no updates" / failures surface in their own dialogs.
-  ipcMain.handle("executor:updates:check", () => runUpdateCheck({ alertOnFail: true }));
+  ipcMain.handle("executor:updates:check", () =>
+    runUpdateCheck({ alertOnFail: true, trigger: "manual" }),
+  );
   ipcMain.handle(UPDATE_STATUS_GET_CHANNEL, (): DesktopUpdateStatus => updateStatus);
   ipcMain.handle(UPDATE_INSTALL_CHANNEL, async (): Promise<void> => {
     const version = "version" in updateStatus ? updateStatus.version : "";
@@ -754,6 +764,7 @@ const registerIpcHandlers = () => {
     }
     // Stop the sidecar cleanly before Squirrel.Mac swaps the bundle, matching
     // the native dialog's restart path.
+    stopSupervisedMonitor();
     if (connection) {
       await stopConnection(connection);
       connection = null;
@@ -804,6 +815,7 @@ const registerIpcHandlers = () => {
 // ──────────────────────────────────────────────────────────────────────
 
 let downloadedUpdateVersion: string | null = null;
+let declinedUpdateVersion: string | null = null;
 let updateDialogOpen = false;
 
 // Renderer-facing auto-update status. The web shell renders a desktop-native
@@ -845,11 +857,16 @@ const applyFakeUpdateFromEnv = () => {
       state === "available" ||
       state === "downloaded" ||
       state === "downloading" ||
+      state === "error" ||
       state === "installing"
     ) {
       if (state === "downloaded") downloadedUpdateVersion = version;
       setUpdateStatus(
-        state === "downloading" ? { state, version, percent: 100 } : { state, version },
+        state === "downloading"
+          ? { state, version, percent: 100 }
+          : state === "error"
+            ? { state, version, message: "Update failed" }
+            : { state, version },
       );
     }
   } catch (error) {
@@ -874,12 +891,15 @@ const promptInstallUpdate = async (version: string) => {
     if (response.response === 0) {
       // Stop the sidecar cleanly before Squirrel.Mac swaps the bundle. A
       // supervised daemon is left running — it's independent of this bundle.
+      stopSupervisedMonitor();
       if (connection) {
         await stopConnection(connection);
         connection = null;
       }
       autoUpdater.quitAndInstall(false, true);
+      return;
     }
+    declinedUpdateVersion = version;
   } finally {
     updateDialogOpen = false;
   }
@@ -910,25 +930,41 @@ const setupAutoUpdater = () => {
     }
   });
   autoUpdater.on("update-downloaded", (info: UpdateInfo) => {
-    downloadedUpdateVersion = info.version;
-    setUpdateStatus({ state: "downloaded", version: info.version });
-    void promptInstallUpdate(info.version);
+    const decision = planDownloadedUpdate({
+      stagedVersion: downloadedUpdateVersion,
+      declinedVersion: declinedUpdateVersion,
+      incomingVersion: info.version,
+      trigger: "boot",
+    });
+    downloadedUpdateVersion = decision.stagedVersion;
+    declinedUpdateVersion = decision.declinedVersion;
+    setUpdateStatus(decision.status);
+    if (decision.promptVersion) void promptInstallUpdate(decision.promptVersion);
   });
   autoUpdater.on("error", (err: Error) => {
     log.warn("[updater] error", err);
+    setUpdateStatus(
+      statusAfterUpdateError(updateStatus, "Update failed. Check again from the menu."),
+    );
+    pendingUpdateVersion = null;
   });
 
   setInterval(() => {
-    if (downloadedUpdateVersion) return; // already staged; waiting on the user
-    void runUpdateCheck({ alertOnFail: false });
+    void runUpdateCheck({ alertOnFail: false, trigger: "interval" });
   }, UPDATE_POLL_INTERVAL_MS);
 };
 
 interface UpdateCheckOptions {
   readonly alertOnFail: boolean;
+  readonly trigger: UpdateCheckTrigger;
 }
 
-const runUpdateCheck = async ({ alertOnFail }: UpdateCheckOptions) => {
+type UpdateCheckResult = {
+  readonly isUpdateAvailable?: boolean;
+  readonly updateInfo?: { readonly version?: string };
+};
+
+const runUpdateCheck = async ({ alertOnFail, trigger }: UpdateCheckOptions) => {
   if (!app.isPackaged) {
     if (alertOnFail) {
       await dialog.showMessageBox({
@@ -939,14 +975,23 @@ const runUpdateCheck = async ({ alertOnFail }: UpdateCheckOptions) => {
     }
     return;
   }
-  if (downloadedUpdateVersion) {
-    await promptInstallUpdate(downloadedUpdateVersion);
-    return;
-  }
+  const checkPlan = planUpdateCheck({ stagedVersion: downloadedUpdateVersion, trigger });
+  if (!checkPlan.check) return;
   // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: surface network/update failures only when the user asked
   try {
-    const result = await autoUpdater.checkForUpdates();
+    const result = (await autoUpdater.checkForUpdates()) as UpdateCheckResult | null;
     const newer = result?.isUpdateAvailable === true;
+    const promptAfterCheck = planCompletedUpdateCheck({
+      stagedVersion: checkPlan.promptVersionAfterCheck,
+      trigger,
+      updateAvailable: newer,
+      availableVersion:
+        typeof result?.updateInfo?.version === "string" ? result.updateInfo.version : null,
+    }).promptVersion;
+    if (promptAfterCheck) {
+      await promptInstallUpdate(promptAfterCheck);
+      return;
+    }
     if (!alertOnFail) return;
     if (newer) return; // 'update-downloaded' handler will fire the install dialog
     await dialog.showMessageBox({
@@ -956,6 +1001,9 @@ const runUpdateCheck = async ({ alertOnFail }: UpdateCheckOptions) => {
     });
   } catch (error) {
     log.warn("[updater] check failed", error);
+    setUpdateStatus(
+      statusAfterUpdateError(updateStatus, "Update failed. Check again from the menu."),
+    );
     if (!alertOnFail) return;
     await dialog.showMessageBox({
       type: "error",
@@ -978,8 +1026,12 @@ const handleFatalSidecarFailure = async (error: unknown) => {
     // Install whatever finishes downloading by the time the user quits the
     // failure dialog; if it downloads while the dialog is open, the regular
     // 'update-downloaded' prompt offers an immediate restart instead.
-    autoUpdater.autoInstallOnAppQuit = true;
-    void runUpdateCheck({ alertOnFail: false });
+    const autoInstallPlan = planFatalAutoInstallOnQuit({
+      packaged: true,
+      retryAfterReset: false,
+    });
+    if (autoInstallPlan.enableDuringFailure) autoUpdater.autoInstallOnAppQuit = true;
+    void runUpdateCheck({ alertOnFail: false, trigger: "boot" });
   }
   // oxlint-disable-next-line executor/no-instanceof-error, executor/no-unknown-error-message -- boundary: sidecar startup failures arrive as plain Node errors and render in a native dialog
   const detail = error instanceof Error ? (error.stack ?? error.message) : String(error);
@@ -995,7 +1047,13 @@ const handleFatalSidecarFailure = async (error: unknown) => {
   // Damaged executor state (failed migration, corrupt SQLite) makes startup
   // fail forever — updating can't fix it. Offer the move-aside reset and one
   // immediate retry. Returns true when boot should be attempted again.
-  if (response === 1 && (await confirmResetState())) {
+  const retryAfterReset = response === 1 && (await confirmResetState());
+  const autoInstallPlan = planFatalAutoInstallOnQuit({
+    packaged: app.isPackaged,
+    retryAfterReset,
+  });
+  if (retryAfterReset) {
+    if (autoInstallPlan.restoreAfterRecovery) autoUpdater.autoInstallOnAppQuit = false;
     const { backupDir } = resetExecutorState();
     await announceBackup(backupDir);
     return true;
@@ -1011,7 +1069,7 @@ const installApplicationMenu = () => {
       { role: "about" },
       {
         label: "Check for Updates…",
-        click: () => void runUpdateCheck({ alertOnFail: true }),
+        click: () => void runUpdateCheck({ alertOnFail: true, trigger: "manual" }),
       },
       {
         label: "Export Diagnostics…",
@@ -1105,7 +1163,7 @@ const boot = async () => {
     // A crashing sidecar may be a broken release — quietly stage any
     // available update so the install prompt appears on its own (same
     // self-heal as the fatal startup path).
-    void runUpdateCheck({ alertOnFail: false });
+    void runUpdateCheck({ alertOnFail: false, trigger: "boot" });
   });
   // Prefer an OS-supervised daemon: attach to one that's running, kick one
   // that's installed, or offer to install on first run. Quitting the app then
@@ -1121,7 +1179,7 @@ const boot = async () => {
       try {
         await createWindow(supervised);
         armSupervisedMonitor();
-        void runUpdateCheck({ alertOnFail: false });
+        void runUpdateCheck({ alertOnFail: false, trigger: "boot" });
         return;
       } catch (error) {
         log.warn("Failed to load supervised daemon; falling back to managed sidecar", error);
@@ -1196,7 +1254,7 @@ const boot = async () => {
   // Check at boot. If an update is available, autoDownload pulls it and
   // the 'update-downloaded' handler fires the install dialog. Silent on
   // no-update / failure so we don't bother users on every launch.
-  void runUpdateCheck({ alertOnFail: false });
+  void runUpdateCheck({ alertOnFail: false, trigger: "boot" });
 };
 
 if (ensureSingleInstance()) {

--- a/apps/desktop/src/main/updater-state.test.ts
+++ b/apps/desktop/src/main/updater-state.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "@effect/vitest";
+import {
+  planCompletedUpdateCheck,
+  planDownloadedUpdate,
+  planFatalAutoInstallOnQuit,
+  planUpdateCheck,
+  statusAfterUpdateError,
+} from "./updater-state";
+
+describe("updater state decisions", () => {
+  it("auto-prompts when a newer version arrives after the staged version was declined", () => {
+    const decision = planDownloadedUpdate({
+      stagedVersion: "1.5.27",
+      declinedVersion: "1.5.27",
+      incomingVersion: "1.5.28",
+      trigger: "interval",
+    });
+
+    expect(decision).toEqual({
+      stagedVersion: "1.5.28",
+      declinedVersion: "1.5.27",
+      status: { state: "downloaded", version: "1.5.28" },
+      promptVersion: "1.5.28",
+    });
+  });
+
+  it("keeps interval checks running without re-prompting the same declined version", () => {
+    const check = planUpdateCheck({
+      stagedVersion: "1.5.27",
+      trigger: "interval",
+    });
+    const downloaded = planDownloadedUpdate({
+      stagedVersion: "1.5.27",
+      declinedVersion: "1.5.27",
+      incomingVersion: "1.5.27",
+      trigger: "interval",
+    });
+
+    expect(check).toEqual({ check: true, promptVersionAfterCheck: null });
+    expect(downloaded.promptVersion).toBeNull();
+  });
+
+  it("manual checks re-check first and then re-prompt the staged version if no newer version wins", () => {
+    const check = planUpdateCheck({
+      stagedVersion: "1.5.27",
+      trigger: "manual",
+    });
+    const completedWithoutNewer = planCompletedUpdateCheck({
+      stagedVersion: check.promptVersionAfterCheck,
+      trigger: "manual",
+      updateAvailable: false,
+      availableVersion: null,
+    });
+    const completedWithNewer = planCompletedUpdateCheck({
+      stagedVersion: check.promptVersionAfterCheck,
+      trigger: "manual",
+      updateAvailable: true,
+      availableVersion: "1.5.28",
+    });
+
+    expect(check.check).toBe(true);
+    expect(completedWithoutNewer.promptVersion).toBe("1.5.27");
+    expect(completedWithNewer.promptVersion).toBeNull();
+  });
+
+  it("moves active update failures to error while idle failures stay idle", () => {
+    expect(
+      statusAfterUpdateError(
+        { state: "downloading", version: "1.5.27", percent: 42 },
+        "Download failed",
+      ),
+    ).toEqual({
+      state: "error",
+      version: "1.5.27",
+      message: "Download failed",
+    });
+    expect(statusAfterUpdateError({ state: "idle" }, "Download failed")).toEqual({
+      state: "idle",
+    });
+  });
+
+  it("restores autoInstallOnAppQuit only when the fatal path recovers", () => {
+    expect(
+      planFatalAutoInstallOnQuit({
+        packaged: true,
+        retryAfterReset: true,
+      }),
+    ).toEqual({
+      enableDuringFailure: true,
+      restoreAfterRecovery: true,
+    });
+    expect(
+      planFatalAutoInstallOnQuit({
+        packaged: true,
+        retryAfterReset: false,
+      }),
+    ).toEqual({
+      enableDuringFailure: true,
+      restoreAfterRecovery: false,
+    });
+  });
+});

--- a/apps/desktop/src/main/updater-state.ts
+++ b/apps/desktop/src/main/updater-state.ts
@@ -1,0 +1,108 @@
+import type { DesktopUpdateStatus } from "../shared/update";
+
+export type UpdateCheckTrigger = "boot" | "interval" | "manual";
+
+export interface UpdateCheckPlan {
+  readonly check: boolean;
+  readonly promptVersionAfterCheck: string | null;
+}
+
+export interface CompletedUpdateCheckInput {
+  readonly stagedVersion: string | null;
+  readonly trigger: UpdateCheckTrigger;
+  readonly updateAvailable: boolean;
+  readonly availableVersion: string | null;
+}
+
+export interface DownloadedUpdateInput {
+  readonly stagedVersion: string | null;
+  readonly declinedVersion: string | null;
+  readonly incomingVersion: string;
+  readonly trigger: UpdateCheckTrigger;
+}
+
+export interface DownloadedUpdatePlan {
+  readonly stagedVersion: string;
+  readonly declinedVersion: string | null;
+  readonly status: DesktopUpdateStatus;
+  readonly promptVersion: string | null;
+}
+
+const parseVersionParts = (version: string): readonly number[] | null => {
+  const core = version.trim().split(/[+-]/, 1)[0];
+  if (!core) return null;
+  const parts = core.split(".").map((part) => Number.parseInt(part, 10));
+  return parts.every((part) => Number.isInteger(part) && part >= 0) ? parts : null;
+};
+
+export const compareUpdateVersions = (left: string, right: string): number | null => {
+  const leftParts = parseVersionParts(left);
+  const rightParts = parseVersionParts(right);
+  if (!leftParts || !rightParts) return null;
+  const length = Math.max(leftParts.length, rightParts.length);
+  for (let index = 0; index < length; index += 1) {
+    const l = leftParts[index] ?? 0;
+    const r = rightParts[index] ?? 0;
+    if (l !== r) return l > r ? 1 : -1;
+  }
+  return 0;
+};
+
+const isNewerUpdateVersion = (incomingVersion: string, declinedVersion: string): boolean => {
+  const comparison = compareUpdateVersions(incomingVersion, declinedVersion);
+  return comparison === null ? incomingVersion !== declinedVersion : comparison > 0;
+};
+
+export const planUpdateCheck = (input: {
+  readonly stagedVersion: string | null;
+  readonly trigger: UpdateCheckTrigger;
+}): UpdateCheckPlan => ({
+  check: true,
+  promptVersionAfterCheck: input.trigger === "manual" ? input.stagedVersion : null,
+});
+
+export const planCompletedUpdateCheck = (
+  input: CompletedUpdateCheckInput,
+): { readonly promptVersion: string | null } => {
+  if (input.trigger !== "manual" || !input.stagedVersion) return { promptVersion: null };
+  if (!input.updateAvailable) return { promptVersion: input.stagedVersion };
+  if (!input.availableVersion) return { promptVersion: null };
+  const comparison = compareUpdateVersions(input.availableVersion, input.stagedVersion);
+  if (comparison === null) {
+    return {
+      promptVersion: input.availableVersion === input.stagedVersion ? input.stagedVersion : null,
+    };
+  }
+  return { promptVersion: comparison <= 0 ? input.stagedVersion : null };
+};
+
+export const planDownloadedUpdate = (input: DownloadedUpdateInput): DownloadedUpdatePlan => {
+  const prompt =
+    input.trigger === "manual" ||
+    !input.declinedVersion ||
+    isNewerUpdateVersion(input.incomingVersion, input.declinedVersion);
+  return {
+    stagedVersion: input.incomingVersion,
+    declinedVersion: input.declinedVersion,
+    status: { state: "downloaded", version: input.incomingVersion },
+    promptVersion: prompt ? input.incomingVersion : null,
+  };
+};
+
+export const statusAfterUpdateError = (
+  status: DesktopUpdateStatus,
+  message: string,
+): DesktopUpdateStatus => {
+  if (status.state === "available" || status.state === "downloading" || status.state === "error") {
+    return { state: "error", version: status.version, message };
+  }
+  return status;
+};
+
+export const planFatalAutoInstallOnQuit = (input: {
+  readonly packaged: boolean;
+  readonly retryAfterReset: boolean;
+}): { readonly enableDuringFailure: boolean; readonly restoreAfterRecovery: boolean } => ({
+  enableDuringFailure: input.packaged,
+  restoreAfterRecovery: input.packaged && input.retryAfterReset,
+});

--- a/apps/desktop/src/shared/update.ts
+++ b/apps/desktop/src/shared/update.ts
@@ -13,6 +13,7 @@ export type DesktopUpdateStatus =
   | { readonly state: "available"; readonly version: string }
   | { readonly state: "downloading"; readonly version: string; readonly percent: number }
   | { readonly state: "downloaded"; readonly version: string }
+  | { readonly state: "error"; readonly version: string; readonly message: string }
   | { readonly state: "installing"; readonly version: string };
 
 /** Push channel: main → renderer, whenever the update status changes. */

--- a/packages/react/src/components/update-card.tsx
+++ b/packages/react/src/components/update-card.tsx
@@ -83,9 +83,13 @@ function useLatestVersion(currentVersion: string | undefined) {
 
 // ── Card chrome ──────────────────────────────────────────────────────────
 
-/** The bordered card with the download glyph + "Update available" + version.
+/** The bordered card with the download glyph + title + version.
  *  Each variant supplies its own action as children. */
-function UpdateCardShell(props: { version: string | null; children?: React.ReactNode }) {
+function UpdateCardShell(props: {
+  title?: string;
+  version: string | null;
+  children?: React.ReactNode;
+}) {
   return (
     <div className="mx-2 mb-2 rounded-xl border border-primary/25 bg-primary/[0.06] p-3">
       <div className="flex items-center gap-2">
@@ -102,7 +106,9 @@ function UpdateCardShell(props: { version: string | null; children?: React.React
           </svg>
         </div>
         <div className="min-w-0">
-          <p className="text-xs font-semibold text-foreground">Update available</p>
+          <p className="text-xs font-semibold text-foreground">
+            {props.title ?? "Update available"}
+          </p>
           {props.version && <p className="text-sm text-muted-foreground">v{props.version}</p>}
         </div>
       </div>
@@ -231,10 +237,20 @@ function DesktopUpdateCard(props: { update: DesktopUpdate }) {
     if (status.state === "installing") {
       return <p className="mt-2.5 text-xs text-muted-foreground">Restarting…</p>;
     }
+    if (status.state === "error") {
+      return <p className="mt-2.5 text-xs text-muted-foreground">{status.message}</p>;
+    }
     return null;
   })();
 
-  return <UpdateCardShell version={version}>{action}</UpdateCardShell>;
+  return (
+    <UpdateCardShell
+      title={status.state === "error" ? "Update failed" : undefined}
+      version={version}
+    >
+      {action}
+    </UpdateCardShell>
+  );
 }
 
 // ── SidebarUpdateCard (the only export the shells consume) ────────────────

--- a/packages/react/src/hooks/desktop-update.ts
+++ b/packages/react/src/hooks/desktop-update.ts
@@ -12,6 +12,7 @@ export type DesktopUpdateStatus =
   | { readonly state: "available"; readonly version: string }
   | { readonly state: "downloading"; readonly version: string; readonly percent: number }
   | { readonly state: "downloaded"; readonly version: string }
+  | { readonly state: "error"; readonly version: string; readonly message: string }
   | { readonly state: "installing"; readonly version: string };
 
 type DesktopUpdateBridge = {


### PR DESCRIPTION
## Summary

Fixes five updater state-machine issues:

- A declined staged update no longer stops the 4 hour auto-check, including the incident where v1.5.27 was staged, "Later" was clicked, and the v1.5.28 notification was suppressed until restart.
- Manual "Check for Updates" now checks upstream before re-prompting a staged version.
- Updater errors transition active available/downloading status to a renderer-visible error state.
- Fatal startup recovery restores `autoInstallOnAppQuit=false` after reset data and retry.
- `quitAndInstall` stops the supervised monitor before restart.

## Re-prompt policy

- Automatic boot and interval checks keep running while a version is staged.
- Automatic prompts are suppressed for the same declined version.
- If a newer version stages, the automatic prompt fires again.
- Manual checks re-check upstream first, then re-prompt the staged version only if no newer version is taking over.

## Unit coverage

- Declined v1.5.27, then v1.5.28 arrives and auto prompts.
- Declined v1.5.27, then interval checks continue without a same-version prompt.
- Manual check with a staged version re-checks and re-prompts when no newer version wins.
- Download error moves active status to error and leaves idle idle.
- Fatal recovery plan restores `autoInstallOnAppQuit` on reset and retry.

## Verification

- `bun run --cwd apps/desktop test -- src/main/updater-state.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`

Behavioral updater verification is deferred. These flows need real GitHub releases; this PR does not launch the Electron app on the host.

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #1297
2. #1303
3. **#1305** 👈 current
<!-- stack:links:end -->