### PR TITLE
Guaranteed identity detection for Google and Microsoft connections

### DIFF
--- a/packages/plugins/google/src/sdk/discovery.test.ts
+++ b/packages/plugins/google/src/sdk/discovery.test.ts
@@ -46,6 +46,105 @@ const ConvertedSpec = Schema.Struct({
 
 const decodeConvertedSpec = Schema.decodeUnknownSync(Schema.fromJsonString(ConvertedSpec));
 
+const OAUTH2_URL = "https://www.googleapis.com/discovery/v1/apis/oauth2/v2/rest";
+const OAUTH2_USERINFO_SCOPES = [
+  "openid",
+  "https://www.googleapis.com/auth/userinfo.email",
+  "https://www.googleapis.com/auth/userinfo.profile",
+] as const;
+
+const oauth2DiscoveryDoc = {
+  name: "oauth2",
+  version: "v2",
+  title: "Google OAuth2 API",
+  rootUrl: "https://www.googleapis.com/",
+  servicePath: "",
+  auth: {
+    oauth2: {
+      scopes: {
+        openid: { description: "Associate you with your personal info on Google" },
+        "https://www.googleapis.com/auth/userinfo.email": {
+          description: "See your primary Google Account email address",
+        },
+        "https://www.googleapis.com/auth/userinfo.profile": {
+          description: "See your personal info",
+        },
+      },
+    },
+  },
+  methods: {
+    tokeninfo: {
+      id: "oauth2.tokeninfo",
+      httpMethod: "POST",
+      path: "oauth2/v2/tokeninfo",
+      parameters: {
+        access_token: {
+          location: "query",
+          type: "string",
+        },
+      },
+      response: { $ref: "Tokeninfo" },
+    },
+  },
+  resources: {
+    userinfo: {
+      methods: {
+        get: {
+          id: "oauth2.userinfo.get",
+          httpMethod: "GET",
+          path: "oauth2/v2/userinfo",
+          scopes: OAUTH2_USERINFO_SCOPES,
+          response: { $ref: "Userinfo" },
+        },
+      },
+      resources: {
+        v2: {
+          resources: {
+            me: {
+              methods: {
+                get: {
+                  id: "oauth2.userinfo.v2.me.get",
+                  httpMethod: "GET",
+                  path: "userinfo/v2/me",
+                  scopes: OAUTH2_USERINFO_SCOPES,
+                  response: { $ref: "Userinfo" },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  schemas: {
+    Tokeninfo: {
+      id: "Tokeninfo",
+      type: "object",
+      properties: {
+        audience: { type: "string" },
+        scope: { type: "string" },
+      },
+    },
+    Userinfo: {
+      id: "Userinfo",
+      type: "object",
+      properties: {
+        email: { type: "string" },
+        family_name: { type: "string" },
+        gender: { type: "string" },
+        given_name: { type: "string" },
+        hd: { type: "string" },
+        id: { type: "string" },
+        link: { type: "string" },
+        locale: { type: "string" },
+        name: { type: "string" },
+        picture: { type: "string" },
+        verified_email: { type: "boolean" },
+      },
+    },
+  },
+};
+
 it("accepts only supported HTTPS Google Discovery endpoints", () => {
   expect(
     normalizeGoogleDiscoveryUrl("https://www.googleapis.com/discovery/v1/apis/gmail/v1/rest/"),
@@ -291,6 +390,46 @@ it.effect("converts Google Discovery documents into Executor-preserving OpenAPI 
     // OAuth2SourceConfig slot model, which no longer exists in v2.
     const oauthTemplate = result.authenticationTemplate?.find((entry) => entry.kind === "oauth2");
     expect(oauthTemplate).toBeDefined();
+  }),
+);
+
+it.effect("converts Google OAuth2 v2 top-level and aliased userinfo methods", () =>
+  Effect.gen(function* () {
+    const result = yield* convertGoogleDiscoveryToOpenApi({
+      discoveryUrl: OAUTH2_URL,
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
+      documentText: JSON.stringify(oauth2DiscoveryDoc),
+    });
+
+    const spec = decodeConvertedSpec(result.specText);
+    const userinfo = spec.paths["/oauth2/v2/userinfo"]?.get;
+    const userinfoMe = spec.paths["/userinfo/v2/me"]?.get;
+    const tokeninfo = spec.paths["/oauth2/v2/tokeninfo"]?.post;
+
+    expect(userinfo).toMatchObject({
+      operationId: "userinfo.get",
+      "x-executor-toolPath": "userinfo.get",
+      "x-google-scopes": [...OAUTH2_USERINFO_SCOPES],
+    });
+    expect(userinfo?.security).toEqual([{ googleOAuth2: [...OAUTH2_USERINFO_SCOPES] }]);
+    expect(userinfo?.responses).toMatchObject({
+      "200": {
+        content: {
+          "application/json": {
+            schema: { $ref: "#/components/schemas/Userinfo" },
+          },
+        },
+      },
+    });
+    expect(userinfoMe).toMatchObject({
+      operationId: "userinfo.v2.me.get",
+      "x-executor-toolPath": "userinfo.v2.me.get",
+      "x-google-scopes": [...OAUTH2_USERINFO_SCOPES],
+    });
+    expect(tokeninfo).toMatchObject({
+      operationId: "tokeninfo",
+      "x-executor-toolPath": "tokeninfo",
+    });
   }),
 );
 

--- a/packages/plugins/google/src/sdk/plugin.test.ts
+++ b/packages/plugins/google/src/sdk/plugin.test.ts
@@ -23,7 +23,8 @@ import {
 } from "@executor-js/sdk";
 import { makeTestConfig, memoryCredentialsPlugin } from "@executor-js/sdk/testing";
 
-import { googlePlugin } from "./plugin";
+import { defaultGoogleHealthCheck, googlePlugin } from "./plugin";
+import { googleOpenApiPresets, type GoogleOpenApiPreset } from "./presets";
 
 // --- Canned Discovery documents -------------------------------------------
 // Each carries one method. Calendar and Gmail BOTH expose a generic `list`
@@ -33,10 +34,18 @@ import { googlePlugin } from "./plugin";
 
 const CALENDAR_URL = "https://www.googleapis.com/discovery/v1/apis/calendar/v3/rest";
 const GMAIL_URL = "https://www.googleapis.com/discovery/v1/apis/gmail/v1/rest";
+const SHEETS_URL = "https://www.googleapis.com/discovery/v1/apis/sheets/v4/rest";
 const DRIVE_URL = "https://www.googleapis.com/discovery/v1/apis/drive/v3/rest";
+const DOCS_URL = "https://www.googleapis.com/discovery/v1/apis/docs/v1/rest";
 const PHOTOS_LIBRARY_URL = "https://www.googleapis.com/discovery/v1/apis/photoslibrary/v1/rest";
 const PHOTOS_PICKER_URL = "https://photospicker.googleapis.com/$discovery/rest?version=v1";
 const PEOPLE_URL = "https://www.googleapis.com/discovery/v1/apis/people/v1/rest";
+const OAUTH2_URL = "https://www.googleapis.com/discovery/v1/apis/oauth2/v2/rest";
+const OAUTH2_USERINFO_SCOPES = [
+  "openid",
+  "https://www.googleapis.com/auth/userinfo.email",
+  "https://www.googleapis.com/auth/userinfo.profile",
+] as const;
 
 const calendarDoc = {
   name: "calendar",
@@ -141,6 +150,72 @@ const driveDoc = {
   },
   schemas: {
     File: { id: "File", type: "object", properties: { id: { type: "string" } } },
+  },
+};
+
+const sheetsDoc = {
+  name: "sheets",
+  version: "v4",
+  title: "Google Sheets API",
+  rootUrl: "https://sheets.googleapis.com/",
+  servicePath: "v4/",
+  auth: {
+    oauth2: {
+      scopes: {
+        "https://www.googleapis.com/auth/spreadsheets": { description: "Manage spreadsheets" },
+      },
+    },
+  },
+  resources: {
+    spreadsheets: {
+      methods: {
+        get: {
+          id: "sheets.spreadsheets.get",
+          httpMethod: "GET",
+          path: "spreadsheets/{spreadsheetId}",
+          scopes: ["https://www.googleapis.com/auth/spreadsheets"],
+          parameters: {
+            spreadsheetId: { location: "path", required: true, type: "string" },
+          },
+        },
+      },
+    },
+  },
+  schemas: {
+    Spreadsheet: { id: "Spreadsheet", type: "object", properties: { id: { type: "string" } } },
+  },
+};
+
+const docsDoc = {
+  name: "docs",
+  version: "v1",
+  title: "Google Docs API",
+  rootUrl: "https://docs.googleapis.com/",
+  servicePath: "v1/",
+  auth: {
+    oauth2: {
+      scopes: {
+        "https://www.googleapis.com/auth/documents": { description: "Manage documents" },
+      },
+    },
+  },
+  resources: {
+    documents: {
+      methods: {
+        get: {
+          id: "docs.documents.get",
+          httpMethod: "GET",
+          path: "documents/{documentId}",
+          scopes: ["https://www.googleapis.com/auth/documents"],
+          parameters: {
+            documentId: { location: "path", required: true, type: "string" },
+          },
+        },
+      },
+    },
+  },
+  schemas: {
+    Document: { id: "Document", type: "object", properties: { documentId: { type: "string" } } },
   },
 };
 
@@ -256,15 +331,104 @@ const peopleDoc = {
   },
 };
 
+const oauth2Doc = {
+  name: "oauth2",
+  version: "v2",
+  title: "Google OAuth2 API",
+  rootUrl: "https://www.googleapis.com/",
+  servicePath: "",
+  auth: {
+    oauth2: {
+      scopes: {
+        openid: { description: "Associate you with your personal info on Google" },
+        "https://www.googleapis.com/auth/userinfo.email": {
+          description: "See your primary Google Account email address",
+        },
+        "https://www.googleapis.com/auth/userinfo.profile": {
+          description: "See your personal info",
+        },
+      },
+    },
+  },
+  methods: {
+    tokeninfo: {
+      id: "oauth2.tokeninfo",
+      httpMethod: "POST",
+      path: "oauth2/v2/tokeninfo",
+      response: { $ref: "Tokeninfo" },
+    },
+  },
+  resources: {
+    userinfo: {
+      methods: {
+        get: {
+          id: "oauth2.userinfo.get",
+          httpMethod: "GET",
+          path: "oauth2/v2/userinfo",
+          scopes: OAUTH2_USERINFO_SCOPES,
+          response: { $ref: "Userinfo" },
+        },
+      },
+      resources: {
+        v2: {
+          resources: {
+            me: {
+              methods: {
+                get: {
+                  id: "oauth2.userinfo.v2.me.get",
+                  httpMethod: "GET",
+                  path: "userinfo/v2/me",
+                  scopes: OAUTH2_USERINFO_SCOPES,
+                  response: { $ref: "Userinfo" },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  schemas: {
+    Tokeninfo: {
+      id: "Tokeninfo",
+      type: "object",
+      properties: {
+        audience: { type: "string" },
+        scope: { type: "string" },
+      },
+    },
+    Userinfo: {
+      id: "Userinfo",
+      type: "object",
+      properties: {
+        email: { type: "string" },
+        family_name: { type: "string" },
+        gender: { type: "string" },
+        given_name: { type: "string" },
+        hd: { type: "string" },
+        id: { type: "string" },
+        link: { type: "string" },
+        locale: { type: "string" },
+        name: { type: "string" },
+        picture: { type: "string" },
+        verified_email: { type: "boolean" },
+      },
+    },
+  },
+};
+
 const toJson = (value: unknown): string => JSON.stringify(value);
 
 const DISCOVERY_BODIES: Readonly<Record<string, string>> = {
   [CALENDAR_URL]: toJson(calendarDoc),
   [GMAIL_URL]: toJson(gmailDoc),
+  [SHEETS_URL]: toJson(sheetsDoc),
   [DRIVE_URL]: toJson(driveDoc),
+  [DOCS_URL]: toJson(docsDoc),
   [PHOTOS_LIBRARY_URL]: toJson(photosLibraryDoc),
   [PHOTOS_PICKER_URL]: toJson(photosPickerDoc),
   [PEOPLE_URL]: toJson(peopleDoc),
+  [OAUTH2_URL]: toJson(oauth2Doc),
 };
 
 // A stub HTTP client that serves the canned Discovery document for whichever
@@ -360,17 +524,27 @@ describe("Google bundle add flow", () => {
           expect(integration?.slug).toBe(IntegrationSlug.make("google"));
 
           // The stored oauth template carries the COMPACTED union of every API's
-          // scopes - the same set the picker previews and `oauth.start` requests.
+          // scopes plus the hidden OAuth2 identity scopes that `oauth.start`
+          // requests.
           // `calendar.readonly` collapses under `calendar`, and `gmail.readonly`
           // collapses under `https://mail.google.com/`, so the requested consent
           // is clean rather than the raw per-method union.
           const config = yield* executor.google.getConfig("google");
+          expect(config?.googleDiscoveryUrls).toEqual([
+            CALENDAR_URL,
+            GMAIL_URL,
+            DRIVE_URL,
+            OAUTH2_URL,
+          ]);
           const oauth = config?.authenticationTemplate?.find((entry) => entry.kind === "oauth2");
           expect(oauth?.kind === "oauth2" ? [...oauth.scopes].sort() : undefined).toEqual(
             [
+              "email",
               "https://mail.google.com/",
               "https://www.googleapis.com/auth/calendar",
               "https://www.googleapis.com/auth/drive",
+              "openid",
+              "profile",
             ].sort(),
           );
 
@@ -415,9 +589,12 @@ describe("Google bundle add flow", () => {
         const oauth = config?.authenticationTemplate?.find((entry) => entry.kind === "oauth2");
         expect(oauth?.kind === "oauth2" ? [...oauth.scopes].sort() : undefined).toEqual(
           [
+            "email",
             "https://www.googleapis.com/auth/photoslibrary.appendonly",
             "https://www.googleapis.com/auth/photoslibrary.readonly.appcreateddata",
             "https://www.googleapis.com/auth/photospicker.mediaitems.readonly",
+            "openid",
+            "profile",
           ].sort(),
         );
 
@@ -453,10 +630,13 @@ describe("Google bundle add flow", () => {
         const oauth = config?.authenticationTemplate?.find((entry) => entry.kind === "oauth2");
         expect(oauth?.kind === "oauth2" ? [...oauth.scopes].sort() : undefined).toEqual(
           [
+            "email",
             "https://www.googleapis.com/auth/calendar",
             "https://www.googleapis.com/auth/photoslibrary.appendonly",
             "https://www.googleapis.com/auth/photoslibrary.readonly.appcreateddata",
             "https://www.googleapis.com/auth/photospicker.mediaitems.readonly",
+            "openid",
+            "profile",
           ].sort(),
         );
 
@@ -493,9 +673,12 @@ describe("Google bundle add flow", () => {
         const oauth = config?.authenticationTemplate?.find((entry) => entry.kind === "oauth2");
         expect(oauth?.kind === "oauth2" ? [...oauth.scopes].sort() : undefined).toEqual(
           [
+            "email",
             "https://www.googleapis.com/auth/calendar",
             "https://www.googleapis.com/auth/photoslibrary.appendonly",
             "https://www.googleapis.com/auth/photoslibrary.readonly.appcreateddata",
+            "openid",
+            "profile",
           ].sort(),
         );
 
@@ -519,7 +702,61 @@ describe("Google bundle add flow", () => {
 });
 
 describe("Google health-check default", () => {
-  it.effect("addBundle with the People API auto-configures the identity health check", () =>
+  it.effect("default featured bundle auto-configures OAuth2 userinfo identity", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const executor = yield* createExecutor(makeTestConfig({ plugins: bundlePlugins() }));
+        const defaultUrls = googleOpenApiPresets
+          .filter((preset: GoogleOpenApiPreset) => preset.featured)
+          .flatMap((preset: GoogleOpenApiPreset) => (preset.url ? [preset.url] : []));
+
+        expect(defaultUrls).toEqual([CALENDAR_URL, GMAIL_URL, SHEETS_URL, DRIVE_URL, DOCS_URL]);
+
+        yield* executor.google.addBundle({
+          urls: defaultUrls,
+          slug: "google_default",
+          description: "Google",
+        });
+
+        const stored = yield* executor.integrations.healthCheck.get(
+          IntegrationSlug.make("google_default"),
+        );
+        expect(stored?.operation, "the default check targets OAuth2 userinfo").toBe(
+          "oauth2.userinfo.get",
+        );
+        expect(stored?.args, "userinfo needs no args").toBeUndefined();
+        expect(stored?.identityField, "the default reads the account email").toBe("email");
+
+        const config = yield* executor.google.getConfig("google_default");
+        expect(config?.googleDiscoveryUrls).toEqual([...defaultUrls, OAUTH2_URL]);
+        const oauth = config?.authenticationTemplate?.find((entry) => entry.kind === "oauth2");
+        expect(oauth?.kind === "oauth2" ? [...oauth.scopes].sort() : undefined).toEqual(
+          [
+            "email",
+            "https://mail.google.com/",
+            "https://www.googleapis.com/auth/calendar",
+            "https://www.googleapis.com/auth/documents",
+            "https://www.googleapis.com/auth/drive",
+            "https://www.googleapis.com/auth/spreadsheets",
+            "openid",
+            "profile",
+          ].sort(),
+        );
+
+        const candidates = yield* executor.integrations.healthCheck.candidates(
+          IntegrationSlug.make("google_default"),
+        );
+        const userinfo = candidates.find((c) => c.operation === "oauth2.userinfo.get");
+        expect(userinfo, "OAuth2 userinfo is a ranked candidate").toBeDefined();
+        expect(
+          (userinfo?.responseFields ?? []).map((field) => field.path),
+          "the email identity field is projected from the response schema",
+        ).toContain("email");
+      }),
+    ),
+  );
+
+  it.effect("addBundle with People still prefers OAuth2 userinfo", () =>
     Effect.scoped(
       Effect.gen(function* () {
         const executor = yield* createExecutor(makeTestConfig({ plugins: bundlePlugins() }));
@@ -530,52 +767,33 @@ describe("Google health-check default", () => {
           description: "Google",
         });
 
-        // The default probe is the People identity call with its required args
-        // pinned and the account email as the identity field - the zero-config
-        // answer to "has this Google connection expired?".
         const stored = yield* executor.integrations.healthCheck.get(
           IntegrationSlug.make("google_people"),
         );
-        expect(stored?.operation, "the default check targets the People identity call").toBe(
-          "people.people.get",
+        expect(stored?.operation, "OAuth2 userinfo beats the People identity call").toBe(
+          "oauth2.userinfo.get",
         );
-        expect(stored?.args, "the People call's required args are pinned").toEqual({
-          resourceName: "people/me",
-          personFields: "names,emailAddresses",
-        });
-        expect(stored?.identityField, "the default reads the account email").toBe(
-          "emailAddresses.0.value",
-        );
-
-        // The check is offered as a candidate with typed response fields, so
-        // the editor's identity picker lists the email path.
-        const candidates = yield* executor.integrations.healthCheck.candidates(
-          IntegrationSlug.make("google_people"),
-        );
-        const peopleGet = candidates.find((c) => c.operation === "people.people.get");
-        expect(peopleGet, "the People call is a ranked candidate").toBeDefined();
-        expect(
-          (peopleGet?.responseFields ?? []).map((field) => field.path),
-          "the email identity field is projected from the response schema",
-        ).toContain("emailAddresses.0.value");
+        expect(stored?.args).toBeUndefined();
+        expect(stored?.identityField).toBe("email");
       }),
     ),
   );
 
-  it.effect("addBundle without the People API leaves the health check unset", () =>
-    Effect.scoped(
-      Effect.gen(function* () {
-        const executor = yield* createExecutor(makeTestConfig({ plugins: bundlePlugins() }));
-        yield* executor.google.addBundle({
-          urls: [CALENDAR_URL],
-          slug: "google_cal_only",
-          description: "Google",
-        });
-        const stored = yield* executor.integrations.healthCheck.get(
-          IntegrationSlug.make("google_cal_only"),
-        );
-        expect(stored, "no People API in the bundle means no default check").toBeNull();
-      }),
-    ),
-  );
+  it("falls back to People when OAuth2 userinfo is absent", () => {
+    expect(
+      defaultGoogleHealthCheck(
+        [PEOPLE_URL],
+        [
+          {
+            toolPath: "people.people.get",
+            operation: { method: "get", pathTemplate: "/v1/{+resourceName}" },
+          },
+        ],
+      ),
+    ).toEqual({
+      operation: "people.people.get",
+      args: { resourceName: "people/me", personFields: "names,emailAddresses" },
+      identityField: "emailAddresses.0.value",
+    });
+  });
 });

--- a/packages/plugins/google/src/sdk/plugin.ts
+++ b/packages/plugins/google/src/sdk/plugin.ts
@@ -25,6 +25,7 @@ import {
   listHealthCheckCandidatesOpenApi,
   makeDefaultOpenapiStore,
   normalizeOpenApiAuthInputs,
+  OpenApiParseError,
   openApiStoredOperationsFromCompiled,
   resolveOpenApiBackedAnnotations,
   resolveOpenApiBackedTools,
@@ -46,18 +47,31 @@ import {
   googlePhotosOpenApiPresets,
 } from "./presets";
 
-/** The default health check for a Google bundle: the People API identity call
- *  (`people.get` with the required `resourceName`/`personFields` pinned), when
- *  the bundle includes the People API. People API is the canonical Google
- *  identity endpoint; if it isn't bundled, no default is written (the editor
- *  remains available). The user can adjust the identity field via the editor. */
-const defaultGoogleHealthCheck = (
+const GOOGLE_OAUTH2_DISCOVERY_URL = "https://www.googleapis.com/discovery/v1/apis/oauth2/v2/rest";
+
+/** The default health check for a Google bundle: prefer the lightweight
+ *  OAuth2 userinfo identity call, which every new Google bundle includes.
+ *  Older bundles may only have People API, so keep that fallback. */
+export const defaultGoogleHealthCheck = (
   urls: readonly string[],
   definitions: readonly {
     readonly toolPath: string;
     readonly operation: { readonly method: string; readonly pathTemplate: string };
   }[],
 ): HealthCheckSpec | undefined => {
+  const userinfoGet = definitions.find(
+    (def) =>
+      def.operation.method.toLowerCase() === "get" &&
+      (def.toolPath === "oauth2.userinfo.get" ||
+        def.operation.pathTemplate === "/oauth2/v2/userinfo"),
+  );
+  if (userinfoGet) {
+    return {
+      operation: userinfoGet.toolPath,
+      identityField: "email",
+    };
+  }
+
   const hasPeopleApi = urls.some((url) => url.includes("/people/"));
   if (!hasPeopleApi) return undefined;
   const peopleGet = definitions.find(
@@ -149,6 +163,24 @@ const uniqueUrls = (urls: readonly string[]): readonly string[] => [
   ...new Set(urls.flatMap((url) => normalizeGoogleDiscoveryUrl(url) ?? [])),
 ];
 
+const googleBundleUrlsWithIdentity = (
+  urls: readonly string[],
+): Effect.Effect<readonly string[], OpenApiParseError> =>
+  Effect.gen(function* () {
+    const normalized: string[] = [];
+    for (const url of urls) {
+      const discoveryUrl = normalizeGoogleDiscoveryUrl(url);
+      if (!discoveryUrl) {
+        return yield* new OpenApiParseError({
+          message:
+            "Google Discovery document URL must be a supported googleapis.com HTTPS Discovery endpoint",
+        });
+      }
+      normalized.push(discoveryUrl);
+    }
+    return uniqueUrls([...normalized, GOOGLE_OAUTH2_DISCOVERY_URL]);
+  });
+
 const describeGoogleAuthMethods = (record: IntegrationRecord): readonly AuthMethodDescriptor[] => {
   const config = decodeGoogleIntegrationConfig(record.config);
   if (!config) return [];
@@ -185,7 +217,7 @@ const makeGooglePluginExtension = (
 
   const addBundle = (config: GoogleBundleConfig) =>
     Effect.gen(function* () {
-      const urls = uniqueUrls(config.urls);
+      const urls = yield* googleBundleUrlsWithIdentity(config.urls);
       const conversion = yield* fetchGoogleBundleConversion(urls, httpClientLayer);
       const compiled = yield* compileOpenApiSpec(conversion.specText);
       const slug = IntegrationSlug.make(config.slug?.trim() || DEFAULT_GOOGLE_SLUG);
@@ -225,10 +257,9 @@ const makeGooglePluginExtension = (
         }),
       );
 
-      // Default the health check to the People API identity call (`people.get`
-      // with `resourceName=people/me`) when the bundle includes the People API,
-      // so connections report alive/expired + identity out of the box. Declared
-      // through core's own storage; the user can adjust it via the editor.
+      // Default the health check to the light OAuth2 userinfo identity call
+      // added to every new bundle. Older bundles without oauth2/v2 can still
+      // fall back to the People API identity operation.
       const defaultHealthCheck = defaultGoogleHealthCheck(urls, compiled.definitions);
       if (defaultHealthCheck) {
         yield* ctx.core.integrations.setHealthCheck(slug, defaultHealthCheck);
@@ -246,7 +277,9 @@ const makeGooglePluginExtension = (
         return yield* new IntegrationNotFoundError({ slug });
       }
 
-      const urls = uniqueUrls(input?.urls ?? current.googleDiscoveryUrls ?? []);
+      const urls = yield* googleBundleUrlsWithIdentity(
+        input?.urls ?? current.googleDiscoveryUrls ?? [],
+      );
       const conversion = yield* fetchGoogleBundleConversion(urls, httpClientLayer);
       const compiled = yield* compileOpenApiSpec(conversion.specText);
 

--- a/packages/plugins/graphql/src/react/GraphqlSignInButton.tsx
+++ b/packages/plugins/graphql/src/react/GraphqlSignInButton.tsx
@@ -2,13 +2,16 @@ import { useState } from "react";
 
 import {
   AuthTemplateSlug,
-  ConnectionName,
   IntegrationSlug,
   OAuthClientSlug,
   type Connection,
   type AuthTemplateSlug as AuthTemplateSlugType,
 } from "@executor-js/sdk/shared";
-import { OAuthSignInButton, useOAuthPopupFlow } from "@executor-js/react/plugins/oauth-sign-in";
+import {
+  OAuthSignInButton,
+  useOAuthPopupFlow,
+  type OAuthCompletionPayload,
+} from "@executor-js/react/plugins/oauth-sign-in";
 import {
   ConnectionOwnerDropdown,
   useConnectionOwner,
@@ -57,10 +60,10 @@ export default function GraphqlSignInButton(props: {
         template: AuthTemplateSlug.make(String(props.template)),
         identityLabel: `${props.displayName} OAuth`,
       },
-      onSuccess: (payload: { readonly connection: ConnectionName }) => {
+      onSuccess: (payload: OAuthCompletionPayload) => {
         // Touch the minted connection name to satisfy the success contract; the
         // connection list re-reads via reactivity keys after the flow completes.
-        void payload.connection;
+        void payload.name;
         setConnectedOwner(connectionOwner);
       },
     });

--- a/packages/plugins/microsoft/src/sdk/graph.test.ts
+++ b/packages/plugins/microsoft/src/sdk/graph.test.ts
@@ -191,6 +191,14 @@ paths:
       responses:
         "200":
           description: OK
+    patch:
+      operationId: me.UpdateUser
+      security:
+        - azureAdDelegated:
+            - User.ReadWrite
+      responses:
+        "200":
+          description: OK
   /me/photo:
     get:
       operationId: me.photo.GetProfilePhoto
@@ -229,6 +237,36 @@ const noWorkloadSelection = {
   pathPrefixes: [],
   tagPrefixes: [],
 } as const;
+
+const profileSelection = {
+  coversFullGraph: false,
+  presetIds: ["profile"],
+  customScopes: [],
+  exactPaths: ["/me", "/me/photo", "/me/photo/$value"],
+  pathPrefixes: [],
+  tagPrefixes: [],
+} as const;
+
+type MicrosoftGraphKeepPathItemSelection = Parameters<typeof microsoftGraphKeepPathItem>[0];
+
+const keptIdentityFixturePaths = (
+  selection: MicrosoftGraphKeepPathItemSelection,
+): Map<string, Record<string, unknown>> => {
+  const structure = structuralSplit(identityPathFixture);
+  expect(structure).not.toBeNull();
+  const keepPathItem = microsoftGraphKeepPathItem(selection);
+  const kept = new Map<string, Record<string, unknown>>();
+
+  for (const range of structure!.pathItems) {
+    const entry = parseEntry(structure!.text, range, 2);
+    expect(entry).not.toBeNull();
+    const [path, rawPathItem] = entry!;
+    const pathItem = keepPathItem(path, rawPathItem as Record<string, unknown>);
+    if (pathItem) kept.set(path, pathItem as Record<string, unknown>);
+  }
+
+  return kept;
+};
 
 const keptPathItem = (fixture: string): Record<string, unknown> => {
   const structure = structuralSplit(fixture);
@@ -285,22 +323,19 @@ const responseFileHintKind = (
   return Option.getOrUndefined(hint)?.kind;
 };
 
-it("keeps bare /me for identity health checks without keeping /me child paths", () => {
-  const structure = structuralSplit(identityPathFixture);
-  expect(structure).not.toBeNull();
-  const keepPathItem = microsoftGraphKeepPathItem(noWorkloadSelection);
-  const kept = new Map<string, Record<string, unknown>>();
-
-  for (const range of structure!.pathItems) {
-    const entry = parseEntry(structure!.text, range, 2);
-    expect(entry).not.toBeNull();
-    const [path, rawPathItem] = entry!;
-    const pathItem = keepPathItem(path, rawPathItem as Record<string, unknown>);
-    if (pathItem) kept.set(path, pathItem as Record<string, unknown>);
-  }
+it("keeps only GET /me for identity health checks without selected workloads", () => {
+  const kept = keptIdentityFixturePaths(noWorkloadSelection);
 
   expect([...kept.keys()]).toEqual(["/me"]);
   expect(kept.get("/me")?.get).toMatchObject({ operationId: "me.GetUser" });
+  expect(kept.get("/me")?.patch).toBeUndefined();
+});
+
+it("keeps all /me operations when profile selects the path", () => {
+  const kept = keptIdentityFixturePaths(profileSelection);
+
+  expect(kept.get("/me")?.get).toMatchObject({ operationId: "me.GetUser" });
+  expect(kept.get("/me")?.patch).toMatchObject({ operationId: "me.UpdateUser" });
 });
 
 it("keeps already-binary drive content responses untouched", () => {

--- a/packages/plugins/microsoft/src/sdk/graph.test.ts
+++ b/packages/plugins/microsoft/src/sdk/graph.test.ts
@@ -174,8 +174,55 @@ components:
             $ref: '#/components/schemas/microsoft.graph.ODataErrors.ODataError'
 `;
 
+const identityPathFixture = `
+openapi: 3.0.4
+info:
+  title: Microsoft Graph Fixture
+  version: v1.0
+servers:
+  - url: https://graph.microsoft.com/v1.0
+paths:
+  /me:
+    get:
+      operationId: me.GetUser
+      security:
+        - azureAdDelegated:
+            - User.Read
+      responses:
+        "200":
+          description: OK
+  /me/photo:
+    get:
+      operationId: me.photo.GetProfilePhoto
+      security:
+        - azureAdDelegated:
+            - User.Read
+      responses:
+        "200":
+          description: OK
+  /me/messages:
+    get:
+      operationId: me.messages.ListMessages
+      security:
+        - azureAdDelegated:
+            - Mail.ReadWrite
+      responses:
+        "200":
+          description: OK
+components: {}
+`;
+
 const fullGraphSelection = {
   coversFullGraph: true,
+  presetIds: [],
+  customScopes: [],
+  exactPaths: [],
+  pathPrefixes: [],
+  tagPrefixes: [],
+} as const;
+
+const noWorkloadSelection = {
+  coversFullGraph: false,
   presetIds: [],
   customScopes: [],
   exactPaths: [],
@@ -237,6 +284,24 @@ const responseFileHintKind = (
   const hint = Option.flatMap(match!.binding.responseBody, (body) => body.fileHint);
   return Option.getOrUndefined(hint)?.kind;
 };
+
+it("keeps bare /me for identity health checks without keeping /me child paths", () => {
+  const structure = structuralSplit(identityPathFixture);
+  expect(structure).not.toBeNull();
+  const keepPathItem = microsoftGraphKeepPathItem(noWorkloadSelection);
+  const kept = new Map<string, Record<string, unknown>>();
+
+  for (const range of structure!.pathItems) {
+    const entry = parseEntry(structure!.text, range, 2);
+    expect(entry).not.toBeNull();
+    const [path, rawPathItem] = entry!;
+    const pathItem = keepPathItem(path, rawPathItem as Record<string, unknown>);
+    if (pathItem) kept.set(path, pathItem as Record<string, unknown>);
+  }
+
+  expect([...kept.keys()]).toEqual(["/me"]);
+  expect(kept.get("/me")?.get).toMatchObject({ operationId: "me.GetUser" });
+});
 
 it("keeps already-binary drive content responses untouched", () => {
   const pathItem = keptPathItem(driveContentFixture);

--- a/packages/plugins/microsoft/src/sdk/graph.ts
+++ b/packages/plugins/microsoft/src/sdk/graph.ts
@@ -525,8 +525,8 @@ const filterPathItem = (
 ): Record<string, unknown> | null => {
   // Always keep bare /me: the default identity health check depends on GET /me
   // even when the profile workload is unchecked.
-  const pathMatches =
-    isIdentityHealthPath(path) || matchesGraphPath(path, options.exactPaths, options.pathPrefixes);
+  const pathMatchesSelection = matchesGraphPath(path, options.exactPaths, options.pathPrefixes);
+  const identityHealthGetOnly = !pathMatchesSelection && isIdentityHealthPath(path);
   const kept: Record<string, unknown> = {};
   let hasOperation = false;
 
@@ -534,8 +534,10 @@ const filterPathItem = (
     const lowerKey = key.toLowerCase();
     if (!HTTP_METHODS.has(lowerKey)) continue;
     if (!isRecord(value)) continue;
+    if (identityHealthGetOnly && lowerKey !== "get") continue;
     if (
-      pathMatches ||
+      pathMatchesSelection ||
+      identityHealthGetOnly ||
       operationMatchesTagPrefix(value, options.tagPrefixes) ||
       operationMatchesScope(value, options.selectedScopes)
     ) {

--- a/packages/plugins/microsoft/src/sdk/graph.ts
+++ b/packages/plugins/microsoft/src/sdk/graph.ts
@@ -24,6 +24,7 @@ import {
   MICROSOFT_GRAPH_CLIENT_CREDENTIALS_SCOPES,
   MICROSOFT_GRAPH_DELEGATED_DEFAULT_SCOPES,
   MICROSOFT_GRAPH_DEFAULT_PRESET_IDS,
+  MICROSOFT_GRAPH_IDENTITY_SCOPE,
   MICROSOFT_GRAPH_OPENAPI_URL,
   MICROSOFT_GRAPH_PERMISSIONS_REFERENCE_URL,
   MICROSOFT_TOKEN_URL,
@@ -185,7 +186,14 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
   value !== null && typeof value === "object" && !Array.isArray(value);
 
 const HTTP_METHODS = new Set(["delete", "get", "patch", "post", "put"]);
-const BASE_OAUTH_SCOPES = new Set(["offline_access", "openid", "profile", "email"]);
+const REQUEST_BASE_SCOPES = new Set(["offline_access", "openid", "profile", "email"]);
+const PATH_SCOPE_IGNORED_SCOPES = new Set([
+  "offline_access",
+  "openid",
+  "profile",
+  "email",
+  MICROSOFT_GRAPH_IDENTITY_SCOPE,
+]);
 
 const firstString = (values: readonly unknown[]): string | undefined =>
   values.find((value): value is string => typeof value === "string" && value.trim().length > 0);
@@ -422,6 +430,9 @@ const matchesGraphPath = (
   );
 };
 
+const isIdentityHealthPath = (path: string): boolean =>
+  graphPathMatchVariants(path).some((variant) => variant === "/me");
+
 const operationTags = (operation: Record<string, unknown>): readonly string[] =>
   Array.isArray(operation.tags)
     ? operation.tags.filter((tag): tag is string => typeof tag === "string")
@@ -499,7 +510,7 @@ const operationMatchesScope = (
   selectedScopes: ReadonlySet<string>,
 ): boolean =>
   permissionScopes(operation).some(
-    (scope) => selectedScopes.has(scope) && !BASE_OAUTH_SCOPES.has(scope),
+    (scope) => selectedScopes.has(scope) && !PATH_SCOPE_IGNORED_SCOPES.has(scope),
   );
 
 const filterPathItem = (
@@ -512,7 +523,10 @@ const filterPathItem = (
     readonly selectedScopes: ReadonlySet<string>;
   },
 ): Record<string, unknown> | null => {
-  const pathMatches = matchesGraphPath(path, options.exactPaths, options.pathPrefixes);
+  // Always keep bare /me: the default identity health check depends on GET /me
+  // even when the profile workload is unchecked.
+  const pathMatches =
+    isIdentityHealthPath(path) || matchesGraphPath(path, options.exactPaths, options.pathPrefixes);
   const kept: Record<string, unknown> = {};
   let hasOperation = false;
 
@@ -719,7 +733,7 @@ const streamSelectedScopes = (
   const collected = [
     ...MICROSOFT_GRAPH_BASE_SCOPES,
     ...fullGraphScopes,
-    ...requestedScopes.filter((scope) => !BASE_OAUTH_SCOPES.has(scope)),
+    ...requestedScopes.filter((scope) => !REQUEST_BASE_SCOPES.has(scope)),
   ];
   for (const range of structure.pathItems) {
     const entry = parseEntry(structure.text, range, 2);

--- a/packages/plugins/microsoft/src/sdk/plugin.test.ts
+++ b/packages/plugins/microsoft/src/sdk/plugin.test.ts
@@ -621,6 +621,51 @@ describe("Microsoft Graph provider", () => {
 });
 
 describe("Microsoft Graph health-check default", () => {
+  it.effect("addGraph without profile still auto-configures the /me identity check", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const executor = yield* createExecutor(makeTestConfig({ plugins: graphPlugins() }));
+
+        yield* executor.microsoft.addGraph({
+          presetIds: ["mail"],
+          slug: "microsoft_graph_mail_hc",
+          description: "Microsoft Graph",
+        });
+
+        const config = yield* executor.microsoft.getConfig("microsoft_graph_mail_hc");
+        expect(config?.microsoftGraphExactPaths).toEqual([]);
+        expect(config?.microsoftGraphScopes).toEqual([
+          "offline_access",
+          "User.Read",
+          "Mail.ReadWrite",
+          "Mail.Send",
+          "MailboxSettings.ReadWrite",
+        ]);
+
+        const stored = yield* executor.integrations.healthCheck.get(
+          IntegrationSlug.make("microsoft_graph_mail_hc"),
+        );
+        expect(stored?.operation, "the default check targets GET /me").toBe("me.getUser");
+        expect(stored?.identityField, "the default reads the principal name").toBe(
+          "userPrincipalName",
+        );
+
+        yield* executor.connections.create({
+          owner: "org",
+          name: ConnectionName.make("mail"),
+          integration: IntegrationSlug.make("microsoft_graph_mail_hc"),
+          template: AuthTemplateSlug.make(MICROSOFT_AUTH_TEMPLATE_SLUG),
+          value: "token-xyz",
+        });
+
+        const toolNames = (yield* executor.tools.list()).map((tool) => String(tool.name));
+        expect(toolNames).toContain("me.getUser");
+        expect(toolNames).toContain("me.messagesListMessages");
+        expect(toolNames).not.toContain("me.eventsListEvents");
+      }),
+    ),
+  );
+
   it.effect("addGraph with a /me workload auto-configures the identity health check", () =>
     Effect.scoped(
       Effect.gen(function* () {

--- a/packages/plugins/microsoft/src/sdk/presets.test.ts
+++ b/packages/plugins/microsoft/src/sdk/presets.test.ts
@@ -58,6 +58,16 @@ describe("Microsoft Graph scope presets", () => {
     ]);
   });
 
+  it("includes User.Read for identity when profile is not selected", () => {
+    expect(microsoftGraphScopesForPresetIds(["mail"])).toEqual([
+      ...MICROSOFT_GRAPH_BASE_SCOPES,
+      "User.Read",
+      "Mail.ReadWrite",
+      "Mail.Send",
+      "MailboxSettings.ReadWrite",
+    ]);
+  });
+
   it("returns path filters for the selected workloads", () => {
     expect(microsoftGraphExactPathsForPresetIds(["profile"])).toContain("/me");
     expect(microsoftGraphPathPrefixesForPresetIds(["mail"])).toContain("/me/messages");

--- a/packages/plugins/microsoft/src/sdk/presets.ts
+++ b/packages/plugins/microsoft/src/sdk/presets.ts
@@ -41,9 +41,11 @@ export const MICROSOFT_TOKEN_URL = "https://login.microsoftonline.com/common/oau
 export const MICROSOFT_AUTH_TEMPLATE_SLUG = "azureAdDelegated";
 export const MICROSOFT_CLIENT_CREDENTIALS_AUTH_TEMPLATE_SLUG = "azureAdClientCredentials";
 export const MICROSOFT_GRAPH_BASE_SCOPES: readonly string[] = ["offline_access"];
+export const MICROSOFT_GRAPH_IDENTITY_SCOPE = "User.Read";
 export const MICROSOFT_GRAPH_DEFAULT_SCOPE = "https://graph.microsoft.com/.default";
 export const MICROSOFT_GRAPH_DELEGATED_DEFAULT_SCOPES: readonly string[] = [
   ...MICROSOFT_GRAPH_BASE_SCOPES,
+  MICROSOFT_GRAPH_IDENTITY_SCOPE,
   MICROSOFT_GRAPH_DEFAULT_SCOPE,
 ];
 export const MICROSOFT_GRAPH_CLIENT_CREDENTIALS_SCOPES: readonly string[] = [
@@ -495,6 +497,7 @@ export const microsoftGraphScopesForPresetIds = (
 ): readonly string[] =>
   orderedUnique([
     ...MICROSOFT_GRAPH_BASE_SCOPES,
+    MICROSOFT_GRAPH_IDENTITY_SCOPE,
     ...[...presetIds].flatMap((presetId) => microsoftGraphPresetForId(presetId)?.scopes ?? []),
     ...customScopes,
   ]);

--- a/packages/react/src/components/add-account-modal.test.ts
+++ b/packages/react/src/components/add-account-modal.test.ts
@@ -17,6 +17,7 @@ import {
   dcrClientNameForIntegration,
   DEFAULT_CONNECTION_OWNER,
   mergeCustomMethods,
+  oauthIdentityLabelFromHealth,
   runCimdConnect,
   runDcrConnect,
 } from "./add-account-modal";
@@ -108,6 +109,66 @@ describe("connectionNameFrom", () => {
   it("derives a callable default from owner and integration when the display name is empty", () => {
     expect(String(connectionNameFrom("", "org", "GitHub", "org_123"))).toBe("workspaceGithub");
     expect(String(connectionNameFrom("", "org", "GitHub", null))).toBe("localGithub");
+  });
+});
+
+describe("oauthIdentityLabelFromHealth", () => {
+  const healthyResult = {
+    status: "healthy" as const,
+    identity: " user@example.com ",
+    checkedAt: 1,
+  };
+
+  it("uses a healthy probed identity when the stored label is still the default", () => {
+    expect(
+      oauthIdentityLabelFromHealth({
+        result: healthyResult,
+        typedLabel: "",
+        storedIdentityLabel: "Personal Google",
+        defaultIdentityLabel: "Personal Google",
+      }),
+    ).toBe("user@example.com");
+  });
+
+  it("does not overwrite a hand-typed label", () => {
+    expect(
+      oauthIdentityLabelFromHealth({
+        result: healthyResult,
+        typedLabel: "My Google Account",
+        storedIdentityLabel: "My Google Account",
+        defaultIdentityLabel: "Personal Google",
+      }),
+    ).toBeNull();
+  });
+
+  it("does not overwrite a stored custom label", () => {
+    expect(
+      oauthIdentityLabelFromHealth({
+        result: healthyResult,
+        typedLabel: "",
+        storedIdentityLabel: "Finance Google",
+        defaultIdentityLabel: "Personal Google",
+      }),
+    ).toBeNull();
+  });
+
+  it("requires a healthy result with an identity", () => {
+    expect(
+      oauthIdentityLabelFromHealth({
+        result: { status: "degraded", checkedAt: 1 },
+        typedLabel: "",
+        storedIdentityLabel: "Personal Google",
+        defaultIdentityLabel: "Personal Google",
+      }),
+    ).toBeNull();
+    expect(
+      oauthIdentityLabelFromHealth({
+        result: { status: "healthy", checkedAt: 1 },
+        typedLabel: "",
+        storedIdentityLabel: "Personal Google",
+        defaultIdentityLabel: "Personal Google",
+      }),
+    ).toBeNull();
   });
 });
 

--- a/packages/react/src/components/add-account-modal.tsx
+++ b/packages/react/src/components/add-account-modal.tsx
@@ -21,6 +21,7 @@ import { toast } from "sonner";
 
 import {
   addConnectionOptimistic,
+  checkConnectionHealth,
   connectionsAllAtom,
   createOAuthClientOptimistic,
   integrationHealthCheckAtom,
@@ -33,9 +34,11 @@ import {
   removeOAuthClientOptimistic,
   setIntegrationHealthCheck,
   startOAuth,
+  updateConnection,
   validateConnection,
 } from "../api/atoms";
 import {
+  connectionCheckKeys,
   connectionWriteKeys,
   healthCheckWriteKeys,
   oauthClientWriteKeys,
@@ -58,6 +61,7 @@ import {
   oauthCallbackUrl,
   oauthClientIdMetadataDocumentUrl,
   useOAuthPopupFlow,
+  type OAuthCompletionPayload,
 } from "../plugins/oauth-sign-in";
 import {
   clientDisplayName,
@@ -566,6 +570,20 @@ export const connectionNameFrom = (
   organizationId: string | null,
 ): ConnectionName =>
   connectionIdentifier(connectionLabelForHost(label, owner, integrationName, organizationId));
+
+export const oauthIdentityLabelFromHealth = (input: {
+  readonly result: HealthCheckResult;
+  readonly typedLabel: string;
+  readonly storedIdentityLabel?: string | null;
+  readonly defaultIdentityLabel: string;
+}): string | null => {
+  const identity = input.result.identity?.trim();
+  if (input.result.status !== "healthy" || !identity) return null;
+  if (input.typedLabel.trim().length > 0) return null;
+  const defaultLabel = input.defaultIdentityLabel.trim();
+  const storedLabel = (input.storedIdentityLabel ?? defaultLabel).trim();
+  return storedLabel === defaultLabel ? identity : null;
+};
 
 // ---------------------------------------------------------------------------
 // Transparent CIMD connect orchestration.
@@ -1186,6 +1204,8 @@ function AddAccountModalView(props: AddAccountModalProps) {
   });
   const doRemoveOAuthClient = useAtomSet(removeOAuthClientOptimistic, { mode: "promise" });
   const doValidate = useAtomSet(validateConnection, { mode: "promiseExit" });
+  const doCheckConnectionHealth = useAtomSet(checkConnectionHealth, { mode: "promiseExit" });
+  const doUpdateConnection = useAtomSet(updateConnection, { mode: "promiseExit" });
   const doSetHealthCheck = useAtomSet(setIntegrationHealthCheck, { mode: "promiseExit" });
 
   // The integration's declared health check + its candidate operations. When a
@@ -1585,6 +1605,42 @@ function AddAccountModalView(props: AddAccountModalProps) {
   // OAuth popup flow's busy state die with this instance.
   const close = () => onOpenChange(false);
 
+  const probeAndAutoNameOAuthConnection = async (
+    connection: OAuthCompletionPayload,
+    typedLabel: string,
+    defaultIdentityLabel: string,
+  ): Promise<void> => {
+    const check = await doCheckConnectionHealth({
+      params: {
+        owner: connection.owner,
+        integration: connection.integration,
+        name: connection.name,
+      },
+      query: {},
+      reactivityKeys: connectionCheckKeys,
+    });
+    if (Exit.isFailure(check)) return;
+    const nextIdentityLabel = oauthIdentityLabelFromHealth({
+      result: check.value,
+      typedLabel,
+      storedIdentityLabel: connection.identityLabel,
+      defaultIdentityLabel,
+    });
+    if (nextIdentityLabel === null) return;
+    const updated = await doUpdateConnection({
+      params: {
+        owner: connection.owner,
+        integration: connection.integration,
+        name: connection.name,
+      },
+      payload: { identityLabel: nextIdentityLabel },
+      reactivityKeys: connectionWriteKeys,
+    });
+    if (Exit.isFailure(updated)) {
+      toast.error(messageFromExit(updated, "Couldn't update connection name"));
+    }
+  };
+
   const credentialPayloadOrigin = createCredentialPayloadOrigin({
     origin: credentialOrigin,
     inputs: credentialInputs,
@@ -1767,6 +1823,12 @@ function AddAccountModalView(props: AddAccountModalProps) {
     // backend resolves the app own→shared from the slug, so the payload carries
     // only the host-resolved connection owner.
     const connectionOwner = oauthConnectionOwner;
+    const identityLabel = connectionLabelForHost(
+      label,
+      connectionOwner,
+      integrationName,
+      organizationId,
+    );
     const payload = {
       client: chosenClient.slug,
       clientOwner: chosenClient.owner,
@@ -1774,12 +1836,7 @@ function AddAccountModalView(props: AddAccountModalProps) {
       name: connectionNameFrom(label, connectionOwner, integrationName, organizationId),
       integration,
       template: method.template,
-      identityLabel: connectionLabelForHost(
-        label,
-        connectionOwner,
-        integrationName,
-        organizationId,
-      ),
+      identityLabel,
     };
     // client_credentials mints inline (no redirect); authorization_code runs the popup.
     if (chosenClient.grant === "client_credentials") {
@@ -1788,7 +1845,6 @@ function AddAccountModalView(props: AddAccountModalProps) {
         payload,
         reactivityKeys: connectionWriteKeys,
       });
-      setCcBusy(false);
       trackEvent("connection_oauth_started", {
         integration_slug: String(integration),
         owner: connectionOwner,
@@ -1796,9 +1852,14 @@ function AddAccountModalView(props: AddAccountModalProps) {
         success: Exit.isSuccess(exit),
       });
       if (Exit.isFailure(exit)) {
+        setCcBusy(false);
         toast.error(messageFromExit(exit, "Failed to connect"));
         return;
       }
+      if (exit.value.status === "connected") {
+        await probeAndAutoNameOAuthConnection(exit.value.connection, label, identityLabel);
+      }
+      setCcBusy(false);
       toast.success("Connection added");
       close();
       return;
@@ -1828,7 +1889,8 @@ function AddAccountModalView(props: AddAccountModalProps) {
           success: false,
         });
       },
-      onSuccess: () => {
+      onSuccess: async (connection: OAuthCompletionPayload) => {
+        await probeAndAutoNameOAuthConnection(connection, label, identityLabel);
         toast.success("Connection added");
         close();
       },
@@ -1878,7 +1940,8 @@ function AddAccountModalView(props: AddAccountModalProps) {
               template: method.template,
               identityLabel,
             },
-            onSuccess: () => {
+            onSuccess: async (connection: OAuthCompletionPayload) => {
+              await probeAndAutoNameOAuthConnection(connection, label, identityLabel);
               toast.success("Connection added");
               close();
             },
@@ -1968,7 +2031,8 @@ function AddAccountModalView(props: AddAccountModalProps) {
               template: method.template,
               identityLabel,
             },
-            onSuccess: () => {
+            onSuccess: async (connection: OAuthCompletionPayload) => {
+              await probeAndAutoNameOAuthConnection(connection, label, identityLabel);
               toast.success("Connection added");
               close();
             },

--- a/packages/react/src/plugins/oauth-sign-in.tsx
+++ b/packages/react/src/plugins/oauth-sign-in.tsx
@@ -52,7 +52,10 @@ import {
 // ---------------------------------------------------------------------------
 
 export type OAuthCompletionPayload = {
-  readonly connection: ConnectionName;
+  readonly owner: Owner;
+  readonly integration: IntegrationSlug;
+  readonly name: ConnectionName;
+  readonly identityLabel?: string | null;
 };
 
 export type OAuthStartPayload = {


### PR DESCRIPTION
Every Google bundle now includes the hidden oauth2/v2 Discovery source and seeds a userinfo-based identity health check regardless of preset selection; Microsoft Graph always keeps GET /me (and only GET) so identity detection survives any workload combination. OAuth completion now probes connection health and auto-fills the connection label with the account email when the user didn't type one.

- Google: oauth2.userinfo.get health check (identityField: email), People API fallback for pre-existing bundles; consent always includes openid/email/profile
- Microsoft: bare /me force-kept GET-only, User.Read always in delegated scopes
- Post-OAuth auto-naming across BYO OAuth, client_credentials, CIMD, DCR (incl. MCP)

Independently reviewed (ship-with-nits; the one fix-worthy nit, PATCH /me leaking through the identity keep, is fixed in the last commit).