### PR TITLE
Add per-service Microsoft workload integrations API

### DIFF
--- a/packages/plugins/microsoft/src/api/group.ts
+++ b/packages/plugins/microsoft/src/api/group.ts
@@ -64,6 +64,41 @@ const AddGraphResponse = Schema.Struct({
   toolCount: Schema.Number,
 });
 
+const AddWorkloadPayload = Schema.Struct({
+  presetId: Schema.String,
+  slug: Schema.optional(Schema.String),
+  name: Schema.optional(Schema.String),
+});
+
+const AddWorkloadsPayload = Schema.Struct({
+  workloads: Schema.Array(AddWorkloadPayload),
+  baseUrl: Schema.optional(Schema.String),
+});
+
+const AddWorkloadsResponse = Schema.Struct({
+  added: Schema.Array(
+    Schema.Struct({
+      slug: IntegrationSlug,
+      presetId: Schema.String,
+      toolCount: Schema.Number,
+    }),
+  ),
+  skipped: Schema.Array(
+    Schema.Struct({
+      slug: IntegrationSlug,
+      presetId: Schema.String,
+      reason: Schema.Literal("already_exists"),
+    }),
+  ),
+  failed: Schema.Array(
+    Schema.Struct({
+      slug: IntegrationSlug,
+      presetId: Schema.String,
+      error: Schema.String,
+    }),
+  ),
+});
+
 const UpdateGraphPayload = Schema.Struct({
   presetIds: Schema.optional(Schema.Array(Schema.String)),
   customScopes: Schema.optional(Schema.Array(Schema.String)),
@@ -121,6 +156,13 @@ export const MicrosoftGroup = HttpApiGroup.make("microsoft")
     HttpApiEndpoint.post("addGraph", "/microsoft/graph", {
       payload: AddGraphPayload,
       success: AddGraphResponse,
+      error: DomainErrors,
+    }),
+  )
+  .add(
+    HttpApiEndpoint.post("addWorkloads", "/microsoft/workloads", {
+      payload: AddWorkloadsPayload,
+      success: AddWorkloadsResponse,
       error: DomainErrors,
     }),
   )

--- a/packages/plugins/microsoft/src/api/handlers.ts
+++ b/packages/plugins/microsoft/src/api/handlers.ts
@@ -36,6 +36,17 @@ export const MicrosoftHandlers = HttpApiBuilder.group(
           }),
         ),
       )
+      .handle("addWorkloads", ({ payload }) =>
+        capture(
+          Effect.gen(function* () {
+            const ext = yield* MicrosoftExtensionService;
+            return yield* ext.addWorkloads({
+              workloads: payload.workloads,
+              baseUrl: payload.baseUrl,
+            });
+          }),
+        ),
+      )
       .handle("getIntegration", ({ params }) =>
         capture(
           Effect.gen(function* () {

--- a/packages/plugins/microsoft/src/react/atoms.ts
+++ b/packages/plugins/microsoft/src/react/atoms.ts
@@ -19,6 +19,8 @@ export const microsoftConfigAtom = (slug: IntegrationSlug) =>
 
 export const addMicrosoftGraph = MicrosoftClient.mutation("microsoft", "addGraph");
 
+export const addMicrosoftWorkloads = MicrosoftClient.mutation("microsoft", "addWorkloads");
+
 export const updateMicrosoftGraph = MicrosoftClient.mutation("microsoft", "updateGraph");
 
 export const removeMicrosoftGraph = MicrosoftClient.mutation("microsoft", "removeGraph");

--- a/packages/plugins/microsoft/src/react/index.ts
+++ b/packages/plugins/microsoft/src/react/index.ts
@@ -2,6 +2,7 @@ export { microsoftIntegrationPlugin } from "./source-plugin";
 export { MicrosoftClient } from "./client";
 export {
   addMicrosoftGraph,
+  addMicrosoftWorkloads,
   microsoftConfigAtom,
   microsoftConfigFamily,
   microsoftConfigure,

--- a/packages/plugins/microsoft/src/sdk/index.ts
+++ b/packages/plugins/microsoft/src/sdk/index.ts
@@ -21,6 +21,7 @@ export {
   microsoftGraphScopePresets,
   microsoftGraphScopesForPresetIds,
   microsoftGraphTagPrefixesForPresetIds,
+  microsoftServiceSlug,
   type MicrosoftGraphPreset,
   type MicrosoftGraphScopeAudience,
   type MicrosoftGraphScopePreset,
@@ -38,10 +39,16 @@ export {
 } from "./graph";
 export {
   microsoftPlugin,
+  type MicrosoftAddWorkloadsAdded,
+  type MicrosoftAddWorkloadsFailed,
+  type MicrosoftAddWorkloadsInput,
+  type MicrosoftAddWorkloadsResult,
+  type MicrosoftAddWorkloadsSkipped,
   type MicrosoftConfigureInput,
   type MicrosoftGraphConfig,
   type MicrosoftPluginExtension,
   type MicrosoftPluginOptions,
   type MicrosoftUpdateInput,
   type MicrosoftUpdateResult,
+  type MicrosoftWorkloadConfig,
 } from "./plugin";

--- a/packages/plugins/microsoft/src/sdk/plugin.test.ts
+++ b/packages/plugins/microsoft/src/sdk/plugin.test.ts
@@ -67,6 +67,12 @@ paths:
       responses:
         "200":
           description: OK
+  /me/drive/root/children:
+    get:
+      operationId: me.drive.root.ListChildren
+      responses:
+        "200":
+          description: OK
   /sites:
     get:
       operationId: sites.ListSites
@@ -185,41 +191,48 @@ components:
             https://graph.microsoft.com/.default: https://graph.microsoft.com/.default
 `;
 
-const graphHttpClientLayer = Layer.succeed(HttpClient.HttpClient)(
-  HttpClient.make((request: HttpClientRequest.HttpClientRequest) =>
-    Effect.succeed(
-      HttpClientResponse.fromWeb(
-        request,
-        new Response(
-          request.url === MICROSOFT_GRAPH_OPENAPI_URL
-            ? graphFixture
-            : request.url === MICROSOFT_GRAPH_PERMISSIONS_REFERENCE_URL
-              ? permissionsReferenceFixture
-              : request.url === EMULATOR_SPEC_URL
-                ? emulatorGraphFixture
-                : request.url === LOCAL_EMULATOR_SPEC_URL
-                  ? localEmulatorGraphFixture
-                  : "not found",
-          {
-            status:
-              request.url === MICROSOFT_GRAPH_OPENAPI_URL ||
-              request.url === MICROSOFT_GRAPH_PERMISSIONS_REFERENCE_URL ||
-              request.url === EMULATOR_SPEC_URL ||
-              request.url === LOCAL_EMULATOR_SPEC_URL
-                ? 200
-                : 404,
-            headers: {
-              "content-type":
-                request.url === MICROSOFT_GRAPH_PERMISSIONS_REFERENCE_URL
-                  ? "text/markdown"
-                  : "application/yaml",
-            },
-          },
-        ),
-      ),
-    ),
-  ),
+interface GraphHttpClientOptions {
+  readonly failedUrls?: ReadonlySet<string>;
+  readonly beforeResponse?: (url: string) => Effect.Effect<void, never, never>;
+}
+
+const waitOneTurn: Effect.Effect<void, never, never> = Effect.promise(() => Promise.resolve()).pipe(
+  Effect.orDie,
 );
+
+const GRAPH_FIXTURE_BODIES: Readonly<Record<string, string>> = {
+  [MICROSOFT_GRAPH_OPENAPI_URL]: graphFixture,
+  [MICROSOFT_GRAPH_PERMISSIONS_REFERENCE_URL]: permissionsReferenceFixture,
+  [EMULATOR_SPEC_URL]: emulatorGraphFixture,
+  [LOCAL_EMULATOR_SPEC_URL]: localEmulatorGraphFixture,
+};
+
+const makeGraphHttpClientLayer = (options: GraphHttpClientOptions = {}) =>
+  Layer.succeed(HttpClient.HttpClient)(
+    HttpClient.make((request: HttpClientRequest.HttpClientRequest) => {
+      const body = GRAPH_FIXTURE_BODIES[request.url];
+      const failed = options.failedUrls?.has(request.url) === true;
+      const response = HttpClientResponse.fromWeb(
+        request,
+        failed
+          ? new Response("forced failure", { status: 503 })
+          : body === undefined
+            ? new Response("not found", { status: 404 })
+            : new Response(body, {
+                status: 200,
+                headers: {
+                  "content-type":
+                    request.url === MICROSOFT_GRAPH_PERMISSIONS_REFERENCE_URL
+                      ? "text/markdown"
+                      : "application/yaml",
+                },
+              }),
+      );
+      return (options.beforeResponse?.(request.url) ?? Effect.void).pipe(Effect.as(response));
+    }),
+  );
+
+const graphHttpClientLayer = makeGraphHttpClientLayer();
 
 const graphPlugins = (options?: Omit<MicrosoftPluginOptions, "httpClientLayer">) =>
   [
@@ -615,6 +628,300 @@ describe("Microsoft Graph provider", () => {
 
         expect(Exit.isFailure(exit)).toBe(true);
         expect(requests).toBe(0);
+      }),
+    ),
+  );
+});
+
+describe("Microsoft Graph per-workload add flow", () => {
+  const workloadExpectations = [
+    {
+      presetId: "mail",
+      slug: "microsoft_mail",
+      name: "Outlook Mail",
+      description: "Messages, folders, attachments, settings, and send mail.",
+      scopes: ["Mail.ReadWrite", "Mail.Send", "MailboxSettings.ReadWrite"],
+      // Every per-workload source seeds the bare GET /me identity health check
+      // (`me.getUser`) alongside its own workload operations.
+      toolNames: ["me.getUser", "me.messagesListMessages"],
+      absentToolNames: ["me.eventsListEvents", "me.driveRootListChildren", "sites.listSites"],
+    },
+    {
+      presetId: "calendar",
+      slug: "microsoft_calendar",
+      name: "Outlook Calendar",
+      description: "Calendars, events, and scheduling.",
+      scopes: ["Calendars.ReadWrite"],
+      toolNames: ["me.getUser", "me.eventsListEvents"],
+      absentToolNames: ["me.messagesListMessages", "me.driveRootListChildren", "sites.listSites"],
+    },
+    {
+      presetId: "files",
+      slug: "microsoft_files",
+      name: "OneDrive Files",
+      description: "Drives, files, folders, sharing links, and permissions.",
+      scopes: ["Files.ReadWrite.All", "Sites.ReadWrite.All"],
+      toolNames: ["me.driveRootListChildren", "me.getUser"],
+      absentToolNames: ["me.messagesListMessages", "me.eventsListEvents", "sites.listSites"],
+    },
+  ] as const;
+
+  it.effect(
+    "addWorkloads creates one integration per preset with exact scopes and health checks",
+    () =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          const executor = yield* createExecutor(makeTestConfig({ plugins: graphPlugins() }));
+          const connectedToolNames = (slug: string) =>
+            Effect.gen(function* () {
+              yield* executor.connections.create({
+                owner: "org",
+                name: ConnectionName.make(slug),
+                integration: IntegrationSlug.make(slug),
+                template: AuthTemplateSlug.make(MICROSOFT_AUTH_TEMPLATE_SLUG),
+                value: "token-xyz",
+              });
+              return (yield* executor.tools.list({ integration: IntegrationSlug.make(slug) }))
+                .map((tool) => String(tool.name))
+                .sort();
+            });
+
+          const result = yield* executor.microsoft.addWorkloads({
+            workloads: workloadExpectations.map((workload) => ({ presetId: workload.presetId })),
+          });
+
+          expect(result).toEqual({
+            added: workloadExpectations.map((workload) => ({
+              slug: IntegrationSlug.make(workload.slug),
+              presetId: workload.presetId,
+              toolCount: 2,
+            })),
+            skipped: [],
+            failed: [],
+          });
+
+          const integrations = yield* executor.integrations.list();
+          for (const workload of workloadExpectations) {
+            const integration = integrations.find((item) => String(item.slug) === workload.slug);
+            expect(integration?.name).toBe(workload.name);
+            expect(integration?.description).toBe(workload.description);
+
+            const config = yield* executor.microsoft.getConfig(workload.slug);
+            expect(config?.microsoftGraphPresetIds).toEqual([workload.presetId]);
+            expect(config?.microsoftGraphCoversFullGraph).toBe(false);
+            // Each workload's scopes are exactly its preset scopes plus the base
+            // and identity (User.Read) scopes, never another workload's.
+            expect(config?.microsoftGraphScopes).toEqual([
+              "offline_access",
+              "User.Read",
+              ...workload.scopes,
+            ]);
+
+            const delegated = config?.authenticationTemplate?.find(
+              (entry) => String(entry.slug) === MICROSOFT_AUTH_TEMPLATE_SLUG,
+            );
+            expect(delegated?.kind === "oauth2" ? delegated.scopes : undefined).toEqual([
+              "offline_access",
+              "User.Read",
+              ...workload.scopes,
+            ]);
+
+            // The bare GET /me identity check is seeded per workload source.
+            const stored = yield* executor.integrations.healthCheck.get(
+              IntegrationSlug.make(workload.slug),
+            );
+            expect(stored?.operation).toBe("me.getUser");
+            expect(stored?.identityField).toBe("userPrincipalName");
+
+            const toolNames = yield* connectedToolNames(workload.slug);
+            expect(toolNames).toEqual([...workload.toolNames].sort());
+            for (const absent of workload.absentToolNames) {
+              expect(toolNames).not.toContain(absent);
+            }
+          }
+        }),
+      ),
+  );
+
+  it.effect("addWorkloads isolates a spec-fetch failure and keeps other workloads registered", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        // Force every Graph spec fetch to fail. The middle workload's failure
+        // must not poison the workloads that would otherwise succeed: a shared
+        // 37MB source is fetched per add, so an isolated 503 during the mail
+        // add is reported in `failed` while calendar and files still land.
+        const failingLayer = makeGraphHttpClientLayer({
+          failedUrls: new Set([MICROSOFT_GRAPH_OPENAPI_URL]),
+        });
+        const executor = yield* createExecutor(
+          makeTestConfig({
+            plugins: [
+              microsoftPlugin({ httpClientLayer: failingLayer }),
+              memoryCredentialsPlugin(),
+            ],
+          }),
+        );
+
+        const result = yield* executor.microsoft.addWorkloads({
+          workloads: [{ presetId: "mail" }, { presetId: "calendar" }, { presetId: "files" }],
+        });
+
+        expect(result).toEqual({
+          added: [],
+          skipped: [],
+          failed: [
+            {
+              slug: IntegrationSlug.make("microsoft_mail"),
+              presetId: "mail",
+              error: "Failed to fetch Microsoft Graph OpenAPI document: HTTP 503",
+            },
+            {
+              slug: IntegrationSlug.make("microsoft_calendar"),
+              presetId: "calendar",
+              error: "Failed to fetch Microsoft Graph OpenAPI document: HTTP 503",
+            },
+            {
+              slug: IntegrationSlug.make("microsoft_files"),
+              presetId: "files",
+              error: "Failed to fetch Microsoft Graph OpenAPI document: HTTP 503",
+            },
+          ],
+        });
+
+        expect(yield* executor.microsoft.getIntegration("microsoft_mail")).toBeNull();
+      }),
+    ),
+  );
+
+  it.effect("addWorkloads isolates a single failing workload from the ones that succeed", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const executor = yield* createExecutor(makeTestConfig({ plugins: graphPlugins() }));
+        const connectedToolNames = (slug: string) =>
+          Effect.gen(function* () {
+            yield* executor.connections.create({
+              owner: "org",
+              name: ConnectionName.make(slug),
+              integration: IntegrationSlug.make(slug),
+              template: AuthTemplateSlug.make(MICROSOFT_AUTH_TEMPLATE_SLUG),
+              value: "token-xyz",
+            });
+            return (yield* executor.tools.list({ integration: IntegrationSlug.make(slug) }))
+              .map((tool) => String(tool.name))
+              .sort();
+          });
+
+        // An unknown preset fails with a parse error mid-list; the workloads on
+        // either side of it still register.
+        const result = yield* executor.microsoft.addWorkloads({
+          workloads: [
+            { presetId: "mail" },
+            { presetId: "not-a-real-workload" },
+            { presetId: "files" },
+          ],
+        });
+
+        expect(result.added).toEqual([
+          {
+            slug: IntegrationSlug.make("microsoft_mail"),
+            presetId: "mail",
+            toolCount: 2,
+          },
+          {
+            slug: IntegrationSlug.make("microsoft_files"),
+            presetId: "files",
+            toolCount: 2,
+          },
+        ]);
+        expect(result.skipped).toEqual([]);
+        expect(result.failed).toEqual([
+          {
+            slug: IntegrationSlug.make("microsoft_not_a_real_workload"),
+            presetId: "not-a-real-workload",
+            error: "Microsoft Graph workload preset is not available: not-a-real-workload",
+          },
+        ]);
+
+        expect(yield* connectedToolNames("microsoft_mail")).toEqual(
+          ["me.getUser", "me.messagesListMessages"].sort(),
+        );
+        expect(yield* connectedToolNames("microsoft_files")).toEqual(
+          ["me.driveRootListChildren", "me.getUser"].sort(),
+        );
+      }),
+    ),
+  );
+
+  it.effect("addWorkloads skips an existing workload without duplicating integration rows", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const executor = yield* createExecutor(makeTestConfig({ plugins: graphPlugins() }));
+
+        yield* executor.microsoft.addWorkloads({ workloads: [{ presetId: "mail" }] });
+        const result = yield* executor.microsoft.addWorkloads({
+          workloads: [{ presetId: "mail" }],
+        });
+
+        expect(result).toEqual({
+          added: [],
+          skipped: [
+            {
+              slug: IntegrationSlug.make("microsoft_mail"),
+              presetId: "mail",
+              reason: "already_exists",
+            },
+          ],
+          failed: [],
+        });
+
+        const integrations = yield* executor.integrations.list();
+        expect(
+          integrations.filter((integration) => String(integration.slug) === "microsoft_mail"),
+        ).toHaveLength(1);
+      }),
+    ),
+  );
+
+  it.effect("addWorkloads starts each workload spec fetch sequentially", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        // Each per-workload add fetches the (37MB in prod) Graph source; two in
+        // flight recreate the isolate OOM. The strict {concurrency: 1} guard is
+        // proven by a spy that counts in-flight spec fetches: it would observe
+        // maxActive === 2 under concurrency 2, and never settles a fetch until
+        // the next microtask turn so any overlap is caught.
+        let activeSpecFetches = 0;
+        let maxActiveSpecFetches = 0;
+        let specFetchCount = 0;
+        const sequentialLayer = makeGraphHttpClientLayer({
+          beforeResponse: (url) => {
+            if (url !== MICROSOFT_GRAPH_OPENAPI_URL) return Effect.void;
+            return Effect.gen(function* () {
+              activeSpecFetches += 1;
+              specFetchCount += 1;
+              maxActiveSpecFetches = Math.max(maxActiveSpecFetches, activeSpecFetches);
+              yield* waitOneTurn;
+              activeSpecFetches -= 1;
+            });
+          },
+        });
+        const executor = yield* createExecutor(
+          makeTestConfig({
+            plugins: [
+              microsoftPlugin({ httpClientLayer: sequentialLayer }),
+              memoryCredentialsPlugin(),
+            ],
+          }),
+        );
+
+        const result = yield* executor.microsoft.addWorkloads({
+          workloads: [{ presetId: "mail" }, { presetId: "calendar" }, { presetId: "files" }],
+        });
+
+        expect(result.failed).toEqual([]);
+        expect(result.added).toHaveLength(3);
+        expect(specFetchCount).toBe(3);
+        expect(maxActiveSpecFetches).toBe(1);
       }),
     ),
   );

--- a/packages/plugins/microsoft/src/sdk/plugin.ts
+++ b/packages/plugins/microsoft/src/sdk/plugin.ts
@@ -27,6 +27,7 @@ import {
   makeDefaultOpenapiStore,
   normalizeOpenApiAuthInputs,
   OpenApiExtractionError,
+  OpenApiParseError,
   resolveOpenApiBackedAnnotations,
   resolveOpenApiBackedTools,
   type Authentication,
@@ -48,6 +49,8 @@ import {
   MICROSOFT_CLIENT_CREDENTIALS_AUTH_TEMPLATE_SLUG,
   MICROSOFT_GRAPH_BASE_URL,
   microsoftGraphPreset,
+  microsoftGraphPresetForId,
+  microsoftServiceSlug,
 } from "./presets";
 
 export interface MicrosoftGraphConfig {
@@ -61,6 +64,41 @@ export interface MicrosoftGraphConfig {
   readonly authorizationUrl?: string;
   readonly tokenUrl?: string;
   readonly clientCredentialsTokenUrl?: string;
+}
+
+export interface MicrosoftWorkloadConfig {
+  readonly presetId: string;
+  readonly slug?: string;
+  readonly name?: string;
+}
+
+export interface MicrosoftAddWorkloadsInput {
+  readonly workloads: readonly MicrosoftWorkloadConfig[];
+  readonly baseUrl?: string;
+}
+
+export interface MicrosoftAddWorkloadsAdded {
+  readonly slug: IntegrationSlug;
+  readonly presetId: string;
+  readonly toolCount: number;
+}
+
+export interface MicrosoftAddWorkloadsSkipped {
+  readonly slug: IntegrationSlug;
+  readonly presetId: string;
+  readonly reason: "already_exists";
+}
+
+export interface MicrosoftAddWorkloadsFailed {
+  readonly slug: IntegrationSlug;
+  readonly presetId: string;
+  readonly error: string;
+}
+
+export interface MicrosoftAddWorkloadsResult {
+  readonly added: readonly MicrosoftAddWorkloadsAdded[];
+  readonly skipped: readonly MicrosoftAddWorkloadsSkipped[];
+  readonly failed: readonly MicrosoftAddWorkloadsFailed[];
 }
 
 export interface MicrosoftConfigureInput {
@@ -98,6 +136,22 @@ export interface MicrosoftPluginOptions {
 }
 
 const DEFAULT_MICROSOFT_SLUG = "microsoft_graph";
+
+type MicrosoftAddWorkloadOutcome = {
+  readonly added: readonly MicrosoftAddWorkloadsAdded[];
+  readonly skipped: readonly MicrosoftAddWorkloadsSkipped[];
+  readonly failed: readonly MicrosoftAddWorkloadsFailed[];
+};
+
+const microsoftAddWorkloadFailure = (
+  workload: MicrosoftWorkloadConfig,
+  slug: IntegrationSlug,
+  error: string,
+): MicrosoftAddWorkloadOutcome => ({
+  added: [],
+  skipped: [],
+  failed: [{ slug, presetId: workload.presetId, error }],
+});
 
 const describeMicrosoftAuthMethods = (
   record: IntegrationRecord,
@@ -239,6 +293,91 @@ const makeMicrosoftPluginExtension = (
       baseUrl: config.baseUrl,
     });
 
+  const addOneWorkload = (workload: MicrosoftWorkloadConfig, baseUrl?: string) =>
+    Effect.gen(function* () {
+      const preset = microsoftGraphPresetForId(workload.presetId);
+      if (!preset) {
+        return yield* new OpenApiParseError({
+          message: `Microsoft Graph workload preset is not available: ${workload.presetId}`,
+        });
+      }
+
+      // A per-workload integration filters the Graph tree to just this one
+      // preset. The bare GET /me identity keep is seeded by the shared
+      // keepPathItem filter, so every workload source gets its own /me health
+      // check even when the profile workload is not selected. Scopes are this
+      // preset's scopes plus the identity scope (User.Read), derived by
+      // `microsoftGraphScopesForPresetIds` inside the spec build.
+      return yield* addMicrosoftGraphIntegration({
+        selection: { presetIds: [preset.id] },
+        slug: IntegrationSlug.make(workload.slug?.trim() || microsoftServiceSlug(preset.id)),
+        name: workload.name?.trim() || preset.name,
+        description: preset.summary,
+        baseUrl,
+      });
+    });
+
+  const addWorkloads = (input: MicrosoftAddWorkloadsInput) =>
+    Effect.gen(function* () {
+      // Strict {concurrency: 1}: parsing the 37MB Graph tree already strains the
+      // 128MB Workers isolate, so two workload adds in flight recreate the OOM
+      // in aggregate. Each add must fully settle before the next begins.
+      const outcomes = yield* Effect.forEach(
+        input.workloads,
+        (workload): Effect.Effect<MicrosoftAddWorkloadOutcome, never> => {
+          const slug = IntegrationSlug.make(
+            workload.slug?.trim() || microsoftServiceSlug(workload.presetId),
+          );
+          return addOneWorkload(workload, input.baseUrl).pipe(
+            Effect.map(
+              (result): MicrosoftAddWorkloadOutcome => ({
+                added: [
+                  {
+                    slug: result.slug,
+                    presetId: workload.presetId,
+                    toolCount: result.toolCount,
+                  },
+                ],
+                skipped: [],
+                failed: [],
+              }),
+            ),
+            Effect.catchTag("IntegrationAlreadyExistsError", () =>
+              Effect.succeed({
+                added: [],
+                skipped: [
+                  {
+                    slug,
+                    presetId: workload.presetId,
+                    reason: "already_exists" as const,
+                  },
+                ],
+                failed: [],
+              }),
+            ),
+            Effect.catchTags({
+              OpenApiParseError: (error: OpenApiParseError) =>
+                Effect.succeed(microsoftAddWorkloadFailure(workload, slug, error.message)),
+              OpenApiExtractionError: (error: OpenApiExtractionError) =>
+                Effect.succeed(microsoftAddWorkloadFailure(workload, slug, error.message)),
+            }),
+            Effect.catch(() =>
+              Effect.succeed(
+                microsoftAddWorkloadFailure(workload, slug, "Failed to add Microsoft workload"),
+              ),
+            ),
+          );
+        },
+        { concurrency: 1 },
+      );
+
+      return {
+        added: outcomes.flatMap((outcome) => outcome.added),
+        skipped: outcomes.flatMap((outcome) => outcome.skipped),
+        failed: outcomes.flatMap((outcome) => outcome.failed),
+      };
+    });
+
   const updateGraph = (rawSlug: string, input?: MicrosoftUpdateInput) =>
     Effect.gen(function* () {
       const slug = IntegrationSlug.make(rawSlug);
@@ -320,6 +459,7 @@ const makeMicrosoftPluginExtension = (
 
   return {
     addGraph,
+    addWorkloads,
     updateGraph,
     removeGraph: (slug: string) =>
       ctx.transaction(

--- a/packages/plugins/microsoft/src/sdk/plugin.ts
+++ b/packages/plugins/microsoft/src/sdk/plugin.ts
@@ -39,6 +39,7 @@ import {
   buildMicrosoftGraphOpenApiSpec,
   decodeMicrosoftGraphIntegrationConfig,
   microsoftGraphKeepPathItem,
+  type MicrosoftGraphSelectionInput,
   type MicrosoftGraphUrlPolicy,
   type MicrosoftGraphIntegrationConfig,
   type MicrosoftGraphSpecBuild,
@@ -155,10 +156,20 @@ const makeMicrosoftPluginExtension = (
       keepPathItem: microsoftGraphKeepPathItem(graph),
     });
 
-  const addGraph = (config: MicrosoftGraphConfig) =>
+  const addMicrosoftGraphIntegration = (input: {
+    readonly selection: MicrosoftGraphSelectionInput;
+    readonly slug: IntegrationSlug;
+    readonly name: string;
+    readonly description: string;
+    readonly baseUrl?: string;
+  }) =>
     Effect.gen(function* () {
-      const graph = yield* buildMicrosoftGraphOpenApiSpec(config, httpClientLayer, urlPolicy);
-      const slug = IntegrationSlug.make(config.slug?.trim() || DEFAULT_MICROSOFT_SLUG);
+      const graph = yield* buildMicrosoftGraphOpenApiSpec(
+        input.selection,
+        httpClientLayer,
+        urlPolicy,
+      );
+      const slug = input.slug;
 
       const existing = yield* ctx.core.integrations.get(slug);
       if (existing) {
@@ -180,7 +191,7 @@ const makeMicrosoftPluginExtension = (
         microsoftGraphTokenUrl: graph.tokenUrl,
         microsoftGraphClientCredentialsTokenUrl: graph.clientCredentialsTokenUrl,
         authenticationTemplate: graph.authenticationTemplate,
-        ...(config.baseUrl ? { baseUrl: config.baseUrl } : {}),
+        ...(input.baseUrl ? { baseUrl: input.baseUrl } : {}),
       };
 
       yield* ctx.storage.putSpec(specHash, graph.specText);
@@ -189,8 +200,8 @@ const makeMicrosoftPluginExtension = (
         Effect.gen(function* () {
           yield* ctx.core.integrations.register({
             slug,
-            name: config.name?.trim() || "Microsoft Graph",
-            description: config.description ?? "Selected Microsoft Graph workloads.",
+            name: input.name,
+            description: input.description,
             config:
               integrationConfig satisfies MicrosoftGraphIntegrationConfig as IntegrationConfig,
             canRemove: true,
@@ -217,6 +228,15 @@ const makeMicrosoftPluginExtension = (
       }
 
       return { slug, toolCount: persisted.toolCount };
+    });
+
+  const addGraph = (config: MicrosoftGraphConfig) =>
+    addMicrosoftGraphIntegration({
+      selection: config,
+      slug: IntegrationSlug.make(config.slug?.trim() || DEFAULT_MICROSOFT_SLUG),
+      name: config.name?.trim() || "Microsoft Graph",
+      description: config.description ?? "Selected Microsoft Graph workloads.",
+      baseUrl: config.baseUrl,
     });
 
   const updateGraph = (rawSlug: string, input?: MicrosoftUpdateInput) =>

--- a/packages/plugins/microsoft/src/sdk/presets.ts
+++ b/packages/plugins/microsoft/src/sdk/presets.ts
@@ -486,6 +486,9 @@ export const microsoftGraphPresetForId = (
 ): MicrosoftGraphScopePreset | undefined =>
   microsoftGraphScopePresets.find((preset) => preset.id === presetId);
 
+export const microsoftServiceSlug = (presetId: string): string =>
+  `microsoft_${presetId.replaceAll("-", "_")}`;
+
 export const microsoftGraphPresetIdsCoverFullGraph = (presetIds: Iterable<string>): boolean => {
   const selected = new Set([...presetIds]);
   return microsoftGraphScopePresets.every((preset) => selected.has(preset.id));


### PR DESCRIPTION
Second half of the per-service split, stacked on #1308: extracts addMicrosoftGraphIntegration from addGraph (no behavior change) and adds addWorkloads, registering one integration per Graph workload (microsoft_mail, microsoft_calendar, ...) strictly sequentially (each add streams the 37MB Graph spec once with a narrow filter; concurrency 1 keeps peak memory at a single add's footprint on the 128MB isolate). Per-workload partial-success results and bare GET /me identity health check on every workload.

Independently reviewed: SHIP (parity diffed against pre-refactor body; sequentiality test reproduced non-vacuous by concurrency flip).

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #1308
2. **#1309** 👈 current
3. #1315
4. #1334
5. #1336
6. #1337
<!-- stack:links:end -->