### PR TITLE
fix(plugin-mcp): import Effect-native SDK symbols from /core in the core build

### DIFF
--- a/packages/plugins/mcp/src/sdk/invoke.ts
+++ b/packages/plugins/mcp/src/sdk/invoke.ts
@@ -26,7 +26,7 @@ import {
   UrlElicitation,
   type Elicit,
   type ElicitationRequest,
-} from "@executor-js/sdk";
+} from "@executor-js/sdk/core";
 
 import { McpConnectionError, McpInvocationError, McpOAuthReauthorizationRequired } from "./errors";
 import type { McpConnection, McpConnector } from "./connection";

--- a/packages/plugins/mcp/src/sdk/plugin.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.ts
@@ -30,7 +30,7 @@ import {
   type ToolAnnotations,
   type ToolDef,
   ToolName,
-} from "@executor-js/sdk";
+} from "@executor-js/sdk/core";
 
 import {
   TOKEN_VARIABLE,


### PR DESCRIPTION
## Summary

`@executor-js/plugin-mcp`'s `./core` entry is unusable. Importing from it throws
at module load:

```
SyntaxError: Export named 'tool' not found in module '.../@executor-js/sdk/dist/index.js'
```

This reproduces in the published `1.5.28` and `2.0.0` artifacts. To use `/core`
today I had to [patch the installed package](https://github.com/fdarian/paper-execute/blob/main/patches/%40executor-js%252Fplugin-mcp%401.5.28.patch);
this PR removes the need for that.

## Root cause

Two mcp plugin source files import Effect-native-only symbols from the bare root
`"@executor-js/sdk"` instead of `"@executor-js/sdk/core"`:

- `packages/plugins/mcp/src/sdk/plugin.ts` (`tool`, `definePlugin`, `ToolResult`, `ToolName`, ...)
- `packages/plugins/mcp/src/sdk/invoke.ts` (`ElicitationId`, `FormElicitation`, `UrlElicitation`)

`tsup` preserves import specifiers verbatim (no build-time rewrite to `/core`), so the
bare root import survives into `dist/core.js`, where it resolves to the promise facade
that lacks those exports. That is why the fix is a source change, not a bundler config
change.

## Fix

Import the Effect-native symbols from `@executor-js/sdk/core` in those two source
files. This matches the existing convention: sibling dual-surface plugins
(`onepassword`, `google`, `microsoft`, `openapi`) already import `definePlugin`,
`tool`, `ToolResult`, and related Effect-native symbols from `@executor-js/sdk/core`
in source.

## Verification

- Rebuilt the plugin and confirmed the emitted `/core` chunk now imports the
  symbols from `@executor-js/sdk/core`, and that no emitted JS in
  `packages/plugins/mcp/dist/*.js` still imports the bare `@executor-js/sdk` root.
- `typecheck` and `lint` pass for the change.

Before (emitted `/core` artifact):

```ts
} from "@executor-js/sdk";
```

After:

```ts
  definePlugin,
  tool,
  ToolResult,
  ToolName,
} from "@executor-js/sdk/core";
```

```ts
import {
  ElicitationId,
  FormElicitation,
  UrlElicitation,
} from "@executor-js/sdk/core";
```

## Scope

Confirmed unique to `plugin-mcp`. Most sibling dual-surface plugins already use
the correct `@executor-js/sdk/core` source imports, so no broader change is
needed.
