### PR TITLE
Group connections into provider accounts with login_hint

### DIFF
--- a/packages/core/api/src/handlers/oauth.ts
+++ b/packages/core/api/src/handlers/oauth.ts
@@ -160,6 +160,7 @@ export const OAuthHandlers = HttpApiBuilder.group(ExecutorApi, "oauth", (handler
             integration: payload.integration,
             template: payload.template,
             identityLabel: payload.identityLabel,
+            loginHint: payload.loginHint,
             redirectUri: payload.redirectUri,
           });
           return startResultToResponse(result);

--- a/packages/core/api/src/oauth/api.ts
+++ b/packages/core/api/src/oauth/api.ts
@@ -159,6 +159,7 @@ const StartPayload = Schema.Struct({
   integration: IntegrationSlug,
   template: AuthTemplateSlug,
   identityLabel: Schema.optional(Schema.NullOr(Schema.String)),
+  loginHint: Schema.optional(Schema.NullOr(Schema.String)),
   redirectUri: Schema.optional(Schema.NullOr(Schema.String)),
 });
 

--- a/packages/core/sdk/src/connections.test.ts
+++ b/packages/core/sdk/src/connections.test.ts
@@ -55,6 +55,12 @@ const demoPlugin = definePlugin(() => ({
     }),
   invokeTool: ({ toolRow, credential }) =>
     Effect.succeed({ ran: toolRow.name, value: credential.value }),
+  checkHealth: () =>
+    Effect.succeed({
+      status: "healthy" as const,
+      identity: "account@example.com",
+      checkedAt: 1234,
+    }),
   extension: (ctx) => ({
     seed: () =>
       ctx.core.integrations.register({
@@ -75,6 +81,12 @@ const setup = () =>
   makeTestExecutor({ plugins: [demoPlugin] as const }).pipe(
     Effect.tap((executor) => executor.demo.seed()),
   );
+
+const setupCoreTools = () =>
+  makeTestExecutor({
+    plugins: [demoPlugin] as const,
+    coreTools: { webBaseUrl: "http://localhost:3000" },
+  }).pipe(Effect.tap((executor) => executor.demo.seed()));
 
 describe("connections.create", () => {
   it.effect("inline value writes to the default writable provider and produces tools", () =>
@@ -262,6 +274,57 @@ describe("connections.create", () => {
 });
 
 describe("connections.list / get", () => {
+  it.effect("core tool list exposes lastHealth after a health check runs", () =>
+    Effect.gen(function* () {
+      const executor = yield* setupCoreTools();
+      yield* executor.connections.create({
+        owner: "org",
+        name: ConnectionName.make("health"),
+        integration: INTEG,
+        template: TEMPLATE,
+        value: "v",
+      });
+
+      type ListOutput = {
+        readonly connections: readonly {
+          readonly name: string;
+          readonly lastHealth?: {
+            readonly status: string;
+            readonly identity?: string;
+            readonly checkedAt: number;
+          } | null;
+        }[];
+      };
+
+      const before = (yield* executor.execute(
+        ToolAddress.make("executor.coreTools.connections.list"),
+        { integration: String(INTEG), owner: "org" },
+      )) as ListOutput;
+      expect(before.connections[0]?.lastHealth ?? null).toBeNull();
+
+      const health = yield* executor.connections.checkHealth({
+        owner: "org",
+        integration: INTEG,
+        name: ConnectionName.make("health"),
+      });
+      expect(health).toEqual({
+        status: "healthy",
+        identity: "account@example.com",
+        checkedAt: 1234,
+      });
+
+      const after = (yield* executor.execute(
+        ToolAddress.make("executor.coreTools.connections.list"),
+        { integration: String(INTEG), owner: "org" },
+      )) as ListOutput;
+      expect(after.connections[0]?.lastHealth).toEqual({
+        status: "healthy",
+        identity: "account@example.com",
+        checkedAt: 1234,
+      });
+    }),
+  );
+
   it.effect("lists created connections and filters by integration", () =>
     Effect.gen(function* () {
       const executor = yield* setup();

--- a/packages/core/sdk/src/connections.test.ts
+++ b/packages/core/sdk/src/connections.test.ts
@@ -60,6 +60,9 @@ const demoPlugin = definePlugin(() => ({
       status: "healthy" as const,
       identity: "account@example.com",
       checkedAt: 1234,
+      httpStatus: 200,
+      detail: "GET /me returned 200",
+      responseSample: [{ path: "user.email", value: "account@example.com" }],
     }),
   extension: (ctx) => ({
     seed: () =>
@@ -311,6 +314,9 @@ describe("connections.list / get", () => {
         status: "healthy",
         identity: "account@example.com",
         checkedAt: 1234,
+        httpStatus: 200,
+        detail: "GET /me returned 200",
+        responseSample: [{ path: "user.email", value: "account@example.com" }],
       });
 
       const after = (yield* executor.execute(
@@ -322,6 +328,9 @@ describe("connections.list / get", () => {
         identity: "account@example.com",
         checkedAt: 1234,
       });
+      expect(after.connections[0]?.lastHealth).not.toHaveProperty("responseSample");
+      expect(after.connections[0]?.lastHealth).not.toHaveProperty("httpStatus");
+      expect(after.connections[0]?.lastHealth).not.toHaveProperty("detail");
     }),
   );
 

--- a/packages/core/sdk/src/core-tools.ts
+++ b/packages/core/sdk/src/core-tools.ts
@@ -21,7 +21,7 @@ import {
   ProviderKey,
   type Owner,
 } from "./ids";
-import { HealthCheckResult } from "./health-check";
+import { HealthStatus } from "./health-check";
 import { definePlugin, tool, type StaticToolSchema } from "./plugin";
 import { ToolPolicyActionSchema } from "./policies";
 import type { Tool } from "./tool";
@@ -85,6 +85,16 @@ const ConnectionsListInput = Schema.Struct({
   verbose: Schema.optional(Schema.Boolean),
 });
 
+/** Lean health verdict for list scans: just the status, extracted identity,
+ *  and timestamp. The diagnostic fields (`httpStatus`, `detail`,
+ *  `responseSample`) stay on the connections DETAIL surface; a list of N
+ *  connections must not carry N response-body samples. */
+const ConnectionListHealth = Schema.Struct({
+  status: HealthStatus,
+  identity: Schema.optional(Schema.String),
+  checkedAt: Schema.optional(Schema.Number),
+});
+
 /** Lean per-connection shape for list scans. Omits the full `oauthScope`
  *  grant string (a single connection's scope list can run to thousands of
  *  characters and dominates the payload) in favor of `oauthScopeCount`. The
@@ -103,7 +113,7 @@ const ConnectionListItem = Schema.Struct({
   oauthClientOwner: Schema.NullOr(OwnerSchema),
   oauthScopeCount: Schema.NullOr(Schema.Number),
   oauthScope: Schema.optional(Schema.NullOr(Schema.String)),
-  lastHealth: Schema.optional(Schema.NullOr(HealthCheckResult)),
+  lastHealth: Schema.optional(Schema.NullOr(ConnectionListHealth)),
 });
 const ConnectionsListOutput = Schema.Struct({
   connections: Schema.Array(ConnectionListItem),
@@ -384,6 +394,19 @@ const connectionToOutput = (connection: Connection) => ({
 const oauthScopeCount = (scope: string | null | undefined): number | null =>
   scope == null ? null : scope.split(/\s+/).filter(Boolean).length;
 
+/** Project a persisted health verdict down to the list shape, dropping the
+ *  diagnostic fields (`httpStatus`, `detail`, `responseSample`). */
+const lastHealthToListItem = (
+  lastHealth: Connection["lastHealth"],
+): typeof ConnectionListHealth.Type | null =>
+  lastHealth == null
+    ? null
+    : {
+        status: lastHealth.status,
+        ...(lastHealth.identity !== undefined ? { identity: lastHealth.identity } : {}),
+        checkedAt: lastHealth.checkedAt,
+      };
+
 /** Lean projection for `connections.list`. Summarizes `oauthScope` to a count
  *  unless `verbose`, where the full grant string is included too. */
 const connectionToListItem = (connection: Connection, verbose: boolean) => ({
@@ -399,7 +422,7 @@ const connectionToListItem = (connection: Connection, verbose: boolean) => ({
   oauthClient: connection.oauthClient == null ? null : String(connection.oauthClient),
   oauthClientOwner: connection.oauthClientOwner ?? null,
   oauthScopeCount: oauthScopeCount(connection.oauthScope),
-  lastHealth: connection.lastHealth ?? null,
+  lastHealth: lastHealthToListItem(connection.lastHealth),
   ...(verbose ? { oauthScope: connection.oauthScope ?? null } : {}),
 });
 

--- a/packages/core/sdk/src/core-tools.ts
+++ b/packages/core/sdk/src/core-tools.ts
@@ -21,6 +21,7 @@ import {
   ProviderKey,
   type Owner,
 } from "./ids";
+import { HealthCheckResult } from "./health-check";
 import { definePlugin, tool, type StaticToolSchema } from "./plugin";
 import { ToolPolicyActionSchema } from "./policies";
 import type { Tool } from "./tool";
@@ -102,6 +103,7 @@ const ConnectionListItem = Schema.Struct({
   oauthClientOwner: Schema.NullOr(OwnerSchema),
   oauthScopeCount: Schema.NullOr(Schema.Number),
   oauthScope: Schema.optional(Schema.NullOr(Schema.String)),
+  lastHealth: Schema.optional(Schema.NullOr(HealthCheckResult)),
 });
 const ConnectionsListOutput = Schema.Struct({
   connections: Schema.Array(ConnectionListItem),
@@ -397,6 +399,7 @@ const connectionToListItem = (connection: Connection, verbose: boolean) => ({
   oauthClient: connection.oauthClient == null ? null : String(connection.oauthClient),
   oauthClientOwner: connection.oauthClientOwner ?? null,
   oauthScopeCount: oauthScopeCount(connection.oauthScope),
+  lastHealth: connection.lastHealth ?? null,
   ...(verbose ? { oauthScope: connection.oauthScope ?? null } : {}),
 });
 

--- a/packages/core/sdk/src/core-tools.ts
+++ b/packages/core/sdk/src/core-tools.ts
@@ -308,6 +308,7 @@ const OAuthStartInput = Schema.Struct({
   integration: Schema.String,
   template: Schema.String,
   identityLabel: Schema.optional(Schema.NullOr(Schema.String)),
+  loginHint: Schema.optional(Schema.NullOr(Schema.String)),
   redirectUri: Schema.optional(Schema.NullOr(Schema.String)),
 });
 const OAuthStartOutput = Schema.Union([
@@ -836,6 +837,7 @@ export const coreToolsPlugin = definePlugin((options: CoreToolsPluginOptions = {
                 integration: IntegrationSlug.make(input.integration),
                 template: AuthTemplateSlug.make(input.template),
                 identityLabel: input.identityLabel,
+                loginHint: input.loginHint,
                 redirectUri: input.redirectUri,
               }),
               (result) =>

--- a/packages/core/sdk/src/oauth-client.ts
+++ b/packages/core/sdk/src/oauth-client.ts
@@ -122,6 +122,8 @@ export interface OAuthStartInput {
   readonly integration: IntegrationSlug;
   readonly template: AuthTemplateSlug;
   readonly identityLabel?: string | null;
+  /** Provider login UX hint. It is never assumed to identify the granted account. */
+  readonly loginHint?: string | null;
   /** Browser-facing callback URL for this flow. Defaults to the executor's configured redirectUri. */
   readonly redirectUri?: string | null;
 }

--- a/packages/core/sdk/src/oauth-flow.test.ts
+++ b/packages/core/sdk/src/oauth-flow.test.ts
@@ -114,6 +114,109 @@ const routeTokenEndpointToLoopback = (
 };
 
 describe("oauth.start / oauth.complete", () => {
+  it.effect("carries login_hint on provider authorize URLs when provided", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const server = yield* serveOAuthTestServer({ scopes: ["read"] });
+        const { executor } = yield* makeTestWorkspaceHarness({ plugins });
+        yield* executor.acme.seed(["read"]);
+
+        yield* executor.oauth.createClient({
+          owner: "org",
+          slug: CLIENT,
+          authorizationUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+          tokenUrl: server.tokenEndpoint,
+          grant: "authorization_code",
+          clientId: "test-client",
+          clientSecret: "test-secret",
+        });
+
+        const started = yield* executor.oauth.start({
+          owner: "org",
+          client: CLIENT,
+          clientOwner: "org",
+          name: ConnectionName.make("main-account"),
+          integration: INTEG,
+          template: TEMPLATE,
+          loginHint: " user@example.com ",
+        });
+        expect(started.status).toBe("redirect");
+        if (started.status !== "redirect") return;
+
+        const url = new URL(started.authorizationUrl);
+        const params = url.searchParams;
+        expect(url.origin + url.pathname).toBe("https://accounts.google.com/o/oauth2/v2/auth");
+        expect([...params.keys()].sort()).toEqual([
+          "access_type",
+          "client_id",
+          "code_challenge",
+          "code_challenge_method",
+          "login_hint",
+          "prompt",
+          "redirect_uri",
+          "response_type",
+          "scope",
+          "state",
+        ]);
+        expect(params.get("client_id")).toBe("test-client");
+        expect(params.get("redirect_uri")).toBe("http://localhost/oauth/callback");
+        expect(params.get("response_type")).toBe("code");
+        expect(params.get("scope")).toBe("read");
+        expect(params.get("code_challenge_method")).toBe("S256");
+        expect(params.get("access_type")).toBe("offline");
+        expect(params.get("prompt")).toBe("consent");
+        expect(params.get("login_hint")).toBe("user@example.com");
+        expect(params.has("include_granted_scopes")).toBe(false);
+      }),
+    ),
+  );
+
+  it.effect("omits login_hint on provider authorize URLs when absent", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const server = yield* serveOAuthTestServer({ scopes: ["read"] });
+        const { executor } = yield* makeTestWorkspaceHarness({ plugins });
+        yield* executor.acme.seed(["read"]);
+
+        yield* executor.oauth.createClient({
+          owner: "org",
+          slug: CLIENT,
+          authorizationUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+          tokenUrl: server.tokenEndpoint,
+          grant: "authorization_code",
+          clientId: "test-client",
+          clientSecret: "test-secret",
+        });
+
+        const started = yield* executor.oauth.start({
+          owner: "org",
+          client: CLIENT,
+          clientOwner: "org",
+          name: ConnectionName.make("main-account"),
+          integration: INTEG,
+          template: TEMPLATE,
+        });
+        expect(started.status).toBe("redirect");
+        if (started.status !== "redirect") return;
+
+        const params = new URL(started.authorizationUrl).searchParams;
+        expect([...params.keys()].sort()).toEqual([
+          "access_type",
+          "client_id",
+          "code_challenge",
+          "code_challenge_method",
+          "prompt",
+          "redirect_uri",
+          "response_type",
+          "scope",
+          "state",
+        ]);
+        expect(params.has("login_hint")).toBe(false);
+        expect(params.has("include_granted_scopes")).toBe(false);
+      }),
+    ),
+  );
+
   it.effect(
     "createClient → start (redirect) → complete mints a connection + tools, executable",
     () =>

--- a/packages/core/sdk/src/oauth-helpers.test.ts
+++ b/packages/core/sdk/src/oauth-helpers.test.ts
@@ -141,6 +141,48 @@ describe("providerAuthorizeExtras (Google offline/consent quirk)", () => {
     expect(providerAuthorizeExtras("https://oauth2.googleapis.com/token")).toEqual({});
     expect(providerAuthorizeExtras("not a url")).toEqual({});
   });
+
+  it("adds a trimmed login_hint for Google without include_granted_scopes", () => {
+    const extras = providerAuthorizeExtras(
+      "https://accounts.google.com/o/oauth2/v2/auth",
+      " user@example.com ",
+    );
+    expect(extras).toEqual({
+      access_type: "offline",
+      prompt: "consent",
+      login_hint: "user@example.com",
+    });
+    expect("include_granted_scopes" in extras).toBe(false);
+  });
+
+  it("adds only login_hint for the Microsoft authorize host", () => {
+    expect(
+      providerAuthorizeExtras(
+        "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+        " user@example.com ",
+      ),
+    ).toEqual({ login_hint: "user@example.com" });
+  });
+
+  it("omits login_hint when the hint is absent or blank", () => {
+    expect(providerAuthorizeExtras("https://accounts.google.com/o/oauth2/v2/auth")).toEqual({
+      access_type: "offline",
+      prompt: "consent",
+    });
+    expect(providerAuthorizeExtras("https://accounts.google.com/o/oauth2/v2/auth", "  ")).toEqual({
+      access_type: "offline",
+      prompt: "consent",
+    });
+    expect(
+      providerAuthorizeExtras("https://login.microsoftonline.com/common/oauth2/v2.0/authorize"),
+    ).toEqual({});
+    expect(
+      providerAuthorizeExtras(
+        "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+        "  ",
+      ),
+    ).toEqual({});
+  });
 });
 
 describe("buildAuthorizationUrl", () => {

--- a/packages/core/sdk/src/oauth-helpers.ts
+++ b/packages/core/sdk/src/oauth-helpers.ts
@@ -183,7 +183,9 @@ export const providerAuthorizeExtras = (
   loginHint?: string | null,
 ): Readonly<Record<string, string>> => {
   const trimmedLoginHint = loginHint?.trim();
-  const loginHintParam = trimmedLoginHint ? { login_hint: trimmedLoginHint } : {};
+  const loginHintParam: Readonly<Record<string, string>> = trimmedLoginHint
+    ? { login_hint: trimmedLoginHint }
+    : {};
   // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: URL() throws on invalid input → no provider extras
   try {
     const host = new URL(authorizationUrl).hostname.toLowerCase();

--- a/packages/core/sdk/src/oauth-helpers.ts
+++ b/packages/core/sdk/src/oauth-helpers.ts
@@ -180,12 +180,18 @@ export const buildAuthorizationUrl = (input: BuildAuthorizationUrlInput): string
  *  can fail inside accounts.google.com before returning to our callback. */
 export const providerAuthorizeExtras = (
   authorizationUrl: string,
+  loginHint?: string | null,
 ): Readonly<Record<string, string>> => {
+  const trimmedLoginHint = loginHint?.trim();
+  const loginHintParam = trimmedLoginHint ? { login_hint: trimmedLoginHint } : {};
   // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: URL() throws on invalid input → no provider extras
   try {
-    const host = new URL(authorizationUrl).host.toLowerCase();
+    const host = new URL(authorizationUrl).hostname.toLowerCase();
     if (host === "accounts.google.com") {
-      return { access_type: "offline", prompt: "consent" };
+      return { access_type: "offline", prompt: "consent", ...loginHintParam };
+    }
+    if (host === "login.microsoftonline.com") {
+      return loginHintParam;
     }
   } catch {
     // Unparseable authorization URL — let buildAuthorizationUrl surface the error.

--- a/packages/core/sdk/src/oauth-service.ts
+++ b/packages/core/sdk/src/oauth-service.ts
@@ -1096,7 +1096,7 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
             // Provider quirks (Google: access_type=offline + prompt=consent) —
             // without these Google returns no refresh token and won't re-consent
             // to widen scopes on reconnect.
-            extraParams: providerAuthorizeExtras(client.authorizationUrl),
+            extraParams: providerAuthorizeExtras(client.authorizationUrl, input.loginHint),
             endpointUrlPolicy: deps.endpointUrlPolicy,
           }),
         catch: (cause) =>

--- a/packages/react/src/api/atoms.tsx
+++ b/packages/react/src/api/atoms.tsx
@@ -19,6 +19,7 @@ import * as Effect from "effect/Effect";
 
 import { ExecutorApiClient } from "./client";
 import { connectionWriteKeys, ReactivityKey } from "./reactivity-keys";
+import { groupProviderAccounts } from "../lib/provider-accounts";
 
 // ---------------------------------------------------------------------------
 // Query atoms — typed, cached, reactive. v2: owner-scoped (org | user) instead
@@ -118,6 +119,22 @@ export const connectionsAllAtom = ExecutorApiClient.query("connections", "list",
   timeToLive: "30 seconds",
   reactivityKeys: [ReactivityKey.connections],
 });
+
+export const providerAccountsAtom = Atom.make(
+  Effect.gen(function* () {
+    const connections = yield* Atom.get(connectionsAllAtom);
+    const integrations = yield* Atom.get(integrationsAtom);
+    return AsyncResult.map(AsyncResult.all({ connections, integrations }), (value) => {
+      const integrationsByKind = new Map(
+        value.integrations.map((integration) => [String(integration.slug), integration]),
+      );
+      return groupProviderAccounts({
+        connections: value.connections,
+        integrationsByKind,
+      });
+    });
+  }),
+);
 
 // ---------------------------------------------------------------------------
 // Providers — credential-backend discovery (new in v2).

--- a/packages/react/src/api/atoms.tsx
+++ b/packages/react/src/api/atoms.tsx
@@ -120,21 +120,19 @@ export const connectionsAllAtom = ExecutorApiClient.query("connections", "list",
   reactivityKeys: [ReactivityKey.connections],
 });
 
-export const providerAccountsAtom = Atom.make(
-  Effect.gen(function* () {
-    const connections = yield* Atom.get(connectionsAllAtom);
-    const integrations = yield* Atom.get(integrationsAtom);
-    return AsyncResult.map(AsyncResult.all({ connections, integrations }), (value) => {
-      const integrationsByKind = new Map(
-        value.integrations.map((integration) => [String(integration.slug), integration]),
-      );
-      return groupProviderAccounts({
-        connections: value.connections,
-        integrationsByKind,
-      });
+export const providerAccountsAtom = Atom.readable((get) => {
+  const connections = get(connectionsAllAtom);
+  const integrations = get(integrationsAtom);
+  return AsyncResult.map(AsyncResult.all({ connections, integrations }), (value) => {
+    const integrationsByKind = new Map(
+      value.integrations.map((integration) => [String(integration.slug), integration]),
+    );
+    return groupProviderAccounts({
+      connections: value.connections,
+      integrationsByKind,
     });
-  }),
-);
+  });
+});
 
 // ---------------------------------------------------------------------------
 // Providers — credential-backend discovery (new in v2).

--- a/packages/react/src/components/accounts-section.tsx
+++ b/packages/react/src/components/accounts-section.tsx
@@ -8,7 +8,9 @@ import { toast } from "sonner";
 
 import {
   addConnectionOptimistic,
+  integrationsAtom,
   connectionsForIntegrationAtom,
+  providerAccountsAtom,
   refreshConnection,
   removeConnectionOptimistic,
   startOAuth,
@@ -21,6 +23,11 @@ import { ownerLabel, useOwnerDisplay } from "../api/owner-display";
 import { trackEvent } from "../api/analytics";
 import type { AuthMethod } from "../lib/auth-placements";
 import {
+  MULTI_SERVICE_FAMILIES,
+  normalizeEmail,
+  type ProviderAccount,
+} from "../lib/provider-accounts";
+import {
   connectionNeedsReconsent,
   oauthReconnectPayload,
   reconnectMode,
@@ -28,6 +35,7 @@ import {
 } from "../plugins/oauth-reconnect";
 import { useOAuthPopupFlow } from "../plugins/oauth-sign-in";
 import { AddAccountModal } from "./add-account-modal";
+import { EnableServicesModal, type EnableServiceIntegration } from "./enable-services-modal";
 import { ConnectionEditSheet } from "./metadata-edit-sheet";
 import type { CreateCustomMethod } from "./add-custom-method-modal";
 import { Badge } from "./badge";
@@ -48,6 +56,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "./dropdown-menu";
+import { PlusIcon } from "lucide-react";
 
 // ---------------------------------------------------------------------------
 // Accounts section — the integration's connections, grouped by owner.
@@ -353,6 +362,142 @@ function OwnerAccounts(props: {
         ))}
       </CardStackContent>
     </CardStack>
+  );
+}
+
+type ProviderAccountForServices = ProviderAccount<Connection, EnableServiceIntegration>;
+
+const connectedServiceSlugs = (account: ProviderAccountForServices): ReadonlySet<string> =>
+  new Set(account.connections.map((entry) => String(entry.integration.slug)));
+
+const missingServicesFor = (
+  account: ProviderAccountForServices,
+  integrations: readonly EnableServiceIntegration[],
+): readonly EnableServiceIntegration[] => {
+  const connected = connectedServiceSlugs(account);
+  return integrations.filter((integration) => !connected.has(String(integration.slug)));
+};
+
+export function ProviderAccountsSection(props: { readonly family: string }) {
+  const accountsResult = useAtomValue(providerAccountsAtom);
+  const integrationsResult = useAtomValue(integrationsAtom);
+  const ownerDisplay = useOwnerDisplay();
+  const [selectedAccount, setSelectedAccount] = useState<ProviderAccountForServices | null>(null);
+
+  if (!MULTI_SERVICE_FAMILIES.has(props.family)) return null;
+
+  const integrations: readonly EnableServiceIntegration[] = AsyncResult.isSuccess(
+    integrationsResult,
+  )
+    ? (integrationsResult.value as readonly EnableServiceIntegration[])
+        .filter((integration) => integration.kind === props.family)
+        .sort((a, b) => a.name.localeCompare(b.name))
+    : [];
+
+  const accounts: readonly ProviderAccountForServices[] = AsyncResult.isSuccess(accountsResult)
+    ? (accountsResult.value as readonly ProviderAccountForServices[]).filter(
+        (account) => account.family === props.family,
+      )
+    : [];
+
+  if (!AsyncResult.isSuccess(accountsResult) || !AsyncResult.isSuccess(integrationsResult)) {
+    return (
+      <section className="space-y-3">
+        <h3 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          Provider accounts
+        </h3>
+        <div className="flex items-center gap-2 py-3">
+          <div className="size-1.5 animate-pulse rounded-full bg-muted-foreground/30" />
+          <p className="text-sm text-muted-foreground">Loading provider accounts...</p>
+        </div>
+      </section>
+    );
+  }
+
+  if (accounts.length === 0) return null;
+
+  const modalIntegrations = selectedAccount
+    ? missingServicesFor(selectedAccount, integrations)
+    : [];
+
+  return (
+    <section className="space-y-3">
+      <div>
+        <h3 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          Provider accounts
+        </h3>
+      </div>
+      <CardStack>
+        <CardStackContent>
+          {accounts.map((account) => {
+            const missing = missingServicesFor(account, integrations);
+            const canAdd =
+              missing.some((integration) =>
+                integration.authMethods.some((method) => method.kind === "oauth"),
+              ) && normalizeEmail(account.label) !== null;
+            return (
+              <CardStackEntry key={account.identityKey} className="flex-wrap items-start gap-3">
+                <CardStackEntryContent>
+                  <CardStackEntryTitle className="flex min-w-0 items-center gap-2">
+                    <span className="truncate">{account.label}</span>
+                    {ownerDisplay.showOwnerLabels ? (
+                      <Badge variant="outline">{ownerLabel(account.owner as Owner)}</Badge>
+                    ) : null}
+                  </CardStackEntryTitle>
+                  <CardStackEntryDescription className="mt-1 text-xs">
+                    {account.connections.length} connected{" "}
+                    {account.connections.length === 1 ? "service" : "services"}
+                  </CardStackEntryDescription>
+                  <div className="mt-3 divide-y divide-border rounded-md border border-border">
+                    {account.connections.map((entry) => (
+                      <div
+                        key={`${entry.connection.owner}:${String(entry.integration.slug)}:${String(
+                          entry.connection.name,
+                        )}`}
+                        className="flex items-center justify-between gap-3 px-3 py-2"
+                      >
+                        <div className="min-w-0">
+                          <p className="truncate text-sm font-medium text-foreground">
+                            {entry.integration.name}
+                          </p>
+                          <p className="truncate text-xs text-muted-foreground">
+                            {entry.connection.identityLabel || String(entry.connection.name)}
+                          </p>
+                        </div>
+                        <Badge variant="outline">{String(entry.connection.name)}</Badge>
+                      </div>
+                    ))}
+                  </div>
+                </CardStackEntryContent>
+                <CardStackEntryActions className="self-start pt-0.5">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    disabled={!canAdd}
+                    onClick={() => setSelectedAccount(account)}
+                  >
+                    <PlusIcon />
+                    Add services
+                  </Button>
+                </CardStackEntryActions>
+              </CardStackEntry>
+            );
+          })}
+        </CardStackContent>
+      </CardStack>
+
+      {selectedAccount ? (
+        <EnableServicesModal
+          open={true}
+          account={selectedAccount}
+          integrations={modalIntegrations}
+          onOpenChange={(open) => {
+            if (!open) setSelectedAccount(null);
+          }}
+        />
+      ) : null}
+    </section>
   );
 }
 

--- a/packages/react/src/components/enable-services-modal.test.ts
+++ b/packages/react/src/components/enable-services-modal.test.ts
@@ -112,12 +112,31 @@ describe("buildEnableServiceOAuthStartPayload", () => {
       client: OAuthClientSlug.make("google-app"),
       clientOwner: "org",
       owner: "user",
-      name: ConnectionName.make("personalGoogleCalendar"),
+      name: ConnectionName.make("userGoogleCalendar"),
       integration: IntegrationSlug.make("google_calendar"),
       template: AuthTemplateSlug.make("calendar_oauth"),
-      identityLabel: "Personal Google Calendar",
+      identityLabel: "user Google Calendar",
       loginHint: "user@example.com",
     });
+  });
+
+  it("derives distinct names for two same-owner accounts enabling the same service", () => {
+    const first = buildEnableServiceOAuthStartPayload({
+      account: account({ label: "rhys@example.com" }),
+      integration: calendar,
+      organizationId: "org_123",
+    });
+    const second = buildEnableServiceOAuthStartPayload({
+      account: account({ label: "work@example.com" }),
+      integration: calendar,
+      organizationId: "org_123",
+    });
+
+    expect(first?.name).toBe(ConnectionName.make("rhysGoogleCalendar"));
+    expect(second?.name).toBe(ConnectionName.make("workGoogleCalendar"));
+    expect(first?.identityLabel).toBe("rhys Google Calendar");
+    expect(second?.identityLabel).toBe("work Google Calendar");
+    expect(first?.name).not.toBe(second?.name);
   });
 
   it("uses the connection owner when the existing connection has no client owner", () => {

--- a/packages/react/src/components/enable-services-modal.test.ts
+++ b/packages/react/src/components/enable-services-modal.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "@effect/vitest";
+import {
+  AuthTemplateSlug,
+  ConnectionAddress,
+  ConnectionName,
+  IntegrationSlug,
+  OAuthClientSlug,
+  ProviderKey,
+  type Connection,
+} from "@executor-js/sdk/shared";
+
+import type { ProviderAccount } from "../lib/provider-accounts";
+import {
+  activeEnableServiceStep,
+  applyEnableServiceStepResult,
+  buildEnableServiceOAuthStartPayload,
+  createEnableServicesQueue,
+  retryEnableServiceStep,
+  type EnableServiceIntegration,
+} from "./enable-services-modal";
+import type { OAuthStartPayload } from "../plugins/oauth-sign-in";
+
+const service = (
+  slug: string,
+  name: string,
+  template = `${slug}_oauth`,
+): EnableServiceIntegration => ({
+  slug: IntegrationSlug.make(slug),
+  name,
+  kind: "google",
+  authMethods: [
+    {
+      id: "oauth",
+      label: "OAuth",
+      kind: "oauth",
+      template,
+    },
+  ],
+});
+
+const gmail = service("google_gmail", "Gmail", "gmail_oauth");
+const calendar = service("google_calendar", "Google Calendar", "calendar_oauth");
+const drive = service("google_drive", "Google Drive", "drive_oauth");
+
+const connection = (input?: { readonly oauthClientOwner?: "org" | "user" | null }): Connection => ({
+  owner: "user",
+  name: ConnectionName.make("gmail"),
+  integration: IntegrationSlug.make("google_gmail"),
+  template: AuthTemplateSlug.make("gmail_oauth"),
+  provider: ProviderKey.make("default"),
+  address: ConnectionAddress.make("tools.google_gmail.user.gmail"),
+  identityLabel: "user@example.com",
+  description: null,
+  expiresAt: null,
+  oauthClient: OAuthClientSlug.make("google-app"),
+  oauthClientOwner: input && "oauthClientOwner" in input ? input.oauthClientOwner : "org",
+  oauthScope: null,
+  lastHealth: null,
+});
+
+const account = (input?: {
+  readonly label?: string;
+  readonly oauthClientOwner?: "org" | "user" | null;
+}): ProviderAccount<Connection, EnableServiceIntegration> => ({
+  family: "google",
+  owner: "user",
+  identityKey: "user:google:user@example.com",
+  label: input?.label ?? "user@example.com",
+  connections: [{ connection: connection(input), integration: gmail }],
+});
+
+describe("enable services queue", () => {
+  it("advances on success, keeps the remainder on failure, and retries", () => {
+    let queue = createEnableServicesQueue([gmail, calendar, drive]);
+    expect(activeEnableServiceStep(queue)?.integration.slug).toBe(gmail.slug);
+
+    queue = applyEnableServiceStepResult(queue, gmail.slug, "done");
+    expect(activeEnableServiceStep(queue)?.integration.slug).toBe(calendar.slug);
+
+    queue = applyEnableServiceStepResult(queue, calendar.slug, "failed");
+    expect(activeEnableServiceStep(queue)?.integration.slug).toBe(calendar.slug);
+    expect(queue.steps.map((step) => [String(step.integration.slug), step.status])).toEqual([
+      ["google_gmail", "done"],
+      ["google_calendar", "failed"],
+      ["google_drive", "pending"],
+    ]);
+
+    queue = retryEnableServiceStep(queue, calendar.slug);
+    expect(activeEnableServiceStep(queue)?.integration.slug).toBe(calendar.slug);
+    expect(queue.steps[1]?.status).toBe("pending");
+
+    queue = applyEnableServiceStepResult(queue, calendar.slug, "done");
+    expect(activeEnableServiceStep(queue)?.integration.slug).toBe(drive.slug);
+  });
+});
+
+describe("buildEnableServiceOAuthStartPayload", () => {
+  it("builds the startOAuth payload with loginHint, mirrored client, and service template", () => {
+    const calls: OAuthStartPayload[] = [];
+    const startOAuth = (payload: OAuthStartPayload) => calls.push(payload);
+    const payload = buildEnableServiceOAuthStartPayload({
+      account: account(),
+      integration: calendar,
+      organizationId: "org_123",
+    });
+
+    expect(payload).not.toBeNull();
+    startOAuth(payload!);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      client: OAuthClientSlug.make("google-app"),
+      clientOwner: "org",
+      owner: "user",
+      name: ConnectionName.make("personalGoogleCalendar"),
+      integration: IntegrationSlug.make("google_calendar"),
+      template: AuthTemplateSlug.make("calendar_oauth"),
+      identityLabel: "Personal Google Calendar",
+      loginHint: "user@example.com",
+    });
+  });
+
+  it("uses the connection owner when the existing connection has no client owner", () => {
+    const payload = buildEnableServiceOAuthStartPayload({
+      account: account({ oauthClientOwner: null }),
+      integration: drive,
+      organizationId: "org_123",
+    });
+
+    expect(payload?.clientOwner).toBe("user");
+  });
+
+  it("does not build a payload without an email account label", () => {
+    expect(
+      buildEnableServiceOAuthStartPayload({
+        account: account({ label: "Personal Google" }),
+        integration: calendar,
+        organizationId: "org_123",
+      }),
+    ).toBeNull();
+  });
+});

--- a/packages/react/src/components/enable-services-modal.test.ts
+++ b/packages/react/src/components/enable-services-modal.test.ts
@@ -14,9 +14,13 @@ import {
   activeEnableServiceStep,
   applyEnableServiceStepResult,
   buildEnableServiceOAuthStartPayload,
+  continueEnableServiceStep,
   createEnableServicesQueue,
+  EnableServicesModal,
   retryEnableServiceStep,
   type EnableServiceIntegration,
+  type EnableServiceQueue,
+  type EnableServiceStepStatus,
 } from "./enable-services-modal";
 import type { OAuthStartPayload } from "../plugins/oauth-sign-in";
 
@@ -157,5 +161,108 @@ describe("buildEnableServiceOAuthStartPayload", () => {
         organizationId: "org_123",
       }),
     ).toBeNull();
+  });
+});
+
+describe("continueEnableServiceStep", () => {
+  /** Drives the queue exactly like EnableServicesModalBody: `continueStep`
+   *  mirrors handleContinue (Continue click), and step completion flows back
+   *  through markActive, so the opener-call count is observable per click. */
+  const harness = () => {
+    let queue: EnableServiceQueue<EnableServiceIntegration> = createEnableServicesQueue([
+      gmail,
+      calendar,
+    ]);
+    const started: {
+      readonly payload: OAuthStartPayload;
+      readonly onSuccess: () => void;
+      readonly onError: () => void;
+    }[] = [];
+    const markActive = (status: EnableServiceStepStatus) => {
+      const active = activeEnableServiceStep(queue);
+      if (active) queue = applyEnableServiceStepResult(queue, active.integration.slug, status);
+    };
+    const continueStep = () => {
+      const active = activeEnableServiceStep(queue);
+      if (!active) return;
+      continueEnableServiceStep({
+        account: account(),
+        integration: active.integration,
+        organizationId: "org_123",
+        start: (input) => started.push(input),
+        markActive,
+      });
+    };
+    return {
+      started,
+      continueStep,
+      queue: () => queue,
+    };
+  };
+
+  it("opens exactly one popup per Continue click and never auto-chains on success", () => {
+    const { started, continueStep, queue } = harness();
+
+    continueStep();
+    expect(started).toHaveLength(1);
+    expect(started[0]?.payload.integration).toBe(gmail.slug);
+
+    // The popup completes: the step is marked done and the queue advances,
+    // but no second popup opens without a fresh Continue click.
+    started[0]!.onSuccess();
+    expect(queue().steps[0]?.status).toBe("done");
+    expect(activeEnableServiceStep(queue())?.integration.slug).toBe(calendar.slug);
+    expect(started).toHaveLength(1);
+
+    continueStep();
+    expect(started).toHaveLength(2);
+    expect(started[1]?.payload.integration).toBe(calendar.slug);
+  });
+
+  it("does not auto-retry or auto-advance when a step fails", () => {
+    const { started, continueStep, queue } = harness();
+
+    continueStep();
+    started[0]!.onError();
+    expect(queue().steps[0]?.status).toBe("failed");
+    expect(activeEnableServiceStep(queue())?.integration.slug).toBe(gmail.slug);
+    expect(started).toHaveLength(1);
+  });
+
+  it("marks the step failed without opening a popup when no payload can be built", () => {
+    const started: OAuthStartPayload[] = [];
+    const statuses: EnableServiceStepStatus[] = [];
+    continueEnableServiceStep({
+      account: account({ label: "Personal Google" }),
+      integration: calendar,
+      organizationId: "org_123",
+      start: (input) => started.push(input.payload),
+      markActive: (status) => statuses.push(status),
+    });
+    expect(started).toHaveLength(0);
+    expect(statuses).toEqual(["failed"]);
+  });
+});
+
+describe("EnableServicesModal mount boundary", () => {
+  // The wrapper renders nothing while closed, so the body (and with it the
+  // useOAuthPopupFlow instance owning the in-flight popup) unmounts on close;
+  // the hook's unmount effect cancels the session. The wrapper has no hooks,
+  // so calling it as a plain function is safe here.
+  const wrapperProps = {
+    integrations: [gmail, calendar],
+    onOpenChange: () => {},
+  };
+
+  it("renders nothing when closed, unmounting the body and its OAuth flow", () => {
+    expect(EnableServicesModal({ ...wrapperProps, open: false, account: account() })).toBeNull();
+  });
+
+  it("renders nothing without an account", () => {
+    expect(EnableServicesModal({ ...wrapperProps, open: true, account: null })).toBeNull();
+  });
+
+  it("mounts the body only while open with an account", () => {
+    expect(EnableServicesModal({ ...wrapperProps, open: true, account: account() })).not.toBeNull();
   });
 });

--- a/packages/react/src/components/enable-services-modal.tsx
+++ b/packages/react/src/components/enable-services-modal.tsx
@@ -1,0 +1,349 @@
+import { useMemo, useState } from "react";
+import {
+  AuthTemplateSlug,
+  IntegrationSlug,
+  type AuthMethodDescriptor,
+  type Connection,
+  type Owner,
+} from "@executor-js/sdk/shared";
+import { CheckCircle2Icon, RotateCcwIcon, XCircleIcon } from "lucide-react";
+import { toast } from "sonner";
+
+import { useOrganizationId } from "../api/organization-context";
+import { normalizeEmail, type ProviderAccount } from "../lib/provider-accounts";
+import { cn } from "../lib/utils";
+import { useOAuthPopupFlow, type OAuthStartPayload } from "../plugins/oauth-sign-in";
+import { Button } from "./button";
+import { Badge } from "./badge";
+import { Checkbox } from "./checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "./dialog";
+import { Label } from "./label";
+import { connectionLabelForHost, connectionNameFrom } from "./add-account-modal";
+
+export type EnableServiceIntegration = {
+  readonly slug: IntegrationSlug;
+  readonly name: string;
+  readonly kind: string;
+  readonly authMethods: readonly AuthMethodDescriptor[];
+};
+
+export type EnableServiceStepStatus = "pending" | "done" | "failed";
+
+export type EnableServiceQueueStep<TIntegration extends EnableServiceIntegration> = {
+  readonly integration: TIntegration;
+  readonly status: EnableServiceStepStatus;
+};
+
+export type EnableServiceQueue<TIntegration extends EnableServiceIntegration> = {
+  readonly steps: readonly EnableServiceQueueStep<TIntegration>[];
+  readonly activeIndex: number;
+};
+
+export const createEnableServicesQueue = <TIntegration extends EnableServiceIntegration>(
+  integrations: readonly TIntegration[],
+): EnableServiceQueue<TIntegration> => ({
+  steps: integrations.map((integration) => ({ integration, status: "pending" })),
+  activeIndex: 0,
+});
+
+const nextPendingIndex = <TIntegration extends EnableServiceIntegration>(
+  steps: readonly EnableServiceQueueStep<TIntegration>[],
+  from: number,
+): number => {
+  const next = steps.findIndex((step, index) => index > from && step.status !== "done");
+  return next === -1 ? steps.length : next;
+};
+
+export const applyEnableServiceStepResult = <TIntegration extends EnableServiceIntegration>(
+  queue: EnableServiceQueue<TIntegration>,
+  slug: IntegrationSlug,
+  status: EnableServiceStepStatus,
+): EnableServiceQueue<TIntegration> => {
+  const stepIndex = queue.steps.findIndex((step) => step.integration.slug === slug);
+  if (stepIndex === -1) return queue;
+  const steps = queue.steps.map((step, index) =>
+    index === stepIndex ? { ...step, status } : step,
+  );
+  return {
+    steps,
+    activeIndex:
+      status === "done" && stepIndex === queue.activeIndex
+        ? nextPendingIndex(steps, stepIndex)
+        : queue.activeIndex,
+  };
+};
+
+export const retryEnableServiceStep = <TIntegration extends EnableServiceIntegration>(
+  queue: EnableServiceQueue<TIntegration>,
+  slug: IntegrationSlug,
+): EnableServiceQueue<TIntegration> => {
+  const stepIndex = queue.steps.findIndex((step) => step.integration.slug === slug);
+  if (stepIndex === -1) return queue;
+  return {
+    steps: queue.steps.map((step, index) =>
+      index === stepIndex ? { ...step, status: "pending" } : step,
+    ),
+    activeIndex: stepIndex,
+  };
+};
+
+export const activeEnableServiceStep = <TIntegration extends EnableServiceIntegration>(
+  queue: EnableServiceQueue<TIntegration>,
+): EnableServiceQueueStep<TIntegration> | null => queue.steps[queue.activeIndex] ?? null;
+
+const oauthMethodFor = (integration: EnableServiceIntegration): AuthMethodDescriptor | null =>
+  integration.authMethods.find((method) => method.kind === "oauth") ?? null;
+
+const mirrorConnectionFor = (
+  account: ProviderAccount<Connection, EnableServiceIntegration>,
+): Connection | null =>
+  account.connections.find((entry) => entry.connection.oauthClient != null)?.connection ?? null;
+
+export const buildEnableServiceOAuthStartPayload = (input: {
+  readonly account: ProviderAccount<Connection, EnableServiceIntegration>;
+  readonly integration: EnableServiceIntegration;
+  readonly organizationId: string | null;
+}): OAuthStartPayload | null => {
+  const loginHint = normalizeEmail(input.account.label);
+  if (loginHint === null) return null;
+  const method = oauthMethodFor(input.integration);
+  if (!method) return null;
+  const mirrored = mirrorConnectionFor(input.account);
+  if (!mirrored?.oauthClient) return null;
+  const owner = input.account.owner as Owner;
+  const identityLabel = connectionLabelForHost(
+    "",
+    owner,
+    input.integration.name,
+    input.organizationId,
+  );
+
+  return {
+    client: mirrored.oauthClient,
+    clientOwner: mirrored.oauthClientOwner ?? mirrored.owner,
+    owner,
+    name: connectionNameFrom("", owner, input.integration.name, input.organizationId),
+    integration: input.integration.slug,
+    template: AuthTemplateSlug.make(method.template),
+    identityLabel,
+    loginHint,
+  };
+};
+
+const serviceKey = (integration: EnableServiceIntegration): string => String(integration.slug);
+
+export function EnableServicesModal(props: {
+  readonly open: boolean;
+  readonly account: ProviderAccount<Connection, EnableServiceIntegration> | null;
+  readonly integrations: readonly EnableServiceIntegration[];
+  readonly onOpenChange: (open: boolean) => void;
+}) {
+  if (!props.open || !props.account) return null;
+  return <EnableServicesModalBody {...props} account={props.account} />;
+}
+
+function EnableServicesModalBody(props: {
+  readonly account: ProviderAccount<Connection, EnableServiceIntegration>;
+  readonly integrations: readonly EnableServiceIntegration[];
+  readonly onOpenChange: (open: boolean) => void;
+  readonly open: boolean;
+}) {
+  const organizationId = useOrganizationId();
+  const defaultSelected = useMemo(
+    () =>
+      new Set(
+        props.integrations
+          .filter((integration) => oauthMethodFor(integration) !== null)
+          .map((integration) => serviceKey(integration)),
+      ),
+    [props.integrations],
+  );
+  const [selected, setSelected] = useState<ReadonlySet<string>>(defaultSelected);
+  const [queue, setQueue] = useState<EnableServiceQueue<EnableServiceIntegration> | null>(null);
+  const oauthPopup = useOAuthPopupFlow({
+    popupName: "enable-provider-service",
+    detectPopupClosed: false,
+    startErrorMessage: "Failed to start service connection",
+  });
+  const active = queue ? activeEnableServiceStep(queue) : null;
+  const selectedIntegrations = props.integrations.filter((integration) =>
+    selected.has(serviceKey(integration)),
+  );
+  const complete = queue ? queue.steps.every((step) => step.status === "done") : false;
+  const loginHint = normalizeEmail(props.account.label);
+
+  const toggleSelected = (integration: EnableServiceIntegration, checked: boolean) => {
+    setSelected((current) => {
+      const next = new Set(current);
+      if (checked) next.add(serviceKey(integration));
+      else next.delete(serviceKey(integration));
+      return next;
+    });
+  };
+
+  const startQueue = () => {
+    setQueue(createEnableServicesQueue(selectedIntegrations));
+  };
+
+  const markActive = (status: EnableServiceStepStatus) => {
+    if (!queue || !active) return;
+    setQueue(applyEnableServiceStepResult(queue, active.integration.slug, status));
+  };
+
+  const handleContinue = () => {
+    if (!active) return;
+    const payload = buildEnableServiceOAuthStartPayload({
+      account: props.account,
+      integration: active.integration,
+      organizationId,
+    });
+    if (!payload) {
+      markActive("failed");
+      toast.error("This service cannot reuse the selected OAuth app");
+      return;
+    }
+    void oauthPopup.start({
+      payload,
+      onSuccess: () => {
+        markActive("done");
+        toast.success(`${active.integration.name} connected`);
+      },
+      onError: () => {
+        markActive("failed");
+      },
+    });
+  };
+
+  const handleRetry = () => {
+    if (!queue || !active) return;
+    setQueue(retryEnableServiceStep(queue, active.integration.slug));
+  };
+
+  return (
+    <Dialog open={props.open} onOpenChange={props.onOpenChange}>
+      <DialogContent className="sm:max-w-xl">
+        <DialogHeader>
+          <DialogTitle>Add services</DialogTitle>
+          <DialogDescription>{loginHint ?? props.account.label}</DialogDescription>
+        </DialogHeader>
+
+        {queue === null ? (
+          <div className="space-y-3">
+            <div className="rounded-md border border-border">
+              {props.integrations.map((integration) => {
+                const key = serviceKey(integration);
+                const disabled = oauthMethodFor(integration) === null || loginHint === null;
+                return (
+                  <Label
+                    key={key}
+                    className={cn(
+                      "flex cursor-pointer items-center gap-3 border-b border-border px-3 py-3 last:border-b-0",
+                      disabled && "cursor-not-allowed opacity-50",
+                    )}
+                  >
+                    <Checkbox
+                      checked={selected.has(key)}
+                      disabled={disabled}
+                      onCheckedChange={(value) => toggleSelected(integration, value === true)}
+                    />
+                    <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+                      <span className="truncate text-sm font-medium text-foreground">
+                        {integration.name}
+                      </span>
+                      <span className="text-xs text-muted-foreground">
+                        {disabled ? "OAuth is not available" : "Ready to connect"}
+                      </span>
+                    </span>
+                  </Label>
+                );
+              })}
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <div className="space-y-2">
+              {queue.steps.map((step, index) => (
+                <div
+                  key={serviceKey(step.integration)}
+                  className="flex items-center justify-between rounded-md border border-border px-3 py-2"
+                >
+                  <div className="min-w-0">
+                    <p className="truncate text-sm font-medium text-foreground">
+                      {step.integration.name}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      {index + 1} of {queue.steps.length}
+                    </p>
+                  </div>
+                  {step.status === "done" ? (
+                    <Badge variant="outline" className="gap-1 text-emerald-700">
+                      <CheckCircle2Icon />
+                      Done
+                    </Badge>
+                  ) : step.status === "failed" ? (
+                    <Badge variant="outline" className="gap-1 text-destructive">
+                      <XCircleIcon />
+                      Failed
+                    </Badge>
+                  ) : (
+                    <Badge variant="outline">Pending</Badge>
+                  )}
+                </div>
+              ))}
+            </div>
+
+            {complete ? (
+              <div className="rounded-md border border-border bg-muted/30 px-3 py-3 text-sm text-foreground">
+                Selected services are connected.
+              </div>
+            ) : active ? (
+              <div className="rounded-md border border-border bg-muted/30 px-3 py-3">
+                <p className="text-sm font-medium text-foreground">
+                  Connecting {active.integration.name} ({queue.activeIndex + 1} of{" "}
+                  {queue.steps.length})
+                </p>
+                {active.status === "failed" ? (
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    Retry this service when ready.
+                  </p>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
+        )}
+
+        <DialogFooter>
+          {queue === null ? (
+            <Button
+              type="button"
+              onClick={startQueue}
+              disabled={selectedIntegrations.length === 0 || loginHint === null}
+            >
+              Start queue
+            </Button>
+          ) : complete ? (
+            <Button type="button" onClick={() => props.onOpenChange(false)}>
+              Done
+            </Button>
+          ) : active?.status === "failed" ? (
+            <Button type="button" onClick={handleRetry} variant="outline">
+              <RotateCcwIcon />
+              Retry
+            </Button>
+          ) : (
+            <Button type="button" onClick={handleContinue} loading={oauthPopup.busy}>
+              Continue
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/react/src/components/enable-services-modal.tsx
+++ b/packages/react/src/components/enable-services-modal.tsx
@@ -118,8 +118,12 @@ export const buildEnableServiceOAuthStartPayload = (input: {
   const mirrored = mirrorConnectionFor(input.account);
   if (!mirrored?.oauthClient) return null;
   const owner = input.account.owner as Owner;
+  // Seed the label with the account email's localpart ("rhys Google Calendar")
+  // so two same-owner accounts enabling the same service don't collide on
+  // (owner, integration, name) and clobber each other's connection.
+  const accountLabel = `${loginHint.split("@")[0] ?? ""} ${input.integration.name}`;
   const identityLabel = connectionLabelForHost(
-    "",
+    accountLabel,
     owner,
     input.integration.name,
     input.organizationId,
@@ -129,7 +133,7 @@ export const buildEnableServiceOAuthStartPayload = (input: {
     client: mirrored.oauthClient,
     clientOwner: mirrored.oauthClientOwner ?? mirrored.owner,
     owner,
-    name: connectionNameFrom("", owner, input.integration.name, input.organizationId),
+    name: connectionNameFrom(accountLabel, owner, input.integration.name, input.organizationId),
     integration: input.integration.slug,
     template: AuthTemplateSlug.make(method.template),
     identityLabel,

--- a/packages/react/src/components/enable-services-modal.tsx
+++ b/packages/react/src/components/enable-services-modal.tsx
@@ -141,6 +141,43 @@ export const buildEnableServiceOAuthStartPayload = (input: {
   };
 };
 
+/** Run one queue step: build the payload and open exactly one OAuth popup.
+ *  The completion callbacks only record the step result; advancing to the next
+ *  service always requires a fresh Continue click, so a finishing popup can
+ *  never auto-open the next one. */
+export const continueEnableServiceStep = (input: {
+  readonly account: ProviderAccount<Connection, EnableServiceIntegration>;
+  readonly integration: EnableServiceIntegration;
+  readonly organizationId: string | null;
+  readonly start: (input: {
+    readonly payload: OAuthStartPayload;
+    readonly onSuccess: () => void;
+    readonly onError: () => void;
+  }) => void;
+  readonly markActive: (status: EnableServiceStepStatus) => void;
+}): void => {
+  const payload = buildEnableServiceOAuthStartPayload({
+    account: input.account,
+    integration: input.integration,
+    organizationId: input.organizationId,
+  });
+  if (!payload) {
+    input.markActive("failed");
+    toast.error("This service cannot reuse the selected OAuth app");
+    return;
+  }
+  input.start({
+    payload,
+    onSuccess: () => {
+      input.markActive("done");
+      toast.success(`${input.integration.name} connected`);
+    },
+    onError: () => {
+      input.markActive("failed");
+    },
+  });
+};
+
 const serviceKey = (integration: EnableServiceIntegration): string => String(integration.slug);
 
 export function EnableServicesModal(props: {
@@ -203,25 +240,12 @@ function EnableServicesModalBody(props: {
 
   const handleContinue = () => {
     if (!active) return;
-    const payload = buildEnableServiceOAuthStartPayload({
+    continueEnableServiceStep({
       account: props.account,
       integration: active.integration,
       organizationId,
-    });
-    if (!payload) {
-      markActive("failed");
-      toast.error("This service cannot reuse the selected OAuth app");
-      return;
-    }
-    void oauthPopup.start({
-      payload,
-      onSuccess: () => {
-        markActive("done");
-        toast.success(`${active.integration.name} connected`);
-      },
-      onError: () => {
-        markActive("failed");
-      },
+      start: (input) => void oauthPopup.start(input),
+      markActive,
     });
   };
 

--- a/packages/react/src/lib/provider-accounts.test.ts
+++ b/packages/react/src/lib/provider-accounts.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import { groupProviderAccounts, normalizeEmail } from "./provider-accounts";
+
+type TestConnection = {
+  readonly owner: "org" | "user";
+  readonly name: string;
+  readonly integration: string;
+  readonly identityLabel?: string | null;
+};
+
+type TestIntegration = {
+  readonly slug: string;
+  readonly kind: string;
+  readonly name: string;
+};
+
+const integration = (slug: string, kind: string): TestIntegration => ({
+  slug,
+  kind,
+  name: slug,
+});
+
+const connection = (input: TestConnection): TestConnection => input;
+
+const integrations = new Map<string, TestIntegration>([
+  ["google_calendar", integration("google_calendar", "google")],
+  ["google_gmail", integration("google_gmail", "google")],
+  ["microsoft_mail", integration("microsoft_mail", "microsoft")],
+  ["microsoft_calendar", integration("microsoft_calendar", "microsoft")],
+  ["github_issues", integration("github_issues", "github")],
+  ["github_prs", integration("github_prs", "github")],
+]);
+
+const memberships = (
+  accounts: ReturnType<typeof groupProviderAccounts<TestConnection, TestIntegration>>,
+) =>
+  accounts.map((account) => ({
+    identityKey: account.identityKey,
+    connections: account.connections.map((entry) => entry.connection.name),
+  }));
+
+describe("normalizeEmail", () => {
+  it("trims, lowercases, and rejects non-email labels", () => {
+    expect(normalizeEmail(" User@Example.COM ")).toBe("user@example.com");
+    expect(normalizeEmail("not an email")).toBeNull();
+    expect(normalizeEmail(null)).toBeNull();
+  });
+});
+
+describe("groupProviderAccounts", () => {
+  it("groups Google services with the same email into one account", () => {
+    const accounts = groupProviderAccounts({
+      integrationsByKind: integrations,
+      connections: [
+        connection({
+          owner: "user",
+          name: "gmail",
+          integration: "google_gmail",
+          identityLabel: "User@Example.com",
+        }),
+        connection({
+          owner: "user",
+          name: "calendar",
+          integration: "google_calendar",
+          identityLabel: " user@example.com ",
+        }),
+      ],
+    });
+
+    expect(accounts).toHaveLength(1);
+    expect(accounts[0]?.identityKey).toBe("user:google:user@example.com");
+    expect(accounts[0]?.label).toBe("user@example.com");
+    expect(accounts[0]?.connections.map((entry) => entry.connection.name)).toEqual([
+      "calendar",
+      "gmail",
+    ]);
+  });
+
+  it("keeps different Google emails as separate accounts", () => {
+    const accounts = groupProviderAccounts({
+      integrationsByKind: integrations,
+      connections: [
+        connection({
+          owner: "user",
+          name: "work",
+          integration: "google_gmail",
+          identityLabel: "work@example.com",
+        }),
+        connection({
+          owner: "user",
+          name: "personal",
+          integration: "google_calendar",
+          identityLabel: "me@example.com",
+        }),
+      ],
+    });
+
+    expect(memberships(accounts)).toEqual([
+      { identityKey: "user:google:me@example.com", connections: ["personal"] },
+      { identityKey: "user:google:work@example.com", connections: ["work"] },
+    ]);
+  });
+
+  it("keeps Microsoft in a separate family from Google", () => {
+    const accounts = groupProviderAccounts({
+      integrationsByKind: integrations,
+      connections: [
+        connection({
+          owner: "user",
+          name: "google",
+          integration: "google_gmail",
+          identityLabel: "user@example.com",
+        }),
+        connection({
+          owner: "user",
+          name: "microsoft",
+          integration: "microsoft_mail",
+          identityLabel: "user@example.com",
+        }),
+      ],
+    });
+
+    expect(memberships(accounts)).toEqual([
+      { identityKey: "user:google:user@example.com", connections: ["google"] },
+      { identityKey: "user:microsoft:user@example.com", connections: ["microsoft"] },
+    ]);
+  });
+
+  it("does not merge non-family integrations", () => {
+    const accounts = groupProviderAccounts({
+      integrationsByKind: integrations,
+      connections: [
+        connection({
+          owner: "user",
+          name: "issues",
+          integration: "github_issues",
+          identityLabel: "user@example.com",
+        }),
+        connection({
+          owner: "user",
+          name: "prs",
+          integration: "github_prs",
+          identityLabel: "user@example.com",
+        }),
+      ],
+    });
+
+    expect(memberships(accounts)).toEqual([
+      { identityKey: "user:github:github_issues:issues", connections: ["issues"] },
+      { identityKey: "user:github:github_prs:prs", connections: ["prs"] },
+    ]);
+  });
+
+  it("keeps organization and user owners separate", () => {
+    const accounts = groupProviderAccounts({
+      integrationsByKind: integrations,
+      connections: [
+        connection({
+          owner: "org",
+          name: "workspace",
+          integration: "google_gmail",
+          identityLabel: "user@example.com",
+        }),
+        connection({
+          owner: "user",
+          name: "personal",
+          integration: "google_calendar",
+          identityLabel: "user@example.com",
+        }),
+      ],
+    });
+
+    expect(memberships(accounts)).toEqual([
+      { identityKey: "org:google:user@example.com", connections: ["workspace"] },
+      { identityKey: "user:google:user@example.com", connections: ["personal"] },
+    ]);
+  });
+
+  it("keeps null or non-email identity labels as singleton accounts", () => {
+    const accounts = groupProviderAccounts({
+      integrationsByKind: integrations,
+      connections: [
+        connection({
+          owner: "user",
+          name: "gmail",
+          integration: "google_gmail",
+          identityLabel: null,
+        }),
+        connection({
+          owner: "user",
+          name: "calendar",
+          integration: "google_calendar",
+          identityLabel: "Personal Google",
+        }),
+      ],
+    });
+
+    expect(memberships(accounts)).toEqual([
+      { identityKey: "user:google:google_calendar:calendar", connections: ["calendar"] },
+      { identityKey: "user:google:google_gmail:gmail", connections: ["gmail"] },
+    ]);
+  });
+
+  it("regroups deterministically when a label changes to a matching email", () => {
+    const before = groupProviderAccounts({
+      integrationsByKind: integrations,
+      connections: [
+        connection({
+          owner: "user",
+          name: "calendar",
+          integration: "google_calendar",
+          identityLabel: "old@example.com",
+        }),
+        connection({
+          owner: "user",
+          name: "gmail",
+          integration: "google_gmail",
+          identityLabel: "user@example.com",
+        }),
+      ],
+    });
+    const after = groupProviderAccounts({
+      integrationsByKind: integrations,
+      connections: [
+        connection({
+          owner: "user",
+          name: "calendar",
+          integration: "google_calendar",
+          identityLabel: " USER@example.com ",
+        }),
+        connection({
+          owner: "user",
+          name: "gmail",
+          integration: "google_gmail",
+          identityLabel: "user@example.com",
+        }),
+      ],
+    });
+
+    expect(memberships(before)).toEqual([
+      { identityKey: "user:google:old@example.com", connections: ["calendar"] },
+      { identityKey: "user:google:user@example.com", connections: ["gmail"] },
+    ]);
+    expect(memberships(after)).toEqual([
+      { identityKey: "user:google:user@example.com", connections: ["calendar", "gmail"] },
+    ]);
+  });
+});

--- a/packages/react/src/lib/provider-accounts.ts
+++ b/packages/react/src/lib/provider-accounts.ts
@@ -1,0 +1,111 @@
+export type ProviderAccountConnectionLike = {
+  readonly owner: string;
+  readonly name: unknown;
+  readonly integration: unknown;
+  readonly identityLabel?: string | null;
+};
+
+export type ProviderAccountIntegrationLike = {
+  readonly slug: unknown;
+  readonly kind: string;
+};
+
+export type ProviderAccountConnection<
+  TConnection extends ProviderAccountConnectionLike = ProviderAccountConnectionLike,
+  TIntegration extends ProviderAccountIntegrationLike = ProviderAccountIntegrationLike,
+> = {
+  readonly connection: TConnection;
+  readonly integration: TIntegration;
+};
+
+export type ProviderAccount<
+  TConnection extends ProviderAccountConnectionLike = ProviderAccountConnectionLike,
+  TIntegration extends ProviderAccountIntegrationLike = ProviderAccountIntegrationLike,
+> = {
+  readonly family: string;
+  readonly owner: TConnection["owner"];
+  readonly identityKey: string;
+  readonly label: string;
+  readonly connections: readonly ProviderAccountConnection<TConnection, TIntegration>[];
+};
+
+export const MULTI_SERVICE_FAMILIES: ReadonlySet<string> = new Set(["google", "microsoft"]);
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export const normalizeEmail = (value: string | null | undefined): string | null => {
+  const normalized = value?.trim().toLowerCase() ?? "";
+  return EMAIL_PATTERN.test(normalized) ? normalized : null;
+};
+
+const singletonIdentityKey = (connection: ProviderAccountConnectionLike, family: string): string =>
+  `${String(connection.owner)}:${family}:${String(connection.integration)}:${String(
+    connection.name,
+  )}`;
+
+const displayLabelFor = (connection: ProviderAccountConnectionLike): string => {
+  const label = connection.identityLabel?.trim();
+  return label && label.length > 0 ? label : String(connection.name);
+};
+
+export function groupProviderAccounts<
+  TConnection extends ProviderAccountConnectionLike,
+  TIntegration extends ProviderAccountIntegrationLike,
+>(input: {
+  readonly connections: readonly TConnection[];
+  readonly integrationsByKind: ReadonlyMap<string, TIntegration>;
+  readonly families?: ReadonlySet<string>;
+}): readonly ProviderAccount<TConnection, TIntegration>[] {
+  const families = input.families ?? MULTI_SERVICE_FAMILIES;
+  const groups = new Map<string, ProviderAccount<TConnection, TIntegration>>();
+
+  for (const connection of input.connections) {
+    const integration = input.integrationsByKind.get(String(connection.integration));
+    if (!integration) continue;
+
+    const family = integration.kind;
+    const email = normalizeEmail(connection.identityLabel);
+    const canMerge = families.has(family) && email !== null;
+    const identityKey = canMerge
+      ? `${String(connection.owner)}:${family}:${email}`
+      : singletonIdentityKey(connection, family);
+    const label = canMerge ? email : displayLabelFor(connection);
+    const existing = groups.get(identityKey);
+    const entry = { connection, integration };
+
+    if (existing) {
+      groups.set(identityKey, {
+        ...existing,
+        connections: [...existing.connections, entry],
+      });
+      continue;
+    }
+
+    groups.set(identityKey, {
+      family,
+      owner: connection.owner,
+      identityKey,
+      label,
+      connections: [entry],
+    });
+  }
+
+  return Array.from(groups.values())
+    .map((account) => ({
+      ...account,
+      connections: [...account.connections].sort((a, b) => {
+        const integrationOrder = String(a.integration.slug).localeCompare(
+          String(b.integration.slug),
+        );
+        if (integrationOrder !== 0) return integrationOrder;
+        return String(a.connection.name).localeCompare(String(b.connection.name));
+      }),
+    }))
+    .sort((a, b) => {
+      const ownerOrder = String(a.owner).localeCompare(String(b.owner));
+      if (ownerOrder !== 0) return ownerOrder;
+      const familyOrder = a.family.localeCompare(b.family);
+      if (familyOrder !== 0) return familyOrder;
+      return a.identityKey.localeCompare(b.identityKey);
+    });
+}

--- a/packages/react/src/pages/integration-detail.tsx
+++ b/packages/react/src/pages/integration-detail.tsx
@@ -25,10 +25,11 @@ import { connectionWriteKeys, integrationWriteKeys } from "../api/reactivity-key
 import { ToolTree } from "../components/tool-tree";
 import { ToolDetail, ToolDetailEmpty } from "../components/tool-detail";
 import type { ToolSummary } from "../components/tool-tree";
-import { AccountsSection } from "../components/accounts-section";
+import { AccountsSection, ProviderAccountsSection } from "../components/accounts-section";
 import { IntegrationEditSheet } from "../components/metadata-edit-sheet";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../components/tabs";
 import { authMethodsFromDescriptors, type AuthMethod } from "../lib/auth-placements";
+import { MULTI_SERVICE_FAMILIES } from "../lib/provider-accounts";
 import { usePolicyActions } from "../hooks/use-policy-actions";
 import { useIntegrationPlugins, type IntegrationAccountHandoff } from "@executor-js/sdk/client";
 import { Button } from "../components/button";
@@ -430,6 +431,11 @@ export function IntegrationDetailPage(props: { namespace: string }) {
               the plugin's config); otherwise we render the generic fallback. */}
         {!isBuiltInIntegration && (
           <TabsContent value="accounts" className="min-h-0 overflow-y-auto">
+            {integrationData && MULTI_SERVICE_FAMILIES.has(integrationData.kind) ? (
+              <div className="mx-auto max-w-3xl px-6 pt-8">
+                <ProviderAccountsSection family={integrationData.kind} />
+              </div>
+            ) : null}
             {editPlugin?.accounts ? (
               <Suspense fallback={<AccountsSkeleton />}>
                 <editPlugin.accounts

--- a/packages/react/src/plugins/oauth-sign-in.tsx
+++ b/packages/react/src/plugins/oauth-sign-in.tsx
@@ -69,6 +69,7 @@ export type OAuthStartPayload = {
   readonly integration: IntegrationSlug;
   readonly template: AuthTemplateSlug;
   readonly identityLabel?: string;
+  readonly loginHint?: string;
   readonly redirectUri?: string;
 };
 
@@ -381,6 +382,7 @@ export function useOAuthPopupFlow<
               integration: input.payload.integration,
               template: input.payload.template,
               identityLabel: input.payload.identityLabel,
+              loginHint: input.payload.loginHint,
               redirectUri: input.payload.redirectUri ?? oauthCallbackUrl(callbackPath),
             },
           }).then((exit) =>


### PR DESCRIPTION
Adds a derived provider-account grouping (no new storage): connections on Google/Microsoft integrations group by probed account email, rendered as one account with its per-service connections. From an account row, additional services can be enabled one consent at a time; each consent carries login_hint so Google/Microsoft pre-select the account. Connection lists now expose a narrow lastHealth projection (status/identity/checkedAt) for the accounts view.

Independently reviewed (ship-with-nits; all three nits addressed: narrowed list projection, per-account connection naming, no-auto-chaining handler tests).