### PR TITLE
Per-service picker fan-out UI

### DIFF
--- a/e2e/scenarios/google-per-service-add-ui.test.ts
+++ b/e2e/scenarios/google-per-service-add-ui.test.ts
@@ -98,8 +98,14 @@ scenario(
           .getByRole("link", { name: "Open" })
           .click();
         await page.waitForURL(/\/integrations\/google_calendar\b/);
-        // The detail header renders the per-service name, not a generic "Google".
-        await page.getByText("Google Calendar").first().waitFor({ timeout: 20_000 });
+        // The detail header renders the per-service name, not a generic
+        // "Google". Scoped to the main region: the shell sidebar also lists
+        // the new integration as "Google Calendar".
+        await page
+          .getByRole("main")
+          .getByText("Google Calendar")
+          .first()
+          .waitFor({ timeout: 20_000 });
       });
 
       await step("The integrations list has three separate Google integrations", async () => {
@@ -107,7 +113,11 @@ scenario(
         // Each fanned-out integration is its own list entry, keyed by its slug
         // (the list renders the slug as each entry's description).
         for (const slug of ["google_calendar", "google_gmail", "google_drive"]) {
-          await page.getByText(slug, { exact: true }).first().waitFor({ timeout: 20_000 });
+          await page
+            .getByRole("main")
+            .getByText(slug, { exact: true })
+            .first()
+            .waitFor({ timeout: 20_000 });
         }
       });
 

--- a/e2e/scenarios/google-per-service-add-ui.test.ts
+++ b/e2e/scenarios/google-per-service-add-ui.test.ts
@@ -1,0 +1,134 @@
+// Google per-service picker fan-out: the add-Google flow lets a user check
+// several Google products and submit them in one action; each checked preset
+// becomes its OWN integration (google_calendar, google_gmail, google_drive),
+// not one bundled "google" source. This drives the whole browser path:
+//
+//   1. Open /integrations/add/google (the Google-owned add flow).
+//   2. Clear the featured defaults, then check exactly Calendar + Gmail + Drive.
+//   3. Submit via `google-add-submit`. The flow fetches each preset's real
+//      Google Discovery document (www.googleapis.com) and registers one
+//      integration per product.
+//   4. The result panel shows three `add-result-row-*` rows, each data-state
+//      "added", each with an Open link.
+//   5. Follow one Open link: the integration detail page shows the per-service
+//      name ("Google Calendar"), proving the fan-out kept preset identities.
+//   6. Back on the integrations list, all three separate integrations exist
+//      (asserted by their distinct slugs in the list UI).
+//   7. Re-open the add flow, check Calendar again, submit: its row now reports
+//      data-state "skipped" (the integration already exists), proving the
+//      idempotent add path.
+//
+// OUTBOUND DISCOVERY: unlike the emulator-backed scenarios, this exercises the
+// real add path. The Google preset add flow HARDCODES the Discovery host
+// (`normalizeGoogleDiscoveryUrl` only accepts googleapis.com HTTPS Discovery
+// endpoints) and the OAuth authorize/token URLs (accounts.google.com /
+// oauth2.googleapis.com). There is no baseUrl or custom-URL override that
+// redirects a preset's Discovery fetch at the emulator, so this scenario adds
+// the integrations against real Google Discovery documents (read-only, no
+// credentials, no OAuth). The cloud e2e runners (and CI's blacksmith runners)
+// have outbound internet, so the fetch resolves; the scenario asserts only on
+// the product's own catalog state, never on Google account data.
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+
+import { scenario } from "../src/scenario";
+import { Browser, Target } from "../src/services";
+import { setPresetChecked } from "./support/picker";
+
+scenario(
+  "Google · the per-service picker fans out to separate integrations and skips existing ones",
+  { timeout: 240_000 },
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const browser = yield* Browser;
+    const identity = yield* target.newIdentity();
+
+    yield* browser.session(identity, async ({ page, step }) => {
+      await step("Open the Google add flow", async () => {
+        await page.goto("/integrations/add/google", { waitUntil: "domcontentloaded" });
+        await page.getByRole("heading", { name: "Add Google integration" }).waitFor();
+        await page.getByText("Customize your Google connection").waitFor();
+        // The picker mounts with the featured defaults checked.
+        await page.getByTestId("preset-checkbox-google-calendar").waitFor();
+      });
+
+      await step("Clear the defaults, then check exactly Calendar + Gmail + Drive", async () => {
+        // Clear every featured default, then select only the three under test.
+        const featuredDefaults = [
+          "google-calendar",
+          "google-gmail",
+          "google-sheets",
+          "google-drive",
+          "google-docs",
+        ];
+        for (const presetId of featuredDefaults) {
+          await setPresetChecked(page, presetId, false);
+        }
+
+        for (const presetId of ["google-calendar", "google-gmail", "google-drive"]) {
+          await setPresetChecked(page, presetId, true);
+        }
+        // Everything else is unchecked: this is a scoped three-product selection.
+        expect(await page.getByTestId("preset-checkbox-google-sheets").isChecked()).toBe(false);
+        expect(await page.getByTestId("preset-checkbox-google-docs").isChecked()).toBe(false);
+      });
+
+      await step("Submit the fan-out and see three added integrations", async () => {
+        await page.getByTestId("google-add-submit").click();
+        // The result panel appears once every product is registered. Discovery
+        // fetch + spec compile per product; allow generous time.
+        const results = page.getByTestId("google-add-results");
+        await results.waitFor({ timeout: 120_000 });
+
+        for (const presetId of ["google-calendar", "google-gmail", "google-drive"]) {
+          const row = page.getByTestId(`add-result-row-${presetId}`);
+          await row.waitFor({ timeout: 120_000 });
+          expect(
+            await row.getAttribute("data-state"),
+            `${presetId} added as its own integration`,
+          ).toBe("added");
+          // Each added row links out to its own integration page.
+          await row.getByRole("link", { name: "Open" }).waitFor();
+        }
+      });
+
+      await step("Open one product: its integration page shows the per-service name", async () => {
+        await page
+          .getByTestId("add-result-row-google-calendar")
+          .getByRole("link", { name: "Open" })
+          .click();
+        await page.waitForURL(/\/integrations\/google_calendar\b/);
+        // The detail header renders the per-service name, not a generic "Google".
+        await page.getByText("Google Calendar").first().waitFor({ timeout: 20_000 });
+      });
+
+      await step("The integrations list has three separate Google integrations", async () => {
+        await page.goto("/integrations", { waitUntil: "networkidle" });
+        // Each fanned-out integration is its own list entry, keyed by its slug
+        // (the list renders the slug as each entry's description).
+        for (const slug of ["google_calendar", "google_gmail", "google_drive"]) {
+          await page.getByText(slug, { exact: true }).first().waitFor({ timeout: 20_000 });
+        }
+      });
+
+      await step("Re-adding an existing product reports it as skipped", async () => {
+        await page.goto("/integrations/add/google", { waitUntil: "domcontentloaded" });
+        await page.getByText("Customize your Google connection").waitFor();
+
+        // Clear the featured defaults so only Calendar (already added) is checked.
+        for (const presetId of ["google-gmail", "google-sheets", "google-drive", "google-docs"]) {
+          await setPresetChecked(page, presetId, false);
+        }
+        await setPresetChecked(page, "google-calendar", true);
+
+        await page.getByTestId("google-add-submit").click();
+        const row = page.getByTestId("add-result-row-google-calendar");
+        await row.waitFor({ timeout: 120_000 });
+        expect(
+          await row.getAttribute("data-state"),
+          "an already-added product is skipped, not re-added or failed",
+        ).toBe("skipped");
+      });
+    });
+  }),
+);

--- a/e2e/scenarios/google-per-service-oauth.test.ts
+++ b/e2e/scenarios/google-per-service-oauth.test.ts
@@ -1,0 +1,53 @@
+// Google per-service OAuth connect + auto-naming + ledger (the intended shape):
+// boot the Google emulator, add ONE per-service integration pointed at the
+// emulator's Discovery + OAuth, drive the browser add-account OAuth flow
+// (auto-approving emulator consent), then assert the connection was created,
+// its identityLabel was auto-filled from the emulator account's email (the
+// userinfo health-check identity branch), and a tool call landed in the
+// emulator ledger with the right auth.
+//
+// BLOCKED (pre-existing, not this PR): the Google per-service add path hardcodes
+// its upstreams to real Google, with NO override toward an emulator:
+//
+//   * Discovery host: `google.addServices` resolves each preset through
+//     `googleBundleUrlsWithIdentity` → `normalizeGoogleDiscoveryUrl`, which only
+//     accepts `https://www.googleapis.com/...` (or `<svc>.googleapis.com`) HTTPS
+//     Discovery endpoints. The emulator serves Discovery at
+//     `http://127.0.0.1:<port>/discovery/v1/apis/...`, which the normalizer
+//     rejects. The `baseUrl` payload field is stored as integration config only;
+//     it does NOT redirect the Discovery fetch.
+//     (packages/plugins/google/src/sdk/discovery.ts, sdk/plugin.ts)
+//
+//   * OAuth authorize/token: the converted spec bakes
+//     `authorizationUrl = https://accounts.google.com/o/oauth2/v2/auth` and
+//     `tokenUrl = https://oauth2.googleapis.com/token` into the integration's
+//     `googleOAuth2` template (googleOauthTemplate in discovery.ts). There is no
+//     per-integration override to point these at the emulator's `/o/oauth2/v2/auth`
+//     + `/token`, so a browser consent can't be redirected at the emulator's
+//     auto-approving pages the way the WorkOS/Microsoft emulator flows are.
+//
+//   * The Google emulator's OAuth credential mint returns only client_id /
+//     client_secret (no authorization_url / token_url), unlike the Microsoft
+//     emulator, so even the microsoft-emulator.test.ts trick of creating an
+//     oauth client with emulator URLs has nothing to point at.
+//
+// Making this real needs the add path to accept a per-integration Discovery +
+// OAuth endpoint override (emulator base), or a Google emulator that serves a
+// googleapis.com-shaped Discovery host the normalizer accepts. Tracked
+// separately. The picker fan-out itself IS covered end-to-end (against real
+// Google Discovery, read-only) in google-per-service-add-ui.test.ts.
+import { Effect } from "effect";
+
+import { scenario } from "../src/scenario";
+import { Target } from "../src/services";
+
+scenario(
+  "Google · per-service OAuth against the emulator auto-names the connection and lands in the ledger",
+  {
+    skip: "google.addServices hardcodes Discovery (googleapis.com) and OAuth (accounts.google.com/oauth2.googleapis.com); no per-integration emulator override, and the Google emulator mint returns no authorization_url/token_url to point a client at",
+    timeout: 180_000,
+  },
+  Effect.gen(function* () {
+    yield* Target;
+  }),
+);

--- a/e2e/scenarios/google-photos-preset-ui.test.ts
+++ b/e2e/scenarios/google-photos-preset-ui.test.ts
@@ -29,14 +29,39 @@ scenario(
         await page.getByRole("heading", { name: "Add Google integration" }).waitFor();
       });
 
-      await step("The Photos preset defaults to the focused namespace and products", async () => {
-        await page.locator('input[value="Google Photos"]').waitFor();
-        await page.locator('input[value="google_photos"]').waitFor();
-        await page.getByText("Google Photos Library").first().waitFor();
-        await page.getByText("Google Photos Picker").first().waitFor();
-        await page.getByText("2 Google APIs").waitFor();
+      await step("The Photos preset pre-checks both Photos products for fan-out", async () => {
+        // The focused flow initializes the multi-select picker with exactly
+        // the two Photos presets checked; each is added as its own
+        // integration on submit.
+        const library = page.getByRole("checkbox", { name: /Google Photos Library/ });
+        const picker = page.getByRole("checkbox", { name: /Google Photos Picker/ });
+        await library.waitFor();
+        await picker.waitFor();
+        expect(await library.isChecked()).toBe(true);
+        expect(await picker.isChecked()).toBe(true);
+        // Other products stay unchecked: the flow is Photos-scoped, not the
+        // featured default selection.
+        expect(await page.getByRole("checkbox", { name: /Google Calendar/ }).isChecked()).toBe(
+          false,
+        );
+        // The scope preview counts exactly the two checked Photos products.
+        await page.getByRole("button", { name: /^View scopes 2$/ }).waitFor();
+      });
+
+      await step("Multi-select keeps preset identities: no name/namespace form", async () => {
+        // With two products checked there is no single-integration identity
+        // form; the settings section spells out that presets keep their own
+        // names and namespaces.
+        await page.getByText("Google product settings").waitFor();
+        await page.getByText("Selected products keep their preset names and namespaces.").waitFor();
+        expect(await page.locator('input[value="Google Photos"]').count()).toBe(0);
+        expect(await page.locator('input[value="google_photos"]').count()).toBe(0);
         expect(await page.locator('input[value="Google"]').count()).toBe(0);
         expect(await page.locator('input[value="google"]').count()).toBe(0);
+        // The submit button is armed for the checked selection.
+        const connect = page.getByRole("button", { name: "Connect Google" });
+        await connect.waitFor();
+        expect(await connect.isEnabled()).toBe(true);
       });
     });
   }),

--- a/e2e/scenarios/microsoft-per-workload-add-ui.test.ts
+++ b/e2e/scenarios/microsoft-per-workload-add-ui.test.ts
@@ -78,14 +78,25 @@ scenario(
         async () => {
           await page.getByTestId("add-result-row-mail").getByRole("link", { name: "Open" }).click();
           await page.waitForURL(/\/integrations\/microsoft_mail\b/);
-          await page.getByText("Outlook Mail").first().waitFor({ timeout: 20_000 });
+          // Scoped to the main region: the shell sidebar also lists the new
+          // integration as "Outlook Mail", so a page-wide lookup would match
+          // the sidebar link instead of the detail page under test.
+          await page
+            .getByRole("main")
+            .getByText("Outlook Mail")
+            .first()
+            .waitFor({ timeout: 20_000 });
         },
       );
 
       await step("The integrations list has two separate Microsoft integrations", async () => {
         await page.goto("/integrations", { waitUntil: "networkidle" });
         for (const slug of ["microsoft_mail", "microsoft_calendar"]) {
-          await page.getByText(slug, { exact: true }).first().waitFor({ timeout: 20_000 });
+          await page
+            .getByRole("main")
+            .getByText(slug, { exact: true })
+            .first()
+            .waitFor({ timeout: 20_000 });
         }
       });
 

--- a/e2e/scenarios/microsoft-per-workload-add-ui.test.ts
+++ b/e2e/scenarios/microsoft-per-workload-add-ui.test.ts
@@ -1,0 +1,111 @@
+// Microsoft per-workload picker fan-out: the mirror of the Google per-service
+// spec. The add-Microsoft flow lets a user check several Graph workloads and
+// submit them in one action; each checked workload becomes its OWN integration
+// (microsoft_mail, microsoft_calendar), each a scope-filtered slice of the
+// Graph, not one bundled "microsoft_graph" source. This drives the whole
+// browser path: clear the featured defaults, check exactly Mail + Calendar,
+// submit, assert two `add-result-row-*` rows added, follow one Open link to a
+// per-workload integration page, confirm both slugs in the list, then re-add
+// Mail and see it reported skipped.
+//
+// OUTBOUND SPEC (same shape as the Google spec, scoped-out reasons below):
+// `microsoft.addWorkloads` fetches the real Microsoft Graph OpenAPI document
+// (the 37MB msgraph-metadata YAML on raw.githubusercontent.com) and streams it
+// through the block-YAML profile compiler per workload; `specUrl` must point at
+// the trusted Microsoft Graph source (graph.microsoft.com / msgraph-metadata),
+// and the emulator's small custom Graph spec is NOT in that streaming profile
+// (see microsoft-emulator.test.ts's skip). So, like the Google add spec, this
+// exercises the REAL add path against the canonical Graph spec (read-only, no
+// credentials, no OAuth); it asserts only on the product's own catalog state.
+//
+// Because the 37MB spec is fetched and stream-compiled once per workload at
+// {concurrency: 1}, the add step is slow; the timeouts below are generous.
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+
+import { scenario } from "../src/scenario";
+import { Browser, Target } from "../src/services";
+import { setPresetChecked } from "./support/picker";
+
+scenario(
+  "Microsoft · the per-workload picker fans out to separate integrations and skips existing ones",
+  { timeout: 420_000 },
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const browser = yield* Browser;
+    const identity = yield* target.newIdentity();
+
+    yield* browser.session(identity, async ({ page, step }) => {
+      await step("Open the Microsoft add flow", async () => {
+        await page.goto("/integrations/add/microsoft", { waitUntil: "domcontentloaded" });
+        await page.getByRole("heading", { name: "Add Microsoft integration" }).waitFor();
+        await page.getByText("Customize Microsoft Graph").waitFor();
+        await page.getByTestId("preset-checkbox-mail").waitFor();
+      });
+
+      await step("Clear the defaults, then check exactly Mail + Calendar", async () => {
+        // The featured defaults (profile, mail, calendar, contacts, tasks, files)
+        // start checked; clear them, then select only the two under test.
+        for (const presetId of ["profile", "mail", "calendar", "contacts", "tasks", "files"]) {
+          await setPresetChecked(page, presetId, false);
+        }
+        for (const presetId of ["mail", "calendar"]) {
+          await setPresetChecked(page, presetId, true);
+        }
+        expect(await page.getByTestId("preset-checkbox-contacts").isChecked()).toBe(false);
+        expect(await page.getByTestId("preset-checkbox-files").isChecked()).toBe(false);
+      });
+
+      await step("Submit the fan-out and see two added integrations", async () => {
+        await page.getByTestId("microsoft-add-submit").click();
+        // Each workload fetches + stream-compiles the 37MB Graph spec; allow a
+        // wide window for the result panel to populate.
+        await page.getByTestId("microsoft-add-results").waitFor({ timeout: 300_000 });
+
+        for (const presetId of ["mail", "calendar"]) {
+          const row = page.getByTestId(`add-result-row-${presetId}`);
+          await row.waitFor({ timeout: 300_000 });
+          expect(
+            await row.getAttribute("data-state"),
+            `${presetId} added as its own integration`,
+          ).toBe("added");
+          await row.getByRole("link", { name: "Open" }).waitFor();
+        }
+      });
+
+      await step(
+        "Open one workload: its integration page shows the per-workload name",
+        async () => {
+          await page.getByTestId("add-result-row-mail").getByRole("link", { name: "Open" }).click();
+          await page.waitForURL(/\/integrations\/microsoft_mail\b/);
+          await page.getByText("Outlook Mail").first().waitFor({ timeout: 20_000 });
+        },
+      );
+
+      await step("The integrations list has two separate Microsoft integrations", async () => {
+        await page.goto("/integrations", { waitUntil: "networkidle" });
+        for (const slug of ["microsoft_mail", "microsoft_calendar"]) {
+          await page.getByText(slug, { exact: true }).first().waitFor({ timeout: 20_000 });
+        }
+      });
+
+      await step("Re-adding an existing workload reports it as skipped", async () => {
+        await page.goto("/integrations/add/microsoft", { waitUntil: "domcontentloaded" });
+        await page.getByText("Customize Microsoft Graph").waitFor();
+
+        for (const presetId of ["profile", "mail", "calendar", "contacts", "tasks", "files"]) {
+          await setPresetChecked(page, presetId, false);
+        }
+        await setPresetChecked(page, "mail", true);
+
+        await page.getByTestId("microsoft-add-submit").click();
+        const row = page.getByTestId("add-result-row-mail");
+        await row.waitFor({ timeout: 300_000 });
+        expect(
+          await row.getAttribute("data-state"),
+          "an already-added workload is skipped, not re-added or failed",
+        ).toBe("skipped");
+      });
+    });
+  }),
+);

--- a/e2e/scenarios/provider-plugins-ui.test.ts
+++ b/e2e/scenarios/provider-plugins-ui.test.ts
@@ -41,34 +41,41 @@ scenario(
         expect(await page.getByText("Customize Microsoft Graph").count()).toBe(0);
       });
 
+      // The picker assertions below are scoped to the page's main region: on
+      // selfhost every scenario shares the bootstrap admin, so integrations
+      // added by earlier scenario files (e.g. the per-workload fan-out specs)
+      // stay in the sidebar under the same workload names ("Outlook Mail"),
+      // making page-wide text lookups ambiguous.
+      const main = page.getByRole("main");
+
       await step("Google has its own product picker", async () => {
         await page.goto("/integrations/add/google", {
           waitUntil: "domcontentloaded",
         });
-        await page.getByRole("heading", { name: "Add Google integration" }).waitFor();
-        await page.getByText("Customize your Google connection").waitFor();
-        await page.getByText("Gmail").first().waitFor();
-        await page.getByText("Google Calendar").first().waitFor();
+        await main.getByRole("heading", { name: "Add Google integration" }).waitFor();
+        await main.getByText("Customize your Google connection").waitFor();
+        await main.getByText("Gmail").first().waitFor();
+        await main.getByText("Google Calendar").first().waitFor();
       });
 
       await step("Microsoft has its own Graph scope picker", async () => {
         await page.goto("/integrations/add/microsoft", {
           waitUntil: "domcontentloaded",
         });
-        await page.getByRole("heading", { name: "Add Microsoft integration" }).waitFor();
-        await page.getByText("Customize Microsoft Graph").waitFor();
-        expect(await page.getByText("All Microsoft Graph", { exact: true }).count()).toBe(0);
-        await page.getByText("Productivity").waitFor();
-        await page.getByText("Directory and identity").waitFor();
-        await page.getByText("Outlook Mail").waitFor();
-        await page.getByText("OneDrive Files").waitFor();
-        await page.getByText("OneNote", { exact: true }).waitFor();
-        await page.getByText("Teams Channels").waitFor();
-        await page.locator('img[src*="svgl.app/library/microsoft-outlook.svg"]').first().waitFor();
-        await page.locator('img[src*="svgl.app/library/microsoft-onedrive.svg"]').waitFor();
-        await page.getByRole("button", { name: /View scopes/ }).click();
-        await page.getByText("offline_access").waitFor();
-        await page.getByText("Mail.ReadWrite").waitFor();
+        await main.getByRole("heading", { name: "Add Microsoft integration" }).waitFor();
+        await main.getByText("Customize Microsoft Graph").waitFor();
+        expect(await main.getByText("All Microsoft Graph", { exact: true }).count()).toBe(0);
+        await main.getByText("Productivity").waitFor();
+        await main.getByText("Directory and identity").waitFor();
+        await main.getByText("Outlook Mail").waitFor();
+        await main.getByText("OneDrive Files").waitFor();
+        await main.getByText("OneNote", { exact: true }).waitFor();
+        await main.getByText("Teams Channels").waitFor();
+        await main.locator('img[src*="svgl.app/library/microsoft-outlook.svg"]').first().waitFor();
+        await main.locator('img[src*="svgl.app/library/microsoft-onedrive.svg"]').first().waitFor();
+        await main.getByRole("button", { name: /View scopes/ }).click();
+        await main.getByText("offline_access").waitFor();
+        await main.getByText("Mail.ReadWrite").waitFor();
       });
     });
   }),

--- a/e2e/scenarios/support/picker.ts
+++ b/e2e/scenarios/support/picker.ts
@@ -1,0 +1,29 @@
+// Shared helper for the provider fan-out pickers (Google products, Microsoft
+// workloads). Each preset checkbox is a Radix `<button role="checkbox">` wrapped
+// in a `<label>` (FieldLabel). A single programmatic click can bubble to the
+// label and re-dispatch to the control, double-toggling it (net no change), so a
+// bare Playwright `check()`/`uncheck()` is racy here and errors with "Clicking
+// the checkbox did not change its state". Drive the box to a known state by
+// reading `aria-checked` and clicking only while it disagrees, polling until it
+// settles.
+import { expect } from "@effect/vitest";
+import type { Page } from "playwright";
+
+export const setPresetChecked = async (
+  page: Page,
+  presetId: string,
+  checked: boolean,
+): Promise<void> => {
+  const box = page.getByTestId(`preset-checkbox-${presetId}`);
+  await box.waitFor();
+  await expect
+    .poll(
+      async () => {
+        if ((await box.getAttribute("aria-checked")) === String(checked)) return String(checked);
+        await box.click();
+        return box.getAttribute("aria-checked");
+      },
+      { timeout: 10_000, interval: 200 },
+    )
+    .toBe(String(checked));
+};

--- a/packages/plugins/google/src/react/AddGoogleSource.test.ts
+++ b/packages/plugins/google/src/react/AddGoogleSource.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "@effect/vitest";
+import { IntegrationSlug } from "@executor-js/sdk/shared";
+import * as Exit from "effect/Exit";
+import * as React from "react";
+import type { ReactElement, ReactNode } from "react";
+
+import {
+  GoogleServiceResultPanel,
+  googleAddServicesPayload,
+  submitGoogleServicesSelection,
+  type AddGoogleServicesMutation,
+} from "./AddGoogleSource";
+import type { GoogleAddServicesResult } from "../sdk/plugin";
+
+type TestElementProps = {
+  readonly children?: ReactNode;
+  readonly onClick?: (event?: unknown) => void;
+};
+
+const collectText = (node: ReactNode): string => {
+  if (node === null || node === undefined || typeof node === "boolean") return "";
+  if (typeof node === "string" || typeof node === "number") return String(node);
+  if (Array.isArray(node)) return node.map(collectText).join(" ");
+  if (React.isValidElement<TestElementProps>(node)) return collectText(node.props.children);
+  return "";
+};
+
+const findElementWithText = (
+  node: ReactNode,
+  text: string,
+): ReactElement<TestElementProps> | null => {
+  if (node === null || node === undefined || typeof node === "boolean") return null;
+  if (typeof node === "string" || typeof node === "number") return null;
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      const found = findElementWithText(child, text);
+      if (found) return found;
+    }
+    return null;
+  }
+  if (!React.isValidElement<TestElementProps>(node)) return null;
+  if (collectText(node.props.children).trim() === text) return node;
+  return findElementWithText(node.props.children, text);
+};
+
+const emptyResult: GoogleAddServicesResult = {
+  added: [],
+  skipped: [],
+  failed: [],
+};
+
+describe("AddGoogleSource per-service submit", () => {
+  it("submits three checked presets in one addServices call", async () => {
+    const calls: Parameters<AddGoogleServicesMutation>[0][] = [];
+    const addServices: AddGoogleServicesMutation = (input) => {
+      calls.push(input);
+      return Promise.resolve(Exit.succeed(emptyResult));
+    };
+
+    await submitGoogleServicesSelection(addServices, {
+      presetIds: ["google-calendar", "google-gmail", "google-drive"],
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.payload).toEqual({
+      services: [
+        { presetId: "google-calendar" },
+        { presetId: "google-gmail" },
+        { presetId: "google-drive" },
+      ],
+    });
+  });
+
+  it("renders added, skipped, and failed result rows", () => {
+    const result: GoogleAddServicesResult = {
+      added: [
+        {
+          slug: IntegrationSlug.make("google_calendar"),
+          presetId: "google-calendar",
+          toolCount: 12,
+        },
+      ],
+      skipped: [
+        {
+          slug: IntegrationSlug.make("google_gmail"),
+          presetId: "google-gmail",
+          reason: "already_exists",
+        },
+      ],
+      failed: [
+        {
+          slug: IntegrationSlug.make("google_drive"),
+          presetId: "google-drive",
+          error: "Discovery fetch failed",
+        },
+      ],
+    };
+
+    const text = collectText(
+      GoogleServiceResultPanel({
+        result,
+        retryingPresetId: null,
+        onRetry: () => {},
+      }),
+    );
+
+    expect(text).toContain("Google Calendar");
+    expect(text).toContain("Added");
+    expect(text).toContain("Gmail");
+    expect(text).toContain("Already exists");
+    expect(text).toContain("Google Drive");
+    expect(text).toContain("Discovery fetch failed");
+    expect(text).toContain("Retry");
+  });
+
+  it("retry re-submits only the failed presetId", async () => {
+    let retryPresetId: string | null = null;
+    const result: GoogleAddServicesResult = {
+      added: [],
+      skipped: [],
+      failed: [
+        {
+          slug: IntegrationSlug.make("google_drive"),
+          presetId: "google-drive",
+          error: "Discovery fetch failed",
+        },
+      ],
+    };
+    const retry = findElementWithText(
+      GoogleServiceResultPanel({
+        result,
+        retryingPresetId: null,
+        onRetry: (presetId: string) => {
+          retryPresetId = presetId;
+        },
+      }),
+      "Retry",
+    );
+
+    retry?.props.onClick?.();
+
+    const calls: Parameters<AddGoogleServicesMutation>[0][] = [];
+    const addServices: AddGoogleServicesMutation = (input) => {
+      calls.push(input);
+      return Promise.resolve(Exit.succeed(emptyResult));
+    };
+    await submitGoogleServicesSelection(addServices, {
+      presetIds: retryPresetId ? [retryPresetId] : [],
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.payload).toEqual({
+      services: [{ presetId: "google-drive" }],
+    });
+  });
+
+  it("passes name and slug overrides for a single selected service", () => {
+    expect(
+      googleAddServicesPayload({
+        presetIds: ["google-calendar"],
+        identityOverride: {
+          slug: "team_calendar",
+          name: "Team Calendar",
+        },
+      }),
+    ).toEqual({
+      services: [
+        {
+          presetId: "google-calendar",
+          slug: "team_calendar",
+          name: "Team Calendar",
+        },
+      ],
+    });
+  });
+});

--- a/packages/plugins/google/src/react/AddGoogleSource.tsx
+++ b/packages/plugins/google/src/react/AddGoogleSource.tsx
@@ -160,7 +160,10 @@ export function GoogleServiceResultPanel(props: {
   if (rows.length === 0) return null;
 
   return (
-    <section className="space-y-3 rounded-lg border border-border bg-muted/10 px-3 py-3">
+    <section
+      data-testid="google-add-results"
+      className="space-y-3 rounded-lg border border-border bg-muted/10 px-3 py-3"
+    >
       <div>
         <h2 className="text-sm font-medium text-foreground">Google products</h2>
         <p className="text-[11px] text-muted-foreground">
@@ -173,6 +176,8 @@ export function GoogleServiceResultPanel(props: {
           return (
             <li
               key={`${row.status}:${row.presetId}`}
+              data-testid={`add-result-row-${row.presetId}`}
+              data-state={row.status}
               className="flex items-start gap-2 rounded-md border border-border bg-background px-2.5 py-2"
             >
               <span
@@ -220,6 +225,7 @@ export function GoogleServiceResultPanel(props: {
                   type="button"
                   variant="outline"
                   size="xs"
+                  data-testid={`add-result-retry-${row.presetId}`}
                   loading={props.retryingPresetId === row.presetId}
                   onClick={() => void props.onRetry(row.presetId)}
                 >
@@ -518,7 +524,12 @@ export default function AddGoogleSource(props: {
         <Button variant="ghost" onClick={dismiss} disabled={adding || retryingPresetId !== null}>
           {servicesResult || customBundleSlug ? "Done" : "Cancel"}
         </Button>
-        <Button onClick={() => void handleAdd()} disabled={!canAdd} loading={adding}>
+        <Button
+          data-testid="google-add-submit"
+          onClick={() => void handleAdd()}
+          disabled={!canAdd}
+          loading={adding}
+        >
           Connect Google
         </Button>
       </FloatActions>

--- a/packages/plugins/google/src/react/AddGoogleSource.tsx
+++ b/packages/plugins/google/src/react/AddGoogleSource.tsx
@@ -1,6 +1,8 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useState, type ChangeEvent } from "react";
 import { useAtomSet } from "@effect/atom-react";
+import { Link } from "@tanstack/react-router";
 import * as Exit from "effect/Exit";
+import { CheckIcon, CircleIcon, TriangleAlert } from "lucide-react";
 
 import { integrationWriteKeys } from "@executor-js/react/api/reactivity-keys";
 import {
@@ -8,23 +10,32 @@ import {
   useIntegrationIdentity,
 } from "@executor-js/react/plugins/integration-identity";
 import { Button } from "@executor-js/react/components/button";
+import { FieldLabel } from "@executor-js/react/components/field";
 import { FloatActions } from "@executor-js/react/components/float-actions";
+import { Input } from "@executor-js/react/components/input";
 import {
   addIntegrationErrorMessage,
+  errorMessageFromExit,
   FormErrorAlert,
   SlugCollisionAlert,
   useSlugAlreadyExists,
 } from "@executor-js/react/lib/integration-add";
 import { OpenApiSourceDetailsFields } from "@executor-js/plugin-openapi/react";
 
-import { addGoogleBundle } from "./atoms";
+import { addGoogleBundle, addGoogleServices } from "./atoms";
 import { GoogleProductPicker } from "./GoogleProductPicker";
 import {
   GOOGLE_PHOTOS_PRESET_ID,
   googleOpenApiPresets,
   googlePhotosPresetIds,
+  googleServiceSlug,
   type GoogleOpenApiPreset,
 } from "../sdk/presets";
+import type {
+  GoogleAddServicesInput,
+  GoogleAddServicesResult,
+  GoogleBundleConfig,
+} from "../sdk/plugin";
 
 const GOOGLE_BUNDLE_FAVICON = "https://fonts.gstatic.com/s/i/productlogos/googleg/v6/192px.svg";
 
@@ -34,14 +45,249 @@ const googleBundleDefaultPresetIds: ReadonlySet<string> = new Set(
     .map((preset: GoogleOpenApiPreset) => preset.id),
 );
 
-const googleBundleUrls = (
-  selectedPresetIds: ReadonlySet<string>,
-  customUrls: readonly string[],
-): readonly string[] => {
-  const fromPresets = googleOpenApiPresets.flatMap((preset: GoogleOpenApiPreset) =>
-    preset.url && selectedPresetIds.has(preset.id) ? [preset.url] : [],
+const googleOpenApiPresetById: ReadonlyMap<string, GoogleOpenApiPreset> = new Map(
+  googleOpenApiPresets.map((preset: GoogleOpenApiPreset) => [preset.id, preset]),
+);
+
+export type GoogleServiceIdentityOverride = {
+  readonly slug: string;
+  readonly name: string;
+};
+
+export type AddGoogleServicesMutation = (input: {
+  readonly payload: GoogleAddServicesInput;
+  readonly reactivityKeys: typeof integrationWriteKeys;
+}) => Promise<Exit.Exit<GoogleAddServicesResult, unknown>>;
+
+export const googleAddServicesPayload = (input: {
+  readonly presetIds: readonly string[];
+  readonly identityOverride?: GoogleServiceIdentityOverride;
+  readonly baseUrl?: string;
+}): GoogleAddServicesInput => {
+  const identityOverride = input.presetIds.length === 1 ? input.identityOverride : undefined;
+  const services = input.presetIds.map((presetId: string) => ({
+    presetId,
+    ...(identityOverride?.slug.trim() ? { slug: identityOverride.slug.trim() } : {}),
+    ...(identityOverride?.name.trim() ? { name: identityOverride.name.trim() } : {}),
+  }));
+  const baseUrl = input.baseUrl?.trim() ?? "";
+  return baseUrl.length > 0 ? { services, baseUrl } : { services };
+};
+
+export const submitGoogleServicesSelection = (
+  doAddServices: AddGoogleServicesMutation,
+  input: {
+    readonly presetIds: readonly string[];
+    readonly identityOverride?: GoogleServiceIdentityOverride;
+    readonly baseUrl?: string;
+  },
+): Promise<Exit.Exit<GoogleAddServicesResult, unknown>> =>
+  doAddServices({
+    payload: googleAddServicesPayload(input),
+    reactivityKeys: integrationWriteKeys,
+  });
+
+export type GoogleServiceResultRow =
+  | {
+      readonly status: "added";
+      readonly presetId: string;
+      readonly slug: string;
+      readonly toolCount: number;
+    }
+  | {
+      readonly status: "skipped";
+      readonly presetId: string;
+      readonly slug: string;
+      readonly reason: "already_exists";
+    }
+  | {
+      readonly status: "failed";
+      readonly presetId: string;
+      readonly slug: string;
+      readonly error: string;
+    };
+
+export const googleAddServicesResultRows = (
+  result: GoogleAddServicesResult,
+): readonly GoogleServiceResultRow[] => [
+  ...result.added.map((entry) => ({
+    status: "added" as const,
+    presetId: entry.presetId,
+    slug: String(entry.slug),
+    toolCount: entry.toolCount,
+  })),
+  ...result.skipped.map((entry) => ({
+    status: "skipped" as const,
+    presetId: entry.presetId,
+    slug: String(entry.slug),
+    reason: entry.reason,
+  })),
+  ...result.failed.map((entry) => ({
+    status: "failed" as const,
+    presetId: entry.presetId,
+    slug: String(entry.slug),
+    error: entry.error,
+  })),
+];
+
+export const mergeGoogleAddServicesResult = (
+  previous: GoogleAddServicesResult,
+  next: GoogleAddServicesResult,
+): GoogleAddServicesResult => {
+  const nextPresetIds = new Set(googleAddServicesResultRows(next).map((row) => row.presetId));
+  return {
+    added: [...previous.added.filter((entry) => !nextPresetIds.has(entry.presetId)), ...next.added],
+    skipped: [
+      ...previous.skipped.filter((entry) => !nextPresetIds.has(entry.presetId)),
+      ...next.skipped,
+    ],
+    failed: [
+      ...previous.failed.filter((entry) => !nextPresetIds.has(entry.presetId)),
+      ...next.failed,
+    ],
+  };
+};
+
+const googlePresetName = (presetId: string): string =>
+  googleOpenApiPresetById.get(presetId)?.name ?? presetId;
+
+export function GoogleServiceResultPanel(props: {
+  readonly result: GoogleAddServicesResult;
+  readonly retryingPresetId: string | null;
+  readonly onRetry: (presetId: string) => void | Promise<void>;
+}) {
+  const rows = googleAddServicesResultRows(props.result);
+  if (rows.length === 0) return null;
+
+  return (
+    <section className="space-y-3 rounded-lg border border-border bg-muted/10 px-3 py-3">
+      <div>
+        <h2 className="text-sm font-medium text-foreground">Google products</h2>
+        <p className="text-[11px] text-muted-foreground">
+          Each selected product is added as its own integration.
+        </p>
+      </div>
+      <ul className="space-y-2">
+        {rows.map((row: GoogleServiceResultRow) => {
+          const presetName = googlePresetName(row.presetId);
+          return (
+            <li
+              key={`${row.status}:${row.presetId}`}
+              className="flex items-start gap-2 rounded-md border border-border bg-background px-2.5 py-2"
+            >
+              <span
+                className={
+                  row.status === "added"
+                    ? "mt-0.5 text-emerald-600"
+                    : row.status === "skipped"
+                      ? "mt-0.5 text-muted-foreground"
+                      : "mt-0.5 text-destructive"
+                }
+              >
+                {row.status === "added" ? (
+                  <CheckIcon className="size-3.5" />
+                ) : row.status === "skipped" ? (
+                  <CircleIcon className="size-3.5" />
+                ) : (
+                  <TriangleAlert className="size-3.5" />
+                )}
+              </span>
+              <div className="min-w-0 flex-1 space-y-0.5">
+                <div className="flex min-w-0 items-center gap-2">
+                  <span className="truncate text-sm font-medium text-foreground">{presetName}</span>
+                  <span className="shrink-0 text-[11px] text-muted-foreground">
+                    {row.status === "added"
+                      ? "Added"
+                      : row.status === "skipped"
+                        ? "Already exists"
+                        : "Failed"}
+                  </span>
+                </div>
+                {row.status === "added" ? (
+                  <p className="text-[11px] text-muted-foreground">
+                    {row.toolCount} tool{row.toolCount === 1 ? "" : "s"} added.
+                  </p>
+                ) : row.status === "skipped" ? (
+                  <p className="text-[11px] text-muted-foreground">
+                    This integration already exists.
+                  </p>
+                ) : (
+                  <p className="text-[11px] text-destructive">{row.error}</p>
+                )}
+              </div>
+              {row.status === "failed" ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="xs"
+                  loading={props.retryingPresetId === row.presetId}
+                  onClick={() => void props.onRetry(row.presetId)}
+                >
+                  Retry
+                </Button>
+              ) : (
+                <Button variant="ghost" size="xs" asChild>
+                  <Link to="/{-$orgSlug}/integrations/$namespace" params={{ namespace: row.slug }}>
+                    Open
+                  </Link>
+                </Button>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </section>
   );
-  return [...new Set([...fromPresets, ...customUrls])];
+}
+
+const BaseUrlSettings = (props: {
+  readonly baseUrl: string;
+  readonly onBaseUrlChange: (value: string) => void;
+}) => (
+  <section className="space-y-2 rounded-lg border border-border bg-muted/10 px-3 py-3">
+    <div className="space-y-1">
+      <FieldLabel>Google product settings</FieldLabel>
+      <p className="text-[11px] text-muted-foreground">
+        Selected products keep their preset names and namespaces.
+      </p>
+    </div>
+    <Input
+      value={props.baseUrl}
+      onChange={(event: ChangeEvent<HTMLInputElement>) => props.onBaseUrlChange(event.target.value)}
+      placeholder="Base URL override (optional)"
+      className="font-mono text-sm"
+    />
+  </section>
+);
+
+const CustomGoogleBundleResult = (props: { readonly slug: string }) => (
+  <section className="rounded-lg border border-border bg-muted/10 px-3 py-3">
+    <div className="flex items-center justify-between gap-3">
+      <div className="min-w-0">
+        <h2 className="text-sm font-medium text-foreground">Custom Discovery URLs</h2>
+        <p className="text-[11px] text-muted-foreground">
+          Custom URLs were added through the legacy Google bundle path.
+        </p>
+      </div>
+      <Button variant="ghost" size="xs" asChild>
+        <Link to="/{-$orgSlug}/integrations/$namespace" params={{ namespace: props.slug }}>
+          Open
+        </Link>
+      </Button>
+    </div>
+  </section>
+);
+
+const googleBundlePayload = (config: GoogleBundleConfig): GoogleBundleConfig => {
+  const baseUrl = config.baseUrl?.trim() ?? "";
+  const description = config.description?.trim() ?? "";
+  return {
+    urls: config.urls,
+    ...(config.slug !== undefined ? { slug: config.slug } : {}),
+    ...(config.name !== undefined ? { name: config.name } : {}),
+    ...(description.length > 0 ? { description } : {}),
+    ...(baseUrl.length > 0 ? { baseUrl } : {}),
+  };
 };
 
 export default function AddGoogleSource(props: {
@@ -58,18 +304,30 @@ export default function AddGoogleSource(props: {
   const [baseUrl, setBaseUrl] = useState("");
   const [descriptionDraft, setDescriptionDraft] = useState<string | null>(null);
   const [adding, setAdding] = useState(false);
+  const [retryingPresetId, setRetryingPresetId] = useState<string | null>(null);
   const [addError, setAddError] = useState<string | null>(null);
+  const [servicesResult, setServicesResult] = useState<GoogleAddServicesResult | null>(null);
+  const [customBundleSlug, setCustomBundleSlug] = useState<string | null>(null);
+
+  const selectedIds = useMemo(() => [...selectedPresetIds], [selectedPresetIds]);
+  const singleSelectedPreset =
+    selectedIds.length === 1 ? googleOpenApiPresetById.get(selectedIds[0]!) : undefined;
+  const usesCustomBundleFallback = customDiscoveryUrls.length > 0;
 
   const identity = useIntegrationIdentity({
-    fallbackName: isGooglePhotosPreset ? "Google Photos" : "Google",
+    fallbackName: usesCustomBundleFallback
+      ? "Custom Google APIs"
+      : (singleSelectedPreset?.name ?? (isGooglePhotosPreset ? "Google Photos" : "Google")),
     fallbackNamespace:
-      props.initialNamespace ?? (isGooglePhotosPreset ? "google_photos" : "google"),
+      props.initialNamespace ??
+      (usesCustomBundleFallback
+        ? "google_custom"
+        : singleSelectedPreset
+          ? googleServiceSlug(singleSelectedPreset.id)
+          : isGooglePhotosPreset
+            ? "google_photos"
+            : "google"),
   });
-
-  const bundleDiscoveryUrls = useMemo(
-    () => googleBundleUrls(selectedPresetIds, customDiscoveryUrls),
-    [selectedPresetIds, customDiscoveryUrls],
-  );
 
   const toggleBundlePreset = useCallback((presetId: string, checked: boolean) => {
     setSelectedPresetIds((current: ReadonlySet<string>) => {
@@ -92,41 +350,119 @@ export default function AddGoogleSource(props: {
     );
   }, []);
 
-  const doAdd = useAtomSet(addGoogleBundle, { mode: "promiseExit" });
+  const doAddServices = useAtomSet(addGoogleServices, { mode: "promiseExit" });
+  const doAddBundle = useAtomSet(addGoogleBundle, { mode: "promiseExit" });
 
-  const resolvedSourceId =
-    slugifyNamespace(identity.namespace) || (isGooglePhotosPreset ? "google_photos" : "google");
+  const resolvedSourceId = slugifyNamespace(identity.namespace) || "google_custom";
   const resolvedDisplayName =
-    identity.name.trim() || (isGooglePhotosPreset ? "Google Photos" : "Google");
+    identity.name.trim() ||
+    (usesCustomBundleFallback
+      ? "Custom Google APIs"
+      : (singleSelectedPreset?.name ?? (isGooglePhotosPreset ? "Google Photos" : "Google")));
   const resolvedDescription =
     descriptionDraft ??
-    (isGooglePhotosPreset
-      ? "Google Photos albums, uploads, app-created media, and selected picker media."
-      : "Google APIs");
-  const slugAlreadyExists = useSlugAlreadyExists(resolvedSourceId);
-  const canAdd = bundleDiscoveryUrls.length > 0 && !slugAlreadyExists;
+    (usesCustomBundleFallback
+      ? "Custom Google APIs."
+      : isGooglePhotosPreset
+        ? "Google Photos albums, uploads, app-created media, and selected picker media."
+        : "Google APIs");
+  const customSlugAlreadyExists = useSlugAlreadyExists(
+    usesCustomBundleFallback ? resolvedSourceId : "",
+  );
+  const identityOverride =
+    selectedIds.length === 1 && !usesCustomBundleFallback
+      ? { slug: resolvedSourceId, name: resolvedDisplayName }
+      : undefined;
+  const canAdd =
+    (selectedIds.length > 0 || customDiscoveryUrls.length > 0) &&
+    !customSlugAlreadyExists &&
+    !adding;
 
-  const handleAdd = async () => {
-    setAdding(true);
-    setAddError(null);
-    const exit = await doAdd({
-      payload: {
-        urls: [...bundleDiscoveryUrls],
+  const addCustomDiscoveryBundle = async (): Promise<boolean> => {
+    if (customDiscoveryUrls.length === 0) return true;
+    const exit = await doAddBundle({
+      payload: googleBundlePayload({
+        urls: [...customDiscoveryUrls],
         slug: resolvedSourceId,
         name: resolvedDisplayName,
-        ...(resolvedDescription.trim().length > 0
-          ? { description: resolvedDescription.trim() }
-          : {}),
-        ...(baseUrl.trim().length > 0 ? { baseUrl: baseUrl.trim() } : {}),
-      },
+        description: resolvedDescription,
+        baseUrl,
+      }),
       reactivityKeys: integrationWriteKeys,
     });
     if (Exit.isFailure(exit)) {
       setAddError(addIntegrationErrorMessage(exit, resolvedSourceId, "Failed to add Google"));
-      setAdding(false);
+      return false;
+    }
+    setCustomBundleSlug(String(exit.value.slug));
+    return true;
+  };
+
+  const handleAdd = async () => {
+    setAdding(true);
+    setAddError(null);
+    setServicesResult(null);
+    setCustomBundleSlug(null);
+    if (selectedIds.length > 0) {
+      const exit = await submitGoogleServicesSelection(doAddServices, {
+        presetIds: selectedIds,
+        ...(identityOverride ? { identityOverride } : {}),
+        baseUrl,
+      });
+      if (Exit.isFailure(exit)) {
+        setAddError(errorMessageFromExit(exit, "Failed to add Google services"));
+        setAdding(false);
+        return;
+      }
+      setServicesResult(exit.value);
+    }
+    await addCustomDiscoveryBundle();
+    setAdding(false);
+  };
+
+  const handleRetry = async (presetId: string) => {
+    setRetryingPresetId(presetId);
+    setAddError(null);
+    const retryIdentityOverride =
+      identityOverride && selectedIds.length === 1 && selectedIds[0] === presetId
+        ? identityOverride
+        : undefined;
+    const exit = await submitGoogleServicesSelection(doAddServices, {
+      presetIds: [presetId],
+      ...(retryIdentityOverride ? { identityOverride: retryIdentityOverride } : {}),
+      baseUrl,
+    });
+    if (Exit.isFailure(exit)) {
+      setAddError(errorMessageFromExit(exit, "Failed to add Google service"));
+      setRetryingPresetId(null);
       return;
     }
-    props.onComplete(String(exit.value.slug));
+    setServicesResult((current) =>
+      current ? mergeGoogleAddServicesResult(current, exit.value) : exit.value,
+    );
+    setRetryingPresetId(null);
+  };
+
+  const showIdentityDetails = selectedIds.length === 1 || usesCustomBundleFallback;
+  const detailTitle = usesCustomBundleFallback
+    ? "Custom Google Discovery URLs"
+    : (singleSelectedPreset?.name ?? "Google");
+  const detailSubtitle = usesCustomBundleFallback
+    ? selectedIds.length > 0
+      ? `${customDiscoveryUrls.length} custom URL${
+          customDiscoveryUrls.length === 1 ? "" : "s"
+        } added through the legacy bundle path. Selected products keep preset names.`
+      : `${customDiscoveryUrls.length} custom URL${
+          customDiscoveryUrls.length === 1 ? "" : "s"
+        } added through the legacy bundle path.`
+    : "This product is added as its own integration.";
+
+  const dismiss = () => {
+    if (servicesResult || customBundleSlug) {
+      props.onComplete();
+      return;
+    }
+    props.onCancel();
   };
 
   return (
@@ -134,7 +470,7 @@ export default function AddGoogleSource(props: {
       <div>
         <h1 className="text-xl font-semibold text-foreground">Add Google integration</h1>
         <p className="mt-1 text-[13px] text-muted-foreground">
-          Bundle Google APIs into one integration with a shared OAuth consent.
+          Each selected product is added as its own integration.
         </p>
       </div>
 
@@ -146,28 +482,41 @@ export default function AddGoogleSource(props: {
         onRemoveCustomUrl={removeCustomDiscoveryUrl}
       />
 
-      <OpenApiSourceDetailsFields
-        title="Google"
-        subtitle={`${bundleDiscoveryUrls.length} Google API${
-          bundleDiscoveryUrls.length !== 1 ? "s" : ""
-        } · one shared OAuth consent`}
-        identity={identity}
-        description={resolvedDescription}
-        onDescriptionChange={setDescriptionDraft}
-        baseUrl={baseUrl}
-        onBaseUrlChange={setBaseUrl}
-        baseUrlLabel="Base URL override (optional)"
-        faviconIcon={GOOGLE_BUNDLE_FAVICON}
-        faviconUrl={baseUrl}
-      />
+      {showIdentityDetails ? (
+        <OpenApiSourceDetailsFields
+          title={detailTitle}
+          subtitle={detailSubtitle}
+          identity={identity}
+          {...(usesCustomBundleFallback
+            ? { description: resolvedDescription, onDescriptionChange: setDescriptionDraft }
+            : {})}
+          baseUrl={baseUrl}
+          onBaseUrlChange={setBaseUrl}
+          baseUrlLabel="Base URL override (optional)"
+          faviconIcon={GOOGLE_BUNDLE_FAVICON}
+          faviconUrl={baseUrl}
+        />
+      ) : (
+        <BaseUrlSettings baseUrl={baseUrl} onBaseUrlChange={setBaseUrl} />
+      )}
 
-      {slugAlreadyExists && !adding && <SlugCollisionAlert slug={resolvedSourceId} />}
+      {customSlugAlreadyExists && !adding && <SlugCollisionAlert slug={resolvedSourceId} />}
 
       {addError && <FormErrorAlert message={addError} />}
 
+      {servicesResult && (
+        <GoogleServiceResultPanel
+          result={servicesResult}
+          retryingPresetId={retryingPresetId}
+          onRetry={handleRetry}
+        />
+      )}
+
+      {customBundleSlug && <CustomGoogleBundleResult slug={customBundleSlug} />}
+
       <FloatActions>
-        <Button variant="ghost" onClick={() => props.onCancel()} disabled={adding}>
-          Cancel
+        <Button variant="ghost" onClick={dismiss} disabled={adding || retryingPresetId !== null}>
+          {servicesResult || customBundleSlug ? "Done" : "Cancel"}
         </Button>
         <Button onClick={() => void handleAdd()} disabled={!canAdd} loading={adding}>
           Connect Google

--- a/packages/plugins/google/src/react/GoogleProductPicker.tsx
+++ b/packages/plugins/google/src/react/GoogleProductPicker.tsx
@@ -103,7 +103,11 @@ const ProductRow = ({
       checked ? "bg-primary/5" : "hover:bg-muted/40",
     )}
   >
-    <Checkbox checked={checked} onCheckedChange={(next) => onToggle(next === true)} />
+    <Checkbox
+      data-testid={`preset-checkbox-${preset.id}`}
+      checked={checked}
+      onCheckedChange={(next) => onToggle(next === true)}
+    />
     <div className="shrink-0">
       <IntegrationFavicon icon={preset.icon} url={preset.url} size={16} />
     </div>

--- a/packages/plugins/google/src/react/GoogleProductPicker.tsx
+++ b/packages/plugins/google/src/react/GoogleProductPicker.tsx
@@ -27,12 +27,10 @@ import { isGoogleDiscoveryUrl } from "../sdk/discovery";
 // GoogleProductPicker - the "customize your Google connection" surface.
 //
 // A checkable card grid over `googleOpenApiPresets`, grouped/annotated by
-// `oauthAudience`. The user picks which Google APIs to bundle into the single
-// `google` integration; the parent turns the selected discovery URLs into a
-// `{ kind: "googleDiscoveryBundle", urls }` add. A "View scopes" panel previews
-// the unioned OAuth consent (via `googleOAuthConsentBatches`) BEFORE connecting,
-// and a custom-URL escape hatch lets advanced users paste any Google Discovery
-// document the preset list doesn't cover.
+// `oauthAudience`. The user picks which Google APIs to add as separate
+// integrations. A "View scopes" panel previews the selected OAuth scopes, and a
+// custom-URL escape hatch lets advanced users paste any Google Discovery document
+// the preset list doesn't cover.
 // ---------------------------------------------------------------------------
 
 // Audience groups, ordered from least- to most-privileged. The warning tiers
@@ -219,9 +217,9 @@ export function GoogleProductPicker({
     [],
   );
 
-  // The "View scopes" preview unions the selected presets' representative
-  // consent scopes through `googleOAuthConsentBatches`, mirroring the unioned
-  // scopes the bundle converter ultimately stores on the integration.
+  // The "View scopes" preview groups the selected presets' representative
+  // consent scopes so the user can review the requested OAuth surface before
+  // adding separate integrations.
   const consentBatches = useMemo(
     () =>
       googleOAuthConsentBatches(
@@ -244,8 +242,7 @@ export function GoogleProductPicker({
       <div className="space-y-1">
         <FieldLabel>Customize your Google connection</FieldLabel>
         <p className="text-[11px] text-muted-foreground">
-          Pick the Google APIs to bundle into one connection. They share a single OAuth consent and
-          appear as merged tools under one Google integration.
+          Pick Google APIs to add. Each selected product becomes its own integration.
         </p>
       </div>
 
@@ -311,8 +308,8 @@ export function GoogleProductPicker({
           <Badge variant="secondary">OAuth</Badge>
         </div>
         <p className="text-[11px] text-muted-foreground">
-          The selected Google APIs share one OAuth consent. Review the scopes below, then connect a
-          Google account from the integration page after adding.
+          Each selected Google product gets its own OAuth setup. Connect accounts from each
+          integration page after adding.
         </p>
       </div>
 

--- a/packages/plugins/microsoft/src/react/AddMicrosoftSource.test.ts
+++ b/packages/plugins/microsoft/src/react/AddMicrosoftSource.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "@effect/vitest";
+import { IntegrationSlug } from "@executor-js/sdk/shared";
+import * as Exit from "effect/Exit";
+import * as React from "react";
+import type { ReactElement, ReactNode } from "react";
+
+import {
+  MicrosoftWorkloadResultPanel,
+  microsoftAddWorkloadsPayload,
+  submitMicrosoftWorkloadsSelection,
+  type AddMicrosoftWorkloadsMutation,
+} from "./AddMicrosoftSource";
+import type { MicrosoftAddWorkloadsResult } from "../sdk/plugin";
+
+type TestElementProps = {
+  readonly children?: ReactNode;
+  readonly onClick?: (event?: unknown) => void;
+};
+
+const collectText = (node: ReactNode): string => {
+  if (node === null || node === undefined || typeof node === "boolean") return "";
+  if (typeof node === "string" || typeof node === "number") return String(node);
+  if (Array.isArray(node)) return node.map(collectText).join(" ");
+  if (React.isValidElement<TestElementProps>(node)) return collectText(node.props.children);
+  return "";
+};
+
+const findElementWithText = (
+  node: ReactNode,
+  text: string,
+): ReactElement<TestElementProps> | null => {
+  if (node === null || node === undefined || typeof node === "boolean") return null;
+  if (typeof node === "string" || typeof node === "number") return null;
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      const found = findElementWithText(child, text);
+      if (found) return found;
+    }
+    return null;
+  }
+  if (!React.isValidElement<TestElementProps>(node)) return null;
+  if (collectText(node.props.children).trim() === text) return node;
+  return findElementWithText(node.props.children, text);
+};
+
+const emptyResult: MicrosoftAddWorkloadsResult = {
+  added: [],
+  skipped: [],
+  failed: [],
+};
+
+describe("AddMicrosoftSource per-workload submit", () => {
+  it("submits three checked presets in one addWorkloads call", async () => {
+    const calls: Parameters<AddMicrosoftWorkloadsMutation>[0][] = [];
+    const addWorkloads: AddMicrosoftWorkloadsMutation = (input) => {
+      calls.push(input);
+      return Promise.resolve(Exit.succeed(emptyResult));
+    };
+
+    await submitMicrosoftWorkloadsSelection(addWorkloads, {
+      presetIds: ["mail", "calendar", "files"],
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.payload).toEqual({
+      workloads: [{ presetId: "mail" }, { presetId: "calendar" }, { presetId: "files" }],
+    });
+  });
+
+  it("renders added, skipped, and failed result rows", () => {
+    const result: MicrosoftAddWorkloadsResult = {
+      added: [
+        {
+          slug: IntegrationSlug.make("microsoft_mail"),
+          presetId: "mail",
+          toolCount: 14,
+        },
+      ],
+      skipped: [
+        {
+          slug: IntegrationSlug.make("microsoft_calendar"),
+          presetId: "calendar",
+          reason: "already_exists",
+        },
+      ],
+      failed: [
+        {
+          slug: IntegrationSlug.make("microsoft_files"),
+          presetId: "files",
+          error: "Graph spec failed",
+        },
+      ],
+    };
+
+    const text = collectText(
+      MicrosoftWorkloadResultPanel({
+        result,
+        retryingPresetId: null,
+        onRetry: () => {},
+      }),
+    );
+
+    expect(text).toContain("Outlook Mail");
+    expect(text).toContain("Added");
+    expect(text).toContain("Outlook Calendar");
+    expect(text).toContain("Already exists");
+    expect(text).toContain("OneDrive Files");
+    expect(text).toContain("Graph spec failed");
+    expect(text).toContain("Retry");
+  });
+
+  it("retry re-submits only the failed presetId", async () => {
+    let retryPresetId: string | null = null;
+    const result: MicrosoftAddWorkloadsResult = {
+      added: [],
+      skipped: [],
+      failed: [
+        {
+          slug: IntegrationSlug.make("microsoft_files"),
+          presetId: "files",
+          error: "Graph spec failed",
+        },
+      ],
+    };
+    const retry = findElementWithText(
+      MicrosoftWorkloadResultPanel({
+        result,
+        retryingPresetId: null,
+        onRetry: (presetId: string) => {
+          retryPresetId = presetId;
+        },
+      }),
+      "Retry",
+    );
+
+    retry?.props.onClick?.();
+
+    const calls: Parameters<AddMicrosoftWorkloadsMutation>[0][] = [];
+    const addWorkloads: AddMicrosoftWorkloadsMutation = (input) => {
+      calls.push(input);
+      return Promise.resolve(Exit.succeed(emptyResult));
+    };
+    await submitMicrosoftWorkloadsSelection(addWorkloads, {
+      presetIds: retryPresetId ? [retryPresetId] : [],
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.payload).toEqual({
+      workloads: [{ presetId: "files" }],
+    });
+  });
+
+  it("passes name and slug overrides for a single selected workload", () => {
+    expect(
+      microsoftAddWorkloadsPayload({
+        presetIds: ["mail"],
+        identityOverride: {
+          slug: "team_mail",
+          name: "Team Mail",
+        },
+      }),
+    ).toEqual({
+      workloads: [
+        {
+          presetId: "mail",
+          slug: "team_mail",
+          name: "Team Mail",
+        },
+      ],
+    });
+  });
+});

--- a/packages/plugins/microsoft/src/react/AddMicrosoftSource.test.ts
+++ b/packages/plugins/microsoft/src/react/AddMicrosoftSource.test.ts
@@ -7,6 +7,7 @@ import type { ReactElement, ReactNode } from "react";
 import {
   MicrosoftWorkloadResultPanel,
   microsoftAddWorkloadsPayload,
+  microsoftCustomGraphPayload,
   submitMicrosoftWorkloadsSelection,
   type AddMicrosoftWorkloadsMutation,
 } from "./AddMicrosoftSource";
@@ -167,6 +168,27 @@ describe("AddMicrosoftSource per-workload submit", () => {
           name: "Team Mail",
         },
       ],
+    });
+  });
+
+  it("mixed flow: the custom Graph payload carries only custom scopes, never the fanned-out presets", () => {
+    // Checked workloads go through addWorkloads as their own integrations in
+    // the same submit; if the custom addGraph payload repeated their preset
+    // ids, the custom bundle would duplicate the same tools.
+    expect(
+      microsoftCustomGraphPayload({
+        customScopes: ["Sites.Read.All", "Custom.Scope"],
+        slug: "microsoft_graph_custom",
+        name: "Custom Microsoft Graph",
+        description: "Custom Microsoft Graph scopes.",
+        baseUrl: "",
+      }),
+    ).toEqual({
+      presetIds: [],
+      customScopes: ["Sites.Read.All", "Custom.Scope"],
+      slug: "microsoft_graph_custom",
+      name: "Custom Microsoft Graph",
+      description: "Custom Microsoft Graph scopes.",
     });
   });
 });

--- a/packages/plugins/microsoft/src/react/AddMicrosoftSource.tsx
+++ b/packages/plugins/microsoft/src/react/AddMicrosoftSource.tsx
@@ -151,7 +151,10 @@ export function MicrosoftWorkloadResultPanel(props: {
   if (rows.length === 0) return null;
 
   return (
-    <section className="space-y-3 rounded-lg border border-border bg-muted/10 px-3 py-3">
+    <section
+      data-testid="microsoft-add-results"
+      className="space-y-3 rounded-lg border border-border bg-muted/10 px-3 py-3"
+    >
       <div>
         <h2 className="text-sm font-medium text-foreground">Microsoft workloads</h2>
         <p className="text-[11px] text-muted-foreground">
@@ -164,6 +167,8 @@ export function MicrosoftWorkloadResultPanel(props: {
           return (
             <li
               key={`${row.status}:${row.presetId}`}
+              data-testid={`add-result-row-${row.presetId}`}
+              data-state={row.status}
               className="flex items-start gap-2 rounded-md border border-border bg-background px-2.5 py-2"
             >
               <span
@@ -211,6 +216,7 @@ export function MicrosoftWorkloadResultPanel(props: {
                   type="button"
                   variant="outline"
                   size="xs"
+                  data-testid={`add-result-retry-${row.presetId}`}
                   loading={props.retryingPresetId === row.presetId}
                   onClick={() => void props.onRetry(row.presetId)}
                 >
@@ -509,7 +515,12 @@ export default function AddMicrosoftSource(props: {
         <Button variant="ghost" onClick={dismiss} disabled={adding || retryingPresetId !== null}>
           {workloadsResult || customGraphSlug ? "Done" : "Cancel"}
         </Button>
-        <Button onClick={() => void handleAdd()} disabled={!canAdd} loading={adding}>
+        <Button
+          data-testid="microsoft-add-submit"
+          onClick={() => void handleAdd()}
+          disabled={!canAdd}
+          loading={adding}
+        >
           Connect Microsoft
         </Button>
       </FloatActions>

--- a/packages/plugins/microsoft/src/react/AddMicrosoftSource.tsx
+++ b/packages/plugins/microsoft/src/react/AddMicrosoftSource.tsx
@@ -1,6 +1,8 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useState, type ChangeEvent } from "react";
 import { useAtomSet } from "@effect/atom-react";
+import { Link } from "@tanstack/react-router";
 import * as Exit from "effect/Exit";
+import { CheckIcon, CircleIcon, TriangleAlert } from "lucide-react";
 
 import { integrationWriteKeys } from "@executor-js/react/api/reactivity-keys";
 import {
@@ -8,26 +10,281 @@ import {
   useIntegrationIdentity,
 } from "@executor-js/react/plugins/integration-identity";
 import { Button } from "@executor-js/react/components/button";
+import { FieldLabel } from "@executor-js/react/components/field";
 import { FloatActions } from "@executor-js/react/components/float-actions";
+import { Input } from "@executor-js/react/components/input";
 import {
   addIntegrationErrorMessage,
+  errorMessageFromExit,
   FormErrorAlert,
   SlugCollisionAlert,
   useSlugAlreadyExists,
 } from "@executor-js/react/lib/integration-add";
 import { OpenApiSourceDetailsFields } from "@executor-js/plugin-openapi/react";
 
-import { addMicrosoftGraph } from "./atoms";
+import { addMicrosoftGraph, addMicrosoftWorkloads } from "./atoms";
 import { MicrosoftScopePicker } from "./MicrosoftScopePicker";
 import {
   MICROSOFT_GRAPH_BASE_URL,
   MICROSOFT_GRAPH_DEFAULT_PRESET_IDS,
-  microsoftGraphScopesForPresetIds,
+  microsoftGraphPresetForId,
+  microsoftServiceSlug,
 } from "../sdk/presets";
+import type {
+  MicrosoftAddWorkloadsInput,
+  MicrosoftAddWorkloadsResult,
+  MicrosoftGraphConfig,
+} from "../sdk/plugin";
 
 const MICROSOFT_FAVICON = "https://www.microsoft.com/favicon.ico";
 
 const defaultPresetIds: ReadonlySet<string> = new Set(MICROSOFT_GRAPH_DEFAULT_PRESET_IDS);
+
+export type MicrosoftWorkloadIdentityOverride = {
+  readonly slug: string;
+  readonly name: string;
+};
+
+export type AddMicrosoftWorkloadsMutation = (input: {
+  readonly payload: MicrosoftAddWorkloadsInput;
+  readonly reactivityKeys: typeof integrationWriteKeys;
+}) => Promise<Exit.Exit<MicrosoftAddWorkloadsResult, unknown>>;
+
+export const microsoftAddWorkloadsPayload = (input: {
+  readonly presetIds: readonly string[];
+  readonly identityOverride?: MicrosoftWorkloadIdentityOverride;
+  readonly baseUrl?: string;
+}): MicrosoftAddWorkloadsInput => {
+  const identityOverride = input.presetIds.length === 1 ? input.identityOverride : undefined;
+  const workloads = input.presetIds.map((presetId: string) => ({
+    presetId,
+    ...(identityOverride?.slug.trim() ? { slug: identityOverride.slug.trim() } : {}),
+    ...(identityOverride?.name.trim() ? { name: identityOverride.name.trim() } : {}),
+  }));
+  const baseUrl = input.baseUrl?.trim() ?? "";
+  return baseUrl.length > 0 ? { workloads, baseUrl } : { workloads };
+};
+
+export const submitMicrosoftWorkloadsSelection = (
+  doAddWorkloads: AddMicrosoftWorkloadsMutation,
+  input: {
+    readonly presetIds: readonly string[];
+    readonly identityOverride?: MicrosoftWorkloadIdentityOverride;
+    readonly baseUrl?: string;
+  },
+): Promise<Exit.Exit<MicrosoftAddWorkloadsResult, unknown>> =>
+  doAddWorkloads({
+    payload: microsoftAddWorkloadsPayload(input),
+    reactivityKeys: integrationWriteKeys,
+  });
+
+export type MicrosoftWorkloadResultRow =
+  | {
+      readonly status: "added";
+      readonly presetId: string;
+      readonly slug: string;
+      readonly toolCount: number;
+    }
+  | {
+      readonly status: "skipped";
+      readonly presetId: string;
+      readonly slug: string;
+      readonly reason: "already_exists";
+    }
+  | {
+      readonly status: "failed";
+      readonly presetId: string;
+      readonly slug: string;
+      readonly error: string;
+    };
+
+export const microsoftAddWorkloadsResultRows = (
+  result: MicrosoftAddWorkloadsResult,
+): readonly MicrosoftWorkloadResultRow[] => [
+  ...result.added.map((entry) => ({
+    status: "added" as const,
+    presetId: entry.presetId,
+    slug: String(entry.slug),
+    toolCount: entry.toolCount,
+  })),
+  ...result.skipped.map((entry) => ({
+    status: "skipped" as const,
+    presetId: entry.presetId,
+    slug: String(entry.slug),
+    reason: entry.reason,
+  })),
+  ...result.failed.map((entry) => ({
+    status: "failed" as const,
+    presetId: entry.presetId,
+    slug: String(entry.slug),
+    error: entry.error,
+  })),
+];
+
+export const mergeMicrosoftAddWorkloadsResult = (
+  previous: MicrosoftAddWorkloadsResult,
+  next: MicrosoftAddWorkloadsResult,
+): MicrosoftAddWorkloadsResult => {
+  const nextPresetIds = new Set(microsoftAddWorkloadsResultRows(next).map((row) => row.presetId));
+  return {
+    added: [...previous.added.filter((entry) => !nextPresetIds.has(entry.presetId)), ...next.added],
+    skipped: [
+      ...previous.skipped.filter((entry) => !nextPresetIds.has(entry.presetId)),
+      ...next.skipped,
+    ],
+    failed: [
+      ...previous.failed.filter((entry) => !nextPresetIds.has(entry.presetId)),
+      ...next.failed,
+    ],
+  };
+};
+
+const microsoftPresetName = (presetId: string): string =>
+  microsoftGraphPresetForId(presetId)?.name ?? presetId;
+
+export function MicrosoftWorkloadResultPanel(props: {
+  readonly result: MicrosoftAddWorkloadsResult;
+  readonly retryingPresetId: string | null;
+  readonly onRetry: (presetId: string) => void | Promise<void>;
+}) {
+  const rows = microsoftAddWorkloadsResultRows(props.result);
+  if (rows.length === 0) return null;
+
+  return (
+    <section className="space-y-3 rounded-lg border border-border bg-muted/10 px-3 py-3">
+      <div>
+        <h2 className="text-sm font-medium text-foreground">Microsoft workloads</h2>
+        <p className="text-[11px] text-muted-foreground">
+          Each selected workload is added as its own integration.
+        </p>
+      </div>
+      <ul className="space-y-2">
+        {rows.map((row: MicrosoftWorkloadResultRow) => {
+          const presetName = microsoftPresetName(row.presetId);
+          return (
+            <li
+              key={`${row.status}:${row.presetId}`}
+              className="flex items-start gap-2 rounded-md border border-border bg-background px-2.5 py-2"
+            >
+              <span
+                className={
+                  row.status === "added"
+                    ? "mt-0.5 text-emerald-600"
+                    : row.status === "skipped"
+                      ? "mt-0.5 text-muted-foreground"
+                      : "mt-0.5 text-destructive"
+                }
+              >
+                {row.status === "added" ? (
+                  <CheckIcon className="size-3.5" />
+                ) : row.status === "skipped" ? (
+                  <CircleIcon className="size-3.5" />
+                ) : (
+                  <TriangleAlert className="size-3.5" />
+                )}
+              </span>
+              <div className="min-w-0 flex-1 space-y-0.5">
+                <div className="flex min-w-0 items-center gap-2">
+                  <span className="truncate text-sm font-medium text-foreground">{presetName}</span>
+                  <span className="shrink-0 text-[11px] text-muted-foreground">
+                    {row.status === "added"
+                      ? "Added"
+                      : row.status === "skipped"
+                        ? "Already exists"
+                        : "Failed"}
+                  </span>
+                </div>
+                {row.status === "added" ? (
+                  <p className="text-[11px] text-muted-foreground">
+                    {row.toolCount} tool{row.toolCount === 1 ? "" : "s"} added.
+                  </p>
+                ) : row.status === "skipped" ? (
+                  <p className="text-[11px] text-muted-foreground">
+                    This integration already exists.
+                  </p>
+                ) : (
+                  <p className="text-[11px] text-destructive">{row.error}</p>
+                )}
+              </div>
+              {row.status === "failed" ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="xs"
+                  loading={props.retryingPresetId === row.presetId}
+                  onClick={() => void props.onRetry(row.presetId)}
+                >
+                  Retry
+                </Button>
+              ) : (
+                <Button variant="ghost" size="xs" asChild>
+                  <Link to="/{-$orgSlug}/integrations/$namespace" params={{ namespace: row.slug }}>
+                    Open
+                  </Link>
+                </Button>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}
+
+const BaseUrlSettings = (props: {
+  readonly baseUrl: string;
+  readonly onBaseUrlChange: (value: string) => void;
+}) => (
+  <section className="space-y-2 rounded-lg border border-border bg-muted/10 px-3 py-3">
+    <div className="space-y-1">
+      <FieldLabel>Microsoft workload settings</FieldLabel>
+      <p className="text-[11px] text-muted-foreground">
+        Selected workloads keep their preset names and namespaces.
+      </p>
+    </div>
+    <Input
+      value={props.baseUrl}
+      onChange={(event: ChangeEvent<HTMLInputElement>) => props.onBaseUrlChange(event.target.value)}
+      placeholder={MICROSOFT_GRAPH_BASE_URL}
+      className="font-mono text-sm"
+    />
+  </section>
+);
+
+const CustomMicrosoftGraphResult = (props: { readonly slug: string }) => (
+  <section className="rounded-lg border border-border bg-muted/10 px-3 py-3">
+    <div className="flex items-center justify-between gap-3">
+      <div className="min-w-0">
+        <h2 className="text-sm font-medium text-foreground">Custom Graph scopes</h2>
+        <p className="text-[11px] text-muted-foreground">
+          Custom scopes were added through the legacy Microsoft Graph path.
+        </p>
+      </div>
+      <Button variant="ghost" size="xs" asChild>
+        <Link to="/{-$orgSlug}/integrations/$namespace" params={{ namespace: props.slug }}>
+          Open
+        </Link>
+      </Button>
+    </div>
+  </section>
+);
+
+type MicrosoftGraphAddPayload = MicrosoftGraphConfig & {
+  readonly presetIds: readonly string[];
+};
+
+const microsoftGraphPayload = (config: MicrosoftGraphAddPayload): MicrosoftGraphAddPayload => {
+  const baseUrl = config.baseUrl?.trim() ?? "";
+  const description = config.description?.trim() ?? "";
+  return {
+    presetIds: config.presetIds,
+    ...(config.customScopes !== undefined ? { customScopes: config.customScopes } : {}),
+    ...(config.slug !== undefined ? { slug: config.slug } : {}),
+    ...(config.name !== undefined ? { name: config.name } : {}),
+    ...(description.length > 0 ? { description } : {}),
+    ...(baseUrl.length > 0 ? { baseUrl } : {}),
+  };
+};
 
 export default function AddMicrosoftSource(props: {
   onComplete: (slug?: string) => void;
@@ -39,18 +296,28 @@ export default function AddMicrosoftSource(props: {
   const [baseUrl, setBaseUrl] = useState("");
   const [descriptionDraft, setDescriptionDraft] = useState<string | null>(null);
   const [adding, setAdding] = useState(false);
+  const [retryingPresetId, setRetryingPresetId] = useState<string | null>(null);
   const [addError, setAddError] = useState<string | null>(null);
-
-  const identity = useIntegrationIdentity({
-    fallbackName: "Microsoft Graph",
-    fallbackNamespace: props.initialNamespace ?? "microsoft_graph",
-  });
+  const [workloadsResult, setWorkloadsResult] = useState<MicrosoftAddWorkloadsResult | null>(null);
+  const [customGraphSlug, setCustomGraphSlug] = useState<string | null>(null);
 
   const selectedIds = useMemo(() => [...selectedPresetIds], [selectedPresetIds]);
-  const selectedScopes = useMemo(
-    () => microsoftGraphScopesForPresetIds(selectedIds, customScopes),
-    [selectedIds, customScopes],
-  );
+  const singleSelectedPreset =
+    selectedIds.length === 1 ? microsoftGraphPresetForId(selectedIds[0]!) : undefined;
+  const usesCustomGraphFallback = customScopes.length > 0;
+
+  const identity = useIntegrationIdentity({
+    fallbackName: usesCustomGraphFallback
+      ? "Custom Microsoft Graph"
+      : (singleSelectedPreset?.name ?? "Microsoft Graph"),
+    fallbackNamespace:
+      props.initialNamespace ??
+      (usesCustomGraphFallback
+        ? "microsoft_graph_custom"
+        : singleSelectedPreset
+          ? microsoftServiceSlug(singleSelectedPreset.id)
+          : "microsoft_graph"),
+  });
 
   const togglePreset = useCallback((presetId: string, checked: boolean) => {
     setSelectedPresetIds((current: ReadonlySet<string>) => {
@@ -73,36 +340,109 @@ export default function AddMicrosoftSource(props: {
     );
   }, []);
 
-  const doAdd = useAtomSet(addMicrosoftGraph, { mode: "promiseExit" });
+  const doAddWorkloads = useAtomSet(addMicrosoftWorkloads, { mode: "promiseExit" });
+  const doAddGraph = useAtomSet(addMicrosoftGraph, { mode: "promiseExit" });
 
-  const resolvedSourceId = slugifyNamespace(identity.namespace) || "microsoft_graph";
-  const resolvedDisplayName = identity.name.trim() || "Microsoft Graph";
-  const resolvedDescription = descriptionDraft ?? "Selected Microsoft Graph workloads.";
-  const slugAlreadyExists = useSlugAlreadyExists(resolvedSourceId);
-  const canAdd = selectedIds.length > 0 && !slugAlreadyExists;
+  const resolvedSourceId = slugifyNamespace(identity.namespace) || "microsoft_graph_custom";
+  const resolvedDisplayName =
+    identity.name.trim() ||
+    (usesCustomGraphFallback
+      ? "Custom Microsoft Graph"
+      : (singleSelectedPreset?.name ?? "Microsoft Graph"));
+  const resolvedDescription =
+    descriptionDraft ??
+    (usesCustomGraphFallback
+      ? "Custom Microsoft Graph scopes."
+      : "Selected Microsoft Graph workloads.");
+  const customGraphSlugAlreadyExists = useSlugAlreadyExists(
+    usesCustomGraphFallback ? resolvedSourceId : "",
+  );
+  const identityOverride =
+    selectedIds.length === 1 && !usesCustomGraphFallback
+      ? { slug: resolvedSourceId, name: resolvedDisplayName }
+      : undefined;
+  const canAdd = selectedIds.length > 0 && !customGraphSlugAlreadyExists && !adding;
 
-  const handleAdd = async () => {
-    setAdding(true);
-    setAddError(null);
-    const exit = await doAdd({
-      payload: {
+  const addCustomGraphScopes = async (): Promise<boolean> => {
+    if (customScopes.length === 0) return true;
+    const exit = await doAddGraph({
+      payload: microsoftGraphPayload({
         presetIds: selectedIds,
         customScopes: [...customScopes],
         slug: resolvedSourceId,
         name: resolvedDisplayName,
-        ...(resolvedDescription.trim().length > 0
-          ? { description: resolvedDescription.trim() }
-          : {}),
-        ...(baseUrl.trim().length > 0 ? { baseUrl: baseUrl.trim() } : {}),
-      },
+        description: resolvedDescription,
+        baseUrl,
+      }),
       reactivityKeys: integrationWriteKeys,
     });
     if (Exit.isFailure(exit)) {
       setAddError(addIntegrationErrorMessage(exit, resolvedSourceId, "Failed to add Microsoft"));
+      return false;
+    }
+    setCustomGraphSlug(String(exit.value.slug));
+    return true;
+  };
+
+  const handleAdd = async () => {
+    setAdding(true);
+    setAddError(null);
+    setWorkloadsResult(null);
+    setCustomGraphSlug(null);
+    const exit = await submitMicrosoftWorkloadsSelection(doAddWorkloads, {
+      presetIds: selectedIds,
+      ...(identityOverride ? { identityOverride } : {}),
+      baseUrl,
+    });
+    if (Exit.isFailure(exit)) {
+      setAddError(errorMessageFromExit(exit, "Failed to add Microsoft workloads"));
       setAdding(false);
       return;
     }
-    props.onComplete(String(exit.value.slug));
+    setWorkloadsResult(exit.value);
+    await addCustomGraphScopes();
+    setAdding(false);
+  };
+
+  const handleRetry = async (presetId: string) => {
+    setRetryingPresetId(presetId);
+    setAddError(null);
+    const retryIdentityOverride =
+      identityOverride && selectedIds.length === 1 && selectedIds[0] === presetId
+        ? identityOverride
+        : undefined;
+    const exit = await submitMicrosoftWorkloadsSelection(doAddWorkloads, {
+      presetIds: [presetId],
+      ...(retryIdentityOverride ? { identityOverride: retryIdentityOverride } : {}),
+      baseUrl,
+    });
+    if (Exit.isFailure(exit)) {
+      setAddError(errorMessageFromExit(exit, "Failed to add Microsoft workload"));
+      setRetryingPresetId(null);
+      return;
+    }
+    setWorkloadsResult((current) =>
+      current ? mergeMicrosoftAddWorkloadsResult(current, exit.value) : exit.value,
+    );
+    setRetryingPresetId(null);
+  };
+
+  const showIdentityDetails = selectedIds.length === 1 || usesCustomGraphFallback;
+  const detailTitle = usesCustomGraphFallback
+    ? "Custom Microsoft Graph scopes"
+    : (singleSelectedPreset?.name ?? "Microsoft Graph");
+  const detailSubtitle = usesCustomGraphFallback
+    ? `${customScopes.length} custom scope${
+        customScopes.length === 1 ? "" : "s"
+      } added through the legacy Graph path.`
+    : "This workload is added as its own integration.";
+
+  const dismiss = () => {
+    if (workloadsResult || customGraphSlug) {
+      props.onComplete();
+      return;
+    }
+    props.onCancel();
   };
 
   return (
@@ -110,7 +450,7 @@ export default function AddMicrosoftSource(props: {
       <div>
         <h1 className="text-xl font-semibold text-foreground">Add Microsoft integration</h1>
         <p className="mt-1 text-[13px] text-muted-foreground">
-          Pick Microsoft 365 workloads and connect them through one delegated OAuth consent.
+          Each selected workload is added as its own integration.
         </p>
       </div>
 
@@ -122,29 +462,42 @@ export default function AddMicrosoftSource(props: {
         onRemoveCustomScope={removeCustomScope}
       />
 
-      <OpenApiSourceDetailsFields
-        title="Microsoft Graph"
-        subtitle={`${selectedIds.length} operation group${
-          selectedIds.length !== 1 ? "s" : ""
-        } with ${selectedScopes.length} preview scope${selectedScopes.length !== 1 ? "s" : ""}`}
-        identity={identity}
-        description={resolvedDescription}
-        onDescriptionChange={setDescriptionDraft}
-        baseUrl={baseUrl}
-        onBaseUrlChange={setBaseUrl}
-        baseUrlLabel="Base URL override (optional)"
-        baseUrlPlaceholder={MICROSOFT_GRAPH_BASE_URL}
-        faviconIcon={MICROSOFT_FAVICON}
-        faviconUrl={baseUrl || MICROSOFT_GRAPH_BASE_URL}
-      />
+      {showIdentityDetails ? (
+        <OpenApiSourceDetailsFields
+          title={detailTitle}
+          subtitle={detailSubtitle}
+          identity={identity}
+          {...(usesCustomGraphFallback
+            ? { description: resolvedDescription, onDescriptionChange: setDescriptionDraft }
+            : {})}
+          baseUrl={baseUrl}
+          onBaseUrlChange={setBaseUrl}
+          baseUrlLabel="Base URL override (optional)"
+          baseUrlPlaceholder={MICROSOFT_GRAPH_BASE_URL}
+          faviconIcon={MICROSOFT_FAVICON}
+          faviconUrl={baseUrl || MICROSOFT_GRAPH_BASE_URL}
+        />
+      ) : (
+        <BaseUrlSettings baseUrl={baseUrl} onBaseUrlChange={setBaseUrl} />
+      )}
 
-      {slugAlreadyExists && !adding && <SlugCollisionAlert slug={resolvedSourceId} />}
+      {customGraphSlugAlreadyExists && !adding && <SlugCollisionAlert slug={resolvedSourceId} />}
 
       {addError && <FormErrorAlert message={addError} />}
 
+      {workloadsResult && (
+        <MicrosoftWorkloadResultPanel
+          result={workloadsResult}
+          retryingPresetId={retryingPresetId}
+          onRetry={handleRetry}
+        />
+      )}
+
+      {customGraphSlug && <CustomMicrosoftGraphResult slug={customGraphSlug} />}
+
       <FloatActions>
-        <Button variant="ghost" onClick={() => props.onCancel()} disabled={adding}>
-          Cancel
+        <Button variant="ghost" onClick={dismiss} disabled={adding || retryingPresetId !== null}>
+          {workloadsResult || customGraphSlug ? "Done" : "Cancel"}
         </Button>
         <Button onClick={() => void handleAdd()} disabled={!canAdd} loading={adding}>
           Connect Microsoft

--- a/packages/plugins/microsoft/src/react/AddMicrosoftSource.tsx
+++ b/packages/plugins/microsoft/src/react/AddMicrosoftSource.tsx
@@ -273,14 +273,25 @@ type MicrosoftGraphAddPayload = MicrosoftGraphConfig & {
   readonly presetIds: readonly string[];
 };
 
-const microsoftGraphPayload = (config: MicrosoftGraphAddPayload): MicrosoftGraphAddPayload => {
-  const baseUrl = config.baseUrl?.trim() ?? "";
-  const description = config.description?.trim() ?? "";
+// The payload for the legacy addGraph call that carries the custom scopes.
+// The checked workloads already fan out as their own integrations through
+// addWorkloads in the same submit, so the custom bundle must carry only the
+// custom scopes (presetIds stays empty): folding the preset ids in again
+// would create a second integration containing the same tools.
+export const microsoftCustomGraphPayload = (input: {
+  readonly customScopes: readonly string[];
+  readonly slug: string;
+  readonly name: string;
+  readonly description: string;
+  readonly baseUrl: string;
+}): MicrosoftGraphAddPayload => {
+  const baseUrl = input.baseUrl.trim();
+  const description = input.description.trim();
   return {
-    presetIds: config.presetIds,
-    ...(config.customScopes !== undefined ? { customScopes: config.customScopes } : {}),
-    ...(config.slug !== undefined ? { slug: config.slug } : {}),
-    ...(config.name !== undefined ? { name: config.name } : {}),
+    presetIds: [],
+    customScopes: [...input.customScopes],
+    slug: input.slug,
+    name: input.name,
     ...(description.length > 0 ? { description } : {}),
     ...(baseUrl.length > 0 ? { baseUrl } : {}),
   };
@@ -366,9 +377,8 @@ export default function AddMicrosoftSource(props: {
   const addCustomGraphScopes = async (): Promise<boolean> => {
     if (customScopes.length === 0) return true;
     const exit = await doAddGraph({
-      payload: microsoftGraphPayload({
-        presetIds: selectedIds,
-        customScopes: [...customScopes],
+      payload: microsoftCustomGraphPayload({
+        customScopes,
         slug: resolvedSourceId,
         name: resolvedDisplayName,
         description: resolvedDescription,

--- a/packages/plugins/microsoft/src/react/MicrosoftScopePicker.tsx
+++ b/packages/plugins/microsoft/src/react/MicrosoftScopePicker.tsx
@@ -71,7 +71,11 @@ const ScopeRow = ({
       checked ? "bg-primary/5" : "hover:bg-muted/40",
     )}
   >
-    <Checkbox checked={checked} onCheckedChange={(next) => onToggle(next === true)} />
+    <Checkbox
+      data-testid={`preset-checkbox-${preset.id}`}
+      checked={checked}
+      onCheckedChange={(next) => onToggle(next === true)}
+    />
     <div className="shrink-0">
       <IntegrationFavicon icon={preset.icon} size={16} />
     </div>

--- a/packages/plugins/microsoft/src/react/MicrosoftScopePicker.tsx
+++ b/packages/plugins/microsoft/src/react/MicrosoftScopePicker.tsx
@@ -192,8 +192,7 @@ export function MicrosoftScopePicker({
       <div className="space-y-1">
         <FieldLabel>Customize Microsoft Graph</FieldLabel>
         <p className="text-[11px] text-muted-foreground">
-          Pick the operation groups to expose as tools. They share one Microsoft OAuth consent and
-          one account connection.
+          Pick Microsoft workloads to add. Each selected workload becomes its own integration.
         </p>
       </div>
 

--- a/packages/plugins/microsoft/src/sdk/graph.ts
+++ b/packages/plugins/microsoft/src/sdk/graph.ts
@@ -124,12 +124,17 @@ const uniqueStrings = (values: Iterable<string>): readonly string[] => {
 };
 
 const normalizeSelection = (input: MicrosoftGraphSelectionInput) => {
+  const customScopes = uniqueStrings(input.customScopes ?? []);
+  // Explicitly empty presetIds alongside custom scopes means "custom scopes
+  // only": the add flow fans checked workloads out as their own integrations
+  // through addWorkloads, so folding the default presets back into the custom
+  // bundle would duplicate their tools. An empty selection without custom
+  // scopes still falls back to the default workloads.
   const presetIds = uniqueStrings(
-    input.presetIds && input.presetIds.length > 0
+    input.presetIds && (input.presetIds.length > 0 || customScopes.length > 0)
       ? input.presetIds
       : MICROSOFT_GRAPH_DEFAULT_PRESET_IDS,
   );
-  const customScopes = uniqueStrings(input.customScopes ?? []);
   const scopes = microsoftGraphScopesForPresetIds(presetIds, customScopes);
   const exactPaths = microsoftGraphExactPathsForPresetIds(presetIds);
   const pathPrefixes = microsoftGraphPathPrefixesForPresetIds(presetIds);

--- a/packages/plugins/microsoft/src/sdk/plugin.test.ts
+++ b/packages/plugins/microsoft/src/sdk/plugin.test.ts
@@ -407,6 +407,33 @@ describe("Microsoft Graph provider", () => {
     ),
   );
 
+  it.effect("empty presetIds with custom scopes stays custom-only, no default workloads", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const executor = yield* createExecutor(makeTestConfig({ plugins: graphPlugins() }));
+
+        // The add flow fans checked workloads out through addWorkloads and
+        // sends the custom scopes here with presetIds: []. Folding the
+        // defaults back in would duplicate the fanned-out workloads' tools.
+        yield* executor.microsoft.addGraph({
+          slug: "microsoft_graph_custom",
+          presetIds: [],
+          customScopes: ["Custom.Scope"],
+        });
+
+        const config = yield* executor.microsoft.getConfig("microsoft_graph_custom");
+        expect(config?.microsoftGraphPresetIds).toEqual([]);
+        expect(config?.microsoftGraphCustomScopes).toEqual(["Custom.Scope"]);
+        expect(config?.microsoftGraphCoversFullGraph).toBe(false);
+        expect(config?.microsoftGraphScopes).toEqual([
+          "offline_access",
+          "User.Read",
+          "Custom.Scope",
+        ]);
+      }),
+    ),
+  );
+
   it.effect("uses the app registration default scope when every Graph workload is selected", () =>
     Effect.scoped(
       Effect.gen(function* () {


### PR DESCRIPTION
Stacked on #1309. The Google and Microsoft add flows keep the bulk-select picker but now create one integration per selected service via addServices/addWorkloads, with an in-modal result panel (added / already exists / failed with per-service retry). Custom Discovery URLs and custom Graph scopes keep their existing paths; a mixed Microsoft submit no longer folds the selected presets into the custom bundle. Adds stable data-testids for the e2e suite.

Independently reviewed (ship-with-nits; both nits fixed: mixed-flow double-add, google-photos e2e spec updated for the multi-select flow).

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #1308
2. #1309
3. **#1315** 👈 current
4. #1334
5. #1336
6. #1337
<!-- stack:links:end -->