### PR TITLE
docs: add Xquik OpenAPI integration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,14 @@ install.
 To run it locally instead (Node.js 20+):
 
 ```bash
-npm install -g executor   # or: pnpm add -g / bun add -g / yarn global add
-executor install          # install the durable background service
-executor web              # open the web UI in your browser
+# Choose one package manager:
+npm install -g executor
+pnpm add -g executor
+bun add -g executor
+yarn global add executor
+
+executor install # install the durable background service
+executor web     # open the web UI in your browser
 ```
 
 `executor install` keeps the service running across restarts. For a throwaway
@@ -111,6 +116,19 @@ executor call executor openapi addIntegration '{
   "baseUrl": "https://petstore3.swagger.io/api/v3"
 }'
 ```
+
+For X research and automation, Xquik's public OpenAPI spec works the same way:
+
+```bash
+executor call executor openapi addIntegration '{
+  "spec": "https://xquik.com/openapi.json",
+  "namespace": "xquik"
+}'
+```
+
+Create a connection for the integration in Executor and store the required
+`x-api-key` credential there. Agents can then use Xquik through the shared
+catalog without copying credentials into each MCP client.
 
 Use `baseUrl` when the OpenAPI document has relative `servers` entries (for
 example `"/api/v3"`). Confirm it is live with `executor tools integrations`.


### PR DESCRIPTION
## Summary

- Add an Xquik OpenAPI integration example using Executor's current `addIntegration` API.
- Show complete global install commands for npm, pnpm, Bun, and Yarn.

## Independent Fix

The existing alternative install commands omitted the `executor` package name.
This change makes each documented command complete and copyable.

## Checks

- `git diff --check`
- `bunx oxfmt@0.44.0 --check README.md`
- Confirmed `https://xquik.com/openapi.json` declares the Xquik server, API-key scheme, and API paths.

The code test suite is unchanged by this README-only update. GitHub's 3 workflows
still require maintainer approval before their jobs can start.
