### PR TITLE
Correlate Sentry errors with OTel traces

### DIFF
--- a/apps/cloud/src/api/error-response.ts
+++ b/apps/cloud/src/api/error-response.ts
@@ -1,7 +1,7 @@
 import { Cause, Data, Effect, Predicate, Result } from "effect";
 import { HttpServerRespondable, HttpServerResponse } from "effect/unstable/http";
 
-import { captureCause } from "../observability";
+import { captureCause, captureCauseEffect } from "../observability";
 
 // Implements `Respondable` so the framework's default cause→response
 // pipeline (`HttpServerRespondable.toResponseOrElse`) renders this as the
@@ -13,13 +13,14 @@ export class HttpResponseError extends Data.TaggedError("HttpResponseError")<{
   readonly message: string;
 }> {
   [HttpServerRespondable.symbol](): Effect.Effect<HttpServerResponse.HttpServerResponse> {
-    if (this.status >= 500) captureCause(this);
-    return Effect.succeed(
-      HttpServerResponse.jsonUnsafe(
-        { error: this.message, code: this.code },
-        { status: this.status },
-      ),
-    );
+    const self = this;
+    return Effect.gen(function* () {
+      if (self.status >= 500) yield* captureCauseEffect(self);
+      return HttpServerResponse.jsonUnsafe(
+        { error: self.message, code: self.code },
+        { status: self.status },
+      );
+    });
   }
 }
 
@@ -65,3 +66,15 @@ export const toErrorServerResponse = (error: unknown): HttpServerResponse.HttpSe
     { status: mapped.status },
   );
 };
+
+export const toErrorServerResponseEffect = (
+  error: unknown,
+): Effect.Effect<HttpServerResponse.HttpServerResponse> =>
+  Effect.gen(function* () {
+    const mapped = toHttpResponseError(error);
+    if (mapped.status >= 500) yield* captureCauseEffect(mapped);
+    return HttpServerResponse.jsonUnsafe(
+      { error: mapped.message, code: mapped.code },
+      { status: mapped.status },
+    );
+  });

--- a/apps/cloud/src/engine/execution-gate.ts
+++ b/apps/cloud/src/engine/execution-gate.ts
@@ -24,12 +24,12 @@
 // `CodeCompilationError` / `SandboxRuntimeError` into `ExecuteResult.error`.
 // ---------------------------------------------------------------------------
 
-import * as Sentry from "@sentry/cloudflare";
 import { Data, Effect } from "effect";
 import type * as Cause from "effect/Cause";
 
 import type { ExecutionEngine, ExecutionResult } from "@executor-js/execution";
 
+import { captureCauseEffect } from "../observability";
 import { EXECUTION_LIMIT_BLOCKED_MESSAGE } from "./execution-limit-messages";
 
 // The engine's completed-result payload (`ExecuteResult` in codemode-core),
@@ -166,10 +166,12 @@ export const makeExecutionLimitGate = (checkBalance: ExecutionBalanceCheck) => {
         // must never block executions. Reported like `trackExecution` so a
         // billing outage still pages; the error outcome is never cached.
         Effect.catch((error: unknown) =>
-          Effect.sync((): GateDecision => {
-            console.warn("[billing] execution balance check failed open:", error);
-            Sentry.captureException(error);
-            return { blocked: false };
+          Effect.gen(function* () {
+            yield* Effect.sync(() => {
+              console.warn("[billing] execution balance check failed open:", error);
+            });
+            yield* captureCauseEffect(error);
+            return { blocked: false } as const satisfies GateDecision;
           }),
         ),
       );

--- a/apps/cloud/src/engine/execution-rate-limit.ts
+++ b/apps/cloud/src/engine/execution-rate-limit.ts
@@ -14,12 +14,12 @@
 // ---------------------------------------------------------------------------
 
 import { DurableObject, env } from "cloudflare:workers";
-import * as Sentry from "@sentry/cloudflare";
 import { Data, Effect } from "effect";
 import type * as Cause from "effect/Cause";
 
 import type { ExecutionEngine } from "@executor-js/execution";
 
+import { captureCauseEffect } from "../observability";
 import { withPreExecutionGate, type GateDecision } from "./execution-gate";
 import { RATE_LIMIT_BLOCKED_MESSAGE } from "./execution-limit-messages";
 
@@ -149,10 +149,12 @@ export const makeExecutionRateLimiter = (
         // FAIL OPEN: the backstop must never block executions because its
         // counter is unreachable or slow.
         Effect.catch((error: unknown) =>
-          Effect.sync((): GateDecision => {
-            console.warn("[rate-limit] execution rate limit check failed open:", error);
-            Sentry.captureException(error);
-            return { blocked: false };
+          Effect.gen(function* () {
+            yield* Effect.sync(() => {
+              console.warn("[rate-limit] execution rate limit check failed open:", error);
+            });
+            yield* captureCauseEffect(error);
+            return { blocked: false } as const satisfies GateDecision;
           }),
         ),
       );

--- a/apps/cloud/src/env-augment.d.ts
+++ b/apps/cloud/src/env-augment.d.ts
@@ -11,6 +11,8 @@ declare global {
       AXIOM_TRACES_URL?: string;
       AXIOM_TRACES_SAMPLE_RATIO?: string;
       SENTRY_DSN?: string;
+      SENTRY_OTEL_LOG_PAYLOAD?: string;
+      SENTRY_OTEL_VERIFY?: string;
       VITE_PUBLIC_SENTRY_DSN?: string;
       VITE_PUBLIC_POSTHOG_KEY?: string;
       VITE_PUBLIC_POSTHOG_HOST?: string;

--- a/apps/cloud/src/extensions/billing/route.ts
+++ b/apps/cloud/src/extensions/billing/route.ts
@@ -5,7 +5,11 @@ import { autumnHandler } from "autumn-js/backend";
 
 import { WorkOSClient } from "../../auth/workos";
 import { ORG_SELECTOR_HEADER, authorizeOrganizationSelector } from "../../auth/organization";
-import { HttpResponseError, isServerError, toErrorServerResponse } from "../../api/error-response";
+import {
+  HttpResponseError,
+  isServerError,
+  toErrorServerResponseEffect,
+} from "../../api/error-response";
 
 type BillingSession = {
   readonly userId: string;
@@ -111,7 +115,7 @@ const handler = Effect.gen(function* () {
     if (isServerError(err)) {
       console.error("[autumn] request failed:", Cause.pretty(err));
     }
-    return Effect.succeed(toErrorServerResponse(err));
+    return toErrorServerResponseEffect(err);
   }),
 );
 

--- a/apps/cloud/src/extensions/billing/service.ts
+++ b/apps/cloud/src/extensions/billing/service.ts
@@ -3,9 +3,10 @@
 // ---------------------------------------------------------------------------
 
 import { env } from "cloudflare:workers";
-import * as Sentry from "@sentry/cloudflare";
 import { Autumn } from "autumn-js";
 import { Context, Data, Effect, Layer } from "effect";
+
+import { captureCauseEffect } from "../../observability";
 
 // ---------------------------------------------------------------------------
 // Errors
@@ -72,12 +73,12 @@ const make = Effect.sync(() => {
       ).pipe(
         Effect.catchTag("AutumnError", (error) =>
           Effect.gen(function* () {
-            // Silent billing data loss is worth paging on — autumn.trackExecution
+            // Silent billing data loss is worth paging on: autumn.trackExecution
             // is fire-and-forget so the caller doesn't handle it themselves.
             yield* Effect.sync(() => {
               console.error("[billing] track failed:", error);
-              Sentry.captureException(error);
             });
+            yield* captureCauseEffect(error);
             yield* Effect.annotateCurrentSpan({ "autumn.track.failed": true });
           }),
         ),

--- a/apps/cloud/src/mcp/session-durable-object.ts
+++ b/apps/cloud/src/mcp/session-durable-object.ts
@@ -68,7 +68,11 @@ import { makeExecutionStack } from "../engine/execution-stack";
 import { CloudMeteredExecutionStackLayer } from "../engine/execution-stack-metered";
 import { AutumnService } from "../extensions/billing/service";
 import { DoTelemetryLive, flushTracerProvider } from "../observability/telemetry";
-import { captureCause as reportCause } from "../observability";
+import {
+  captureCause as reportCause,
+  captureCauseEffect as reportCauseEffect,
+  tagCurrentSentryScopeWithCurrentOtelSpan,
+} from "../observability";
 
 // Re-export the shared types so existing cloud importers
 // (`auth/handlers.ts`, etc.) keep their `../mcp/session-durable-object` path.
@@ -322,6 +326,16 @@ export class McpSessionDOSqlite extends McpAgentSessionDOBase<Env, CloudSessionD
 
   protected override captureCause(cause: Cause.Cause<unknown>): void {
     reportCause(cause);
+  }
+
+  protected override captureCauseEffect(
+    cause: Cause.Cause<unknown>,
+  ): Effect.Effect<string | undefined> {
+    return reportCauseEffect(cause);
+  }
+
+  protected override prepareErrorCaptureScope(): Effect.Effect<void> {
+    return Effect.asVoid(tagCurrentSentryScopeWithCurrentOtelSpan);
   }
 
   // Best-effort export the DO isolate's buffered spans after the RPC settles,

--- a/apps/cloud/src/observability/index.ts
+++ b/apps/cloud/src/observability/index.ts
@@ -11,7 +11,9 @@
 // ---------------------------------------------------------------------------
 
 import * as Sentry from "@sentry/cloudflare";
+import type { ErrorEvent, Scope } from "@sentry/cloudflare";
 import { Cause, Effect, Layer } from "effect";
+import type * as Tracer from "effect/Tracer";
 
 import { ErrorCapture } from "@executor-js/api";
 
@@ -21,11 +23,105 @@ import { ErrorCapture } from "@executor-js/api";
 // error. Sentry still receives the full, untruncated cause via
 // `setExtra`; only the dev-console mirror is capped.
 const MAX_CONSOLE_CAUSE_CHARS = 4_000;
+const OTEL_TRACE_ID_PATTERN = /^[0-9a-f]{32}$/;
+const OTEL_SPAN_ID_PATTERN = /^[0-9a-f]{16}$/;
+
+export const OTEL_TRACE_ID_TAG = "otel_trace_id";
+export const OTEL_SPAN_ID_TAG = "otel_span_id";
+export const SENTRY_EVENT_ID_ATTRIBUTE = "sentry.event_id";
+
+export type OtelCorrelationContext = {
+  readonly traceId: string;
+  readonly spanId: string;
+};
 
 const truncate = (s: string): string =>
   s.length <= MAX_CONSOLE_CAUSE_CHARS
     ? s
     : `${s.slice(0, MAX_CONSOLE_CAUSE_CHARS)}\n…[truncated ${s.length - MAX_CONSOLE_CAUSE_CHARS} chars]`;
+
+const validOtelContext = (context: OtelCorrelationContext): boolean =>
+  OTEL_TRACE_ID_PATTERN.test(context.traceId) && OTEL_SPAN_ID_PATTERN.test(context.spanId);
+
+export const otelCorrelationContextFromEffectSpan = (
+  span: Tracer.Span,
+): OtelCorrelationContext | null => {
+  const context = { traceId: span.traceId, spanId: span.spanId };
+  return validOtelContext(context) ? context : null;
+};
+
+export const otelCorrelationContextFromOpenTelemetrySpan = (span: {
+  readonly spanContext: () => { readonly traceId: string; readonly spanId: string };
+}): OtelCorrelationContext | null => {
+  const { traceId, spanId } = span.spanContext();
+  const context = { traceId, spanId };
+  return validOtelContext(context) ? context : null;
+};
+
+export const addOtelCorrelationTags = <T extends { readonly tags?: Record<string, unknown> }>(
+  event: T,
+  context: OtelCorrelationContext | null,
+): T => {
+  if (!context) return event;
+  return {
+    ...event,
+    tags: {
+      ...event.tags,
+      [OTEL_TRACE_ID_TAG]: context.traceId,
+      [OTEL_SPAN_ID_TAG]: context.spanId,
+    },
+  };
+};
+
+export const tagSentryScopeWithOtelContext = (
+  scope: Scope,
+  context: OtelCorrelationContext | null,
+): void => {
+  if (!context) return;
+  scope.setTag(OTEL_TRACE_ID_TAG, context.traceId);
+  scope.setTag(OTEL_SPAN_ID_TAG, context.spanId);
+};
+
+export const tagCurrentSentryScopeWithOtelContext = (
+  context: OtelCorrelationContext | null,
+): void => {
+  tagSentryScopeWithOtelContext(Sentry.getCurrentScope(), context);
+};
+
+const currentOtelContext = Effect.map(
+  Effect.currentSpan,
+  otelCorrelationContextFromEffectSpan,
+).pipe(Effect.orElseSucceed(() => null));
+
+export const tagCurrentSentryScopeWithCurrentOtelSpan: Effect.Effect<OtelCorrelationContext | null> =
+  Effect.map(currentOtelContext, (context) => {
+    tagCurrentSentryScopeWithOtelContext(context);
+    return context;
+  });
+
+export const beforeSendWithOtelCorrelation = (
+  event: ErrorEvent,
+  options?: { readonly logPayload?: boolean },
+): ErrorEvent => {
+  if (options?.logPayload) {
+    console.info(
+      JSON.stringify({
+        event: "sentry_before_send_otel_correlation",
+        sentry_event_id: event.event_id ?? "",
+        otel_trace_id: String(event.tags?.[OTEL_TRACE_ID_TAG] ?? ""),
+        otel_span_id: String(event.tags?.[OTEL_SPAN_ID_TAG] ?? ""),
+      }),
+    );
+  }
+  return event;
+};
+
+export const addCurrentOtelCorrelationTags = <
+  T extends { readonly tags?: Record<string, unknown> },
+>(
+  event: T,
+): Effect.Effect<T> =>
+  Effect.map(currentOtelContext, (context) => addOtelCorrelationTags(event, context));
 
 // Sentry's `captureException` can't serialize Effect's `CauseImpl` (it logs
 // `'CauseImpl' captured as exception with keys: reasons, ~effect/Cause` and
@@ -48,21 +144,36 @@ export const sentryPayloadForCause = (
   return { primary: input, pretty: null };
 };
 
-export const captureCause = (input: unknown): string | undefined => {
+export const captureCause = (
+  input: unknown,
+  context: OtelCorrelationContext | null = null,
+): string | undefined => {
   const { primary, pretty } = sentryPayloadForCause(input);
+  tagCurrentSentryScopeWithOtelContext(context);
   return Sentry.captureException(primary, (scope) => {
+    tagSentryScopeWithOtelContext(scope, context);
     if (pretty !== null) scope.setExtra("cause", pretty);
     return scope;
   });
 };
 
+export const captureCauseEffect = (input: unknown): Effect.Effect<string | undefined> =>
+  Effect.gen(function* () {
+    const context = yield* tagCurrentSentryScopeWithCurrentOtelSpan;
+    const eventId = yield* Effect.sync(() => captureCause(input, context));
+    if (eventId && context) {
+      yield* Effect.annotateCurrentSpan(SENTRY_EVENT_ID_ATTRIBUTE, eventId);
+    }
+    return eventId;
+  });
+
 export const ErrorCaptureLive: Layer.Layer<ErrorCapture> = Layer.succeed(
   ErrorCapture,
   ErrorCapture.of({
     captureException: (cause) =>
-      Effect.sync(() => {
+      Effect.gen(function* () {
         console.error("[api] unhandled cause:", truncate(Cause.pretty(cause)));
-        return captureCause(cause) ?? "";
+        return (yield* captureCauseEffect(cause)) ?? "";
       }),
   }),
 );

--- a/apps/cloud/src/observability/observability.test.ts
+++ b/apps/cloud/src/observability/observability.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from "@effect/vitest";
-import { Cause } from "effect";
+import { Cause, Effect } from "effect";
+import type * as Tracer from "effect/Tracer";
 
-import { sentryPayloadForCause } from "./index";
+import {
+  addCurrentOtelCorrelationTags,
+  OTEL_SPAN_ID_TAG,
+  OTEL_TRACE_ID_TAG,
+  sentryPayloadForCause,
+} from "./index";
 
 // Mirrors Sentry core's `is.isError`: it picks the proper-Error path iff
 // `Object.prototype.toString.call(x) === "[object Error]"`. Anything that
@@ -9,6 +15,39 @@ import { sentryPayloadForCause } from "./index";
 // with keys: ..." path that produced the original CauseImpl Sentry issue.
 const looksLikeErrorToSentry = (value: unknown): boolean =>
   Object.prototype.toString.call(value) === "[object Error]";
+
+const traceId = "4268a606000000000000000000000000";
+const spanId = "1234567890abcdef";
+
+const makeFixedTracer = (): Tracer.Tracer => ({
+  span: (options) => {
+    const attributes = new Map<string, unknown>();
+    let status: Tracer.SpanStatus = { _tag: "Started", startTime: options.startTime };
+    return {
+      _tag: "Span",
+      name: options.name,
+      spanId,
+      traceId,
+      parent: options.parent,
+      annotations: options.annotations,
+      get status() {
+        return status;
+      },
+      attributes,
+      links: options.links,
+      sampled: options.sampled,
+      kind: options.kind,
+      end: (endTime, exit) => {
+        status = { _tag: "Ended", startTime: options.startTime, endTime, exit };
+      },
+      attribute: (key, value) => {
+        attributes.set(key, value);
+      },
+      event: () => undefined,
+      addLinks: () => undefined,
+    };
+  },
+});
 
 describe("sentryPayloadForCause", () => {
   it("hands Sentry a real Error when the defect is itself a Cause", () => {
@@ -38,4 +77,17 @@ describe("sentryPayloadForCause", () => {
     expect(primary).toBe(err);
     expect(pretty).toBeNull();
   });
+});
+
+describe("Sentry OTel correlation", () => {
+  it.effect("adds tags from the active Effect span", () =>
+    Effect.gen(function* () {
+      const baseEvent: { readonly tags: Record<string, unknown> } = { tags: { existing: "tag" } };
+      const event = yield* addCurrentOtelCorrelationTags(baseEvent);
+
+      expect(event.tags.existing).toBe("tag");
+      expect(event.tags[OTEL_TRACE_ID_TAG]).toBe(traceId);
+      expect(event.tags[OTEL_SPAN_ID_TAG]).toBe(spanId);
+    }).pipe(Effect.withSpan("test.sentry_capture"), Effect.withTracer(makeFixedTracer())),
+  );
 });

--- a/apps/cloud/src/server.ts
+++ b/apps/cloud/src/server.ts
@@ -1,5 +1,6 @@
 import { DurableObject } from "cloudflare:workers";
 import { SpanKind, SpanStatusCode, context, trace } from "@opentelemetry/api";
+import type { ErrorEvent } from "@sentry/cloudflare";
 import {
   ATTR_HTTP_REQUEST_METHOD,
   ATTR_HTTP_RESPONSE_STATUS_CODE,
@@ -14,6 +15,13 @@ import { isAppOwnedPath } from "./app-paths";
 import { makeCloudMcpAgentHandler } from "./mcp/agent-handler";
 import { classifyMcpPath, prepareMcpOrgScope } from "./mcp/mount";
 import { McpSessionDOSqlite as McpSessionDOBase } from "./mcp/session-durable-object";
+import {
+  beforeSendWithOtelCorrelation,
+  captureCause,
+  otelCorrelationContextFromOpenTelemetrySpan,
+  SENTRY_EVENT_ID_ATTRIBUTE,
+  tagCurrentSentryScopeWithOtelContext,
+} from "./observability";
 import { browserTracesResponse } from "./observability/browser-traces";
 import { flushTracerProvider, installTracerProvider } from "./observability/telemetry";
 
@@ -27,6 +35,10 @@ const sentryOptions = (env: Env) => ({
   enableLogs: true,
   sendDefaultPii: true,
   skipOpenTelemetrySetup: true,
+  beforeSend: (event: ErrorEvent) =>
+    beforeSendWithOtelCorrelation(event, {
+      logPayload: !env.SENTRY_DSN || env.SENTRY_OTEL_LOG_PAYLOAD === "true",
+    }),
   // NOTE: do NOT enable `instrumentPrototypeMethods`. It walks the DO prototype
   // and reads every property — including accessors — to find methods to wrap,
   // which invokes the `sessionId` getter with `this` bound to the prototype
@@ -158,6 +170,8 @@ const cloudflareHandler: ExportedHandler<Env> = {
       { kind: SpanKind.SERVER },
       parentContext,
       async (span) => {
+        const otelContext = otelCorrelationContextFromOpenTelemetrySpan(span);
+        tagCurrentSentryScopeWithOtelContext(otelContext);
         span.setAttribute(ATTR_HTTP_REQUEST_METHOD, request.method);
         span.setAttribute(ATTR_URL_FULL, request.url);
         span.setAttribute(ATTR_URL_PATH, url.pathname);
@@ -168,6 +182,22 @@ const cloudflareHandler: ExportedHandler<Env> = {
         // outer wrapper still captures the exception; we only mark span status.
         // oxlint-disable-next-line executor/no-try-catch-or-throw -- adapter boundary
         try {
+          if (env.SENTRY_OTEL_VERIFY === "true" && url.pathname === "/__sentry-otel-verify") {
+            // oxlint-disable-next-line executor/no-error-constructor -- boundary: synthetic verification needs an Error payload for Sentry grouping
+            const eventId = captureCause(new Error("sentry otel verification"), otelContext) ?? "";
+            if (eventId) span.setAttribute(SENTRY_EVENT_ID_ATTRIBUTE, eventId);
+            span.setAttribute("sentry_otel.verify", true);
+            span.setAttribute(ATTR_HTTP_RESPONSE_STATUS_CODE, 500);
+            span.setStatus({ code: SpanStatusCode.ERROR });
+            return Response.json(
+              {
+                sentryEventId: eventId,
+                otelTraceId: otelContext?.traceId ?? "",
+                otelSpanId: otelContext?.spanId ?? "",
+              },
+              { status: 500 },
+            );
+          }
           const response = await fetchHandler(request, env, ctx);
           span.setAttribute(ATTR_HTTP_RESPONSE_STATUS_CODE, response.status);
           if (response.status >= 500) {

--- a/e2e/cloud/sentry-otel-correlation.test.ts
+++ b/e2e/cloud/sentry-otel-correlation.test.ts
@@ -1,0 +1,70 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { expect } from "@effect/vitest";
+import { Effect, Schedule } from "effect";
+
+import { RUNS_DIR, scenario } from "../src/scenario";
+import { Target, Telemetry } from "../src/services";
+
+type VerificationResponse = {
+  readonly sentryEventId: string;
+  readonly otelTraceId: string;
+  readonly otelSpanId: string;
+};
+
+const beforeSendLogFile = resolve(RUNS_DIR, "cloud", "server-logs", "boot.log");
+
+const hasCorrelationPayload = (line: string, body: VerificationResponse): boolean =>
+  line.includes('"event":"sentry_before_send_otel_correlation"') &&
+  line.includes(`"sentry_event_id":"${body.sentryEventId}"`) &&
+  line.includes(`"otel_trace_id":"${body.otelTraceId}"`) &&
+  line.includes(`"otel_span_id":"${body.otelSpanId}"`);
+
+const findBeforeSendPayload = (body: VerificationResponse): Effect.Effect<string, string> =>
+  Effect.sync(() => {
+    const text = readFileSync(beforeSendLogFile, "utf8");
+    return text
+      .split("\n")
+      .slice()
+      .reverse()
+      .find((line) => hasCorrelationPayload(line, body));
+  }).pipe(
+    Effect.filterOrFail(
+      (line): line is string => line !== undefined,
+      () =>
+        `no Sentry beforeSend correlation payload matched ${body.sentryEventId} in ${beforeSendLogFile}`,
+    ),
+    Effect.retry(Schedule.both(Schedule.spaced("500 millis"), Schedule.recurs(20))),
+  );
+
+scenario(
+  "Telemetry · Sentry error payload joins to exported OTel span",
+  { timeout: 120_000 },
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const telemetry = yield* Telemetry;
+
+    const response = yield* Effect.promise(() =>
+      fetch(new URL("/__sentry-otel-verify", target.baseUrl)),
+    );
+    expect(response.status).toBe(500);
+
+    const body = (yield* Effect.promise(() => response.json())) as VerificationResponse;
+    expect(body.sentryEventId).toMatch(/^[0-9a-f]{32}$/);
+    expect(body.otelTraceId).toMatch(/^[0-9a-f]{32}$/);
+    expect(body.otelSpanId).toMatch(/^[0-9a-f]{16}$/);
+
+    const beforeSendLine = yield* findBeforeSendPayload(body);
+    expect(beforeSendLine).toContain(body.otelTraceId);
+
+    const span = yield* telemetry.expectSpan({
+      traceId: body.otelTraceId,
+      attributes: {
+        "sentry.event_id": body.sentryEventId,
+        "sentry_otel.verify": "true",
+      },
+    });
+    expect(span.span.spanId).toBe(body.otelSpanId);
+  }),
+);

--- a/e2e/setup/cloud.globalsetup.ts
+++ b/e2e/setup/cloud.globalsetup.ts
@@ -25,6 +25,15 @@ const bootLogFile = process.env.E2E_VERBOSE
   ? undefined
   : resolve(RUNS_DIR, "cloud", "server-logs", "boot.log");
 
+const optionalCloudEnv = (): Record<string, string> => {
+  const env: Record<string, string> = {};
+  for (const key of ["SENTRY_DSN", "SENTRY_OTEL_LOG_PAYLOAD", "SENTRY_OTEL_VERIFY"]) {
+    const value = process.env[key];
+    if (value) env[key] = value;
+  }
+  return env;
+};
+
 export default async function setup(): Promise<(() => Promise<void>) | void> {
   if (process.env.E2E_CLOUD_URL) {
     await waitForHttp(process.env.E2E_CLOUD_URL);
@@ -74,7 +83,7 @@ export default async function setup(): Promise<(() => Promise<void>) | void> {
           // endpoint-agnostic, so the same layer that ships prod traces to
           // Axiom ships e2e traces to the suite store — "why was that page
           // slow" gets a span waterfall, not a guess.
-          extraEnv: motelExporterEnv(motel, publicUrl),
+          extraEnv: { ...motelExporterEnv(motel, publicUrl), ...optionalCloudEnv() },
         });
         return { teardown: cloud.teardown, value: cloud };
       },

--- a/e2e/setup/cloud.globalsetup.ts
+++ b/e2e/setup/cloud.globalsetup.ts
@@ -26,7 +26,13 @@ const bootLogFile = process.env.E2E_VERBOSE
   : resolve(RUNS_DIR, "cloud", "server-logs", "boot.log");
 
 const optionalCloudEnv = (): Record<string, string> => {
-  const env: Record<string, string> = {};
+  // The Sentry/OTel correlation scenario always runs in this suite, so the
+  // verification route and beforeSend payload logging default on here; the
+  // env vars remain overridable for local runs against a different setup.
+  const env: Record<string, string> = {
+    SENTRY_OTEL_VERIFY: "true",
+    SENTRY_OTEL_LOG_PAYLOAD: "true",
+  };
   for (const key of ["SENTRY_DSN", "SENTRY_OTEL_LOG_PAYLOAD", "SENTRY_OTEL_VERIFY"]) {
     const value = process.env[key];
     if (value) env[key] = value;

--- a/packages/hosts/cloudflare/src/mcp/agent-session-durable-object.ts
+++ b/packages/hosts/cloudflare/src/mcp/agent-session-durable-object.ts
@@ -236,6 +236,17 @@ export abstract class McpAgentSessionDOBase<
 
   protected captureCause(_cause: Cause.Cause<unknown>): void {}
 
+  protected captureCauseEffect(cause: Cause.Cause<unknown>): Effect.Effect<string | undefined> {
+    return Effect.sync(() => {
+      this.captureCause(cause);
+      return undefined;
+    });
+  }
+
+  protected prepareErrorCaptureScope(): Effect.Effect<void> {
+    return Effect.void;
+  }
+
   protected flushTelemetry(): Promise<void> {
     return Promise.resolve();
   }
@@ -604,6 +615,7 @@ export abstract class McpAgentSessionDOBase<
     }
     const self = this;
     const program = Effect.gen(function* () {
+      yield* self.prepareErrorCaptureScope();
       const sessionMeta = yield* self.resolveAndStoreSessionMeta(props.session);
       const dbHandle = yield* self.openSessionDbHandle();
       const { mcpServer, engine } = yield* self.buildRuntime(sessionMeta, dbHandle);
@@ -618,7 +630,7 @@ export abstract class McpAgentSessionDOBase<
       Effect.tapCause((cause) =>
         Effect.gen(function* () {
           console.error("[mcp-session] init failed:", Cause.pretty(cause));
-          self.captureCause(cause);
+          yield* self.captureCauseEffect(cause);
           yield* self.recordCauseOnSpan(cause);
         }),
       ),
@@ -650,6 +662,7 @@ export abstract class McpAgentSessionDOBase<
     const self = this;
     return Effect.runPromise(
       Effect.gen(function* () {
+        yield* self.prepareErrorCaptureScope();
         const sessionMeta = yield* self.loadSessionMeta();
         if (!sessionMeta) return "not_found" as const;
         if (self.initialized) {
@@ -681,6 +694,7 @@ export abstract class McpAgentSessionDOBase<
     const self = this;
     return Effect.runPromise(
       Effect.gen(function* () {
+        yield* self.prepareErrorCaptureScope();
         const owner = yield* self.validateApprovalIdentity(identity);
         if (owner !== "ok") return { status: owner } as const;
 
@@ -718,6 +732,7 @@ export abstract class McpAgentSessionDOBase<
     const self = this;
     return Effect.runPromise(
       Effect.gen(function* () {
+        yield* self.prepareErrorCaptureScope();
         const owner = yield* self.validateApprovalIdentity(identity);
         if (owner === "forbidden") return { status: "execution_forbidden" } as const;
         if (owner === "not_found") {
@@ -775,6 +790,7 @@ export abstract class McpAgentSessionDOBase<
     const self = this;
     return Effect.runPromise(
       Effect.gen(function* () {
+        yield* self.prepareErrorCaptureScope();
         const owner = yield* self.validateApprovalIdentity(identity);
         if (owner !== "ok") return { status: owner } as const;
 
@@ -1015,6 +1031,7 @@ export abstract class McpAgentSessionDOBase<
   ): Effect.Effect<void> {
     const self = this;
     return Effect.gen(function* () {
+      yield* self.prepareErrorCaptureScope();
       if (self.pendingApprovalLeases.has(executionId)) return;
 
       yield* Effect.promise(() => self.markActivity()).pipe(
@@ -1031,9 +1048,14 @@ export abstract class McpAgentSessionDOBase<
         attributes: { "mcp.execution.id": executionId },
       }),
       Effect.tapCause((cause) =>
-        Effect.sync(() => {
-          console.error("[mcp-session] pending approval lease start failed:", Cause.pretty(cause));
-          self.captureCause(cause);
+        Effect.gen(function* () {
+          yield* Effect.sync(() => {
+            console.error(
+              "[mcp-session] pending approval lease start failed:",
+              Cause.pretty(cause),
+            );
+          });
+          yield* self.captureCauseEffect(cause);
         }),
       ),
       Effect.ignore,
@@ -1048,16 +1070,19 @@ export abstract class McpAgentSessionDOBase<
   }
 
   private queuePendingApprovalLeaseExpiration(executionId: string): void {
+    const self = this;
     this.ctx.waitUntil(
       Effect.runPromise(
         this.expirePendingApproval(executionId).pipe(
           Effect.tapCause((cause) =>
-            Effect.sync(() => {
-              console.error(
-                "[mcp-session] pending approval lease expiration failed:",
-                Cause.pretty(cause),
-              );
-              this.captureCause(cause);
+            Effect.gen(function* () {
+              yield* Effect.sync(() => {
+                console.error(
+                  "[mcp-session] pending approval lease expiration failed:",
+                  Cause.pretty(cause),
+                );
+              });
+              yield* self.captureCauseEffect(cause);
             }),
           ),
           Effect.ignore,
@@ -1134,6 +1159,7 @@ export abstract class McpAgentSessionDOBase<
   private expirePendingApproval(executionId: string): Effect.Effect<void> {
     const self = this;
     return Effect.gen(function* () {
+      yield* self.prepareErrorCaptureScope();
       const lease = self.pendingApprovalLeases.get(executionId);
       if (!lease || lease.expiring) return;
       lease.expiring = true;


### PR DESCRIPTION
## Why

Sentry error events and the OTel traces exported to Axiom carried unrelated trace ids: Sentry mints its own trace context while the app owns a separate WebTracerProvider, so going from an error event to its request trace (or back) required manual timestamp and attribute joins during incident debugging.

## Change

Minimal bidirectional tag join, no trace-context unification:

- Every outgoing Sentry event gets `otel_trace_id` and `otel_span_id` tags from the active OTel span (`beforeSend` for auto-captured errors, plus an Effect-aware capture helper for explicit captures).
- Explicit captures annotate the active OTel span with a `sentry.event_id` attribute for the reverse lookup.
- Scattered direct `Sentry.captureException` call sites migrated to the shared helper so they all carry the tags.
- DO-side captures stitch the worker-propagated trace parent, so session DO errors correlate too; paths with no active span leave the tags unset rather than inventing ids.

Full unification (Sentry adopting the OTel trace id as its own) was rejected: the app deliberately opts out of Sentry OTel mode and owns its tracer provider; Sentry Cloudflare OTel mode replaces the global provider and documents no support for custom context handling.

## Verification

- Unit tests for the tagging helpers.
- New e2e scenario (env-gated synthetic error route, only mounted when `SENTRY_OTEL_VERIFY=true` in the e2e stack) asserting the captured event id, trace id, and span id match between the Sentry payload and the exported span.
- Typecheck, cloud build, format all green.