### PR TITLE
Reconnect updates the existing DCR connection

### DIFF
--- a/e2e/selfhost/mcp-oauth-reconnect-duplicate.test.ts
+++ b/e2e/selfhost/mcp-oauth-reconnect-duplicate.test.ts
@@ -1,0 +1,289 @@
+import { randomBytes } from "node:crypto";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import type { HttpApiClient } from "effect/unstable/httpapi";
+import type { Page } from "playwright";
+import { composePluginApi } from "@executor-js/api/server";
+import { mcpHttpPlugin } from "@executor-js/plugin-mcp/api";
+import {
+  AuthTemplateSlug,
+  ConnectionName,
+  IntegrationSlug,
+  OAuthClientSlug,
+  type Owner,
+} from "@executor-js/sdk/shared";
+import { serveOAuthTestServer } from "@executor-js/sdk/testing";
+
+import { scenario } from "../src/scenario";
+import { Api, Browser, Target } from "../src/services";
+
+const api = composePluginApi([mcpHttpPlugin()] as const);
+type Client = HttpApiClient.ForApi<typeof api>;
+
+const owner: Owner = "user";
+const template = AuthTemplateSlug.make("oauth2");
+const seededName = ConnectionName.make("mcp-linear-app-oauth");
+const originalName = ConnectionName.make("mcpLinearAppOauth");
+const duplicateName = ConnectionName.make("mcplinearappoauth");
+const displayLabel = "mcpLinearAppOauth";
+
+const freshSlug = (prefix: string): string => `${prefix}-${randomBytes(4).toString("hex")}`;
+
+const connectionsSection = (page: Page) =>
+  page.locator("section").filter({
+    has: page.getByRole("heading", { level: 3, name: "Connections" }),
+  });
+
+const requiredRedirect = (response: Response, from: string): string => {
+  const location = response.headers.get("location");
+  if (!location) {
+    throw new Error(`Expected redirect from ${from}, got HTTP ${response.status}`);
+  }
+  return new URL(location, from).toString();
+};
+
+const completeAuthorizationHeadlessly = (authorizationUrl: string) =>
+  Effect.promise(async () => {
+    const login = await fetch(authorizationUrl, { redirect: "manual" });
+    const loginUrl = requiredRedirect(login, authorizationUrl);
+    const credentials = Buffer.from("alice:password").toString("base64");
+    const callback = await fetch(loginUrl, {
+      method: "POST",
+      headers: { authorization: `Basic ${credentials}` },
+      redirect: "manual",
+    });
+    const callbackUrl = requiredRedirect(callback, loginUrl);
+    const parsed = new URL(callbackUrl);
+    const code = parsed.searchParams.get("code");
+    if (!code) throw new Error(`OAuth callback did not include a code: ${callbackUrl}`);
+    return { code };
+  });
+
+const completePopupLogin = async (popup: Page): Promise<void> => {
+  await popup.waitForURL(/\/login\?transaction=/, { timeout: 30_000 });
+  await popup.setExtraHTTPHeaders({
+    authorization: `Basic ${Buffer.from("alice:password").toString("base64")}`,
+  });
+  const callbackResponse = popup.waitForResponse(
+    (response) => response.url().includes("/api/oauth/callback") && response.status() === 200,
+    { timeout: 30_000 },
+  );
+  await popup.evaluate(() => {
+    const form = document.createElement("form");
+    form.method = "POST";
+    form.action = window.location.href;
+    document.body.append(form);
+    form.submit();
+  });
+  await callbackResponse;
+};
+
+const listScenarioConnections = (client: Client, slug: IntegrationSlug) =>
+  client.connections.list({ query: { integration: slug, owner } });
+
+const summarizeConnections = (
+  rows: readonly {
+    readonly owner: Owner;
+    readonly name: ConnectionName;
+    readonly address: unknown;
+    readonly identityLabel: string | null;
+    readonly lastHealth: { readonly status: string } | null;
+  }[],
+): string =>
+  JSON.stringify(
+    rows.map((row) => ({
+      owner: row.owner,
+      name: String(row.name),
+      address: String(row.address),
+      identityLabel: row.identityLabel,
+      health: row.lastHealth?.status ?? null,
+    })),
+  );
+
+const seedExpiredDcrMcpOAuthConnection = (client: Client, prefix: string) =>
+  Effect.gen(function* () {
+    const oauth = yield* serveOAuthTestServer({
+      scopes: ["channels:history", "users:read"],
+      supportRefresh: false,
+      tokenExpiresInSeconds: 0,
+      invalidRefreshTokenDescription: "Grant not found",
+    });
+    const slug = IntegrationSlug.make(freshSlug(prefix));
+    const clientSlug = OAuthClientSlug.make(freshSlug(`${prefix}-client`));
+
+    yield* client.mcp.addServer({
+      payload: {
+        transport: "remote",
+        name: `DCR reconnect duplicate ${String(slug)}`,
+        endpoint: oauth.mcpResourceUrl,
+        slug: String(slug),
+        authenticationTemplate: [{ kind: "oauth2" }],
+      },
+    });
+    yield* Effect.addFinalizer(() =>
+      client.mcp.removeServer({ params: { slug } }).pipe(Effect.ignore),
+    );
+
+    const probe = yield* client.oauth.probe({ payload: { url: oauth.mcpResourceUrl } });
+    if (!probe.registrationEndpoint) {
+      return yield* Effect.die("OAuth probe did not discover a DCR registration endpoint");
+    }
+
+    const registered = yield* client.oauth.registerDynamic({
+      payload: {
+        owner,
+        slug: clientSlug,
+        issuer: probe.issuer ?? null,
+        registrationEndpoint: probe.registrationEndpoint,
+        authorizationUrl: probe.authorizationUrl,
+        tokenUrl: probe.tokenUrl,
+        resource: probe.resource ?? oauth.mcpResourceUrl,
+        scopes: probe.scopesSupported ?? [],
+        tokenEndpointAuthMethodsSupported: probe.tokenEndpointAuthMethodsSupported,
+        clientName: "Executor e2e MCP OAuth reconnect duplicate",
+        originIntegration: slug,
+      },
+    });
+    yield* Effect.addFinalizer(() =>
+      client.oauth
+        .removeClient({ params: { slug: registered.client }, payload: { owner } })
+        .pipe(Effect.ignore),
+    );
+
+    const started = yield* client.oauth.start({
+      payload: {
+        owner,
+        client: registered.client,
+        clientOwner: owner,
+        name: seededName,
+        integration: slug,
+        template,
+        identityLabel: displayLabel,
+      },
+    });
+    expect(started.status, "DCR MCP OAuth starts an authorization-code redirect").toBe("redirect");
+    if (started.status !== "redirect") return yield* Effect.die("OAuth start did not redirect");
+
+    const callback = yield* completeAuthorizationHeadlessly(started.authorizationUrl);
+    yield* client.oauth.complete({ payload: { state: started.state, code: callback.code } });
+    yield* Effect.addFinalizer(() =>
+      Effect.all(
+        [
+          client.connections
+            .remove({ params: { owner, integration: slug, name: originalName } })
+            .pipe(Effect.ignore),
+          client.connections
+            .remove({ params: { owner, integration: slug, name: duplicateName } })
+            .pipe(Effect.ignore),
+        ],
+        { concurrency: "unbounded" },
+      ).pipe(Effect.ignore),
+    );
+
+    const initial = yield* listScenarioConnections(client, slug);
+    console.info(`[DCR duplicate repro] initial API connections: ${summarizeConnections(initial)}`);
+    expect(initial.map((connection) => String(connection.name))).toEqual([String(originalName)]);
+
+    const health = yield* client.connections.checkHealth({
+      params: { owner, integration: slug, name: originalName },
+      query: {},
+    });
+    expect(health.status, "the seed connection is expired before reconnect").toBe("expired");
+    yield* oauth.clearRequests;
+
+    return { oauth, slug };
+  });
+
+const oauthRequestSummary = (
+  requests: readonly { readonly method: string; readonly path: string }[],
+) => requests.map((request) => `${request.method} ${request.path}`).join(", ");
+
+scenario(
+  "MCP OAuth reconnect updates the existing DCR connection",
+  {
+    timeout: 180_000,
+    expectedFailure:
+      "DCR reconnect currently remints mcpLinearAppOauth as mcplinearappoauth and leaves the expired row behind.",
+  },
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const browser = yield* Browser;
+      const { client: makeApiClient } = yield* Api;
+      const identity = yield* target.newIdentity();
+      const client = yield* makeApiClient(api, identity);
+      const { oauth, slug } = yield* seedExpiredDcrMcpOAuthConnection(
+        client,
+        "mcp-dcr-reconnect-duplicate",
+      );
+
+      let uiRowCount = -1;
+      let uiLabelCount = -1;
+      let uiExpiredCount = -1;
+
+      yield* browser.session(identity, async ({ page, step }) => {
+        const connections = connectionsSection(page);
+        const menuTrigger = connections.locator('button[aria-haspopup="menu"]').first();
+
+        await step("Open the integration with one expired OAuth connection", async () => {
+          await page.goto(`/integrations/${slug}`, { waitUntil: "networkidle" });
+          await connections.getByText(displayLabel, { exact: true }).waitFor({ timeout: 30_000 });
+          await connections.getByLabel("Status: Expired").waitFor({ timeout: 30_000 });
+          expect(
+            await connections.locator('button[aria-haspopup="menu"]').count(),
+            "the UI starts with one connection row",
+          ).toBe(1);
+        });
+
+        await step("Reconnect and complete the OAuth popup", async () => {
+          const popupPromise = page.waitForEvent("popup", { timeout: 30_000 });
+          await menuTrigger.click();
+          await page.getByRole("menuitem", { name: "Reconnect" }).click();
+          const popup = await popupPromise;
+          await completePopupLogin(popup);
+          await page.getByText("Reconnected", { exact: true }).waitFor({ timeout: 30_000 });
+          await page.getByRole("dialog").waitFor({ state: "hidden", timeout: 30_000 });
+        });
+
+        await step("Read the connection list after reconnect", async () => {
+          await page.goto(`/integrations/${slug}`, { waitUntil: "networkidle" });
+          await connections
+            .getByText(displayLabel, { exact: true })
+            .first()
+            .waitFor({ timeout: 30_000 });
+          uiRowCount = await connections.locator('button[aria-haspopup="menu"]').count();
+          uiLabelCount = await connections.getByText(displayLabel, { exact: true }).count();
+          uiExpiredCount = await connections.getByLabel("Status: Expired").count();
+          console.info(
+            `[DCR duplicate repro] UI rows=${uiRowCount} labels=${uiLabelCount} expired=${uiExpiredCount}`,
+          );
+        });
+      });
+
+      const requests = yield* oauth.requests;
+      console.info(`[DCR duplicate repro] OAuth server requests: ${oauthRequestSummary(requests)}`);
+
+      const after = yield* listScenarioConnections(client, slug);
+      console.info(`[DCR duplicate repro] after API connections: ${summarizeConnections(after)}`);
+
+      expect(after, "API list should contain exactly one connection after reconnect").toHaveLength(
+        1,
+      );
+      expect(String(after[0]?.name), "Reconnect should preserve the original connection name").toBe(
+        String(originalName),
+      );
+      expect(
+        String(after[0]?.address),
+        "Reconnect should preserve the original connection address",
+      ).toContain(`.${String(originalName)}`);
+      expect(
+        after[0]?.lastHealth?.status,
+        "Reconnect should clear the expired health state",
+      ).not.toBe("expired");
+      expect(uiRowCount, "UI list should contain exactly one connection row").toBe(1);
+      expect(uiLabelCount, "UI list should show the original connection label once").toBe(1);
+      expect(uiExpiredCount, "UI list should not show an expired row after reconnect").toBe(0);
+    }),
+  ),
+);

--- a/e2e/selfhost/mcp-oauth-reconnect-duplicate.test.ts
+++ b/e2e/selfhost/mcp-oauth-reconnect-duplicate.test.ts
@@ -105,7 +105,6 @@ const seedExpiredDcrMcpOAuthConnection = (client: Client, prefix: string) =>
   Effect.gen(function* () {
     const oauth = yield* serveOAuthTestServer({
       scopes: ["channels:history", "users:read"],
-      supportRefresh: false,
       tokenExpiresInSeconds: 0,
       invalidRefreshTokenDescription: "Grant not found",
     });
@@ -167,6 +166,7 @@ const seedExpiredDcrMcpOAuthConnection = (client: Client, prefix: string) =>
 
     const callback = yield* completeAuthorizationHeadlessly(started.authorizationUrl);
     yield* client.oauth.complete({ payload: { state: started.state, code: callback.code } });
+    yield* oauth.clearRefreshTokens;
     yield* Effect.addFinalizer(() =>
       Effect.all(
         [
@@ -200,11 +200,37 @@ const oauthRequestSummary = (
 ) => requests.map((request) => `${request.method} ${request.path}`).join(", ");
 
 scenario(
+  "MCP OAuth add creates one normalized DCR connection",
+  {
+    timeout: 180_000,
+  },
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const { client: makeApiClient } = yield* Api;
+      const identity = yield* target.newIdentity();
+      const client = yield* makeApiClient(api, identity);
+      const { slug } = yield* seedExpiredDcrMcpOAuthConnection(client, "mcp-dcr-add-normalize");
+
+      const rows = yield* listScenarioConnections(client, slug);
+      console.info(`[DCR add regression] API connections: ${summarizeConnections(rows)}`);
+
+      expect(rows, "DCR add should create exactly one connection").toHaveLength(1);
+      expect(String(rows[0]?.name), "DCR add should keep create normalization unchanged").toBe(
+        String(originalName),
+      );
+      expect(
+        rows.map((connection) => String(connection.name)),
+        "DCR add should not create the reconnect-only lower-case duplicate",
+      ).not.toContain(String(duplicateName));
+    }),
+  ),
+);
+
+scenario(
   "MCP OAuth reconnect updates the existing DCR connection",
   {
     timeout: 180_000,
-    expectedFailure:
-      "DCR reconnect currently remints mcpLinearAppOauth as mcplinearappoauth and leaves the expired row behind.",
   },
   Effect.scoped(
     Effect.gen(function* () {
@@ -247,7 +273,7 @@ scenario(
         });
 
         await step("Read the connection list after reconnect", async () => {
-          await page.goto(`/integrations/${slug}`, { waitUntil: "networkidle" });
+          await page.goto(`/integrations/${slug}`, { waitUntil: "domcontentloaded" });
           await connections
             .getByText(displayLabel, { exact: true })
             .first()

--- a/e2e/selfhost/mcp-oauth-reconnect-stale-health.test.ts
+++ b/e2e/selfhost/mcp-oauth-reconnect-stale-health.test.ts
@@ -1,0 +1,272 @@
+import { randomBytes } from "node:crypto";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import type { HttpApiClient } from "effect/unstable/httpapi";
+import type { Page } from "playwright";
+import { composePluginApi } from "@executor-js/api/server";
+import { mcpHttpPlugin } from "@executor-js/plugin-mcp/api";
+import {
+  AuthTemplateSlug,
+  ConnectionName,
+  IntegrationSlug,
+  OAuthClientSlug,
+  type Owner,
+} from "@executor-js/sdk/shared";
+import { serveOAuthTestServer } from "@executor-js/sdk/testing";
+
+import { scenario } from "../src/scenario";
+import { Api, Browser, Target } from "../src/services";
+
+const api = composePluginApi([mcpHttpPlugin()] as const);
+type Client = HttpApiClient.ForApi<typeof api>;
+
+const owner: Owner = "user";
+const template = AuthTemplateSlug.make("oauth2");
+const seededName = ConnectionName.make("mcp-linear-app-oauth");
+const originalName = ConnectionName.make("mcpLinearAppOauth");
+const duplicateName = ConnectionName.make("mcplinearappoauth");
+const displayLabel = "mcpLinearAppOauth";
+
+const freshSlug = (prefix: string): string => `${prefix}-${randomBytes(4).toString("hex")}`;
+
+const requiredRedirect = (response: Response, from: string): string => {
+  const location = response.headers.get("location");
+  if (!location) {
+    throw new Error(`Expected redirect from ${from}, got HTTP ${response.status}`);
+  }
+  return new URL(location, from).toString();
+};
+
+const completeAuthorizationHeadlessly = (authorizationUrl: string) =>
+  Effect.promise(async () => {
+    const login = await fetch(authorizationUrl, { redirect: "manual" });
+    const loginUrl = requiredRedirect(login, authorizationUrl);
+    const credentials = Buffer.from("alice:password").toString("base64");
+    const callback = await fetch(loginUrl, {
+      method: "POST",
+      headers: { authorization: `Basic ${credentials}` },
+      redirect: "manual",
+    });
+    const callbackUrl = requiredRedirect(callback, loginUrl);
+    const parsed = new URL(callbackUrl);
+    const code = parsed.searchParams.get("code");
+    if (!code) throw new Error(`OAuth callback did not include a code: ${callbackUrl}`);
+    return { code };
+  });
+
+const completePopupLogin = async (popup: Page): Promise<void> => {
+  await popup.waitForURL(/\/login\?transaction=/, { timeout: 30_000 });
+  await popup.setExtraHTTPHeaders({
+    authorization: `Basic ${Buffer.from("alice:password").toString("base64")}`,
+  });
+  const callbackResponse = popup.waitForResponse(
+    (response) => response.url().includes("/api/oauth/callback") && response.status() === 200,
+    { timeout: 30_000 },
+  );
+  await popup.evaluate(() => {
+    const form = document.createElement("form");
+    form.method = "POST";
+    form.action = window.location.href;
+    document.body.append(form);
+    form.submit();
+  });
+  await callbackResponse;
+};
+
+const listScenarioConnections = (client: Client, slug: IntegrationSlug) =>
+  client.connections.list({ query: { integration: slug, owner } });
+
+const summarizeConnections = (
+  rows: readonly {
+    readonly owner: Owner;
+    readonly name: ConnectionName;
+    readonly address: unknown;
+    readonly identityLabel: string | null;
+    readonly lastHealth: { readonly status: string } | null;
+  }[],
+): string =>
+  JSON.stringify(
+    rows.map((row) => ({
+      owner: row.owner,
+      name: String(row.name),
+      address: String(row.address),
+      identityLabel: row.identityLabel,
+      health: row.lastHealth?.status ?? null,
+    })),
+  );
+
+const seedExpiredDcrMcpOAuthConnection = (client: Client, prefix: string) =>
+  Effect.gen(function* () {
+    const oauth = yield* serveOAuthTestServer({
+      scopes: ["channels:history", "users:read"],
+      tokenExpiresInSeconds: 0,
+      invalidRefreshTokenDescription: "Grant not found",
+    });
+    const slug = IntegrationSlug.make(freshSlug(prefix));
+    const clientSlug = OAuthClientSlug.make(freshSlug(`${prefix}-client`));
+
+    yield* client.mcp.addServer({
+      payload: {
+        transport: "remote",
+        name: `DCR reconnect stale health ${String(slug)}`,
+        endpoint: oauth.mcpResourceUrl,
+        slug: String(slug),
+        authenticationTemplate: [{ kind: "oauth2" }],
+      },
+    });
+    yield* Effect.addFinalizer(() =>
+      client.mcp.removeServer({ params: { slug } }).pipe(Effect.ignore),
+    );
+
+    const probe = yield* client.oauth.probe({ payload: { url: oauth.mcpResourceUrl } });
+    if (!probe.registrationEndpoint) {
+      return yield* Effect.die("OAuth probe did not discover a DCR registration endpoint");
+    }
+
+    const registered = yield* client.oauth.registerDynamic({
+      payload: {
+        owner,
+        slug: clientSlug,
+        issuer: probe.issuer ?? null,
+        registrationEndpoint: probe.registrationEndpoint,
+        authorizationUrl: probe.authorizationUrl,
+        tokenUrl: probe.tokenUrl,
+        resource: probe.resource ?? oauth.mcpResourceUrl,
+        scopes: probe.scopesSupported ?? [],
+        tokenEndpointAuthMethodsSupported: probe.tokenEndpointAuthMethodsSupported,
+        clientName: "Executor e2e MCP OAuth reconnect stale health",
+        originIntegration: slug,
+      },
+    });
+    yield* Effect.addFinalizer(() =>
+      client.oauth
+        .removeClient({ params: { slug: registered.client }, payload: { owner } })
+        .pipe(Effect.ignore),
+    );
+
+    const started = yield* client.oauth.start({
+      payload: {
+        owner,
+        client: registered.client,
+        clientOwner: owner,
+        name: seededName,
+        integration: slug,
+        template,
+        identityLabel: displayLabel,
+      },
+    });
+    expect(started.status, "DCR MCP OAuth starts an authorization-code redirect").toBe("redirect");
+    if (started.status !== "redirect") return yield* Effect.die("OAuth start did not redirect");
+
+    const callback = yield* completeAuthorizationHeadlessly(started.authorizationUrl);
+    yield* client.oauth.complete({ payload: { state: started.state, code: callback.code } });
+    yield* oauth.clearRefreshTokens;
+    yield* Effect.addFinalizer(() =>
+      Effect.all(
+        [
+          client.connections
+            .remove({ params: { owner, integration: slug, name: originalName } })
+            .pipe(Effect.ignore),
+          client.connections
+            .remove({ params: { owner, integration: slug, name: duplicateName } })
+            .pipe(Effect.ignore),
+        ],
+        { concurrency: "unbounded" },
+      ).pipe(Effect.ignore),
+    );
+
+    const initial = yield* listScenarioConnections(client, slug);
+    expect(initial.map((connection) => String(connection.name))).toEqual([String(originalName)]);
+
+    const health = yield* client.connections.checkHealth({
+      params: { owner, integration: slug, name: originalName },
+      query: {},
+    });
+    expect(health.status, "the seed connection is expired before reconnect").toBe("expired");
+    yield* oauth.clearRequests;
+
+    return { slug };
+  });
+
+const openConnectionMenu = async (page: Page): Promise<void> => {
+  await page.getByText(displayLabel, { exact: true }).hover();
+  const buttons = page.getByRole("button");
+  const count = await buttons.count();
+  for (let index = 0; index < count; index++) {
+    const button = buttons.nth(index);
+    const text = ((await button.textContent().catch(() => null)) ?? "").trim();
+    if (text === "Add connection") continue;
+    await button.click({ timeout: 1_000 }).catch(() => {});
+    if (
+      await page
+        .getByRole("menuitem", { name: "Reconnect" })
+        .isVisible()
+        .catch(() => false)
+    ) {
+      return;
+    }
+    await page.keyboard.press("Escape").catch(() => {});
+  }
+  throw new Error("Could not open the connection row menu");
+};
+
+scenario(
+  "MCP OAuth reconnect clears an expired row without a page reload",
+  {
+    timeout: 180_000,
+    expectedFailure:
+      "OAuth reconnect clears server-side health, but the mounted account row keeps its stale Expired badge until the route reloads.",
+  },
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const browser = yield* Browser;
+      const { client: makeApiClient } = yield* Api;
+      const identity = yield* target.newIdentity();
+      const client = yield* makeApiClient(api, identity);
+      const { slug } = yield* seedExpiredDcrMcpOAuthConnection(
+        client,
+        "mcp-dcr-reconnect-stale-health",
+      );
+
+      yield* browser.session(identity, async ({ page, step }) => {
+        await step("Open the integration with an expired OAuth connection", async () => {
+          await page.goto(`/integrations/${slug}`, { waitUntil: "networkidle" });
+          await page.getByText(displayLabel, { exact: true }).waitFor({ timeout: 30_000 });
+          await page.getByLabel("Status: Expired", { exact: true }).waitFor({
+            timeout: 30_000,
+          });
+          await page.getByText("Expired", { exact: true }).waitFor({ timeout: 30_000 });
+        });
+
+        await step("Reconnect and complete the OAuth popup", async () => {
+          const popupPromise = page.waitForEvent("popup", { timeout: 30_000 });
+          await openConnectionMenu(page);
+          await page.getByRole("menuitem", { name: "Reconnect" }).click();
+          const popup = await popupPromise;
+          await completePopupLogin(popup);
+          await page.getByText("Reconnected", { exact: true }).waitFor({ timeout: 30_000 });
+          await page.getByRole("dialog").waitFor({ state: "hidden", timeout: 30_000 });
+        });
+
+        const rows = await Effect.runPromise(listScenarioConnections(client, slug));
+        console.info(`[stale health repro] API after reconnect: ${summarizeConnections(rows)}`);
+        expect(rows, "API list should still contain one connection after reconnect").toHaveLength(
+          1,
+        );
+        expect(
+          rows[0]?.lastHealth?.status,
+          "server-side reconnect should clear the expired health state",
+        ).not.toBe("expired");
+
+        await step("The mounted row should clear Expired without reload", async () => {
+          await page.getByLabel("Status: Expired", { exact: true }).waitFor({
+            state: "hidden",
+            timeout: 10_000,
+          });
+        });
+      });
+    }),
+  ),
+);

--- a/e2e/selfhost/mcp-oauth-reconnect-stale-health.test.ts
+++ b/e2e/selfhost/mcp-oauth-reconnect-stale-health.test.ts
@@ -215,8 +215,6 @@ scenario(
   "MCP OAuth reconnect clears an expired row without a page reload",
   {
     timeout: 180_000,
-    expectedFailure:
-      "OAuth reconnect clears server-side health, but the mounted account row keeps its stale Expired badge until the route reloads.",
   },
   Effect.scoped(
     Effect.gen(function* () {

--- a/packages/core/api/src/handlers/oauth.ts
+++ b/packages/core/api/src/handlers/oauth.ts
@@ -160,6 +160,7 @@ export const OAuthHandlers = HttpApiBuilder.group(ExecutorApi, "oauth", (handler
             integration: payload.integration,
             template: payload.template,
             identityLabel: payload.identityLabel,
+            reconnectRef: payload.reconnectRef ?? null,
             redirectUri: payload.redirectUri,
           });
           return startResultToResponse(result);

--- a/packages/core/api/src/oauth/api.ts
+++ b/packages/core/api/src/oauth/api.ts
@@ -159,6 +159,15 @@ const StartPayload = Schema.Struct({
   integration: IntegrationSlug,
   template: AuthTemplateSlug,
   identityLabel: Schema.optional(Schema.NullOr(Schema.String)),
+  reconnectRef: Schema.optional(
+    Schema.NullOr(
+      Schema.Struct({
+        owner: Owner,
+        integration: IntegrationSlug,
+        name: ConnectionName,
+      }),
+    ),
+  ),
   redirectUri: Schema.optional(Schema.NullOr(Schema.String)),
 });
 

--- a/packages/core/sdk/src/client.ts
+++ b/packages/core/sdk/src/client.ts
@@ -124,6 +124,12 @@ export interface IntegrationAccountHandoff {
   readonly label?: string;
   /** Existing display identity to preserve when reconnecting a saved row. */
   readonly identityLabel?: string;
+  /** Exact saved connection row to update when the handoff is a reconnect. */
+  readonly reconnectRef?: {
+    readonly owner: "org" | "user";
+    readonly integration: string;
+    readonly name: string;
+  };
   /** Present when the agent handed off a CONFIDENTIAL OAuth-app registration
    *  (via `oauth.clients.createHandoff`) or when a saved OAuth connection is
    *  reconnecting through its stored app. Registration opens the

--- a/packages/core/sdk/src/core-tools.ts
+++ b/packages/core/sdk/src/core-tools.ts
@@ -308,6 +308,7 @@ const OAuthStartInput = Schema.Struct({
   integration: Schema.String,
   template: Schema.String,
   identityLabel: Schema.optional(Schema.NullOr(Schema.String)),
+  reconnectRef: Schema.optional(Schema.NullOr(ConnectionRefInput)),
   redirectUri: Schema.optional(Schema.NullOr(Schema.String)),
 });
 const OAuthStartOutput = Schema.Union([
@@ -836,6 +837,8 @@ export const coreToolsPlugin = definePlugin((options: CoreToolsPluginOptions = {
                 integration: IntegrationSlug.make(input.integration),
                 template: AuthTemplateSlug.make(input.template),
                 identityLabel: input.identityLabel,
+                reconnectRef:
+                  input.reconnectRef == null ? null : connectionRefFromInput(input.reconnectRef),
                 redirectUri: input.redirectUri,
               }),
               (result) =>

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -2354,23 +2354,26 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
       input: MintOAuthConnectionInput,
     ): Effect.Effect<Connection, StorageFailure> =>
       Effect.gen(function* () {
-        const name = connectionIdentifier(String(input.name));
-        yield* requireUserSubject(input.owner);
-        const integrationRow = yield* findIntegrationRow(input.integration);
+        const reconnectRef = input.reconnectRef ?? null;
+        const name = reconnectRef?.name ?? connectionIdentifier(String(input.name));
+        const owner = reconnectRef?.owner ?? input.owner;
+        const integration = reconnectRef?.integration ?? input.integration;
+        yield* requireUserSubject(owner);
+        const integrationRow = yield* findIntegrationRow(integration);
         if (!integrationRow) {
           return yield* new StorageError({
-            message: `Integration not found: ${input.integration}`,
+            message: `Integration not found: ${integration}`,
             cause: undefined,
           });
         }
         const keys = yield* Effect.try({
-          try: () => ownedKeys(input.owner),
+          try: () => ownedKeys(owner),
           catch: (cause) => storageFailureFromUnknown("invalid owner", cause),
         });
         const now = new Date();
         const ref: ConnectionRef = {
-          owner: input.owner,
-          integration: input.integration,
+          owner,
+          integration,
           name,
         };
         yield* transaction(
@@ -2387,24 +2390,30 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
               expires_at: input.expiresAt,
               oauth_scope: input.oauthScope,
               oauth_token_url: input.oauthTokenUrl ?? null,
+              last_health: null,
               updated_at: now,
             };
             if (existing) {
               yield* core.updateMany("connection", {
                 where: (b: AnyCb) =>
                   b.and(
-                    byOwner(input.owner)(b),
-                    b("integration", "=", String(input.integration)),
+                    byOwner(owner)(b),
+                    b("integration", "=", String(integration)),
                     b("name", "=", String(name)),
                   ),
                 set,
+              });
+            } else if (reconnectRef !== null) {
+              return yield* new StorageError({
+                message: `Connection no longer exists for reconnect: ${owner}/${String(integration)}/${String(name)}`,
+                cause: undefined,
               });
             } else {
               yield* core.create("connection", {
                 tenant: keys.tenant,
                 owner: keys.owner,
                 subject: keys.subject,
-                integration: String(input.integration),
+                integration: String(integration),
                 name: String(name),
                 template: String(input.template),
                 provider: input.provider,
@@ -2440,7 +2449,7 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
               tenant: keys.tenant,
               owner: keys.owner,
               subject: keys.subject,
-              integration: String(input.integration),
+              integration: String(integration),
               name: String(name),
               template: String(input.template),
               provider: input.provider,
@@ -3607,6 +3616,7 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
       ownedKeys: (owner: Owner) => ownedKeys(owner),
       defaultWritableProvider,
       mintOAuthConnection: (input: MintOAuthConnectionInput) => mintOAuthConnection(input),
+      findConnection: (ref: ConnectionRef) => connectionsGet(ref),
       // One integration-row read + one projector run. Resolve the method this
       // template selects exactly as the runtime's `selectAuthMethod` does —
       // exact slug match, else the sole declared method (single-method

--- a/packages/core/sdk/src/oauth-client.ts
+++ b/packages/core/sdk/src/oauth-client.ts
@@ -1,7 +1,7 @@
 import type { Effect } from "effect";
 import { Schema } from "effect";
 
-import type { Connection } from "./connection";
+import type { Connection, ConnectionRef } from "./connection";
 import type { StorageFailure } from "./fuma-runtime";
 import {
   type AuthTemplateSlug,
@@ -122,6 +122,8 @@ export interface OAuthStartInput {
   readonly integration: IntegrationSlug;
   readonly template: AuthTemplateSlug;
   readonly identityLabel?: string | null;
+  /** Exact existing row to update when this flow is a reconnect. */
+  readonly reconnectRef?: ConnectionRef | null;
   /** Browser-facing callback URL for this flow. Defaults to the executor's configured redirectUri. */
   readonly redirectUri?: string | null;
 }

--- a/packages/core/sdk/src/oauth-flow.test.ts
+++ b/packages/core/sdk/src/oauth-flow.test.ts
@@ -10,6 +10,7 @@ import {
   ToolAddress,
   ToolName,
 } from "./ids";
+import type { FumaDb } from "./fuma-runtime";
 import { decodeOAuthCallbackState } from "./oauth";
 import { OAuthStartError } from "./oauth-client";
 import { definePlugin } from "./plugin";
@@ -23,6 +24,7 @@ import { serveOAuthTestServer } from "./testing/oauth-test-server";
 const INTEG = IntegrationSlug.make("acme");
 const TEMPLATE = AuthTemplateSlug.make("oauth");
 const CLIENT = OAuthClientSlug.make("acme-app");
+const ORG_SUBJECT = "";
 
 const oauthPlugin = definePlugin(() => ({
   id: "acme" as const,
@@ -61,6 +63,41 @@ const oauthPlugin = definePlugin(() => ({
 }))();
 
 const plugins = [memoryCredentialsPlugin(), oauthPlugin] as const;
+
+const seedExistingOAuthConnection = (
+  db: FumaDb,
+  input: {
+    readonly tenant: string;
+    readonly name: ConnectionName;
+    readonly lastHealth?: unknown;
+  },
+): Effect.Effect<void> =>
+  Effect.promise(() => {
+    const now = new Date();
+    return db.create("connection", {
+      tenant: input.tenant,
+      owner: "org",
+      subject: ORG_SUBJECT,
+      integration: String(INTEG),
+      name: String(input.name),
+      template: String(TEMPLATE),
+      provider: "memory",
+      item_ids: { token: "old-token-item" },
+      identity_label: "Mixed case account",
+      description: "preserve this note",
+      last_health: input.lastHealth ?? null,
+      tools_synced_at: null,
+      oauth_client: String(CLIENT),
+      oauth_client_owner: "org",
+      refresh_item_id: "old-refresh-item",
+      expires_at: Date.now() - 60_000,
+      oauth_scope: "old",
+      oauth_token_url: null,
+      provider_state: null,
+      created_at: now,
+      updated_at: now,
+    });
+  }).pipe(Effect.asVoid);
 
 interface TokenEndpointCall {
   readonly host: string;
@@ -190,6 +227,192 @@ describe("oauth.start / oauth.complete", () => {
           expect(yield* server.acceptsAccessToken(out.token)).toBe(true);
         }),
       ),
+  );
+
+  it.effect("complete with reconnectRef updates the exact existing row in place", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const server = yield* serveOAuthTestServer({ scopes: ["read"] });
+        const { executor, config, tenant } = yield* makeTestWorkspaceHarness({ plugins });
+        yield* executor.acme.seed();
+
+        yield* executor.oauth.createClient({
+          owner: "org",
+          slug: CLIENT,
+          authorizationUrl: server.authorizationEndpoint,
+          tokenUrl: server.tokenEndpoint,
+          grant: "authorization_code",
+          clientId: "test-client",
+          clientSecret: "test-secret",
+          resource: server.mcpResourceUrl,
+        });
+
+        const originalName = ConnectionName.make("mcpLinearAppOauth");
+        const reconnectRef = { owner: "org" as const, integration: INTEG, name: originalName };
+        yield* seedExistingOAuthConnection(config.db, {
+          tenant,
+          name: originalName,
+          lastHealth: { status: "expired", checkedAt: Date.now() - 60_000 },
+        });
+
+        const started = yield* executor.oauth.start({
+          owner: "org",
+          client: CLIENT,
+          clientOwner: "org",
+          name: originalName,
+          integration: INTEG,
+          template: TEMPLATE,
+          identityLabel: "Mixed case account",
+          reconnectRef,
+        });
+        expect(started.status).toBe("redirect");
+        if (started.status !== "redirect") return;
+
+        const callback = yield* server.completeAuthorizationCodeFlow({
+          authorizationUrl: started.authorizationUrl,
+        });
+        const connection = yield* executor.oauth.complete({
+          state: started.state,
+          code: callback.code,
+        });
+
+        expect(String(connection.name)).toBe("mcpLinearAppOauth");
+        expect(String(connection.address)).toBe("tools.acme.org.mcpLinearAppOauth");
+        expect(connection.lastHealth).toBeNull();
+
+        const rows = yield* Effect.promise(() =>
+          config.db.findMany("connection", {
+            where: (b) => b("integration", "=", String(INTEG)),
+          }),
+        );
+        expect(rows.map((row) => row.name)).toEqual(["mcpLinearAppOauth"]);
+        expect(rows[0]?.description).toBe("preserve this note");
+
+        const token = (yield* executor.execute(
+          ToolAddress.make("tools.acme.org.mcpLinearAppOauth.whoami"),
+          {},
+        )) as { token: string };
+        expect(token.token).toMatch(/^at_/);
+      }),
+    ),
+  );
+
+  it.effect("complete with a deleted reconnectRef fails instead of creating", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const server = yield* serveOAuthTestServer({ scopes: ["read"] });
+        const { executor, config, tenant } = yield* makeTestWorkspaceHarness({ plugins });
+        yield* executor.acme.seed();
+
+        yield* executor.oauth.createClient({
+          owner: "org",
+          slug: CLIENT,
+          authorizationUrl: server.authorizationEndpoint,
+          tokenUrl: server.tokenEndpoint,
+          grant: "authorization_code",
+          clientId: "test-client",
+          clientSecret: "test-secret",
+          resource: server.mcpResourceUrl,
+        });
+
+        const originalName = ConnectionName.make("mcpLinearAppOauth");
+        const reconnectRef = { owner: "org" as const, integration: INTEG, name: originalName };
+        yield* seedExistingOAuthConnection(config.db, { tenant, name: originalName });
+
+        const started = yield* executor.oauth.start({
+          owner: "org",
+          client: CLIENT,
+          clientOwner: "org",
+          name: originalName,
+          integration: INTEG,
+          template: TEMPLATE,
+          reconnectRef,
+        });
+        expect(started.status).toBe("redirect");
+        if (started.status !== "redirect") return;
+
+        yield* Effect.promise(() =>
+          config.db.deleteMany("connection", {
+            where: (b) =>
+              b.and(
+                b("owner", "=", "org"),
+                b("subject", "=", ORG_SUBJECT),
+                b("integration", "=", String(INTEG)),
+                b("name", "=", String(originalName)),
+              ),
+          }),
+        );
+
+        const callback = yield* server.completeAuthorizationCodeFlow({
+          authorizationUrl: started.authorizationUrl,
+        });
+        const error = yield* Effect.flip(
+          executor.oauth.complete({
+            state: started.state,
+            code: callback.code,
+          }),
+        );
+
+        expect(Predicate.isTagged("OAuthCompleteError")(error)).toBe(true);
+        expect(error).toMatchObject({
+          message: expect.stringContaining("Connection no longer exists for reconnect"),
+        });
+        const rows = yield* Effect.promise(() =>
+          config.db.findMany("connection", {
+            where: (b) => b("integration", "=", String(INTEG)),
+          }),
+        );
+        expect(rows).toHaveLength(0);
+      }),
+    ),
+  );
+
+  it.effect("complete without reconnectRef still normalizes create names", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const server = yield* serveOAuthTestServer({ scopes: ["read"] });
+        const { executor, config } = yield* makeTestWorkspaceHarness({ plugins });
+        yield* executor.acme.seed();
+
+        yield* executor.oauth.createClient({
+          owner: "org",
+          slug: CLIENT,
+          authorizationUrl: server.authorizationEndpoint,
+          tokenUrl: server.tokenEndpoint,
+          grant: "authorization_code",
+          clientId: "test-client",
+          clientSecret: "test-secret",
+          resource: server.mcpResourceUrl,
+        });
+
+        const started = yield* executor.oauth.start({
+          owner: "org",
+          client: CLIENT,
+          clientOwner: "org",
+          name: ConnectionName.make("mcpLinearAppOauth"),
+          integration: INTEG,
+          template: TEMPLATE,
+        });
+        expect(started.status).toBe("redirect");
+        if (started.status !== "redirect") return;
+
+        const callback = yield* server.completeAuthorizationCodeFlow({
+          authorizationUrl: started.authorizationUrl,
+        });
+        const connection = yield* executor.oauth.complete({
+          state: started.state,
+          code: callback.code,
+        });
+
+        expect(String(connection.name)).toBe("mcplinearappoauth");
+        const rows = yield* Effect.promise(() =>
+          config.db.findMany("connection", {
+            where: (b) => b("integration", "=", String(INTEG)),
+          }),
+        );
+        expect(rows.map((row) => row.name)).toEqual(["mcplinearappoauth"]);
+      }),
+    ),
   );
 
   it.effect("carries the URL org selector in provider state without changing redirect_uri", () =>

--- a/packages/core/sdk/src/oauth-service.ts
+++ b/packages/core/sdk/src/oauth-service.ts
@@ -17,7 +17,7 @@
 import { Duration, Effect, Layer, Option, Schema } from "effect";
 import { FetchHttpClient, type HttpClient } from "effect/unstable/http";
 
-import type { Connection } from "./connection";
+import type { Connection, ConnectionRef } from "./connection";
 import type { IFumaClient, StorageFailure } from "./fuma-runtime";
 import { StorageError } from "./fuma-runtime";
 import {
@@ -91,6 +91,8 @@ export interface MintOAuthConnectionInput {
   readonly refreshItemId: string | null;
   readonly expiresAt: number | null;
   readonly oauthScope: string | null;
+  /** Exact existing row to update. When present, minting must never create. */
+  readonly reconnectRef?: ConnectionRef | null;
   /** Per-connection override for the token endpoint, persisted only when the
    *  code was redeemed at a region other than the client's configured token
    *  host (Datadog multi-site). Null means refresh uses the client's token URL. */
@@ -125,6 +127,8 @@ export interface OAuthServiceDeps {
   readonly mintOAuthConnection: (
     input: MintOAuthConnectionInput,
   ) => Effect.Effect<Connection, StorageFailure>;
+  /** Load one saved connection by exact identity before reconnect token exchange. */
+  readonly findConnection: (ref: ConnectionRef) => Effect.Effect<Connection | null, StorageFailure>;
   /**
    * Resolve the OAuth scope policy for a `(integration, template)`:
    *  - `{ kind: "scopes", scopes }`: the scopes the integration's auth template
@@ -205,16 +209,18 @@ const recordedOAuthScope = (
 
 const decodeJsonPayload = Schema.decodeUnknownOption(Schema.UnknownFromJsonString);
 
+const decodeSessionPayload = (payload: unknown): unknown =>
+  typeof payload === "string"
+    ? decodeJsonPayload(payload).pipe(Option.getOrElse(() => payload))
+    : payload;
+
 /** Extract the persisted `requestedScopes` from an `oauth_session.payload`. The
  *  jsonColumn may surface as a parsed object (in-memory backends) or a JSON
  *  string (serialized backends); decode strings before reading. Returns `null`
  *  for legacy sessions written before `requestedScopes` was persisted, so
  *  `complete` can fall back to the client's scopes. */
 const requestedScopesFromPayload = (payload: unknown): readonly string[] | null => {
-  const decoded =
-    typeof payload === "string"
-      ? decodeJsonPayload(payload).pipe(Option.getOrElse(() => payload))
-      : payload;
+  const decoded = decodeSessionPayload(payload);
   if (decoded === null || typeof decoded !== "object") return null;
   const value = (decoded as Record<string, unknown>).requestedScopes;
   return Array.isArray(value) ? value.filter((s): s is string => typeof s === "string") : null;
@@ -224,14 +230,42 @@ const requestedScopesFromPayload = (payload: unknown): readonly string[] | null 
  *  (same-owner connects, or sessions written before this field), so `complete`
  *  falls back to the session owner. */
 const clientOwnerFromPayload = (payload: unknown): Owner | null => {
-  const decoded =
-    typeof payload === "string"
-      ? decodeJsonPayload(payload).pipe(Option.getOrElse(() => payload))
-      : payload;
+  const decoded = decodeSessionPayload(payload);
   if (decoded === null || typeof decoded !== "object") return null;
   const value = (decoded as Record<string, unknown>).clientOwner;
   return value === "user" || value === "org" ? value : null;
 };
+
+const reconnectRefFromPayload = (payload: unknown): ConnectionRef | null => {
+  const decoded = decodeSessionPayload(payload);
+  if (decoded === null || typeof decoded !== "object") return null;
+  const value = (decoded as Record<string, unknown>).reconnectRef;
+  if (value === null || typeof value !== "object") return null;
+  const ref = value as Record<string, unknown>;
+  const owner = ref.owner;
+  const integration = ref.integration;
+  const name = ref.name;
+  if (
+    (owner !== "user" && owner !== "org") ||
+    typeof integration !== "string" ||
+    typeof name !== "string"
+  ) {
+    return null;
+  }
+  return {
+    owner,
+    integration: IntegrationSlug.make(integration),
+    name: ConnectionName.make(name),
+  };
+};
+
+const formatConnectionRef = (ref: ConnectionRef): string =>
+  `${ref.owner}/${String(ref.integration)}/${String(ref.name)}`;
+
+const sameConnectionRef = (a: ConnectionRef, b: ConnectionRef): boolean =>
+  a.owner === b.owner &&
+  String(a.integration) === String(b.integration) &&
+  String(a.name) === String(b.name);
 
 /** Narrow a stored `grant` string to the `OAuthGrant` union, or `null` when the
  *  value is neither known grant. EXPLICIT — there is no silent fallback to
@@ -951,6 +985,32 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
           message: "A Workspace connection must use a Workspace app.",
         });
       }
+      const inputRef: ConnectionRef = {
+        owner: input.owner,
+        integration: input.integration,
+        name: input.name,
+      };
+      const reconnectRef = input.reconnectRef ?? null;
+      if (reconnectRef !== null && !sameConnectionRef(reconnectRef, inputRef)) {
+        return yield* new OAuthStartError({
+          message: `Reconnect target does not match OAuth start target: ${formatConnectionRef(reconnectRef)}`,
+        });
+      }
+      if (reconnectRef !== null) {
+        const existing = yield* deps.findConnection(reconnectRef).pipe(
+          Effect.mapError(
+            () =>
+              new OAuthStartError({
+                message: `Failed to load reconnect target ${formatConnectionRef(reconnectRef)}`,
+              }),
+          ),
+        );
+        if (existing === null) {
+          return yield* new OAuthStartError({
+            message: `Connection no longer exists for reconnect: ${formatConnectionRef(reconnectRef)}`,
+          });
+        }
+      }
       // Load the app by its EXPLICIT owner (the caller knows it — no derivation).
       // The connection is still minted under `input.owner`. Storage visibility
       // policy hides apps the actor cannot see, so a wrong owner yields null.
@@ -1015,6 +1075,7 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
           input.clientOwner,
           // client_credentials has no callback, so no regional rebind applies.
           null,
+          input.reconnectRef ?? null,
         ).pipe(
           Effect.mapError(
             (cause) =>
@@ -1077,6 +1138,7 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
             owner: input.owner,
             clientOwner: input.clientOwner,
             requestedScopes: authorizationRequestedScopes,
+            reconnectRef,
           },
           expires_at: expiresAt,
           created_at: now,
@@ -1139,6 +1201,7 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
         // recorded-scope fallback when the AS omits `scope`. Missing/legacy
         // payloads fall back to the client's scopes below.
         requestedScopes: requestedScopesFromPayload(sessionRow.payload),
+        reconnectRef: reconnectRefFromPayload(sessionRow.payload),
         // The app's owner, recorded by `start` — reload the SAME app at
         // completion by explicit owner (no derivation). Defaults to the session
         // owner for same-owner connects.
@@ -1150,6 +1213,25 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
       if (Number.isFinite(session.expiresAt) && session.expiresAt <= Date.now()) {
         yield* deleteSession(input.state);
         return yield* new OAuthSessionNotFoundError({ state: input.state });
+      }
+
+      if (session.reconnectRef !== null) {
+        const reconnectRef = session.reconnectRef;
+        const existing = yield* deps.findConnection(reconnectRef).pipe(
+          Effect.mapError(
+            () =>
+              new OAuthCompleteError({
+                message: `Failed to load reconnect target ${formatConnectionRef(reconnectRef)}`,
+                restartRequired: true,
+              }),
+          ),
+        );
+        if (existing === null) {
+          return yield* new OAuthCompleteError({
+            message: `Connection no longer exists for reconnect: ${formatConnectionRef(reconnectRef)}`,
+            restartRequired: true,
+          });
+        }
       }
 
       // Reload the SAME app `start` resolved, by its explicit recorded owner.
@@ -1220,6 +1302,7 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
         // Persist the regional token endpoint ONLY when it differs from the
         // client's configured one, so refresh redeems against the same region.
         tokenUrl === client.tokenUrl ? null : tokenUrl,
+        session.reconnectRef,
       ).pipe(
         Effect.mapError(
           (cause) =>
@@ -1259,6 +1342,7 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
     /** Regional token endpoint override to persist when the code was redeemed
      *  off the client's configured host; null to use the client's token URL. */
     oauthTokenUrl: string | null,
+    reconnectRef: ConnectionRef | null,
   ): Effect.Effect<Connection, StorageFailure> =>
     Effect.gen(function* () {
       const provider = deps.defaultWritableProvider();
@@ -1295,6 +1379,7 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
         // non-resource scope from the token `scope` string, so preserve it when
         // the refresh token proves it was granted.
         oauthScope: recordedOAuthScope(token, requestedScopes),
+        reconnectRef,
         oauthTokenUrl,
       });
     });

--- a/packages/core/sdk/src/testing/oauth-test-server.ts
+++ b/packages/core/sdk/src/testing/oauth-test-server.ts
@@ -86,6 +86,7 @@ export interface OAuthTestServerShape {
   }) => Effect.Effect<OAuthTokenSet, OAuthTestServerFlowError>;
   readonly requests: Effect.Effect<readonly OAuthTestServerRequest[]>;
   readonly clearRequests: Effect.Effect<void>;
+  readonly clearRefreshTokens: Effect.Effect<void>;
   readonly issuedAccessTokens: Effect.Effect<readonly string[]>;
   readonly acceptsAccessToken: (token: string) => Effect.Effect<boolean>;
   readonly acceptsAuthorizationHeader: (
@@ -754,6 +755,9 @@ export const serveOAuthTestServer = (
       }),
       requests: Ref.get(requests),
       clearRequests: Ref.set(requests, []),
+      clearRefreshTokens: Effect.sync(() => {
+        refreshTokens.clear();
+      }),
       issuedAccessTokens: accessTokenSet.pipe(Effect.map((tokens) => [...tokens])),
       acceptsAccessToken: (token) => accessTokenSet.pipe(Effect.map((tokens) => tokens.has(token))),
       acceptsAuthorizationHeader: (authorization) => {

--- a/packages/plugins/mcp/src/sdk/connection.ts
+++ b/packages/plugins/mcp/src/sdk/connection.ts
@@ -118,43 +118,51 @@ const abortError = (signal: AbortSignal): unknown => {
   return error;
 };
 
+const observedPromise = <A>(promise: Promise<A>): Promise<A> => {
+  void promise.then(undefined, () => undefined);
+  return promise;
+};
+
 const fetchFromHttpClientLayer = (
   httpClientLayer: Layer.Layer<HttpClient.HttpClient>,
 ): FetchLike => {
-  const execute: FetchLike = async (url, init) => {
-    const headers = headersFrom(init?.headers);
-    const requestWithoutBody = HttpClientRequest.make(httpMethodFrom(init?.method))(url, {
-      headers: recordFromHeaders(headers),
-    });
-    const request = await applyBody(requestWithoutBody, headers, init?.body);
-    const effect = Effect.gen(function* () {
-      const client = yield* HttpClient.HttpClient;
-      const response = yield* client.execute(request);
-      const responseHeaders = new Headers();
-      for (const [key, value] of Object.entries(response.headers)) {
-        if (value !== undefined) responseHeaders.set(key, value);
-      }
-      const body =
-        response.status === 204 || response.status === 205 || response.status === 304
-          ? null
-          : Stream.toReadableStream(response.stream);
-      return new Response(body, {
-        status: response.status,
-        headers: responseHeaders,
-      });
-    }).pipe(Effect.provide(httpClientLayer));
-    const promise = Effect.runPromise(effect);
-    if (!init?.signal) return promise;
-    // oxlint-disable-next-line executor/no-promise-reject -- boundary: Fetch-compatible adapter mirrors abort rejection semantics
-    if (init.signal.aborted) return Promise.reject(abortError(init.signal));
-    const aborted = new Promise<never>((_, reject) => {
-      // oxlint-disable-next-line executor/no-promise-reject -- boundary: Fetch-compatible adapter races the Effect request against AbortSignal
-      init.signal?.addEventListener("abort", () => reject(abortError(init.signal!)), {
-        once: true,
-      });
-    });
-    return Promise.race([promise, aborted]);
-  };
+  const execute: FetchLike = (url, init) =>
+    observedPromise(
+      (async () => {
+        const headers = headersFrom(init?.headers);
+        const requestWithoutBody = HttpClientRequest.make(httpMethodFrom(init?.method))(url, {
+          headers: recordFromHeaders(headers),
+        });
+        const request = await applyBody(requestWithoutBody, headers, init?.body);
+        const effect = Effect.gen(function* () {
+          const client = yield* HttpClient.HttpClient;
+          const response = yield* client.execute(request);
+          const responseHeaders = new Headers();
+          for (const [key, value] of Object.entries(response.headers)) {
+            if (value !== undefined) responseHeaders.set(key, value);
+          }
+          const body =
+            response.status === 204 || response.status === 205 || response.status === 304
+              ? null
+              : Stream.toReadableStream(response.stream);
+          return new Response(body, {
+            status: response.status,
+            headers: responseHeaders,
+          });
+        }).pipe(Effect.provide(httpClientLayer));
+        const promise = observedPromise(Effect.runPromise(effect));
+        if (!init?.signal) return await promise;
+        // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: Fetch-compatible adapter mirrors AbortSignal rejection semantics
+        if (init.signal.aborted) throw abortError(init.signal);
+        const aborted = new Promise<never>((_, reject) => {
+          // oxlint-disable-next-line executor/no-promise-reject -- boundary: Fetch-compatible adapter races the Effect request against AbortSignal
+          init.signal?.addEventListener("abort", () => reject(abortError(init.signal!)), {
+            once: true,
+          });
+        });
+        return await Promise.race([promise, aborted]);
+      })(),
+    );
   return execute;
 };
 

--- a/packages/react/src/components/accounts-section.tsx
+++ b/packages/react/src/components/accounts-section.tsx
@@ -287,8 +287,8 @@ function OwnerAccounts(props: {
             success: true,
           });
         },
-        onError: () => {
-          toast.error("Failed to reconnect");
+        onError: (error: string, details?: string) => {
+          toast.error(details ?? error);
           trackEvent("connection_reconnected", {
             integration_slug: String(connection.integration),
             owner: connection.owner,
@@ -509,6 +509,11 @@ export function AccountsSection(props: {
                   owner: connection.owner,
                   template: String(connection.template),
                   label: String(connection.name),
+                  reconnectRef: {
+                    owner: connection.owner,
+                    integration: String(connection.integration),
+                    name: String(connection.name),
+                  },
                   ...(connection.identityLabel != null
                     ? { identityLabel: connection.identityLabel }
                     : {}),

--- a/packages/react/src/components/add-account-modal.tsx
+++ b/packages/react/src/components/add-account-modal.tsx
@@ -1614,8 +1614,13 @@ function AddAccountModalView(props: AddAccountModalProps) {
     if (oauthReconnectOpenedKey.current === handoff.key) return;
     const client = oauthClient.slug;
     const clientOwner = oauthClient.owner ?? handoff.owner;
-    const connectionOwner = handoff.owner;
-    const connectionName = handoff.label;
+    const reconnectRef = handoff.reconnectRef;
+    const connectionOwner = reconnectRef?.owner ?? handoff.owner;
+    const connectionName = reconnectRef?.name ?? handoff.label;
+    const connectionIntegration =
+      reconnectRef?.integration != null
+        ? IntegrationSlug.make(reconnectRef.integration)
+        : integration;
     const oauthMethod = handoff.template
       ? allMethods.find(
           (m: AuthMethod) =>
@@ -1633,8 +1638,17 @@ function AddAccountModalView(props: AddAccountModalProps) {
         clientOwner,
         owner: connectionOwner,
         name: ConnectionName.make(connectionName),
-        integration,
+        integration: connectionIntegration,
         template: oauthMethod.template,
+        ...(reconnectRef
+          ? {
+              reconnectRef: {
+                owner: reconnectRef.owner,
+                integration: connectionIntegration,
+                name: ConnectionName.make(reconnectRef.name),
+              },
+            }
+          : {}),
         ...(handoff.identityLabel !== undefined ? { identityLabel: handoff.identityLabel } : {}),
       },
       onAuthorizationStarted: () => {
@@ -1644,7 +1658,8 @@ function AddAccountModalView(props: AddAccountModalProps) {
           success: true,
         });
       },
-      onError: () => {
+      onError: (error: string, details?: string) => {
+        toast.error(details ?? error);
         trackEvent("connection_reconnected", {
           integration_slug: String(integration),
           owner: connectionOwner,

--- a/packages/react/src/lib/use-connection-health.test.ts
+++ b/packages/react/src/lib/use-connection-health.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "@effect/vitest";
+import {
+  AuthTemplateSlug,
+  ConnectionAddress,
+  ConnectionName,
+  IntegrationSlug,
+  OAuthClientSlug,
+  ProviderKey,
+  type Connection,
+  type HealthCheckResult,
+} from "@executor-js/sdk/shared";
+
+import {
+  connectionHealthProbeSnapshot,
+  resolveConnectionHealthProbe,
+} from "./use-connection-health";
+
+const health = (status: HealthCheckResult["status"], checkedAt: number): HealthCheckResult => ({
+  status,
+  checkedAt,
+});
+
+const connection = (
+  lastHealth: HealthCheckResult | null,
+  overrides: Partial<Connection> = {},
+): Connection => ({
+  owner: "user",
+  name: ConnectionName.make("main"),
+  integration: IntegrationSlug.make("mcp"),
+  template: AuthTemplateSlug.make("oauth2"),
+  provider: ProviderKey.make("default"),
+  address: ConnectionAddress.make("tools.mcp.user.main"),
+  identityLabel: "Main account",
+  description: null,
+  expiresAt: 1_000,
+  oauthClient: OAuthClientSlug.make("mcp-client"),
+  oauthClientOwner: "user",
+  oauthScope: "channels:history users:read",
+  lastHealth,
+  ...overrides,
+});
+
+describe("resolveConnectionHealthProbe", () => {
+  it("surfaces a live Check now result for the row snapshot that was checked", () => {
+    const row = connection(health("expired", 100));
+    const live = connectionHealthProbeSnapshot(row, health("healthy", 200));
+
+    expect(resolveConnectionHealthProbe(row, live)?.status).toBe("healthy");
+  });
+
+  it("does not let a stale live probe shadow a fresher persisted server verdict", () => {
+    const before = connection(health("expired", 100));
+    const live = connectionHealthProbeSnapshot(before, health("expired", 150));
+    const after = connection(health("healthy", 250));
+
+    expect(resolveConnectionHealthProbe(after, live)?.status).toBe("healthy");
+  });
+
+  it("clears a stale live probe after the credential row is reminted", () => {
+    const before = connection(health("expired", 100), { expiresAt: 1_000 });
+    const live = connectionHealthProbeSnapshot(before, health("expired", 150));
+    const after = connection(null, { expiresAt: 2_000 });
+
+    expect(resolveConnectionHealthProbe(after, live)).toBeNull();
+  });
+});

--- a/packages/react/src/lib/use-connection-health.ts
+++ b/packages/react/src/lib/use-connection-health.ts
@@ -42,6 +42,53 @@ const revalidateQuery = (
 ): { readonly ifStaleMs?: number } =>
   last?.status === "healthy" ? { ifStaleMs: HEALTH_REVALIDATE_MS } : {};
 
+const healthVersion = (health: HealthCheckResult | null | undefined): string =>
+  health === null || health === undefined ? "none" : `${health.status}:${health.checkedAt}`;
+
+const connectionCredentialKey = (connection: Connection): string =>
+  JSON.stringify({
+    owner: connection.owner,
+    integration: connection.integration,
+    name: connection.name,
+    template: connection.template,
+    provider: connection.provider,
+    address: connection.address,
+    expiresAt: connection.expiresAt ?? null,
+    oauthClient: connection.oauthClient ?? null,
+    oauthClientOwner: connection.oauthClientOwner ?? null,
+    oauthScope: connection.oauthScope ?? null,
+  });
+
+const connectionHealthRowKey = (connection: Connection): string =>
+  JSON.stringify({
+    credential: connectionCredentialKey(connection),
+    lastHealth: healthVersion(connection.lastHealth),
+  });
+
+export interface ConnectionHealthProbeSnapshot {
+  readonly rowKey: string;
+  readonly result: HealthCheckResult;
+}
+
+export const connectionHealthProbeSnapshot = (
+  connection: Connection,
+  result: HealthCheckResult,
+): ConnectionHealthProbeSnapshot => ({
+  rowKey: connectionHealthRowKey(connection),
+  result,
+});
+
+export const resolveConnectionHealthProbe = (
+  connection: Connection,
+  liveProbe: ConnectionHealthProbeSnapshot | null,
+): HealthCheckResult | null => {
+  const persisted = connection.lastHealth ?? null;
+  if (liveProbe === null) return persisted;
+  if (liveProbe.rowKey !== connectionHealthRowKey(connection)) return persisted;
+  if (persisted !== null && persisted.checkedAt > liveProbe.result.checkedAt) return persisted;
+  return liveProbe.result;
+};
+
 /**
  * Imperative invalidation of the connections cache for one owner. The server
  * persists every verdict on `last_health`, so after a check we must re-read the
@@ -70,24 +117,25 @@ export function useConnectionHealth(connection: Connection): {
   readonly status: HealthStatus;
   readonly runCheck: () => Promise<Exit.Exit<HealthCheckResult, unknown>>;
 } {
-  // A live probe result, once a check has run, overrides the persisted one.
-  const [liveProbe, setLiveProbe] = useState<HealthCheckResult | null>(null);
+  // A live probe result can override only the row snapshot it checked.
+  const [liveProbe, setLiveProbe] = useState<ConnectionHealthProbeSnapshot | null>(null);
   const doCheck = useAtomSet(checkConnectionHealth, { mode: "promiseExit" });
   const invalidateConnections = useInvalidateConnections();
 
-  const probe = liveProbe ?? connection.lastHealth ?? null;
+  const probe = resolveConnectionHealthProbe(connection, liveProbe);
   const status: HealthStatus = probe?.status ?? "unknown";
 
   // Health checks are AUTOMATIC: loading the list revalidates any verdict
   // older than the freshness window (or never checked), stale-while-revalidate
   // style: the persisted verdict renders instantly, the probe corrects it in
   // place.
-  const revalidated = useRef(false);
+  const revalidated = useRef<string | null>(null);
   useEffect(() => {
-    if (revalidated.current) return;
+    const credentialKey = connectionCredentialKey(connection);
+    if (revalidated.current === credentialKey) return;
     const last = connection.lastHealth;
     if (healthyAndFresh(last)) return;
-    revalidated.current = true;
+    revalidated.current = credentialKey;
     void doCheck({
       params: connectionParams(connection),
       query: revalidateQuery(last),
@@ -99,7 +147,7 @@ export function useConnectionHealth(connection: Connection): {
       // cache (which would refetch connections, re-run this effect, and, but
       // for the once-per-mount ref guard, risk a probe loop).
       if (!Exit.isSuccess(exit)) return;
-      setLiveProbe(exit.value);
+      setLiveProbe(connectionHealthProbeSnapshot(connection, exit.value));
       if (exit.value.status !== (last?.status ?? "unknown")) {
         invalidateConnections(connection.owner);
       }
@@ -115,7 +163,7 @@ export function useConnectionHealth(connection: Connection): {
       query: {},
       reactivityKeys: connectionCheckKeys,
     });
-    if (Exit.isSuccess(exit)) setLiveProbe(exit.value);
+    if (Exit.isSuccess(exit)) setLiveProbe(connectionHealthProbeSnapshot(connection, exit.value));
     return exit;
   }, [connection, doCheck]);
 
@@ -136,7 +184,9 @@ const probeKey = (connection: Connection): string =>
 export function useConnectionsHealth(
   connections: readonly Connection[],
 ): (connection: Connection) => HealthCheckResult | null {
-  const [liveProbes, setLiveProbes] = useState<ReadonlyMap<string, HealthCheckResult>>(new Map());
+  const [liveProbes, setLiveProbes] = useState<ReadonlyMap<string, ConnectionHealthProbeSnapshot>>(
+    new Map(),
+  );
   const doCheck = useAtomSet(checkConnectionHealth, { mode: "promiseExit" });
   const invalidateConnections = useInvalidateConnections();
 
@@ -146,10 +196,11 @@ export function useConnectionsHealth(
   useEffect(() => {
     for (const connection of connections) {
       const key = probeKey(connection);
-      if (revalidated.current.has(key)) continue;
+      const credentialKey = `${key}:${connectionCredentialKey(connection)}`;
+      if (revalidated.current.has(credentialKey)) continue;
       const last = connection.lastHealth;
       if (healthyAndFresh(last)) continue;
-      revalidated.current.add(key);
+      revalidated.current.add(credentialKey);
       void doCheck({
         params: connectionParams(connection),
         query: revalidateQuery(last),
@@ -159,7 +210,9 @@ export function useConnectionsHealth(
         // an unchanged reconfirm never churns the cache (the per-key ref guard
         // already prevents a re-probe on the resulting re-render).
         if (!Exit.isSuccess(exit)) return;
-        setLiveProbes((current) => new Map(current).set(key, exit.value));
+        setLiveProbes((current) =>
+          new Map(current).set(key, connectionHealthProbeSnapshot(connection, exit.value)),
+        );
         if (exit.value.status !== (last?.status ?? "unknown")) {
           invalidateConnections(connection.owner);
         }
@@ -169,7 +222,7 @@ export function useConnectionsHealth(
 
   return useCallback(
     (connection: Connection) =>
-      liveProbes.get(probeKey(connection)) ?? connection.lastHealth ?? null,
+      resolveConnectionHealthProbe(connection, liveProbes.get(probeKey(connection)) ?? null),
     [liveProbes],
   );
 }

--- a/packages/react/src/plugins/oauth-reconnect.test.ts
+++ b/packages/react/src/plugins/oauth-reconnect.test.ts
@@ -58,6 +58,11 @@ describe("oauthReconnectPayload (re-mint the SAME connection)", () => {
     expect(payload!.integration).toBe(IntegrationSlug.make("github"));
     expect(payload!.template).toBe(AuthTemplateSlug.make("oauth"));
     expect(payload!.identityLabel).toBe("Personal GitHub");
+    expect(payload!.reconnectRef).toEqual({
+      owner: "user",
+      integration: IntegrationSlug.make("github"),
+      name: ConnectionName.make("personal-github"),
+    });
   });
 
   it("maps a null identityLabel to undefined (optional payload field)", () => {

--- a/packages/react/src/plugins/oauth-reconnect.ts
+++ b/packages/react/src/plugins/oauth-reconnect.ts
@@ -40,6 +40,11 @@ export function oauthReconnectPayload(connection: Connection): OAuthStartPayload
     integration: connection.integration,
     template: connection.template,
     identityLabel: connection.identityLabel ?? undefined,
+    reconnectRef: {
+      owner: connection.owner,
+      integration: connection.integration,
+      name: connection.name,
+    },
   };
 }
 

--- a/packages/react/src/plugins/oauth-sign-in.tsx
+++ b/packages/react/src/plugins/oauth-sign-in.tsx
@@ -34,6 +34,7 @@ import {
   OAuthState,
   type AuthTemplateSlug,
   type ConnectionName,
+  type ConnectionRef,
   type IntegrationSlug,
   type OAuthClientSlug,
   type Owner,
@@ -69,13 +70,14 @@ export type OAuthStartPayload = {
   readonly integration: IntegrationSlug;
   readonly template: AuthTemplateSlug;
   readonly identityLabel?: string;
+  readonly reconnectRef?: ConnectionRef | null;
   readonly redirectUri?: string;
 };
 
 export type StartOAuthPopupInput<TPayload extends OAuthCompletionPayload> = {
   readonly payload: OAuthStartPayload;
   readonly onSuccess: (payload: TPayload) => void | Promise<void>;
-  readonly onError?: (error: string) => void;
+  readonly onError?: (error: string, details?: string) => void;
   readonly onAuthorizationStarted?: (result: OAuthAuthorizationStartResult) => void;
 };
 
@@ -381,6 +383,7 @@ export function useOAuthPopupFlow<
               integration: input.payload.integration,
               template: input.payload.template,
               identityLabel: input.payload.identityLabel,
+              reconnectRef: input.payload.reconnectRef ?? null,
               redirectUri: input.payload.redirectUri ?? oauthCallbackUrl(callbackPath),
             },
           }).then((exit) =>


### PR DESCRIPTION
Reconnecting an expired DCR OAuth connection created a second connection instead of re-authing the existing one: the flow went through the create path with the old name as a display label, which got re-normalized into a new slug. Reconnect now carries an exact connection reference through the OAuth session so the same row is updated in place, with a typed error if the connection was removed mid-flow.

Includes an e2e repro for the duplicate, plus an expected-failure repro for a related symptom: after a successful reconnect the row keeps showing Expired until a hard refresh (the mounted health probe isn't cleared). That fix will follow.