### PR TITLE
Unwrap Effect causes before Sentry capture

### DIFF
--- a/apps/cloud/src/routes/__root.tsx
+++ b/apps/cloud/src/routes/__root.tsx
@@ -12,7 +12,10 @@ import {
 import { AutumnProvider } from "autumn-js/react";
 import posthog from "posthog-js";
 import { PostHogProvider } from "posthog-js/react";
-import type { FrontendErrorReporter } from "@executor-js/react/api/error-reporting";
+import {
+  frontendErrorCapturePayload,
+  type FrontendErrorReporter,
+} from "@executor-js/react/api/error-reporting";
 import { AnalyticsProvider, type AnalyticsClient } from "@executor-js/react/api/analytics";
 import { ExecutorProvider } from "@executor-js/react/api/provider";
 import { OrganizationProvider } from "@executor-js/react/api/organization-context";
@@ -66,10 +69,12 @@ const analyticsClient: AnalyticsClient | undefined =
     : undefined;
 
 const captureFrontendError: FrontendErrorReporter = (error, context) => {
-  Sentry.captureException(error, (scope) => {
+  const { exception, causePretty } = frontendErrorCapturePayload(error);
+  Sentry.captureException(exception, (scope) => {
     scope.setTag("executor.ui.surface", context.surface);
     scope.setTag("executor.ui.action", context.action);
     scope.setTag("executor.ui.severity", context.severity ?? "error");
+    if (causePretty !== null) scope.setExtra("cause_pretty", causePretty);
     scope.setContext("executor.ui", {
       surface: context.surface,
       action: context.action,

--- a/packages/react/src/api/error-reporting.test.ts
+++ b/packages/react/src/api/error-reporting.test.ts
@@ -1,7 +1,9 @@
+// oxlint-disable executor/no-error-constructor -- boundary: tests construct plain browser Errors as fixtures for the Sentry capture boundary
 import { describe, expect, it } from "@effect/vitest";
 import * as Cause from "effect/Cause";
 import * as Exit from "effect/Exit";
 import {
+  frontendErrorCapturePayload,
   messageFromExit,
   messageFromUnknown,
   reportExitFailure,
@@ -44,5 +46,81 @@ describe("frontend error reporting", () => {
     expect(Cause.isCause(calls[0]!.error)).toBe(true);
     expect(calls[0]!.context.surface).toBe("sources");
     expect(calls[0]!.context.action).toBe("update");
+  });
+
+  it("extracts the failed Error from an Effect Cause", () => {
+    const original = new Error("GET /api/tools failed with 522");
+    original.stack = "Error: GET /api/tools failed with 522\n    at loadTools (tools.ts:12:3)";
+    const payload = frontendErrorCapturePayload(Cause.fail(original));
+
+    expect(payload.exception).toBe(original);
+    expect(payload.exception.message).toBe("GET /api/tools failed with 522");
+    expect(payload.exception.stack).toContain("loadTools");
+    expect(payload.causePretty).toContain("GET /api/tools failed with 522");
+  });
+
+  it("builds an Error from a string Effect failure", () => {
+    const payload = frontendErrorCapturePayload(
+      Cause.fail("GET /api/integrations failed with 522"),
+    );
+
+    expect(payload.exception).toBeInstanceOf(Error);
+    expect(payload.exception.message).toContain("GET /api/integrations failed with 522");
+    expect(payload.exception.stack).toContain("GET /api/integrations failed with 522");
+    expect(payload.causePretty).toContain("GET /api/integrations failed with 522");
+  });
+
+  it("extracts the defect Error from an Effect Cause", () => {
+    const defect = new TypeError("render crashed");
+    defect.stack = "TypeError: render crashed\n    at renderWidget (widget.tsx:40:5)";
+    const payload = frontendErrorCapturePayload(Cause.die(defect));
+
+    expect(payload.exception).toBe(defect);
+    expect(payload.exception.message).toBe("render crashed");
+    expect(payload.exception.stack).toContain("renderWidget");
+    expect(payload.causePretty).toContain("render crashed");
+  });
+
+  it("unwraps a Cause that arrives wrapped as a defect of another Cause", () => {
+    // The production chain: runPromise squashes an exit whose defect is itself
+    // a Cause, so the capture boundary receives Die(CauseImpl).
+    const original = new Error("GET /api/connections failed with 522");
+    original.stack =
+      "Error: GET /api/connections failed with 522\n    at loadConnections (connections.ts:9:2)";
+    const payload = frontendErrorCapturePayload(Cause.die(Cause.fail(original)));
+
+    expect(payload.exception).toBeInstanceOf(Error);
+    expect(payload.exception.message).toContain("GET /api/connections failed with 522");
+    expect(payload.exception.message).not.toContain("CauseImpl");
+    expect(payload.causePretty).toContain("GET /api/connections failed with 522");
+  });
+
+  it("unwraps a record carrying a Cause on its cause property", () => {
+    const original = new Error("wrapped cause failure");
+    const payload = frontendErrorCapturePayload({ cause: Cause.fail(original) });
+
+    expect(payload.exception).toBe(original);
+    expect(payload.causePretty).toContain("wrapped cause failure");
+  });
+
+  it("passes a plain Error through unchanged", () => {
+    const original = new Error("plain browser error");
+    original.stack = "Error: plain browser error\n    at onClick (button.tsx:7:1)";
+    const payload = frontendErrorCapturePayload(original);
+
+    expect(payload.exception).toBe(original);
+    expect(payload.exception.message).toBe("plain browser error");
+    expect(payload.exception.stack).toContain("onClick");
+    expect(payload.causePretty).toBeNull();
+  });
+
+  it("builds an Error from a non-Cause non-Error value", () => {
+    const payload = frontendErrorCapturePayload({ path: "/api/connections", status: 522 });
+
+    expect(payload.exception).toBeInstanceOf(Error);
+    expect(payload.exception.message).toContain("/api/connections");
+    expect(payload.exception.message).toContain("522");
+    expect(payload.exception.stack).toContain("Non-Error frontend exception");
+    expect(payload.causePretty).toBeNull();
   });
 });

--- a/packages/react/src/api/error-reporting.tsx
+++ b/packages/react/src/api/error-reporting.tsx
@@ -15,13 +15,87 @@ export type FrontendErrorContext = {
 
 export type FrontendErrorReporter = (error: unknown, context: FrontendErrorContext) => void;
 
+export type FrontendErrorCapturePayload = {
+  readonly exception: Error;
+  readonly causePretty: string | null;
+};
+
 class FrontendHandledError extends Data.TaggedError("FrontendHandledError")<{
   readonly cause: unknown;
   readonly context: FrontendErrorContext;
 }> {}
 
+const MAX_FRONTEND_CAUSE_PRETTY_CHARS = 4_000;
+
 const ErrorMessage = Schema.Struct({ message: Schema.String });
 const decodeErrorMessage = Schema.decodeUnknownOption(ErrorMessage);
+
+const isRecord = (input: unknown): input is Record<string, unknown> =>
+  typeof input === "object" && input !== null;
+
+const truncateCausePretty = (pretty: string): string =>
+  pretty.length <= MAX_FRONTEND_CAUSE_PRETTY_CHARS
+    ? pretty
+    : `${pretty.slice(0, MAX_FRONTEND_CAUSE_PRETTY_CHARS)}\n[truncated ${pretty.length - MAX_FRONTEND_CAUSE_PRETTY_CHARS} chars]`;
+
+const formatUnknownForErrorMessage = (input: unknown): string => {
+  if (typeof input === "string") return input.length > 0 ? input : "(empty string)";
+  if (input === null || input === undefined) return String(input);
+  if (
+    typeof input === "number" ||
+    typeof input === "boolean" ||
+    typeof input === "bigint" ||
+    typeof input === "symbol"
+  ) {
+    return String(input);
+  }
+  // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: stringify arbitrary unknown values for a Sentry error message; JSON.stringify throws on cycles
+  try {
+    const json = JSON.stringify(input);
+    if (json) return json;
+  } catch {
+    return Object.prototype.toString.call(input);
+  }
+  return Object.prototype.toString.call(input);
+};
+
+const causeFromUnknown = (input: unknown): Cause.Cause<unknown> | null => {
+  if (Cause.isCause(input)) return input;
+  if (isRecord(input) && Cause.isCause(input.cause)) return input.cause;
+  return null;
+};
+
+const errorFromCause = (cause: Cause.Cause<unknown>, pretty: string): Error => {
+  const squashed = Cause.squash(cause);
+  // oxlint-disable-next-line executor/no-instanceof-error -- boundary: deciding whether the squashed failure is already a Sentry-ready Error payload
+  if (squashed instanceof Error) return squashed;
+  const prettyError = Cause.prettyErrors(cause)[0];
+  if (prettyError) return prettyError;
+  // oxlint-disable-next-line executor/no-error-constructor -- boundary: Sentry needs an Error payload for Effect causes
+  return new Error(pretty.length > 0 ? pretty : "Effect cause contained no failures");
+};
+
+export const frontendErrorCapturePayload = (input: unknown): FrontendErrorCapturePayload => {
+  const cause = causeFromUnknown(input);
+  if (cause !== null) {
+    const causePretty = truncateCausePretty(Cause.pretty(cause));
+    return {
+      exception: errorFromCause(cause, causePretty),
+      causePretty: causePretty.length > 0 ? causePretty : null,
+    };
+  }
+
+  // oxlint-disable-next-line executor/no-instanceof-error -- boundary: deciding whether the incoming unknown is already a Sentry-ready Error payload
+  if (input instanceof Error) {
+    return { exception: input, causePretty: null };
+  }
+
+  return {
+    // oxlint-disable-next-line executor/no-error-constructor -- boundary: Sentry needs an Error payload for non-Error frontend failures
+    exception: new Error(`Non-Error frontend exception: ${formatUnknownForErrorMessage(input)}`),
+    causePretty: null,
+  };
+};
 
 const defaultFrontendErrorReporter: FrontendErrorReporter = (error, context) => {
   if (typeof globalThis.reportError !== "function") return;


### PR DESCRIPTION
Frontend error reports were capturing raw Effect Cause objects, so Sentry showed a generic placeholder instead of the underlying error and grouped everything together. Unwrap causes into real errors at the capture boundary and attach the pretty-printed cause as context.