### PR TITLE
Fix Windows updater signing config

### DIFF
--- a/.github/workflows/publish-desktop.yml
+++ b/.github/workflows/publish-desktop.yml
@@ -136,18 +136,18 @@ jobs:
           # --publish never here and attach assets explicitly in the release
           # job so we don't fight electron-updater's metadata expectations.
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Apple signing + notarization. electron-builder picks these up:
-          #   CSC_LINK / CSC_KEY_PASSWORD → import the Developer ID Application
-          #     cert (.p12, base64) into a temp keychain for codesign
-          #   APPLE_API_KEY (file path) / APPLE_API_KEY_ID / APPLE_API_ISSUER
-          #     → notarytool authentication for the notarization upload
-          # When the secrets aren't set (forks, local), electron-builder
-          # silently produces an unsigned build.
-          CSC_LINK: ${{ secrets.CSC_LINK }}
-          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          # Mac signing + notarization. Keep CSC_LINK scoped to mac so the
+          # Windows leg cannot reuse the Developer ID Application certificate.
+          CSC_LINK: ${{ matrix.platform == 'mac' && secrets.CSC_LINK || '' }}
+          CSC_KEY_PASSWORD: ${{ matrix.platform == 'mac' && secrets.CSC_KEY_PASSWORD || '' }}
           APPLE_API_KEY: ${{ env.APPLE_API_KEY_PATH }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          # Windows Authenticode signing. electron-builder derives
+          # resources/app-update.yml publisherName from this certificate.
+          # Missing secrets fail the CI Windows build via win.forceCodeSigning.
+          WIN_CSC_LINK: ${{ matrix.platform == 'win' && secrets.WIN_CSC_LINK || '' }}
+          WIN_CSC_KEY_PASSWORD: ${{ matrix.platform == 'win' && secrets.WIN_CSC_KEY_PASSWORD || '' }}
         run: bunx --bun electron-builder --${{ matrix.platform }} --${{ matrix.arch }} --publish never --config electron-builder.config.ts
         working-directory: apps/desktop
 

--- a/apps/desktop/electron-builder.config.ts
+++ b/apps/desktop/electron-builder.config.ts
@@ -46,6 +46,12 @@ const config: Configuration = {
   // artifact only exists once a leg stages an arm64 executor for it.
   win: {
     target: ["nsis"],
+    // CI release builds must fail if a Windows Authenticode certificate is not
+    // provided. Local packaging can still produce unsigned smoke builds.
+    // publisherName is intentionally not set: electron-builder derives it from
+    // the signing certificate subject, and pinning it here would risk drifting
+    // from the cert embedded in the installer.
+    forceCodeSigning: process.env.CI === "true",
   },
   nsis: {
     oneClick: true,

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -66,6 +66,7 @@ import {
   planDownloadedUpdate,
   planFatalAutoInstallOnQuit,
   planUpdateCheck,
+  handleUpdateDownloadRejection,
   statusAfterUpdateError,
   type UpdateCheckTrigger,
 } from "./updater-state";
@@ -962,6 +963,7 @@ interface UpdateCheckOptions {
 type UpdateCheckResult = {
   readonly isUpdateAvailable?: boolean;
   readonly updateInfo?: { readonly version?: string };
+  readonly downloadPromise?: Promise<unknown> | null;
 };
 
 const runUpdateCheck = async ({ alertOnFail, trigger }: UpdateCheckOptions) => {
@@ -980,6 +982,10 @@ const runUpdateCheck = async ({ alertOnFail, trigger }: UpdateCheckOptions) => {
   // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: surface network/update failures only when the user asked
   try {
     const result = (await autoUpdater.checkForUpdates()) as UpdateCheckResult | null;
+    handleUpdateDownloadRejection(result?.downloadPromise, () => {
+      // The autoUpdater error event already logs the failure and updates state.
+      // Catching here prevents autoDownload failures from surfacing globally.
+    });
     const newer = result?.isUpdateAvailable === true;
     const promptAfterCheck = planCompletedUpdateCheck({
       stagedVersion: checkPlan.promptVersionAfterCheck,

--- a/apps/desktop/src/main/updater-state.test.ts
+++ b/apps/desktop/src/main/updater-state.test.ts
@@ -4,6 +4,7 @@ import {
   planDownloadedUpdate,
   planFatalAutoInstallOnQuit,
   planUpdateCheck,
+  handleUpdateDownloadRejection,
   statusAfterUpdateError,
 } from "./updater-state";
 
@@ -77,6 +78,25 @@ describe("updater state decisions", () => {
     expect(statusAfterUpdateError({ state: "idle" }, "Download failed")).toEqual({
       state: "idle",
     });
+  });
+
+  it("handles auto-download promise rejections after update checks resolve", async () => {
+    const errors: unknown[] = [];
+    const failure = "bad signature";
+
+    // oxlint-disable-next-line executor/no-promise-reject -- boundary: simulates electron-updater's native rejected download promise
+    const handled = handleUpdateDownloadRejection(Promise.reject(failure), (error) => {
+      errors.push(error);
+    });
+
+    await Promise.resolve();
+
+    expect(handled).toBe(true);
+    expect(errors).toEqual([failure]);
+  });
+
+  it("ignores missing auto-download promises", () => {
+    expect(handleUpdateDownloadRejection(null, () => undefined)).toBe(false);
   });
 
   it("restores autoInstallOnAppQuit only when the fatal path recovers", () => {

--- a/apps/desktop/src/main/updater-state.ts
+++ b/apps/desktop/src/main/updater-state.ts
@@ -99,6 +99,16 @@ export const statusAfterUpdateError = (
   return status;
 };
 
+export const handleUpdateDownloadRejection = (
+  downloadPromise: Promise<unknown> | null | undefined,
+  onRejected: (error: unknown) => void,
+): boolean => {
+  if (!downloadPromise) return false;
+  // oxlint-disable-next-line executor/no-promise-catch -- boundary: electron-updater hands back a floating native promise; attaching a rejection handler is the whole point
+  void downloadPromise.catch(onRejected);
+  return true;
+};
+
 export const planFatalAutoInstallOnQuit = (input: {
   readonly packaged: boolean;
   readonly retryAfterReset: boolean;


### PR DESCRIPTION
The publish workflow passed the mac signing env to every build leg, so Windows releases were signed with the wrong certificate and clients reject updates. Scope the mac cert to mac legs, add dedicated Windows signing env, fail CI packaging when the Windows cert is missing, and handle updater download rejections instead of letting them surface as unhandled errors.