### PR TITLE
Sidebar Integrations heading links to the page, with a connect button

### DIFF
--- a/e2e/scenarios/sidebar-integrations-heading-ui.test.ts
+++ b/e2e/scenarios/sidebar-integrations-heading-ui.test.ts
@@ -1,0 +1,51 @@
+// The sidebar "INTEGRATIONS" section heading used to be inert text. It is now a
+// live link to the integrations page, and a plus button beside it opens the
+// same Connect dialog the integrations page uses. This drives the browser path:
+//   1. Land on a non-integrations route so navigation is observable.
+//   2. Click the sidebar Integrations heading and assert we arrive on the
+//      integrations page (its own "Integrations" <h1> renders).
+//   3. Click the plus button and assert the "Connect an integration" dialog
+//      opens, without leaving the current page.
+import { Effect } from "effect";
+
+import { scenario } from "../src/scenario";
+import { Browser, Target } from "../src/services";
+
+scenario(
+  "Sidebar · the Integrations heading links to the page and its plus button opens the Connect dialog",
+  { timeout: 120_000 },
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const browser = yield* Browser;
+    const identity = yield* target.newIdentity();
+
+    yield* browser.session(identity, async ({ page, step }) => {
+      await step("Open the app on the Secrets route", async () => {
+        await page.goto("/secrets", { waitUntil: "domcontentloaded" });
+        await page.getByTestId("sidebar-integrations-heading").waitFor();
+      });
+
+      await step(
+        "Clicking the sidebar Integrations heading opens the integrations page",
+        async () => {
+          await page.getByTestId("sidebar-integrations-heading").click();
+          // The integrations page renders its own title as an <h1> inside <main>;
+          // the sidebar copy is scoped out via getByRole("main").
+          await page
+            .getByRole("main")
+            .getByRole("heading", { name: "Integrations", level: 1 })
+            .waitFor({ timeout: 20_000 });
+        },
+      );
+
+      await step("The sidebar plus button opens the Connect dialog", async () => {
+        await page.getByTestId("sidebar-connect-integration").click();
+        const dialog = page.getByRole("dialog");
+        await dialog.waitFor({ timeout: 20_000 });
+        await dialog
+          .getByRole("heading", { name: "Connect an integration" })
+          .waitFor({ state: "visible", timeout: 20_000 });
+      });
+    });
+  }),
+);

--- a/packages/app/src/web/shell.tsx
+++ b/packages/app/src/web/shell.tsx
@@ -212,6 +212,7 @@ function SidebarContent(props: {
           <Link
             to="/{-$orgSlug}"
             onClick={props.onNavigate}
+            data-testid="sidebar-integrations-heading"
             className="text-xs font-medium uppercase tracking-widest text-muted-foreground transition-colors hover:text-foreground"
           >
             Integrations
@@ -220,6 +221,7 @@ function SidebarContent(props: {
             variant="ghost"
             size="icon-xs"
             aria-label="Connect an integration"
+            data-testid="sidebar-connect-integration"
             className="text-muted-foreground/60 hover:text-foreground"
             onClick={() => setConnectOpen(true)}
           >

--- a/packages/app/src/web/shell.tsx
+++ b/packages/app/src/web/shell.tsx
@@ -2,6 +2,7 @@ import { Link, Outlet, useLocation } from "@tanstack/react-router";
 import { useEffect, useRef, useState } from "react";
 import { useAtomRefresh, useAtomValue } from "@effect/atom-react";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
+import { PlusIcon } from "lucide-react";
 import type { Integration } from "@executor-js/sdk/shared";
 import {
   integrationsAtom,
@@ -15,6 +16,7 @@ import { CommandPalette } from "@executor-js/react/components/command-palette";
 import { useClientPlugins, useIntegrationPlugins } from "@executor-js/sdk/client";
 import { SidebarUpdateCard } from "@executor-js/react/components/update-card";
 import { Wordmark } from "@executor-js/react/components/wordmark";
+import { ConnectDialog } from "@executor-js/react/pages/integrations";
 import { ServerConnectionMenu } from "./server-connection-menu";
 
 // ── Env ─────────────────────────────────────────────────────────────────
@@ -162,6 +164,7 @@ function SidebarContent(props: {
   const isSecrets = props.pathname === "/secrets";
   const isPolicies = props.pathname === "/policies";
   const isToolkits = props.pathname === "/toolkits" || props.pathname.startsWith("/toolkits/");
+  const [connectOpen, setConnectOpen] = useState(false);
 
   return (
     <>
@@ -205,12 +208,29 @@ function SidebarContent(props: {
         <PluginNav pathname={props.pathname} onNavigate={props.onNavigate} />
 
         {/* Sources list */}
-        <div className="mt-5 mb-1 px-2.5 text-xs font-medium uppercase tracking-widest text-muted-foreground">
-          <a href="/">Integrations</a>
+        <div className="mt-5 mb-1 flex items-center justify-between gap-1 pr-1 pl-2.5">
+          <Link
+            to="/{-$orgSlug}"
+            onClick={props.onNavigate}
+            className="text-xs font-medium uppercase tracking-widest text-muted-foreground transition-colors hover:text-foreground"
+          >
+            Integrations
+          </Link>
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            aria-label="Connect an integration"
+            className="text-muted-foreground/60 hover:text-foreground"
+            onClick={() => setConnectOpen(true)}
+          >
+            <PlusIcon className="size-3.5" />
+          </Button>
         </div>
 
         <IntegrationList pathname={props.pathname} onNavigate={props.onNavigate} />
       </nav>
+
+      <ConnectDialog open={connectOpen} onOpenChange={setConnectOpen} />
 
       <SidebarUpdateCard />
 

--- a/packages/react/src/multiplayer/shell.tsx
+++ b/packages/react/src/multiplayer/shell.tsx
@@ -2,7 +2,7 @@ import { Link, Outlet, useLocation, useParams } from "@tanstack/react-router";
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import { useAtomValue } from "@effect/atom-react";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
-import { BookOpen, Command, ExternalLink } from "lucide-react";
+import { BookOpen, Command, ExternalLink, Plus } from "lucide-react";
 import type { Integration } from "@executor-js/sdk/shared";
 import { integrationsOptimisticAtom } from "../api/atoms";
 import { trackEvent } from "../api/analytics";
@@ -22,6 +22,7 @@ import {
   integrationPresetIconUrl,
 } from "../components/integration-favicon";
 import { CommandPalette } from "../components/command-palette";
+import { ConnectDialog } from "../pages/integrations";
 import { Wordmark } from "../components/wordmark";
 import { useClientPlugins, useIntegrationPlugins } from "@executor-js/sdk/client";
 import { useAuth } from "./auth-context";
@@ -362,6 +363,7 @@ function SidebarContent(
     ),
   );
   const navItems = [...(props.navItems ?? defaultShellNavItems), ...pluginNavItems];
+  const [connectOpen, setConnectOpen] = useState(false);
   return (
     <>
       {props.showBrand !== false && (
@@ -381,12 +383,31 @@ function SidebarContent(
           />
         ))}
 
-        <div className="mt-5 mb-1 px-2.5 text-xs font-medium uppercase tracking-widest text-muted-foreground">
-          <span>Integrations</span>
+        <div className="mt-5 mb-1 flex items-center justify-between gap-1 pr-1 pl-2.5">
+          <Link
+            to="/{-$orgSlug}"
+            onClick={props.onNavigate}
+            data-testid="sidebar-integrations-heading"
+            className="text-xs font-medium uppercase tracking-widest text-muted-foreground transition-colors hover:text-foreground"
+          >
+            Integrations
+          </Link>
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            aria-label="Connect an integration"
+            data-testid="sidebar-connect-integration"
+            className="text-muted-foreground/60 hover:text-foreground"
+            onClick={() => setConnectOpen(true)}
+          >
+            <Plus className="size-3.5" />
+          </Button>
         </div>
 
         <IntegrationList pathname={props.pathname} onNavigate={props.onNavigate} />
       </nav>
+
+      <ConnectDialog open={connectOpen} onOpenChange={setConnectOpen} />
 
       <SidebarUpdateCard />
 

--- a/packages/react/src/pages/integrations.tsx
+++ b/packages/react/src/pages/integrations.tsx
@@ -149,7 +149,7 @@ const looksLikeUrl = (raw: string): boolean => {
   return false;
 };
 
-function ConnectDialog(props: { open: boolean; onOpenChange: (open: boolean) => void }) {
+export function ConnectDialog(props: { open: boolean; onOpenChange: (open: boolean) => void }) {
   const integrationPlugins = useIntegrationPlugins();
   const doDetect = useAtomSet(detectIntegration, { mode: "promiseExit" });
   const navigate = useNavigate();


### PR DESCRIPTION
The sidebar "INTEGRATIONS" section heading was inert text. It is now a link to the integrations page, and a plus button beside it opens the same Connect dialog used on that page.

Builds on `5206af21` (which made the app-shell heading a bare `<a href="/">`): this uses a proper router `<Link>` (no full-page reload, org-scope aware) and adds the plus button, on both shells that render this heading, `packages/app/src/web/shell.tsx` (desktop/local) and `packages/react/src/multiplayer/shell.tsx` (cloud + self-host). The dialog is the existing `ConnectDialog`, now exported and reused (no duplicate modal).

Covered by an e2e scenario (`sidebar-integrations-heading-ui.test.ts`, selfhost): clicking the heading opens the integrations page, and the plus button opens the Connect dialog.

![Sidebar Integrations heading links to the page and its plus button opens the Connect dialog](https://raw.githubusercontent.com/UsefulSoftwareCo/executor/e2e-media/sidebar-the-integrations-heading-links-to-the-page-and-its-plus-button-opens-the-0909eee7.gif)