### PR TITLE
Add changeset for the 1Password SDK fix

### DIFF
--- a/.changeset/onepassword-sdk-compiled-fix.md
+++ b/.changeset/onepassword-sdk-compiled-fix.md
@@ -1,0 +1,5 @@
+---
+"executor": patch
+---
+
+Fix 1Password desktop-app connections failing with "undefined is not a constructor (evaluating 'new n.DesktopAuth(...)')" in packaged builds. The compiled binary now bundles the 1Password SDK's wasm core correctly and falls back to a copy shipped next to the binary, so vault listing and secret resolution work without the `op` CLI installed.


### PR DESCRIPTION
Adds a patch changeset so the 1Password SDK compiled-binary fix from #1298 ships in the next release. v1.5.28 was tagged before that fix landed, so packaged desktop builds still fail to connect 1Password without the op CLI installed.