### PR TITLE
Run publish jobs on ubuntu-latest for npm provenance

### DIFF
--- a/.github/workflows/publish-executor-package.yml
+++ b/.github/workflows/publish-executor-package.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   publish:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       actions: write
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   release:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       actions: write
       contents: write


### PR DESCRIPTION
The 1.5.29 package publish failed with `Unsupported GitHub Actions runner environment: "self-hosted"` from npm's sigstore verification. Blacksmith runners report as self-hosted, and npm only accepts provenance from github-hosted runners, so this re-applies #1291 for the release and CLI publish jobs (#1292 reverted it based on a different diagnosis; the filename mismatch it found was real but was not the only blocker). CI jobs stay on Blacksmith. Unblocks the 1.5.29 release.