### PR TITLE
Preserve MCP tool results across dropped SSE connections

### DIFF
--- a/.changeset/mcp-sse-result-replay.md
+++ b/.changeset/mcp-sse-result-replay.md
@@ -1,0 +1,5 @@
+---
+"executor": patch
+---
+
+Preserve MCP tool results across dropped streamable HTTP SSE connections.

--- a/apps/cloud/src/mcp/agent-handler.ts
+++ b/apps/cloud/src/mcp/agent-handler.ts
@@ -153,6 +153,12 @@ export const makeCloudMcpAgentHandler = () => {
       if (owner === "not_found") {
         return jsonRpcResponse(404, -32001, "Session not found");
       }
+      if (owner === "terminated") {
+        // DELETE-condemned but the deferred destroy alarm hasn't wiped storage
+        // yet. Same envelope as the post-destroy race below: the client must
+        // treat the id as dead and reconnect.
+        return jsonRpcResponse(404, -32001, "Session timed out, please reconnect");
+      }
       if (owner === "forbidden") {
         return jsonRpcResponse(403, -32003, "MCP session does not belong to the current bearer");
       }

--- a/apps/host-cloudflare/src/mcp/agent-handler.ts
+++ b/apps/host-cloudflare/src/mcp/agent-handler.ts
@@ -124,6 +124,11 @@ export const makeCloudflareMcpAgentHandler = (config: CloudflareConfig) => {
       if (owner === "not_found") {
         return jsonRpcResponse(404, -32001, "Session not found");
       }
+      if (owner === "terminated") {
+        // DELETE-condemned but the deferred destroy alarm hasn't wiped storage
+        // yet; the terminated id must read as dead immediately.
+        return jsonRpcResponse(404, -32001, "Session timed out, please reconnect");
+      }
       if (owner === "forbidden") {
         return jsonRpcResponse(403, -32003, "MCP session does not belong to the current bearer");
       }

--- a/e2e/cloud/mcp-sse-replay.test.ts
+++ b/e2e/cloud/mcp-sse-replay.test.ts
@@ -1,0 +1,277 @@
+import { randomUUID } from "node:crypto";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+
+import { scenario } from "../src/scenario";
+import { Mcp, Target } from "../src/services";
+import type { Identity } from "../src/target";
+import { configuredMcpSessionTimeoutMs } from "../setup/mcp-session-timeouts";
+
+const PROTOCOL_VERSION = "2025-03-26";
+const JSON_AND_SSE = "application/json, text/event-stream";
+
+const emailOf = (identity: Identity): string => identity.credentials?.email ?? identity.label;
+
+const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+const initializeBody = {
+  jsonrpc: "2.0" as const,
+  id: "initialize",
+  method: "initialize",
+  params: {
+    protocolVersion: PROTOCOL_VERSION,
+    capabilities: {},
+    clientInfo: { name: "executor-e2e-mcp-sse-replay", version: "0.0.1" },
+  },
+};
+
+const initializedNotification = {
+  jsonrpc: "2.0" as const,
+  method: "notifications/initialized",
+};
+
+const executeBody = (id: string, code: string) => ({
+  jsonrpc: "2.0" as const,
+  id,
+  method: "tools/call",
+  params: { name: "execute", arguments: { code } },
+});
+
+const mcpHeaders = (bearer: string, sessionId?: string) => ({
+  accept: JSON_AND_SSE,
+  authorization: `Bearer ${bearer}`,
+  "content-type": "application/json",
+  "mcp-protocol-version": PROTOCOL_VERSION,
+  ...(sessionId ? { "mcp-session-id": sessionId } : {}),
+});
+
+const postJson = (mcpUrl: string, bearer: string, body: unknown, sessionId?: string) =>
+  fetch(mcpUrl, {
+    method: "POST",
+    headers: mcpHeaders(bearer, sessionId),
+    body: JSON.stringify(body),
+  });
+
+const openSession = async (mcpUrl: string, bearer: string): Promise<string> => {
+  const initialized = await postJson(mcpUrl, bearer, initializeBody);
+  const sessionId = initialized.headers.get("mcp-session-id");
+  await initialized.text();
+  if (initialized.status !== 200 || !sessionId) {
+    throw new Error(`openSession: initialize failed (${initialized.status})`);
+  }
+
+  const notification = await postJson(mcpUrl, bearer, initializedNotification, sessionId);
+  await notification.text();
+  expect(notification.status, "notifications/initialized is accepted").toBe(202);
+  return sessionId;
+};
+
+type JsonRpcMessage = {
+  readonly id?: unknown;
+  readonly result?: unknown;
+  readonly error?: unknown;
+};
+
+class SseCapture {
+  readonly messages: JsonRpcMessage[] = [];
+  readonly eventIds: string[] = [];
+  private reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+  private readonly waiters = new Map<
+    string,
+    Array<{ readonly resolve: (message: JsonRpcMessage) => void }>
+  >();
+  readonly finished: Promise<void>;
+
+  constructor(
+    private readonly response: Response,
+    private readonly abortController?: AbortController,
+  ) {
+    this.finished = this.consume();
+  }
+
+  waitForId(id: string, timeoutMs: number): Promise<JsonRpcMessage> {
+    const existing = this.messages.find((message) => message.id === id);
+    if (existing) return Promise.resolve(existing);
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        // oxlint-disable-next-line executor/no-promise-reject, executor/no-error-constructor -- boundary: Promise timeout adapter for e2e polling.
+        reject(new Error(`timed out waiting for JSON-RPC id ${id}`));
+      }, timeoutMs);
+      const waiter = {
+        resolve: (message: JsonRpcMessage) => {
+          clearTimeout(timeout);
+          resolve(message);
+        },
+      };
+      this.waiters.set(id, [...(this.waiters.get(id) ?? []), waiter]);
+    });
+  }
+
+  abort(reason: string): void {
+    this.abortController?.abort(reason);
+    this.reader?.cancel(reason).catch(() => undefined);
+  }
+
+  private async consume(): Promise<void> {
+    const reader = this.response.body?.getReader();
+    if (!reader) return;
+    this.reader = reader;
+    const decoder = new TextDecoder();
+    let buffer = "";
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        buffer = this.consumeBlocks(buffer);
+      }
+      buffer += decoder.decode();
+      this.consumeBlocks(`${buffer}\n\n`);
+    } catch {
+      return;
+    } finally {
+      if (this.reader === reader) this.reader = null;
+      reader.releaseLock();
+    }
+  }
+
+  private consumeBlocks(buffer: string): string {
+    let next = buffer;
+    for (;;) {
+      const index = next.indexOf("\n\n");
+      if (index === -1) return next;
+      const block = next.slice(0, index);
+      next = next.slice(index + 2);
+      this.recordBlock(block);
+    }
+  }
+
+  private recordBlock(block: string): void {
+    let data = "";
+    let id: string | null = null;
+    for (const line of block.replace(/\r/g, "").split("\n")) {
+      if (line.startsWith("data:")) data += `${line.slice("data:".length).trimStart()}\n`;
+      if (line.startsWith("id:")) id = line.slice("id:".length).trim();
+    }
+    if (id) this.eventIds.push(id);
+    const trimmed = data.trim();
+    if (!trimmed) return;
+    const parsed = JSON.parse(trimmed) as JsonRpcMessage;
+    this.messages.push(parsed);
+    if (typeof parsed.id !== "string") return;
+    const waiters = this.waiters.get(parsed.id) ?? [];
+    this.waiters.delete(parsed.id);
+    for (const waiter of waiters) waiter.resolve(parsed);
+  }
+}
+
+const openGet = async (mcpUrl: string, bearer: string, sessionId: string): Promise<SseCapture> => {
+  const abortController = new AbortController();
+  const response = await fetch(mcpUrl, {
+    method: "GET",
+    headers: {
+      accept: "text/event-stream",
+      authorization: `Bearer ${bearer}`,
+      "mcp-protocol-version": PROTOCOL_VERSION,
+      "mcp-session-id": sessionId,
+    },
+    signal: abortController.signal,
+  });
+  expect(response.status, "GET SSE opens").toBe(200);
+  return new SseCapture(response, abortController);
+};
+
+const startPostCapture = async (
+  mcpUrl: string,
+  bearer: string,
+  sessionId: string,
+  body: unknown,
+  abortController?: AbortController,
+): Promise<SseCapture> => {
+  const response = await fetch(mcpUrl, {
+    method: "POST",
+    headers: mcpHeaders(bearer, sessionId),
+    body: JSON.stringify(body),
+    ...(abortController ? { signal: abortController.signal } : {}),
+  });
+  expect(response.status, "POST tools/call opens an SSE response").toBe(200);
+  return new SseCapture(response, abortController);
+};
+
+const delayedCode = (marker: string, delayMs: number): string =>
+  [
+    `const marker = ${JSON.stringify(marker)};`,
+    `await new Promise((resolve) => setTimeout(resolve, ${delayMs}));`,
+    "return marker;",
+  ].join("\n");
+
+scenario(
+  "MCP streamable HTTP · POST response abort is replayed on the next GET stream",
+  { timeout: 160_000 },
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const mcp = yield* Mcp;
+    const identity = yield* target.newIdentity();
+    const bearer = yield* mcp.mintBearer(emailOf(identity));
+    const sessionId = yield* Effect.promise(() => openSession(target.mcpUrl, bearer));
+
+    const callId = `post-abort-${randomUUID()}`;
+    const marker = `MARKER_POST_ABORT_${randomUUID()}`;
+    const post = yield* Effect.promise(() =>
+      startPostCapture(
+        target.mcpUrl,
+        bearer,
+        sessionId,
+        executeBody(callId, delayedCode(marker, 40_000)),
+      ),
+    );
+    yield* Effect.promise(() => delay(500));
+    post.abort("simulate client disconnect before result");
+    yield* Effect.promise(() => post.finished.catch(() => undefined));
+
+    yield* Effect.promise(() => delay(42_000));
+
+    const replay = yield* Effect.promise(() => openGet(target.mcpUrl, bearer, sessionId));
+    const message = yield* Effect.promise(() => replay.waitForId(callId, 15_000));
+    replay.abort("scenario complete");
+
+    expect(
+      JSON.stringify(message),
+      "the replayed response contains the completed tool result",
+    ).toContain(marker);
+    expect(replay.eventIds.length, "the replayed result carries an SSE event id").toBeGreaterThan(
+      0,
+    );
+  }),
+);
+
+scenario(
+  "MCP streamable HTTP · in-flight call survives the session idle timeout",
+  { timeout: 90_000 },
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const mcp = yield* Mcp;
+    const identity = yield* target.newIdentity();
+    const bearer = yield* mcp.mintBearer(emailOf(identity));
+    const sessionId = yield* Effect.promise(() => openSession(target.mcpUrl, bearer));
+
+    const callId = `idle-survive-${randomUUID()}`;
+    const marker = `MARKER_IDLE_SURVIVE_${randomUUID()}`;
+    const delayMs = configuredMcpSessionTimeoutMs() + 2_000;
+    const post = yield* Effect.promise(() =>
+      startPostCapture(
+        target.mcpUrl,
+        bearer,
+        sessionId,
+        executeBody(callId, delayedCode(marker, delayMs)),
+      ),
+    );
+    const message = yield* Effect.promise(() => post.waitForId(callId, delayMs + 20_000));
+
+    expect(
+      JSON.stringify(message),
+      "the long call completes after the idle alarm window",
+    ).toContain(marker);
+  }),
+);

--- a/packages/hosts/cloudflare/src/mcp/agent-session-durable-object.test.ts
+++ b/packages/hosts/cloudflare/src/mcp/agent-session-durable-object.test.ts
@@ -103,7 +103,7 @@ type HarnessSession = {
   validateMcpSessionOwner: (identity: {
     readonly accountId: string;
     readonly organizationId: string;
-  }) => Promise<"ok" | "not_found" | "forbidden">;
+  }) => Promise<"ok" | "not_found" | "forbidden" | "terminated">;
 };
 
 class StaleCloseTransport implements Transport {

--- a/packages/hosts/cloudflare/src/mcp/agent-session-durable-object.ts
+++ b/packages/hosts/cloudflare/src/mcp/agent-session-durable-object.ts
@@ -368,9 +368,7 @@ export abstract class McpAgentSessionDOBase<
   }
 
   private activeStreamCount(): number {
-    const getConnections = (this as { getConnections?: () => Iterable<Connection> }).getConnections;
-    if (!getConnections) return 0;
-    return Array.from(getConnections.call(this)).length;
+    return this.connectionsOrNone().length;
   }
 
   private async runningExecutionCount(): Promise<number> {
@@ -392,13 +390,35 @@ export abstract class McpAgentSessionDOBase<
   }
 
   private closeActiveStreams(): void {
-    const getConnections = (this as { getConnections?: () => Iterable<Connection> }).getConnections;
-    if (!getConnections) return;
-    for (const connection of getConnections.call(this)) {
+    for (const connection of this.connectionsOrNone()) {
       // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: best-effort WebSocket close during runtime disposal.
       try {
         connection.close(1000, "Session closed");
       } catch {}
+    }
+  }
+
+  /**
+   * partyserver's `getConnections` dereferences a `#connectionManager`
+   * private field that is only initialized once the DO has accepted a
+   * websocket (never in unit harnesses), and partyserver exposes no
+   * non-throwing probe for that state, so "it throws" IS the signal for
+   * "no connections yet". Treating that as an empty set is safe for both
+   * callers: `closeActiveStreams` then has nothing to close, and
+   * `activeStreamCount` feeds the idle-lease decision where zero at worst
+   * disposes an idle-looking runtime whose undelivered responses are
+   * persisted in durable storage and replayed by the next reconnect GET.
+   * Before this guard the alarm crashed and retried instead, which kept
+   * the session pinned without ever making progress.
+   */
+  private connectionsOrNone(): ReadonlyArray<Connection> {
+    const getConnections = (this as { getConnections?: () => Iterable<Connection> }).getConnections;
+    if (!getConnections) return [];
+    // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: see doc comment; partyserver offers no non-throwing way to ask whether the connection manager exists.
+    try {
+      return Array.from(getConnections.call(this));
+    } catch {
+      return [];
     }
   }
 

--- a/packages/hosts/cloudflare/src/mcp/agent-session-durable-object.ts
+++ b/packages/hosts/cloudflare/src/mcp/agent-session-durable-object.ts
@@ -31,6 +31,7 @@ import {
   SESSION_TIMEOUT_MS,
   decideSessionAlarm,
   pausedLeaseExtensionLog,
+  runningLeaseExtensionLog,
 } from "./session-alarm-policy";
 
 export type IncomingTraceHeaders = IncomingPropagationHeaders;
@@ -118,9 +119,9 @@ const LAST_ACTIVITY_KEY = "last-activity-ms";
 const PARTYSERVER_NAME_KEY = "__ps_name";
 const MCP_HTTP_METHOD_HEADER = "cf-mcp-method";
 const MCP_MESSAGE_HEADER = "cf-mcp-message";
-const ACTIVE_POST_RESPONSE_WAIT_POLL_MS = 25;
-const ACTIVE_POST_RESPONSE_WAIT_MAX_MS = PAUSED_APPROVAL_TIMEOUT_MS + 30_000;
 const MODEL_RESUME_FORWARD_TIMEOUT_MS = 10_000;
+const MCP_STREAM_REQS_KEY_PREFIX = "__mcp_stream_reqs__:";
+const MCP_UNDELIVERED_STREAM_KEY_PREFIX = "__mcp_undelivered_stream__:";
 const approvalResponseKey = (executionId: string) => `approval-response:${executionId}`;
 
 type JsonRpcRequestId = string | number;
@@ -162,8 +163,6 @@ const isSessionProps = (props: unknown): props is McpSessionProps =>
   "session" in props &&
   typeof (props as { readonly session?: unknown }).session === "object" &&
   (props as { readonly session?: unknown }).session !== null;
-
-const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
 const readActivePostRequestIds = (request: Request): readonly JsonRpcRequestId[] => {
   if (request.headers.get(MCP_HTTP_METHOD_HEADER) !== "POST") return [];
@@ -319,34 +318,13 @@ export abstract class McpAgentSessionDOBase<
     }
 
     await this.keepAliveWhile(async () => {
+      await this.setStreamRequestIds(conn.id, [...requestIds]);
       await super.onConnect(conn, context);
-      await this.waitForActivePostResponseDrain(conn.id);
     });
   }
 
   private openSessionDbHandle(): Effect.Effect<TDbHandle> {
     return Effect.promise(() => Promise.resolve(this.openSessionDb()));
-  }
-
-  private async waitForActivePostResponseDrain(streamId: string): Promise<void> {
-    const startedAt = Date.now();
-    for (;;) {
-      const requestIds = await this.getStreamRequestIds(streamId);
-      if (!requestIds || requestIds.length === 0) return;
-      if (Date.now() - startedAt >= ACTIVE_POST_RESPONSE_WAIT_MAX_MS) {
-        console.warn(
-          JSON.stringify({
-            event: "mcp_active_post_response_wait_timeout",
-            sessionId: this.sessionId,
-            streamId,
-            requestIds,
-            elapsedMs: Date.now() - startedAt,
-          }),
-        );
-        return;
-      }
-      await sleep(ACTIVE_POST_RESPONSE_WAIT_POLL_MS);
-    }
   }
 
   private loadSessionMeta(): Effect.Effect<SessionMeta | null> {
@@ -388,6 +366,40 @@ export abstract class McpAgentSessionDOBase<
     if (this.ctx.id.name) return true;
     const stored = await this.ctx.storage.get<string>(PARTYSERVER_NAME_KEY);
     return !!stored;
+  }
+
+  private activeStreamCount(): number {
+    const getConnections = (this as { getConnections?: () => Iterable<Connection> }).getConnections;
+    if (!getConnections) return 0;
+    return Array.from(getConnections.call(this)).length;
+  }
+
+  private async runningExecutionCount(): Promise<number> {
+    const rows = await this.ctx.storage.list<readonly JsonRpcRequestId[]>({
+      prefix: MCP_STREAM_REQS_KEY_PREFIX,
+      limit: 1_000,
+    });
+    let count = 0;
+    for (const requestIds of rows.values()) {
+      if (Array.isArray(requestIds)) count += requestIds.length;
+    }
+    const undelivered = await this.ctx.storage.list<boolean>({
+      prefix: MCP_UNDELIVERED_STREAM_KEY_PREFIX,
+      limit: 1_000,
+    });
+    count += undelivered.size;
+    return count;
+  }
+
+  private closeActiveStreams(): void {
+    const getConnections = (this as { getConnections?: () => Iterable<Connection> }).getConnections;
+    if (!getConnections) return;
+    for (const connection of getConnections.call(this)) {
+      // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: best-effort WebSocket close during runtime disposal.
+      try {
+        connection.close(1000, "Session closed");
+      } catch {}
+    }
   }
 
   private async cleanupUnaddressableSessionAlarm(): Promise<void> {
@@ -543,6 +555,7 @@ export abstract class McpAgentSessionDOBase<
     const self = this;
     return Effect.gen(function* () {
       yield* self.releaseAllPendingApprovalLeases();
+      yield* Effect.sync(() => self.closeActiveStreams());
       if (self.server) {
         const server = self.server;
         delete (self as { server?: McpServer }).server;
@@ -832,9 +845,13 @@ export abstract class McpAgentSessionDOBase<
     const lastActivityMs = await this.loadLastActivity();
     const idleMs = lastActivityMs > 0 ? Date.now() - lastActivityMs : 0;
     const pausedExecutionCount = await this.pausedExecutionCount();
+    const runningExecutionCount = await this.runningExecutionCount();
+    const activeStreamCount = this.activeStreamCount();
     const decision = decideSessionAlarm({
       idleMs,
       pausedExecutionCount,
+      runningExecutionCount,
+      activeStreamCount,
       sessionTimeoutMs: this.sessionTimeoutMs(),
       maxPausedSessionIdleMs: this.maxPausedSessionIdleMs(),
     });
@@ -855,6 +872,26 @@ export abstract class McpAgentSessionDOBase<
           }),
         ),
       );
+      await this.ctx.storage.setAlarm(Date.now() + decision.leaseMs);
+      return;
+    }
+
+    if (decision.kind === "extend_running_lease") {
+      console.info(
+        JSON.stringify(
+          runningLeaseExtensionLog({
+            sessionId: this.sessionId,
+            runningExecutionCount,
+            activeStreamCount,
+            idleMs,
+            leaseMs: decision.leaseMs,
+          }),
+        ),
+      );
+      // Open streamable-HTTP bridges and persisted request ids represent work
+      // that can still deliver or replay a response. Buggy dead pipes are
+      // closed by the SSE writer's terminal failure path, so they stop
+      // extending the lease once the bridge observes the failure.
       await this.ctx.storage.setAlarm(Date.now() + decision.leaseMs);
       return;
     }

--- a/packages/hosts/cloudflare/src/mcp/agent-session-durable-object.ts
+++ b/packages/hosts/cloudflare/src/mcp/agent-session-durable-object.ts
@@ -117,6 +117,8 @@ export interface BrowserApprovalStore {
 const SESSION_META_KEY = "session-meta";
 const LAST_ACTIVITY_KEY = "last-activity-ms";
 const PARTYSERVER_NAME_KEY = "__ps_name";
+/** The agents SDK's durable "condemned" marker (`_cf_scheduleDestroy`). */
+const AGENTS_DESTROY_PENDING_KEY = "cf_agents_destroy_pending";
 const MCP_HTTP_METHOD_HEADER = "cf-mcp-method";
 const MCP_MESSAGE_HEADER = "cf-mcp-message";
 const MODEL_RESUME_FORWARD_TIMEOUT_MS = 10_000;
@@ -691,11 +693,23 @@ export abstract class McpAgentSessionDOBase<
 
   async validateMcpSessionOwner(
     identity: McpApprovalOwner,
-  ): Promise<"ok" | "not_found" | "forbidden"> {
+  ): Promise<"ok" | "not_found" | "forbidden" | "terminated"> {
     const self = this;
     return Effect.runPromise(
       Effect.gen(function* () {
         yield* self.prepareErrorCaptureScope();
+        // A DELETE-terminated session is condemned via `_cf_scheduleDestroy`,
+        // which writes a durable marker and defers the actual `destroy()` to
+        // an alarm (~1s later). A request that races into that window still
+        // sees the session's storage intact, so without this gate the session
+        // would restore and answer — but the protocol contract is that a
+        // terminated id is dead the moment the DELETE returns. (The old code
+        // won this race by accident: its onConnect drain-wait stalled the
+        // request until the destroy alarm aborted the isolate.)
+        const destroyPending = yield* Effect.promise(() =>
+          self.ctx.storage.get<boolean>(AGENTS_DESTROY_PENDING_KEY),
+        );
+        if (destroyPending === true) return "terminated" as const;
         const sessionMeta = yield* self.loadSessionMeta();
         if (!sessionMeta) return "not_found" as const;
         if (self.initialized) {
@@ -1091,10 +1105,18 @@ export abstract class McpAgentSessionDOBase<
       yield* self.prepareErrorCaptureScope();
       if (self.pendingApprovalLeases.has(executionId)) return;
 
+      // keepAlive BEFORE markActivity: acquiring the first keepAlive ref runs
+      // the SDK's _scheduleNextAlarm, which re-arms the DO alarm to its 30s
+      // heartbeat and would overwrite the idle alarm markActivity sets. With
+      // this ordering markActivity's setAlarm(now + sessionTimeoutMs) lands
+      // last, so the idle/paused-expiry clock keeps ticking while the lease
+      // holds the runtime alive. (Round 1 removed onConnect's drain-wait,
+      // which used to hold a ref across the pause and mask this by keeping
+      // the ref transition away from 0->1.)
+      const disposeKeepAlive = yield* Effect.promise(() => self.keepAlive());
       yield* Effect.promise(() => self.markActivity()).pipe(
         Effect.withSpan("McpSessionDO.markActivity"),
       );
-      const disposeKeepAlive = yield* Effect.promise(() => self.keepAlive());
       const timeout = setTimeout(() => {
         self.queuePendingApprovalLeaseExpiration(executionId);
       }, PAUSED_APPROVAL_TIMEOUT_MS);

--- a/packages/hosts/cloudflare/src/mcp/agent-session-durable-object.ts
+++ b/packages/hosts/cloudflare/src/mcp/agent-session-durable-object.ts
@@ -121,7 +121,6 @@ const MCP_HTTP_METHOD_HEADER = "cf-mcp-method";
 const MCP_MESSAGE_HEADER = "cf-mcp-message";
 const MODEL_RESUME_FORWARD_TIMEOUT_MS = 10_000;
 const MCP_STREAM_REQS_KEY_PREFIX = "__mcp_stream_reqs__:";
-const MCP_UNDELIVERED_STREAM_KEY_PREFIX = "__mcp_undelivered_stream__:";
 const approvalResponseKey = (executionId: string) => `approval-response:${executionId}`;
 
 type JsonRpcRequestId = string | number;
@@ -375,6 +374,12 @@ export abstract class McpAgentSessionDOBase<
   }
 
   private async runningExecutionCount(): Promise<number> {
+    // Only requests still awaiting a result count as running work. Undelivered
+    // response markers (the transport's __mcp_undelivered_stream__: keys)
+    // deliberately do NOT extend the lease: the response is persisted in storage,
+    // which survives disposeIdleRuntime, so a later reconnect GET re-inits the
+    // DO and replays it. Counting them would make every delivered-but-unacked
+    // POST response pin the runtime alive indefinitely.
     const rows = await this.ctx.storage.list<readonly JsonRpcRequestId[]>({
       prefix: MCP_STREAM_REQS_KEY_PREFIX,
       limit: 1_000,
@@ -383,11 +388,6 @@ export abstract class McpAgentSessionDOBase<
     for (const requestIds of rows.values()) {
       if (Array.isArray(requestIds)) count += requestIds.length;
     }
-    const undelivered = await this.ctx.storage.list<boolean>({
-      prefix: MCP_UNDELIVERED_STREAM_KEY_PREFIX,
-      limit: 1_000,
-    });
-    count += undelivered.size;
     return count;
   }
 

--- a/packages/hosts/cloudflare/src/mcp/agents-event-store.test.ts
+++ b/packages/hosts/cloudflare/src/mcp/agents-event-store.test.ts
@@ -1,0 +1,147 @@
+// Unit coverage for the patched agents DurableObjectEventStore (see
+// patches/agents@0.17.3.patch). The store is the durable half of the MCP
+// result-replay fix: a final tool response persisted here is the only copy a
+// recovery GET can replay after the client's POST response body died, so
+// trimStream must never evict it.
+import { afterEach, beforeEach, describe, expect, it, vi } from "@effect/vitest";
+import { DurableObjectEventStore } from "agents/mcp";
+
+type ListOptions = {
+  readonly prefix?: string;
+  readonly start?: string;
+  readonly limit?: number;
+  readonly reverse?: boolean;
+};
+
+/** Minimal in-memory stand-in for DurableObjectStorage's sorted KV surface. */
+const makeFakeStorage = () => {
+  const entries = new Map<string, unknown>();
+  return {
+    entries,
+    put: (key: string, value: unknown) => {
+      entries.set(key, value);
+      return Promise.resolve();
+    },
+    delete: (keys: string | ReadonlyArray<string>) => {
+      for (const key of Array.isArray(keys) ? keys : [keys]) entries.delete(key);
+      return Promise.resolve();
+    },
+    list: (options: ListOptions = {}) => {
+      const keys = [...entries.keys()]
+        .filter((key) => (options.prefix === undefined ? true : key.startsWith(options.prefix)))
+        .filter((key) => (options.start === undefined ? true : key >= options.start))
+        .sort();
+      if (options.reverse === true) keys.reverse();
+      const limited = options.limit === undefined ? keys : keys.slice(0, options.limit);
+      return Promise.resolve(new Map(limited.map((key) => [key, entries.get(key)])));
+    },
+  };
+};
+
+const makeStore = () => {
+  const storage = makeFakeStorage();
+  // The store only touches put/list/delete; the fake covers exactly that.
+  const store = new DurableObjectEventStore(storage as never);
+  return { storage, store };
+};
+
+const eventKeys = (storage: ReturnType<typeof makeFakeStorage>): ReadonlyArray<string> =>
+  [...storage.entries.keys()].sort();
+
+describe("DurableObjectEventStore trimStream", () => {
+  let warnings: string[] = [];
+
+  beforeEach(() => {
+    warnings = [];
+    vi.spyOn(console, "warn").mockImplementation((line: string) => {
+      warnings.push(line);
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("keeps an oversize final response instead of evicting the only event", async () => {
+    const { storage, store } = makeStore();
+    const hugeResult = {
+      jsonrpc: "2.0" as const,
+      id: 1,
+      result: { content: [{ type: "text", text: "x".repeat(3 * 1024 * 1024) }] },
+    };
+
+    const eventId = await store.storeEvent("post-stream", hugeResult);
+
+    expect(eventId, "storeEvent returns the event id").toBe("post-stream:0000000000000001");
+    expect(eventKeys(storage), "the >2MB final response survives its own trim pass").toEqual([
+      "__mcp_event__:post-stream:0000000000000001",
+    ]);
+    expect(warnings, "no eviction happened, so no eviction warning").toEqual([]);
+  });
+
+  it("evicts oldest events at the byte cap but never the newest", async () => {
+    const { storage, store } = makeStore();
+    const bigMessage = (marker: string) => ({
+      jsonrpc: "2.0" as const,
+      method: "notifications/progress",
+      params: { marker, blob: "y".repeat(1024 * 1024) },
+    });
+
+    await store.storeEvent("post-stream", bigMessage("one"));
+    await store.storeEvent("post-stream", bigMessage("two"));
+    await store.storeEvent("post-stream", bigMessage("three"));
+
+    const remaining = eventKeys(storage);
+    expect(remaining[remaining.length - 1], "the newest event is always retained").toBe(
+      "__mcp_event__:post-stream:0000000000000003",
+    );
+    expect(
+      remaining.length,
+      "older events were evicted to satisfy the 2MB stream cap",
+    ).toBeLessThan(3);
+    expect(warnings.length, "eviction logs a warning").toBeGreaterThan(0);
+    expect(warnings.at(-1)).toContain("mcp_event_store_evicted");
+    expect(warnings.at(-1)).toContain("post-stream");
+  });
+
+  it("evicts oldest events past the per-stream event-count cap", async () => {
+    const { storage, store } = makeStore();
+    const total = 70; // MAX_EVENTS_PER_STREAM is 64
+    for (let index = 0; index < total; index += 1) {
+      await store.storeEvent("chatty-stream", {
+        jsonrpc: "2.0" as const,
+        method: "notifications/progress",
+        params: { index },
+      });
+    }
+
+    const remaining = eventKeys(storage);
+    expect(remaining.length, "stream is capped at 64 events").toBe(64);
+    expect(remaining[remaining.length - 1], "the newest event survives the count cap").toBe(
+      `__mcp_event__:chatty-stream:${total.toString(16).padStart(16, "0")}`,
+    );
+    expect(remaining[0], "the oldest surviving event is the one just inside the cap").toBe(
+      `__mcp_event__:chatty-stream:${(total - 63).toString(16).padStart(16, "0")}`,
+    );
+  });
+
+  it("leaves streams under both caps untouched", async () => {
+    const { storage, store } = makeStore();
+    await store.storeEvent("quiet-stream", {
+      jsonrpc: "2.0" as const,
+      id: 1,
+      result: { ok: true },
+    });
+    await store.storeEvent("quiet-stream", {
+      jsonrpc: "2.0" as const,
+      id: 2,
+      result: { ok: true },
+    });
+
+    expect(eventKeys(storage)).toEqual([
+      "__mcp_event__:quiet-stream:0000000000000001",
+      "__mcp_event__:quiet-stream:0000000000000002",
+    ]);
+    expect(warnings).toEqual([]);
+  });
+});

--- a/packages/hosts/cloudflare/src/mcp/agents-sse-max-age.test.ts
+++ b/packages/hosts/cloudflare/src/mcp/agents-sse-max-age.test.ts
@@ -11,8 +11,10 @@ type FakeWebSocket = EventTarget & {
   accepted: boolean;
   closeCode: number | undefined;
   closeReason: string | undefined;
+  sent: string[];
   accept: () => void;
   close: (code?: number, reason?: string) => void;
+  send: (message: string) => void;
 };
 
 type FakeAgentStub = {
@@ -41,7 +43,13 @@ const RotationLogEvent = Schema.Struct({
     Schema.Literal("legacy-sse"),
   ]),
 });
+const DeliveryAck = Schema.Struct({
+  eventId: Schema.String,
+  streamId: Schema.String,
+  type: Schema.Literal("cf_mcp_delivery_ack"),
+});
 const decodeRotationLogEvent = Schema.decodeUnknownOption(Schema.fromJsonString(RotationLogEvent));
+const decodeDeliveryAck = Schema.decodeUnknownSync(Schema.fromJsonString(DeliveryAck));
 
 const flushMicrotasks = async (): Promise<void> => {
   await Promise.resolve();
@@ -120,6 +128,71 @@ const installStallingTransformStream = () => {
   };
 };
 
+const installRejectingTransformStream = () => {
+  let abortReason: unknown;
+  let writeCount = 0;
+  const writer = {
+    abort: (reason: unknown) => {
+      abortReason = reason;
+      return Promise.resolve();
+    },
+    close: () => Promise.resolve(),
+    write: () => {
+      writeCount += 1;
+      // oxlint-disable-next-line executor/no-promise-reject, executor/no-error-constructor -- boundary: fake writer models WHATWG stream write rejection in a unit test.
+      return Promise.reject(new Error("client disconnected"));
+    },
+  };
+
+  vi.stubGlobal(
+    "TransformStream",
+    class {
+      readonly readable = new ReadableStream<Uint8Array>();
+      readonly writable = {
+        getWriter: () => writer,
+      };
+    },
+  );
+
+  return {
+    abortReason: () => abortReason,
+    writeCount: () => writeCount,
+  };
+};
+
+const installClosedRejectingTransformStream = () => {
+  let abortReason: unknown;
+  let rejectClosed: ((error: Error) => void) | undefined;
+  const closed = new Promise<never>((_, reject) => {
+    rejectClosed = reject;
+  });
+  const writer = {
+    abort: (reason: unknown) => {
+      abortReason = reason;
+      return Promise.resolve();
+    },
+    close: () => Promise.resolve(),
+    closed,
+    write: () => Promise.resolve(),
+  };
+
+  vi.stubGlobal(
+    "TransformStream",
+    class {
+      readonly readable = new ReadableStream<Uint8Array>();
+      readonly writable = {
+        getWriter: () => writer,
+      };
+    },
+  );
+
+  return {
+    abortReason: () => abortReason,
+    // oxlint-disable-next-line executor/no-error-constructor -- boundary: fake writer models WHATWG writer.closed rejection in a unit test.
+    rejectClosed: () => rejectClosed?.(new Error("client canceled response body")),
+  };
+};
+
 const makeExecutionContext = (): ExecutionContext => ({
   passThroughOnException: () => {},
   props: undefined,
@@ -131,12 +204,16 @@ const makeWebSocket = (): FakeWebSocket => {
   ws.accepted = false;
   ws.closeCode = undefined;
   ws.closeReason = undefined;
+  ws.sent = [];
   ws.accept = () => {
     ws.accepted = true;
   };
   ws.close = (code?: number, reason?: string) => {
     ws.closeCode = code;
     ws.closeReason = reason;
+  };
+  ws.send = (message: string) => {
+    ws.sent.push(message);
   };
   return ws;
 };
@@ -221,13 +298,19 @@ const openPostSse = async () => {
   return { response, ws };
 };
 
-const emitAgentEvent = (ws: FakeWebSocket, event: string, close?: true): void => {
+const emitAgentEvent = (
+  ws: FakeWebSocket,
+  event: string,
+  close?: true,
+  extra?: Record<string, unknown>,
+): void => {
   ws.dispatchEvent(
     new MessageEvent("message", {
       data: JSON.stringify({
         close,
         event,
         type: "cf_mcp_agent_event",
+        ...extra,
       }),
     }),
   );
@@ -309,8 +392,78 @@ describe("agents SSE max-age rotation", () => {
     );
     await drained;
 
+    expect(ws.closeCode).toBe(1000);
+    expect(ws.closeReason).toBe("SSE response delivered");
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("acknowledges a final POST response only after the SSE write drains", async () => {
+    const { response, ws } = await openPostSse();
+    const drained = drainResponse(response);
+
+    emitAgentEvent(
+      ws,
+      `event: message\nid: post-stream:0000000000000001\ndata: {"jsonrpc":"2.0","id":1,"result":{"ok":true}}\n\n`,
+      true,
+      {
+        eventId: "post-stream:0000000000000001",
+        streamId: "post-stream",
+      },
+    );
+    await drained;
+
+    expect(ws.closeCode).toBe(1000);
+    expect(ws.closeReason).toBe("SSE response delivered");
+    expect(ws.sent.map((line) => decodeDeliveryAck(line))).toContainEqual({
+      type: "cf_mcp_delivery_ack",
+      eventId: "post-stream:0000000000000001",
+      streamId: "post-stream",
+    });
+  });
+
+  it("treats an SSE writer rejection as terminal and does not acknowledge delivery", async () => {
+    const transform = installRejectingTransformStream();
+    const { ws } = await openPostSse();
+
+    emitAgentEvent(
+      ws,
+      `event: message\nid: post-stream:0000000000000001\ndata: {"jsonrpc":"2.0","id":1,"result":{"ok":true}}\n\n`,
+      true,
+      {
+        eventId: "post-stream:0000000000000001",
+        streamId: "post-stream",
+      },
+    );
+    await waitFor(() => ws.closeCode === 1013);
+
+    expect(transform.writeCount()).toBe(1);
+    expect(transform.abortReason()).toBeInstanceOf(Error);
+    expect(ws.closeReason).toBe("SSE client not draining");
+    expect(ws.sent).toEqual([]);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("does not acknowledge a final POST response after the response body was canceled", async () => {
+    const transform = installClosedRejectingTransformStream();
+    const { ws } = await openPostSse();
+
+    transform.rejectClosed();
+    await flushMicrotasks();
+
+    emitAgentEvent(
+      ws,
+      `event: message\nid: post-stream:0000000000000001\ndata: {"jsonrpc":"2.0","id":1,"result":{"ok":true}}\n\n`,
+      true,
+      {
+        eventId: "post-stream:0000000000000001",
+        streamId: "post-stream",
+      },
+    );
+    await flushMicrotasks();
+
+    expect(transform.abortReason()).toBeInstanceOf(Error);
     expect(ws.closeCode).toBeUndefined();
-    expect(ws.closeReason).toBeUndefined();
+    expect(ws.sent).toEqual([]);
     expect(vi.getTimerCount()).toBe(0);
   });
 

--- a/packages/hosts/cloudflare/src/mcp/agents-sse-max-age.test.ts
+++ b/packages/hosts/cloudflare/src/mcp/agents-sse-max-age.test.ts
@@ -43,13 +43,7 @@ const RotationLogEvent = Schema.Struct({
     Schema.Literal("legacy-sse"),
   ]),
 });
-const DeliveryAck = Schema.Struct({
-  eventId: Schema.String,
-  streamId: Schema.String,
-  type: Schema.Literal("cf_mcp_delivery_ack"),
-});
 const decodeRotationLogEvent = Schema.decodeUnknownOption(Schema.fromJsonString(RotationLogEvent));
-const decodeDeliveryAck = Schema.decodeUnknownSync(Schema.fromJsonString(DeliveryAck));
 
 const flushMicrotasks = async (): Promise<void> => {
   await Promise.resolve();
@@ -397,7 +391,11 @@ describe("agents SSE max-age rotation", () => {
     expect(vi.getTimerCount()).toBe(0);
   });
 
-  it("acknowledges a final POST response only after the SSE write drains", async () => {
+  it("never acknowledges a POST response delivery, even after a clean drain", async () => {
+    // workerd resolves writer.close() even when the client canceled the POST
+    // response body, so a clean close is not proof of delivery. The bridge must
+    // NOT send cf_mcp_delivery_ack for POST streams: the DO keeps the response
+    // persisted and the client's reconnect GET replays and acks it instead.
     const { response, ws } = await openPostSse();
     const drained = drainResponse(response);
 
@@ -414,11 +412,7 @@ describe("agents SSE max-age rotation", () => {
 
     expect(ws.closeCode).toBe(1000);
     expect(ws.closeReason).toBe("SSE response delivered");
-    expect(ws.sent.map((line) => decodeDeliveryAck(line))).toContainEqual({
-      type: "cf_mcp_delivery_ack",
-      eventId: "post-stream:0000000000000001",
-      streamId: "post-stream",
-    });
+    expect(ws.sent).toEqual([]);
   });
 
   it("treats an SSE writer rejection as terminal and does not acknowledge delivery", async () => {

--- a/packages/hosts/cloudflare/src/mcp/agents-sse-max-age.test.ts
+++ b/packages/hosts/cloudflare/src/mcp/agents-sse-max-age.test.ts
@@ -43,7 +43,17 @@ const RotationLogEvent = Schema.Struct({
     Schema.Literal("legacy-sse"),
   ]),
 });
+const DeliveryAck = Schema.Struct({
+  streamId: Schema.String,
+  type: Schema.Literal("cf_mcp_delivery_ack"),
+});
 const decodeRotationLogEvent = Schema.decodeUnknownOption(Schema.fromJsonString(RotationLogEvent));
+const decodeDeliveryAck = Schema.decodeUnknownOption(Schema.fromJsonString(DeliveryAck));
+const deliveryAcks = (sent: ReadonlyArray<string>): ReadonlyArray<string> =>
+  sent.flatMap((line) => {
+    const decoded = decodeDeliveryAck(line);
+    return Option.isSome(decoded) ? [decoded.value.streamId] : [];
+  });
 
 const flushMicrotasks = async (): Promise<void> => {
   await Promise.resolve();
@@ -458,6 +468,52 @@ describe("agents SSE max-age rotation", () => {
     expect(transform.abortReason()).toBeInstanceOf(Error);
     expect(ws.closeCode).toBeUndefined();
     expect(ws.sent).toEqual([]);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("acks each replayed stream only after the recovery GET drained and closed", async () => {
+    // The replay path never clears storage on enqueue: the transport sends a
+    // replay-complete close frame and the bridge echoes one delivery ack per
+    // replayed stream only once writer.close() resolved with the client still
+    // attached. McpAgent.onMessage clears storage on those acks.
+    const { response, ws } = await openSse();
+    const drained = drainResponse(response);
+
+    emitAgentEvent(
+      ws,
+      `event: message\nid: stream-a:0000000000000001\ndata: {"jsonrpc":"2.0","id":1,"result":{"ok":true}}\n\n`,
+    );
+    emitAgentEvent(ws, ": replay-complete\n\n", true, {
+      ackStreamIds: ["stream-a", "stream-b"],
+    });
+    await drained;
+
+    expect(ws.closeCode).toBe(1000);
+    expect(ws.closeReason).toBe("SSE response delivered");
+    expect(deliveryAcks(ws.sent), "one ack per replayed stream").toEqual(["stream-a", "stream-b"]);
+  });
+
+  it("does not ack replayed streams when the recovery GET body was canceled", async () => {
+    // A recovery GET can itself be a dead pipe (workerd surfaces nothing at
+    // write time). The bridge must not ack in that case, so the responses stay
+    // persisted and replayable for the next reconnect.
+    const transform = installClosedRejectingTransformStream();
+    const { ws } = await openSse();
+
+    transform.rejectClosed();
+    await flushMicrotasks();
+
+    emitAgentEvent(
+      ws,
+      `event: message\nid: stream-a:0000000000000001\ndata: {"jsonrpc":"2.0","id":1,"result":{"ok":true}}\n\n`,
+    );
+    emitAgentEvent(ws, ": replay-complete\n\n", true, {
+      ackStreamIds: ["stream-a"],
+    });
+    await flushMicrotasks();
+
+    expect(transform.abortReason()).toBeInstanceOf(Error);
+    expect(deliveryAcks(ws.sent), "no acks for a dead recovery GET").toEqual([]);
     expect(vi.getTimerCount()).toBe(0);
   });
 

--- a/packages/hosts/cloudflare/src/mcp/session-alarm-policy.test.ts
+++ b/packages/hosts/cloudflare/src/mcp/session-alarm-policy.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "@effect/vitest";
 import {
   MAX_PAUSED_SESSION_IDLE_MS,
   PAUSED_EXECUTION_LEASE_MS,
+  RUNNING_EXECUTION_LEASE_MS,
   SESSION_TIMEOUT_MS,
   decideSessionAlarm,
 } from "./session-alarm-policy";
@@ -68,5 +69,31 @@ describe("decideSessionAlarm", () => {
         pausedExecutionCount: 1,
       }),
     ).toEqual({ kind: "destroy_idle_session" });
+  });
+
+  it("extends the lease when a request is still running", () => {
+    expect(
+      decideSessionAlarm({
+        idleMs: SESSION_TIMEOUT_MS,
+        pausedExecutionCount: 0,
+        runningExecutionCount: 1,
+      }),
+    ).toEqual({
+      kind: "extend_running_lease",
+      leaseMs: RUNNING_EXECUTION_LEASE_MS,
+    });
+  });
+
+  it("extends the lease when a client stream is still open", () => {
+    expect(
+      decideSessionAlarm({
+        idleMs: SESSION_TIMEOUT_MS,
+        pausedExecutionCount: 0,
+        activeStreamCount: 1,
+      }),
+    ).toEqual({
+      kind: "extend_running_lease",
+      leaseMs: RUNNING_EXECUTION_LEASE_MS,
+    });
   });
 });

--- a/packages/hosts/cloudflare/src/mcp/session-alarm-policy.test.ts
+++ b/packages/hosts/cloudflare/src/mcp/session-alarm-policy.test.ts
@@ -72,6 +72,21 @@ describe("decideSessionAlarm", () => {
     ).toEqual({ kind: "destroy_idle_session" });
   });
 
+  it("expires a paused execution at the paused ceiling even while its request id is still persisted", () => {
+    // A paused execution's originating POST leaves an un-responded request id
+    // (and often an open stream). Those must not divert the decision into the
+    // running-lease branch: paused work expires on its own clock, and the
+    // product contract past the ceiling is the expired-resume re-run guidance.
+    expect(
+      decideSessionAlarm({
+        idleMs: MAX_PAUSED_SESSION_IDLE_MS,
+        pausedExecutionCount: 1,
+        runningExecutionCount: 1,
+        activeStreamCount: 1,
+      }),
+    ).toEqual({ kind: "destroy_idle_session" });
+  });
+
   it("extends the lease when a request is still running", () => {
     expect(
       decideSessionAlarm({

--- a/packages/hosts/cloudflare/src/mcp/session-alarm-policy.test.ts
+++ b/packages/hosts/cloudflare/src/mcp/session-alarm-policy.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "@effect/vitest";
 
 import {
   MAX_PAUSED_SESSION_IDLE_MS,
+  MAX_RUNNING_SESSION_IDLE_MS,
   PAUSED_EXECUTION_LEASE_MS,
   RUNNING_EXECUTION_LEASE_MS,
   SESSION_TIMEOUT_MS,
@@ -95,5 +96,40 @@ describe("decideSessionAlarm", () => {
       kind: "extend_running_lease",
       leaseMs: RUNNING_EXECUTION_LEASE_MS,
     });
+  });
+
+  it("caps the running lease at the configured running idle ceiling", () => {
+    expect(
+      decideSessionAlarm({
+        idleMs: 5_000,
+        pausedExecutionCount: 0,
+        runningExecutionCount: 1,
+        sessionTimeoutMs: 3_000,
+        maxRunningSessionIdleMs: 8_000,
+      }),
+    ).toEqual({
+      kind: "extend_running_lease",
+      leaseMs: 3_000,
+    });
+  });
+
+  it("destroys a session with running work once the running lease cap elapses", () => {
+    expect(
+      decideSessionAlarm({
+        idleMs: MAX_RUNNING_SESSION_IDLE_MS,
+        pausedExecutionCount: 0,
+        runningExecutionCount: 1,
+      }),
+    ).toEqual({ kind: "destroy_idle_session" });
+  });
+
+  it("destroys a session with an open stream once the running lease cap elapses", () => {
+    expect(
+      decideSessionAlarm({
+        idleMs: MAX_RUNNING_SESSION_IDLE_MS,
+        pausedExecutionCount: 0,
+        activeStreamCount: 1,
+      }),
+    ).toEqual({ kind: "destroy_idle_session" });
   });
 });

--- a/packages/hosts/cloudflare/src/mcp/session-alarm-policy.ts
+++ b/packages/hosts/cloudflare/src/mcp/session-alarm-policy.ts
@@ -54,14 +54,25 @@ export const decideSessionAlarm = (input: {
   if (input.idleMs < sessionTimeoutMs) {
     return { kind: "idle_within_timeout" };
   }
-  if (input.pausedExecutionCount > 0 && input.idleMs < maxPausedSessionIdleMs) {
-    return {
-      kind: "extend_paused_lease",
-      leaseMs: Math.max(
-        1,
-        Math.min(PAUSED_EXECUTION_LEASE_MS, maxPausedSessionIdleMs - input.idleMs),
-      ),
-    };
+  if (input.pausedExecutionCount > 0) {
+    // Paused work expires on its own clock, full stop. A paused execution's
+    // originating POST also leaves an un-responded request id (and often an
+    // open client stream), so the running-lease branch below would otherwise
+    // keep the runtime warm past the paused ceiling and a stale approval
+    // would silently resume. Once maxPausedSessionIdleMs elapses the browser
+    // approval wait has already timed out and the product contract is an
+    // expired-resume error with re-run guidance, so the session is destroyed
+    // regardless of running work or open streams.
+    if (input.idleMs < maxPausedSessionIdleMs) {
+      return {
+        kind: "extend_paused_lease",
+        leaseMs: Math.max(
+          1,
+          Math.min(PAUSED_EXECUTION_LEASE_MS, maxPausedSessionIdleMs - input.idleMs),
+        ),
+      };
+    }
+    return { kind: "destroy_idle_session" };
   }
   if (
     ((input.runningExecutionCount ?? 0) > 0 || (input.activeStreamCount ?? 0) > 0) &&

--- a/packages/hosts/cloudflare/src/mcp/session-alarm-policy.ts
+++ b/packages/hosts/cloudflare/src/mcp/session-alarm-policy.ts
@@ -18,6 +18,21 @@ export const RUNNING_EXECUTION_LEASE_MS = PAUSED_APPROVAL_TIMEOUT_MS;
  */
 export const MAX_PAUSED_SESSION_IDLE_MS = SESSION_TIMEOUT_MS + PAUSED_EXECUTION_LEASE_MS;
 
+/** Matches the patched agents transport's MAX_SSE_AGE_MS (30 minutes). */
+const SSE_MAX_AGE_MS = 30 * 60 * 1000;
+
+/**
+ * Hard upper bound on idle time while running work or open streams keep
+ * extending the lease. Running executions are already bounded by the runtime's
+ * own execution timeout and open streams by the SSE max-age rotation, so this
+ * ceiling is a structural backstop for the case where neither bound fires
+ * (a wedged execution that never sends, or a stream close event workerd never
+ * delivers). It sits one full SSE max-age window past the idle timeout so a
+ * legitimately connected-but-quiet client stream is never cut before its
+ * scheduled rotation.
+ */
+export const MAX_RUNNING_SESSION_IDLE_MS = SESSION_TIMEOUT_MS + SSE_MAX_AGE_MS;
+
 export type SessionAlarmDecision =
   | { readonly kind: "idle_within_timeout" }
   | { readonly kind: "destroy_idle_session" }
@@ -31,9 +46,11 @@ export const decideSessionAlarm = (input: {
   readonly activeStreamCount?: number;
   readonly sessionTimeoutMs?: number;
   readonly maxPausedSessionIdleMs?: number;
+  readonly maxRunningSessionIdleMs?: number;
 }): SessionAlarmDecision => {
   const sessionTimeoutMs = input.sessionTimeoutMs ?? SESSION_TIMEOUT_MS;
   const maxPausedSessionIdleMs = input.maxPausedSessionIdleMs ?? MAX_PAUSED_SESSION_IDLE_MS;
+  const maxRunningSessionIdleMs = input.maxRunningSessionIdleMs ?? MAX_RUNNING_SESSION_IDLE_MS;
   if (input.idleMs < sessionTimeoutMs) {
     return { kind: "idle_within_timeout" };
   }
@@ -46,8 +63,17 @@ export const decideSessionAlarm = (input: {
       ),
     };
   }
-  if ((input.runningExecutionCount ?? 0) > 0 || (input.activeStreamCount ?? 0) > 0) {
-    return { kind: "extend_running_lease", leaseMs: RUNNING_EXECUTION_LEASE_MS };
+  if (
+    ((input.runningExecutionCount ?? 0) > 0 || (input.activeStreamCount ?? 0) > 0) &&
+    input.idleMs < maxRunningSessionIdleMs
+  ) {
+    return {
+      kind: "extend_running_lease",
+      leaseMs: Math.max(
+        1,
+        Math.min(RUNNING_EXECUTION_LEASE_MS, maxRunningSessionIdleMs - input.idleMs),
+      ),
+    };
   }
   return { kind: "destroy_idle_session" };
 };

--- a/packages/hosts/cloudflare/src/mcp/session-alarm-policy.ts
+++ b/packages/hosts/cloudflare/src/mcp/session-alarm-policy.ts
@@ -6,6 +6,9 @@ export const SESSION_TIMEOUT_MS = 5 * 60 * 1000;
 /** Lease extension while paused executions block hibernation (matches browser approval wait). */
 export const PAUSED_EXECUTION_LEASE_MS = PAUSED_APPROVAL_TIMEOUT_MS;
 
+/** Lease extension while requests or client streams are still active. */
+export const RUNNING_EXECUTION_LEASE_MS = PAUSED_APPROVAL_TIMEOUT_MS;
+
 /**
  * Hard upper bound on idle time before a paused session is torn down regardless
  * of outstanding paused work. The lease grants a single approval window of grace
@@ -18,11 +21,14 @@ export const MAX_PAUSED_SESSION_IDLE_MS = SESSION_TIMEOUT_MS + PAUSED_EXECUTION_
 export type SessionAlarmDecision =
   | { readonly kind: "idle_within_timeout" }
   | { readonly kind: "destroy_idle_session" }
-  | { readonly kind: "extend_paused_lease"; readonly leaseMs: number };
+  | { readonly kind: "extend_paused_lease"; readonly leaseMs: number }
+  | { readonly kind: "extend_running_lease"; readonly leaseMs: number };
 
 export const decideSessionAlarm = (input: {
   readonly idleMs: number;
   readonly pausedExecutionCount: number;
+  readonly runningExecutionCount?: number;
+  readonly activeStreamCount?: number;
   readonly sessionTimeoutMs?: number;
   readonly maxPausedSessionIdleMs?: number;
 }): SessionAlarmDecision => {
@@ -40,6 +46,9 @@ export const decideSessionAlarm = (input: {
       ),
     };
   }
+  if ((input.runningExecutionCount ?? 0) > 0 || (input.activeStreamCount ?? 0) > 0) {
+    return { kind: "extend_running_lease", leaseMs: RUNNING_EXECUTION_LEASE_MS };
+  }
   return { kind: "destroy_idle_session" };
 };
 
@@ -52,6 +61,21 @@ export const pausedLeaseExtensionLog = (input: {
   event: "mcp_session_paused_lease_extension",
   sessionId: input.sessionId,
   pausedExecutionCount: input.pausedExecutionCount,
+  idleMs: input.idleMs,
+  leaseMs: input.leaseMs,
+});
+
+export const runningLeaseExtensionLog = (input: {
+  readonly sessionId: string;
+  readonly runningExecutionCount: number;
+  readonly activeStreamCount: number;
+  readonly idleMs: number;
+  readonly leaseMs: number;
+}): Record<string, unknown> => ({
+  event: "mcp_session_running_lease_extension",
+  sessionId: input.sessionId,
+  runningExecutionCount: input.runningExecutionCount,
+  activeStreamCount: input.activeStreamCount,
   idleMs: input.idleMs,
   leaseMs: input.leaseMs,
 });

--- a/packages/hosts/cloudflare/src/mcp/session-stub.ts
+++ b/packages/hosts/cloudflare/src/mcp/session-stub.ts
@@ -17,7 +17,7 @@ export interface McpSessionNamespace<Id> {
 export interface McpSessionStub {
   readonly validateMcpSessionOwner: (
     identity: McpApprovalOwner,
-  ) => Promise<"ok" | "not_found" | "forbidden">;
+  ) => Promise<"ok" | "not_found" | "forbidden" | "terminated">;
   readonly _cf_scheduleDestroy: () => Promise<void>;
   readonly getPausedExecutionForApproval: (
     executionId: string,

--- a/patches/agents@0.17.3.patch
+++ b/patches/agents@0.17.3.patch
@@ -19,7 +19,7 @@ index c8fad448e8797b89690a99d93490d1363851b225..77f9fe3f6f2375eadc9f7a2974f0d202
    McpAgent,
    type McpAuthContext,
 diff --git a/dist/mcp/index.js b/dist/mcp/index.js
-index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..db35f39456ed71b6c33562f69bdebadc84d1774e 100644
+index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..a43fe0686ceeb3e777b4140c96106a44b113ada4 100644
 --- a/dist/mcp/index.js
 +++ b/dist/mcp/index.js
 @@ -28,13 +28,17 @@ import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/
@@ -62,7 +62,7 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..db35f39456ed71b6c33562f69bdebadc
  				request.headers.forEach((value, key) => {
  					existingHeaders[key] = value;
  				});
-@@ -206,45 +215,94 @@ const createStreamingHttpHandler = (basePath, namespace, options = {}) => {
+@@ -206,45 +215,99 @@ const createStreamingHttpHandler = (basePath, namespace, options = {}) => {
  						jsonrpc: "2.0"
  					});
  					return new Response(body, { status: 500 });
@@ -95,6 +95,7 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..db35f39456ed71b6c33562f69bdebadc
 +					writer.closed?.catch(() => {
 +						__markSseClientClosed();
 +					});
++					request.signal.addEventListener("abort", __closeSse, { once: true });
 +					const __forwardSse = (frame) => {
 +						if (__sseClosed) return __writeChain;
 +						if (__pendingBytes + frame.byteLength > MAX_PENDING_SSE_BYTES) {
@@ -141,16 +142,20 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..db35f39456ed71b6c33562f69bdebadc
 +								if (message.close) {
 +									clearInterval(keepAlive);
 +									await writePromise;
-+									if (!__sseClosed) {
-+										try {
-+											ws.send(JSON.stringify({
-+												type: "cf_mcp_delivery_ack",
-+												eventId: message.eventId,
-+												streamId: message.streamId
-+											}));
-+										} catch {}
++									await writer.close();
++									if (!__sseClosed && !request.signal.aborted) {
++										// workerd resolves writer.close() even when the client
++										// canceled the POST response body, and request.signal does
++										// not reliably fire for that cancellation, so a successful
++										// close is NOT proof of delivery. Never ack POST-stream
++										// deliveries: the DO keeps the response persisted and the
++										// client's own reconnect GET replays and acks it. A client
++										// that DID receive the result closes the POST body reader
++										// without a Last-Event-ID reconnect, and the SDK drops
++										// responses for request ids it no longer tracks, so the
++										// worst case of this at-least-once choice is a benign
++										// replay to a fresh GET, not a wedged tool call.
 +										ws?.close(1000, "SSE response delivered");
-+										await writer.close().catch(() => {});
 +									}
 +								}
  						} catch (error) {
@@ -183,7 +188,7 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..db35f39456ed71b6c33562f69bdebadc
  					}
  					onClose().catch(console.error);
  				});
-@@ -279,10 +337,16 @@ const createStreamingHttpHandler = (basePath, namespace, options = {}) => {
+@@ -279,10 +342,16 @@ const createStreamingHttpHandler = (basePath, namespace, options = {}) => {
  					id: null,
  					jsonrpc: "2.0"
  				}), { status: 400 });
@@ -204,7 +209,7 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..db35f39456ed71b6c33562f69bdebadc
  					props: ctx.props,
  					jurisdiction: options.jurisdiction
  				});
-@@ -306,27 +370,93 @@ const createStreamingHttpHandler = (basePath, namespace, options = {}) => {
+@@ -306,27 +375,108 @@ const createStreamingHttpHandler = (basePath, namespace, options = {}) => {
  				if (!ws) {
  					await writer.close();
  					return new Response("Failed to establish WS to DO", { status: 500 });
@@ -227,6 +232,7 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..db35f39456ed71b6c33562f69bdebadc
 +					writer.closed?.catch(() => {
 +						__abortSse();
 +					});
++					request.signal.addEventListener("abort", __abortSse, { once: true });
 +					const __closeSseGracefully = () => {
 +						if (__sseClosed) return __writeChain;
 +						__sseClosed = true;
@@ -286,7 +292,21 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..db35f39456ed71b6c33562f69bdebadc
 +								const data = typeof ev.data === "string" ? ev.data : new TextDecoder().decode(ev.data);
 +								const message = JSON.parse(data);
 +								if (message.type !== "cf_mcp_agent_event") return;
-+								__forwardSse(encoder.encode(message.event));
++								const writePromise = __forwardSse(encoder.encode(message.event));
++								if (message.close) {
++									await writePromise;
++									await writer.close();
++									if (!__sseClosed && !request.signal.aborted) {
++										try {
++											ws.send(JSON.stringify({
++												type: "cf_mcp_delivery_ack",
++												eventId: message.eventId,
++												streamId: message.streamId
++											}));
++										} catch {}
++										ws?.close(1000, "SSE response delivered");
++									}
++								}
 +							}
  						onMessage(event).catch(console.error);
  					} catch (e) {
@@ -313,7 +333,7 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..db35f39456ed71b6c33562f69bdebadc
  				return new Response(readable, {
  					headers: {
  						"Cache-Control": "no-cache",
-@@ -389,10 +519,16 @@ const createLegacySseHandler = (basePath, namespace, options = {}) => {
+@@ -389,10 +539,16 @@ const createLegacySseHandler = (basePath, namespace, options = {}) => {
  		const url = new URL(request.url);
  		if (request.method === "GET" && basePattern.test(url)) {
  			const sessionId = url.searchParams.get("sessionId") || namespace.newUniqueId().toString();
@@ -334,7 +354,7 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..db35f39456ed71b6c33562f69bdebadc
  			endpointUrl.pathname = encodeURI(`${basePath}/message`);
  			endpointUrl.searchParams.set("sessionId", sessionId);
  			const endpointMessage = `event: endpoint\ndata: ${endpointUrl.pathname + endpointUrl.search + endpointUrl.hash}\n\n`;
-@@ -414,35 +550,94 @@ const createLegacySseHandler = (basePath, namespace, options = {}) => {
+@@ -414,35 +570,94 @@ const createLegacySseHandler = (basePath, namespace, options = {}) => {
  				console.error("Failed to establish WebSocket connection");
  				await writer.close();
  				return new Response("Failed to establish WebSocket connection", { status: 500 });
@@ -447,17 +467,23 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..db35f39456ed71b6c33562f69bdebadc
  						console.error("Error closing SSE connection:", error);
  					}
  				}
-@@ -634,7 +829,8 @@ var StreamableHTTPServerTransport = class {
+@@ -634,7 +849,14 @@ var StreamableHTTPServerTransport = class {
  				}
  				this.supersedePriorStreamConnections(agent, connection.id, resumedStreamId);
  				connection.setState(resumeState);
 -				await this.replayEvents(lastEventId);
 +				const replayedResponse = await this.replayEvents(lastEventId);
 +				if (resumedStreamId !== STANDALONE_STREAM_ID && replayedResponse) await this.acknowledgeDeliveredStream(agent, resumedStreamId);
++				// A reconnect can carry a Last-Event-ID for an already-delivered
++				// stream (e.g. the initialize response) while a tool result
++				// completed on a since-abandoned POST stream. Replay those other
++				// undelivered responses on this connection too, otherwise they are
++				// stranded until the session is torn down.
++				await this.replayUndeliveredResponses(agent, connection, resumedStreamId);
  				return;
  			}
  		}
-@@ -644,6 +840,7 @@ var StreamableHTTPServerTransport = class {
+@@ -644,6 +866,7 @@ var StreamableHTTPServerTransport = class {
  			_standaloneSse: true
  		};
  		connection.setState(standaloneState);
@@ -465,7 +491,7 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..db35f39456ed71b6c33562f69bdebadc
  	}
  	/**
  	* Close any connection (other than `selfId`) currently bound to
-@@ -664,12 +861,14 @@ var StreamableHTTPServerTransport = class {
+@@ -664,12 +887,14 @@ var StreamableHTTPServerTransport = class {
  	* Only used when resumability is enabled
  	*/
  	async replayEvents(lastEventId) {
@@ -481,16 +507,17 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..db35f39456ed71b6c33562f69bdebadc
  					this.writeSSEEvent(connection, message, eventId);
  				} catch (error) {
  					this.onerror?.(error);
-@@ -678,6 +877,27 @@ var StreamableHTTPServerTransport = class {
+@@ -678,6 +903,29 @@ var StreamableHTTPServerTransport = class {
  		} catch (error) {
  			this.onerror?.(error);
  		}
 +		return replayedResponse;
 +	}
-+	async replayUndeliveredResponses(agent, connection) {
++	async replayUndeliveredResponses(agent, connection, skipStreamId) {
 +		if (!this._eventStore?.replayEventsForStream) return;
 +		const streamIds = await agent.getUndeliveredStreamIds();
 +		for (const streamId of streamIds) {
++			if (skipStreamId !== void 0 && streamId === skipStreamId) continue;
 +			let replayedResponse = false;
 +			await this._eventStore.replayEventsForStream(streamId, { send: async (eventId, message) => {
 +				try {
@@ -505,11 +532,12 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..db35f39456ed71b6c33562f69bdebadc
 +	}
 +	async acknowledgeDeliveredStream(agent, streamId) {
 +		await agent.deleteStreamRequestIds(streamId);
++		await agent.deleteUndeliveredStream(streamId);
 +		if (this._eventStore && isClearableEventStore(this._eventStore)) await this._eventStore.clearStream(streamId);
  	}
  	/**
  	* Writes an event to the SSE stream with proper formatting
-@@ -689,6 +909,8 @@ var StreamableHTTPServerTransport = class {
+@@ -689,6 +937,8 @@ var StreamableHTTPServerTransport = class {
  		return connection.send(JSON.stringify({
  			type: "cf_mcp_agent_event",
  			event: eventData,
@@ -518,7 +546,7 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..db35f39456ed71b6c33562f69bdebadc
  			close
  		}));
  	}
-@@ -777,9 +999,11 @@ var StreamableHTTPServerTransport = class {
+@@ -777,9 +1027,11 @@ var StreamableHTTPServerTransport = class {
  		} catch (error) {
  			this.onerror?.(error);
  		}
@@ -532,7 +560,7 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..db35f39456ed71b6c33562f69bdebadc
  		}
  	}
  	async send(message, options) {
-@@ -861,12 +1085,10 @@ var StreamableHTTPServerTransport = class {
+@@ -861,12 +1113,10 @@ var StreamableHTTPServerTransport = class {
  *
  * ## Lifecycle
  *
@@ -549,7 +577,7 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..db35f39456ed71b6c33562f69bdebadc
  *
  * Standalone GET stream events (`_GET_stream`) are *not* cleared
  * automatically; they accumulate for the lifetime of the DO. Bounded
-@@ -899,6 +1121,7 @@ var DurableObjectEventStore = class DurableObjectEventStore {
+@@ -899,6 +1149,7 @@ var DurableObjectEventStore = class DurableObjectEventStore {
  		const eventId = `${streamId}:${seq.toString(16).padStart(DurableObjectEventStore.SEQ_PAD, "0")}`;
  		const eventKey = `${DurableObjectEventStore.EVENT_KEY_PREFIX}${eventId}`;
  		await this.storage.put(eventKey, message);
@@ -557,7 +585,7 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..db35f39456ed71b6c33562f69bdebadc
  		return eventId;
  	}
  	async getStreamIdForEventId(eventId) {
-@@ -915,9 +1138,46 @@ var DurableObjectEventStore = class DurableObjectEventStore {
+@@ -915,9 +1166,46 @@ var DurableObjectEventStore = class DurableObjectEventStore {
  			start: startKey,
  			limit: DurableObjectEventStore.REPLAY_LIMIT
  		});
@@ -605,7 +633,7 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..db35f39456ed71b6c33562f69bdebadc
  	/**
  	* Drop the event log for a single stream. Called by the transport
  	* immediately after a POST's final response has been written to the
-@@ -973,6 +1233,9 @@ DurableObjectEventStore.EVENT_KEY_PREFIX = "__mcp_event__:";
+@@ -973,6 +1261,9 @@ DurableObjectEventStore.EVENT_KEY_PREFIX = "__mcp_event__:";
  DurableObjectEventStore.SEQ_PAD = 16;
  DurableObjectEventStore.DELETE_CHUNK = 128;
  DurableObjectEventStore.REPLAY_LIMIT = 1e3;
@@ -615,7 +643,7 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..db35f39456ed71b6c33562f69bdebadc
  //#endregion
  //#region src/mcp/client-transports.ts
  /**
-@@ -1381,6 +1644,47 @@ var McpAgent = class McpAgent extends Agent {
+@@ -1381,6 +1672,47 @@ var McpAgent = class McpAgent extends Agent {
  	async deleteStreamRequestIds(streamId) {
  		await this.ctx.storage.delete(`${McpAgent.STREAM_REQS_KEY_PREFIX}${streamId}`);
  	}
@@ -663,7 +691,7 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..db35f39456ed71b6c33562f69bdebadc
  	/**
  	* Reverse lookup: find which POST stream a given `requestId` belongs
  	* to, and return the stream's full `requestIds` list in the same
-@@ -1697,7 +2001,8 @@ var McpAgent = class McpAgent extends Agent {
+@@ -1697,7 +2029,8 @@ var McpAgent = class McpAgent extends Agent {
  	}
  };
  McpAgent.STREAM_REQS_KEY_PREFIX = "__mcp_stream_reqs__:";
@@ -673,3 +701,4 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..db35f39456ed71b6c33562f69bdebadc
 +export { DurableObjectEventStore, ElicitRequestSchema, MAX_SSE_AGE_MS, MCP_SERVER_ID_MAX_LENGTH, McpAgent, RPCClientTransport, RPCServerTransport, RPC_DO_PREFIX, SSEEdgeClientTransport, StreamableHTTPEdgeClientTransport, WorkerTransport, createMcpHandler, experimental_createMcpHandler, getMcpAuthContext, normalizeServerId };
  
  //# sourceMappingURL=index.js.map
+\ No newline at end of file

--- a/patches/agents@0.17.3.patch
+++ b/patches/agents@0.17.3.patch
@@ -19,7 +19,7 @@ index c8fad448e8797b89690a99d93490d1363851b225..77f9fe3f6f2375eadc9f7a2974f0d202
    McpAgent,
    type McpAuthContext,
 diff --git a/dist/mcp/index.js b/dist/mcp/index.js
-index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..a43fe0686ceeb3e777b4140c96106a44b113ada4 100644
+index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..b0d1c55eda79324b6d76a1177519d26a62be2e41 100644
 --- a/dist/mcp/index.js
 +++ b/dist/mcp/index.js
 @@ -28,13 +28,17 @@ import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/
@@ -209,7 +209,7 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..a43fe0686ceeb3e777b4140c96106a44
  					props: ctx.props,
  					jurisdiction: options.jurisdiction
  				});
-@@ -306,27 +375,108 @@ const createStreamingHttpHandler = (basePath, namespace, options = {}) => {
+@@ -306,27 +375,116 @@ const createStreamingHttpHandler = (basePath, namespace, options = {}) => {
  				if (!ws) {
  					await writer.close();
  					return new Response("Failed to establish WS to DO", { status: 500 });
@@ -294,14 +294,22 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..a43fe0686ceeb3e777b4140c96106a44
 +								if (message.type !== "cf_mcp_agent_event") return;
 +								const writePromise = __forwardSse(encoder.encode(message.event));
 +								if (message.close) {
++									clearInterval(keepAlive);
 +									await writePromise;
 +									await writer.close();
 +									if (!__sseClosed && !request.signal.aborted) {
-+										try {
++										// Storage is cleared only on this ack, which fires only
++										// after writer.close() resolved with the client still
++										// attached; a replayed response enqueued into a dead GET
++										// never acks and stays replayable. `ackStreamIds` lets a
++										// replay-complete frame confirm several replayed streams
++										// at once; a live final response carries its `streamId`.
++										const ackStreamIds = Array.isArray(message.ackStreamIds) ? message.ackStreamIds : message.streamId ? [message.streamId] : [];
++										for (const ackStreamId of ackStreamIds) try {
 +											ws.send(JSON.stringify({
 +												type: "cf_mcp_delivery_ack",
 +												eventId: message.eventId,
-+												streamId: message.streamId
++												streamId: ackStreamId
 +											}));
 +										} catch {}
 +										ws?.close(1000, "SSE response delivered");
@@ -333,7 +341,7 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..a43fe0686ceeb3e777b4140c96106a44
  				return new Response(readable, {
  					headers: {
  						"Cache-Control": "no-cache",
-@@ -389,10 +539,16 @@ const createLegacySseHandler = (basePath, namespace, options = {}) => {
+@@ -389,10 +547,16 @@ const createLegacySseHandler = (basePath, namespace, options = {}) => {
  		const url = new URL(request.url);
  		if (request.method === "GET" && basePattern.test(url)) {
  			const sessionId = url.searchParams.get("sessionId") || namespace.newUniqueId().toString();
@@ -354,7 +362,7 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..a43fe0686ceeb3e777b4140c96106a44
  			endpointUrl.pathname = encodeURI(`${basePath}/message`);
  			endpointUrl.searchParams.set("sessionId", sessionId);
  			const endpointMessage = `event: endpoint\ndata: ${endpointUrl.pathname + endpointUrl.search + endpointUrl.hash}\n\n`;
-@@ -414,35 +570,94 @@ const createLegacySseHandler = (basePath, namespace, options = {}) => {
+@@ -414,35 +578,94 @@ const createLegacySseHandler = (basePath, namespace, options = {}) => {
  				console.error("Failed to establish WebSocket connection");
  				await writer.close();
  				return new Response("Failed to establish WebSocket connection", { status: 500 });
@@ -467,31 +475,59 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..a43fe0686ceeb3e777b4140c96106a44
  						console.error("Error closing SSE connection:", error);
  					}
  				}
-@@ -634,7 +849,14 @@ var StreamableHTTPServerTransport = class {
+@@ -634,7 +857,23 @@ var StreamableHTTPServerTransport = class {
  				}
  				this.supersedePriorStreamConnections(agent, connection.id, resumedStreamId);
  				connection.setState(resumeState);
 -				await this.replayEvents(lastEventId);
++				const ackStreamIds = [];
 +				const replayedResponse = await this.replayEvents(lastEventId);
-+				if (resumedStreamId !== STANDALONE_STREAM_ID && replayedResponse) await this.acknowledgeDeliveredStream(agent, resumedStreamId);
++				if (resumedStreamId !== STANDALONE_STREAM_ID && replayedResponse) ackStreamIds.push(resumedStreamId);
 +				// A reconnect can carry a Last-Event-ID for an already-delivered
 +				// stream (e.g. the initialize response) while a tool result
 +				// completed on a since-abandoned POST stream. Replay those other
 +				// undelivered responses on this connection too, otherwise they are
 +				// stranded until the session is torn down.
-+				await this.replayUndeliveredResponses(agent, connection, resumedStreamId);
++				ackStreamIds.push(...await this.replayUndeliveredResponses(agent, connection, resumedStreamId));
++				// Storage is NOT cleared here: replayed events are only enqueued
++				// on the WS bridge, and workerd cannot tell a dead client from a
++				// live one at write time. The close frame below makes the bridge
++				// drain the writes, close the HTTP response, and send one
++				// cf_mcp_delivery_ack per replayed stream only if the client was
++				// still attached; McpAgent.onMessage clears storage on that ack.
++				// A dead recovery GET therefore leaves everything replayable.
++				if (ackStreamIds.length > 0) this.sendReplayComplete(connection, ackStreamIds);
  				return;
  			}
  		}
-@@ -644,6 +866,7 @@ var StreamableHTTPServerTransport = class {
+@@ -644,6 +883,26 @@ var StreamableHTTPServerTransport = class {
  			_standaloneSse: true
  		};
  		connection.setState(standaloneState);
-+		await this.replayUndeliveredResponses(agent, connection);
++		const replayedStreamIds = await this.replayUndeliveredResponses(agent, connection);
++		// Same delivery-confirmed clearing as the resume branch above. When
++		// nothing was replayed no close frame is sent and this connection stays
++		// open as the session's long-lived standalone listener.
++		if (replayedStreamIds.length > 0) this.sendReplayComplete(connection, replayedStreamIds);
++	}
++	/**
++	* Ask the Worker bridge to flush everything queued on `connection`,
++	* close the client-facing SSE response, and, only if the writer close
++	* completed with the client still attached, echo one
++	* `cf_mcp_delivery_ack` per stream id in `ackStreamIds`. The event
++	* payload is an SSE comment so client parsers drop it.
++	*/
++	sendReplayComplete(connection, ackStreamIds) {
++		return connection.send(JSON.stringify({
++			type: "cf_mcp_agent_event",
++			event: ": replay-complete\n\n",
++			ackStreamIds,
++			close: true
++		}));
  	}
  	/**
  	* Close any connection (other than `selfId`) currently bound to
-@@ -664,12 +887,14 @@ var StreamableHTTPServerTransport = class {
+@@ -664,12 +923,14 @@ var StreamableHTTPServerTransport = class {
  	* Only used when resumability is enabled
  	*/
  	async replayEvents(lastEventId) {
@@ -507,14 +543,22 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..a43fe0686ceeb3e777b4140c96106a44
  					this.writeSSEEvent(connection, message, eventId);
  				} catch (error) {
  					this.onerror?.(error);
-@@ -678,6 +903,29 @@ var StreamableHTTPServerTransport = class {
+@@ -678,6 +939,33 @@ var StreamableHTTPServerTransport = class {
  		} catch (error) {
  			this.onerror?.(error);
  		}
 +		return replayedResponse;
 +	}
++	/**
++	* Enqueue every undelivered stream's events on `connection` and return
++	* the stream ids whose replay included a response. Deliberately does
++	* NOT clear storage: the caller sends a replay-complete close frame and
++	* the bridge acks each stream only after the client-facing writer
++	* drained and closed with the client still attached.
++	*/
 +	async replayUndeliveredResponses(agent, connection, skipStreamId) {
-+		if (!this._eventStore?.replayEventsForStream) return;
++		const replayedStreamIds = [];
++		if (!this._eventStore?.replayEventsForStream) return replayedStreamIds;
 +		const streamIds = await agent.getUndeliveredStreamIds();
 +		for (const streamId of streamIds) {
 +			if (skipStreamId !== void 0 && streamId === skipStreamId) continue;
@@ -527,17 +571,13 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..a43fe0686ceeb3e777b4140c96106a44
 +					this.onerror?.(error);
 +				}
 +			} });
-+			if (replayedResponse) await this.acknowledgeDeliveredStream(agent, streamId);
++			if (replayedResponse) replayedStreamIds.push(streamId);
 +		}
-+	}
-+	async acknowledgeDeliveredStream(agent, streamId) {
-+		await agent.deleteStreamRequestIds(streamId);
-+		await agent.deleteUndeliveredStream(streamId);
-+		if (this._eventStore && isClearableEventStore(this._eventStore)) await this._eventStore.clearStream(streamId);
++		return replayedStreamIds;
  	}
  	/**
  	* Writes an event to the SSE stream with proper formatting
-@@ -689,6 +937,8 @@ var StreamableHTTPServerTransport = class {
+@@ -689,6 +977,8 @@ var StreamableHTTPServerTransport = class {
  		return connection.send(JSON.stringify({
  			type: "cf_mcp_agent_event",
  			event: eventData,
@@ -546,7 +586,7 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..a43fe0686ceeb3e777b4140c96106a44
  			close
  		}));
  	}
-@@ -777,9 +1027,11 @@ var StreamableHTTPServerTransport = class {
+@@ -777,9 +1067,11 @@ var StreamableHTTPServerTransport = class {
  		} catch (error) {
  			this.onerror?.(error);
  		}
@@ -560,7 +600,7 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..a43fe0686ceeb3e777b4140c96106a44
  		}
  	}
  	async send(message, options) {
-@@ -861,12 +1113,10 @@ var StreamableHTTPServerTransport = class {
+@@ -861,12 +1153,10 @@ var StreamableHTTPServerTransport = class {
  *
  * ## Lifecycle
  *
@@ -577,7 +617,7 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..a43fe0686ceeb3e777b4140c96106a44
  *
  * Standalone GET stream events (`_GET_stream`) are *not* cleared
  * automatically; they accumulate for the lifetime of the DO. Bounded
-@@ -899,6 +1149,7 @@ var DurableObjectEventStore = class DurableObjectEventStore {
+@@ -899,6 +1189,7 @@ var DurableObjectEventStore = class DurableObjectEventStore {
  		const eventId = `${streamId}:${seq.toString(16).padStart(DurableObjectEventStore.SEQ_PAD, "0")}`;
  		const eventKey = `${DurableObjectEventStore.EVENT_KEY_PREFIX}${eventId}`;
  		await this.storage.put(eventKey, message);
@@ -585,7 +625,7 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..a43fe0686ceeb3e777b4140c96106a44
  		return eventId;
  	}
  	async getStreamIdForEventId(eventId) {
-@@ -915,9 +1166,46 @@ var DurableObjectEventStore = class DurableObjectEventStore {
+@@ -915,9 +1206,59 @@ var DurableObjectEventStore = class DurableObjectEventStore {
  			start: startKey,
  			limit: DurableObjectEventStore.REPLAY_LIMIT
  		});
@@ -593,8 +633,8 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..a43fe0686ceeb3e777b4140c96106a44
 +		for (const [key, message] of rows) try {
 +			await send(key.slice(DurableObjectEventStore.EVENT_KEY_PREFIX.length), message);
 +		} catch {}
-+		return streamId;
-+	}
+ 		return streamId;
+ 	}
 +	async replayEventsForStream(streamId, { send }) {
 +		const prefix = `${DurableObjectEventStore.EVENT_KEY_PREFIX}${streamId}:`;
 +		const rows = await this.storage.list({
@@ -604,8 +644,8 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..a43fe0686ceeb3e777b4140c96106a44
 +		for (const [key, message] of rows) try {
 +			await send(key.slice(DurableObjectEventStore.EVENT_KEY_PREFIX.length), message);
 +		} catch {}
- 		return streamId;
- 	}
++		return streamId;
++	}
 +	async trimStream(streamId) {
 +		const prefix = `${DurableObjectEventStore.EVENT_KEY_PREFIX}${streamId}:`;
 +		const rows = await this.storage.list({
@@ -622,18 +662,31 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..a43fe0686ceeb3e777b4140c96106a44
 +			return { key, bytes };
 +		});
 +		const deleteKeys = [];
-+		while (entries.length > DurableObjectEventStore.MAX_EVENTS_PER_STREAM || totalBytes > DurableObjectEventStore.MAX_BYTES_PER_STREAM) {
++		// Never evict the newest entry: trimStream runs right after storeEvent
++		// put it, and for a final tool response it is the only copy a recovery
++		// GET can replay. An oversize final response is kept even past the byte
++		// cap; the cap then squeezes out older events instead.
++		while (entries.length > 1 && (entries.length > DurableObjectEventStore.MAX_EVENTS_PER_STREAM || totalBytes > DurableObjectEventStore.MAX_BYTES_PER_STREAM)) {
 +			const evicted = entries.shift();
 +			if (!evicted) break;
 +			deleteKeys.push(evicted.key);
 +			totalBytes -= evicted.bytes;
 +		}
-+		for (let i = 0; i < deleteKeys.length; i += DurableObjectEventStore.DELETE_CHUNK) await this.storage.delete(deleteKeys.slice(i, i + DurableObjectEventStore.DELETE_CHUNK));
++		if (deleteKeys.length > 0) {
++			console.warn(JSON.stringify({
++				event: "mcp_event_store_evicted",
++				streamId,
++				evictedCount: deleteKeys.length,
++				remainingCount: entries.length,
++				remainingBytes: totalBytes
++			}));
++			for (let i = 0; i < deleteKeys.length; i += DurableObjectEventStore.DELETE_CHUNK) await this.storage.delete(deleteKeys.slice(i, i + DurableObjectEventStore.DELETE_CHUNK));
++		}
 +	}
  	/**
  	* Drop the event log for a single stream. Called by the transport
  	* immediately after a POST's final response has been written to the
-@@ -973,6 +1261,9 @@ DurableObjectEventStore.EVENT_KEY_PREFIX = "__mcp_event__:";
+@@ -973,6 +1314,9 @@ DurableObjectEventStore.EVENT_KEY_PREFIX = "__mcp_event__:";
  DurableObjectEventStore.SEQ_PAD = 16;
  DurableObjectEventStore.DELETE_CHUNK = 128;
  DurableObjectEventStore.REPLAY_LIMIT = 1e3;
@@ -643,7 +696,7 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..a43fe0686ceeb3e777b4140c96106a44
  //#endregion
  //#region src/mcp/client-transports.ts
  /**
-@@ -1381,6 +1672,47 @@ var McpAgent = class McpAgent extends Agent {
+@@ -1381,6 +1725,47 @@ var McpAgent = class McpAgent extends Agent {
  	async deleteStreamRequestIds(streamId) {
  		await this.ctx.storage.delete(`${McpAgent.STREAM_REQS_KEY_PREFIX}${streamId}`);
  	}
@@ -691,7 +744,7 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..a43fe0686ceeb3e777b4140c96106a44
  	/**
  	* Reverse lookup: find which POST stream a given `requestId` belongs
  	* to, and return the stream's full `requestIds` list in the same
-@@ -1697,7 +2029,8 @@ var McpAgent = class McpAgent extends Agent {
+@@ -1697,7 +2082,8 @@ var McpAgent = class McpAgent extends Agent {
  	}
  };
  McpAgent.STREAM_REQS_KEY_PREFIX = "__mcp_stream_reqs__:";

--- a/patches/agents@0.17.3.patch
+++ b/patches/agents@0.17.3.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/mcp/index.d.ts b/dist/mcp/index.d.ts
-index c8fad448e8797b89690a99d93490d1363851b225..439da01e789713d217778e8bdebfa1a9d52a71e2 100644
+index c8fad448e8797b89690a99d93490d1363851b225..77f9fe3f6f2375eadc9f7a2974f0d202fe75b3bd 100644
 --- a/dist/mcp/index.d.ts
 +++ b/dist/mcp/index.d.ts
 @@ -29,6 +29,7 @@ import {
@@ -19,7 +19,7 @@ index c8fad448e8797b89690a99d93490d1363851b225..439da01e789713d217778e8bdebfa1a9
    McpAgent,
    type McpAuthContext,
 diff --git a/dist/mcp/index.js b/dist/mcp/index.js
-index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..0ba4f5bff8e6a968aa18c609952e576cedf13d8f 100644
+index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..db35f39456ed71b6c33562f69bdebadc84d1774e 100644
 --- a/dist/mcp/index.js
 +++ b/dist/mcp/index.js
 @@ -28,13 +28,17 @@ import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/
@@ -62,7 +62,7 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..0ba4f5bff8e6a968aa18c609952e576c
  				request.headers.forEach((value, key) => {
  					existingHeaders[key] = value;
  				});
-@@ -206,45 +215,71 @@ const createStreamingHttpHandler = (basePath, namespace, options = {}) => {
+@@ -206,45 +215,94 @@ const createStreamingHttpHandler = (basePath, namespace, options = {}) => {
  						jsonrpc: "2.0"
  					});
  					return new Response(body, { status: 500 });
@@ -74,6 +74,7 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..0ba4f5bff8e6a968aa18c609952e576c
 +					}
 +					ws.accept();
 +					const __closeSse = () => {
++						if (__sseClosed) return;
 +						__sseClosed = true;
 +						try {
 +							clearInterval(keepAlive);
@@ -83,6 +84,17 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..0ba4f5bff8e6a968aa18c609952e576c
 +						} catch {}
 +						writer.abort(new Error("SSE client not draining")).catch(() => {});
 +					};
++					const __markSseClientClosed = () => {
++						if (__sseClosed) return;
++						__sseClosed = true;
++						try {
++							clearInterval(keepAlive);
++						} catch {}
++						writer.abort(new Error("SSE client disconnected")).catch(() => {});
++					};
++					writer.closed?.catch(() => {
++						__markSseClientClosed();
++					});
 +					const __forwardSse = (frame) => {
 +						if (__sseClosed) return __writeChain;
 +						if (__pendingBytes + frame.byteLength > MAX_PENDING_SSE_BYTES) {
@@ -90,7 +102,9 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..0ba4f5bff8e6a968aa18c609952e576c
 +							return Promise.resolve();
 +						}
 +						__pendingBytes += frame.byteLength;
-+						__writeChain = __writeChain.then(() => writer.write(frame)).catch(() => {}).finally(() => {
++						__writeChain = __writeChain.then(() => writer.write(frame)).catch(() => {
++							__closeSse();
++						}).finally(() => {
 +							__pendingBytes -= frame.byteLength;
 +						});
 +						return __writeChain;
@@ -126,9 +140,18 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..0ba4f5bff8e6a968aa18c609952e576c
 +								const writePromise = __forwardSse(encoder.encode(message.event));
 +								if (message.close) {
 +									clearInterval(keepAlive);
-+									ws?.close();
 +									await writePromise;
-+									await writer.close().catch(() => {});
++									if (!__sseClosed) {
++										try {
++											ws.send(JSON.stringify({
++												type: "cf_mcp_delivery_ack",
++												eventId: message.eventId,
++												streamId: message.streamId
++											}));
++										} catch {}
++										ws?.close(1000, "SSE response delivered");
++										await writer.close().catch(() => {});
++									}
 +								}
  						} catch (error) {
  							console.error("Error forwarding message to SSE:", error);
@@ -160,7 +183,7 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..0ba4f5bff8e6a968aa18c609952e576c
  					}
  					onClose().catch(console.error);
  				});
-@@ -279,10 +314,16 @@ const createStreamingHttpHandler = (basePath, namespace, options = {}) => {
+@@ -279,10 +337,16 @@ const createStreamingHttpHandler = (basePath, namespace, options = {}) => {
  					id: null,
  					jsonrpc: "2.0"
  				}), { status: 400 });
@@ -181,7 +204,7 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..0ba4f5bff8e6a968aa18c609952e576c
  					props: ctx.props,
  					jurisdiction: options.jurisdiction
  				});
-@@ -306,27 +347,86 @@ const createStreamingHttpHandler = (basePath, namespace, options = {}) => {
+@@ -306,27 +370,93 @@ const createStreamingHttpHandler = (basePath, namespace, options = {}) => {
  				if (!ws) {
  					await writer.close();
  					return new Response("Failed to establish WS to DO", { status: 500 });
@@ -191,6 +214,7 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..0ba4f5bff8e6a968aa18c609952e576c
 +					}
 +					ws.accept();
 +					const __abortSse = () => {
++						if (__sseClosed) return;
 +						__sseClosed = true;
 +						try {
 +							clearInterval(keepAlive);
@@ -200,7 +224,11 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..0ba4f5bff8e6a968aa18c609952e576c
 +						} catch {}
 +						writer.abort(new Error("SSE client not draining")).catch(() => {});
 +					};
++					writer.closed?.catch(() => {
++						__abortSse();
++					});
 +					const __closeSseGracefully = () => {
++						if (__sseClosed) return __writeChain;
 +						__sseClosed = true;
 +						try {
 +							clearInterval(keepAlive);
@@ -239,7 +267,9 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..0ba4f5bff8e6a968aa18c609952e576c
 +							return Promise.resolve();
 +						}
 +						__pendingBytes += frame.byteLength;
-+						__writeChain = __writeChain.then(() => writer.write(frame)).catch(() => {}).finally(() => {
++						__writeChain = __writeChain.then(() => writer.write(frame)).catch(() => {
++							__abortSse();
++						}).finally(() => {
 +							__pendingBytes -= frame.byteLength;
 +						});
 +						return __writeChain;
@@ -283,7 +313,7 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..0ba4f5bff8e6a968aa18c609952e576c
  				return new Response(readable, {
  					headers: {
  						"Cache-Control": "no-cache",
-@@ -389,10 +489,16 @@ const createLegacySseHandler = (basePath, namespace, options = {}) => {
+@@ -389,10 +519,16 @@ const createLegacySseHandler = (basePath, namespace, options = {}) => {
  		const url = new URL(request.url);
  		if (request.method === "GET" && basePattern.test(url)) {
  			const sessionId = url.searchParams.get("sessionId") || namespace.newUniqueId().toString();
@@ -304,7 +334,7 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..0ba4f5bff8e6a968aa18c609952e576c
  			endpointUrl.pathname = encodeURI(`${basePath}/message`);
  			endpointUrl.searchParams.set("sessionId", sessionId);
  			const endpointMessage = `event: endpoint\ndata: ${endpointUrl.pathname + endpointUrl.search + endpointUrl.hash}\n\n`;
-@@ -414,35 +520,94 @@ const createLegacySseHandler = (basePath, namespace, options = {}) => {
+@@ -414,35 +550,94 @@ const createLegacySseHandler = (basePath, namespace, options = {}) => {
  				console.error("Failed to establish WebSocket connection");
  				await writer.close();
  				return new Response("Failed to establish WebSocket connection", { status: 500 });
@@ -417,9 +447,227 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..0ba4f5bff8e6a968aa18c609952e576c
  						console.error("Error closing SSE connection:", error);
  					}
  				}
-@@ -1698,6 +1863,6 @@ var McpAgent = class McpAgent extends Agent {
+@@ -634,7 +829,8 @@ var StreamableHTTPServerTransport = class {
+ 				}
+ 				this.supersedePriorStreamConnections(agent, connection.id, resumedStreamId);
+ 				connection.setState(resumeState);
+-				await this.replayEvents(lastEventId);
++				const replayedResponse = await this.replayEvents(lastEventId);
++				if (resumedStreamId !== STANDALONE_STREAM_ID && replayedResponse) await this.acknowledgeDeliveredStream(agent, resumedStreamId);
+ 				return;
+ 			}
+ 		}
+@@ -644,6 +840,7 @@ var StreamableHTTPServerTransport = class {
+ 			_standaloneSse: true
+ 		};
+ 		connection.setState(standaloneState);
++		await this.replayUndeliveredResponses(agent, connection);
+ 	}
+ 	/**
+ 	* Close any connection (other than `selfId`) currently bound to
+@@ -664,12 +861,14 @@ var StreamableHTTPServerTransport = class {
+ 	* Only used when resumability is enabled
+ 	*/
+ 	async replayEvents(lastEventId) {
+-		if (!this._eventStore) return;
++		if (!this._eventStore) return false;
+ 		const { connection } = getCurrentAgent();
+ 		if (!connection) throw new Error("Connection was not available in replayEvents");
++		let replayedResponse = false;
+ 		try {
+ 			await this._eventStore?.replayEventsAfter(lastEventId, { send: async (eventId, message) => {
+ 				try {
++					if (isJSONRPCResultResponse(message) || isJSONRPCErrorResponse(message)) replayedResponse = true;
+ 					this.writeSSEEvent(connection, message, eventId);
+ 				} catch (error) {
+ 					this.onerror?.(error);
+@@ -678,6 +877,27 @@ var StreamableHTTPServerTransport = class {
+ 		} catch (error) {
+ 			this.onerror?.(error);
+ 		}
++		return replayedResponse;
++	}
++	async replayUndeliveredResponses(agent, connection) {
++		if (!this._eventStore?.replayEventsForStream) return;
++		const streamIds = await agent.getUndeliveredStreamIds();
++		for (const streamId of streamIds) {
++			let replayedResponse = false;
++			await this._eventStore.replayEventsForStream(streamId, { send: async (eventId, message) => {
++				try {
++					if (isJSONRPCResultResponse(message) || isJSONRPCErrorResponse(message)) replayedResponse = true;
++					this.writeSSEEvent(connection, message, eventId);
++				} catch (error) {
++					this.onerror?.(error);
++				}
++			} });
++			if (replayedResponse) await this.acknowledgeDeliveredStream(agent, streamId);
++		}
++	}
++	async acknowledgeDeliveredStream(agent, streamId) {
++		await agent.deleteStreamRequestIds(streamId);
++		if (this._eventStore && isClearableEventStore(this._eventStore)) await this._eventStore.clearStream(streamId);
+ 	}
+ 	/**
+ 	* Writes an event to the SSE stream with proper formatting
+@@ -689,6 +909,8 @@ var StreamableHTTPServerTransport = class {
+ 		return connection.send(JSON.stringify({
+ 			type: "cf_mcp_agent_event",
+ 			event: eventData,
++			eventId,
++			streamId: eventId ? eventId.slice(0, eventId.lastIndexOf(":")) : void 0,
+ 			close
+ 		}));
+ 	}
+@@ -777,9 +999,11 @@ var StreamableHTTPServerTransport = class {
+ 		} catch (error) {
+ 			this.onerror?.(error);
+ 		}
+-		if (shouldClose) {
++		if (shouldClose && !this._eventStore) {
++			await agent.deleteStreamRequestIds(streamId);
++		} else if (shouldClose) {
++			await agent.markStreamUndelivered(streamId);
+ 			await agent.deleteStreamRequestIds(streamId);
+-			if (this._eventStore && isClearableEventStore(this._eventStore)) await this._eventStore.clearStream(streamId);
+ 		}
+ 	}
+ 	async send(message, options) {
+@@ -861,12 +1085,10 @@ var StreamableHTTPServerTransport = class {
+ *
+ * ## Lifecycle
+ *
+-* Each POST tool-call stream's events live only until the final
+-* response is delivered. The transport calls {@link clearStream}
+-* immediately after writing the close frame, so storage growth is
+-* bounded by the in-flight POST streams plus the standalone GET
+-* stream. There is no background sweep — quiescent agents do no work,
+-* and the DO itself dies with the session.
++* Each POST tool-call stream's response events live until the Worker
++* bridge confirms the final SSE write or a reconnect GET replays them.
++* Per-stream storage is capped at 64 events or roughly 2 MB; oldest
++* entries are evicted first.
+ *
+ * Standalone GET stream events (`_GET_stream`) are *not* cleared
+ * automatically; they accumulate for the lifetime of the DO. Bounded
+@@ -899,6 +1121,7 @@ var DurableObjectEventStore = class DurableObjectEventStore {
+ 		const eventId = `${streamId}:${seq.toString(16).padStart(DurableObjectEventStore.SEQ_PAD, "0")}`;
+ 		const eventKey = `${DurableObjectEventStore.EVENT_KEY_PREFIX}${eventId}`;
+ 		await this.storage.put(eventKey, message);
++		await this.trimStream(streamId);
+ 		return eventId;
+ 	}
+ 	async getStreamIdForEventId(eventId) {
+@@ -915,9 +1138,46 @@ var DurableObjectEventStore = class DurableObjectEventStore {
+ 			start: startKey,
+ 			limit: DurableObjectEventStore.REPLAY_LIMIT
+ 		});
+-		for (const [key, message] of rows) await send(key.slice(DurableObjectEventStore.EVENT_KEY_PREFIX.length), message);
++		for (const [key, message] of rows) try {
++			await send(key.slice(DurableObjectEventStore.EVENT_KEY_PREFIX.length), message);
++		} catch {}
++		return streamId;
++	}
++	async replayEventsForStream(streamId, { send }) {
++		const prefix = `${DurableObjectEventStore.EVENT_KEY_PREFIX}${streamId}:`;
++		const rows = await this.storage.list({
++			prefix,
++			limit: DurableObjectEventStore.REPLAY_LIMIT
++		});
++		for (const [key, message] of rows) try {
++			await send(key.slice(DurableObjectEventStore.EVENT_KEY_PREFIX.length), message);
++		} catch {}
+ 		return streamId;
+ 	}
++	async trimStream(streamId) {
++		const prefix = `${DurableObjectEventStore.EVENT_KEY_PREFIX}${streamId}:`;
++		const rows = await this.storage.list({
++			prefix,
++			limit: DurableObjectEventStore.REPLAY_LIMIT
++		});
++		let totalBytes = 0;
++		const entries = [...rows].map(([key, message]) => {
++			let bytes = DurableObjectEventStore.MAX_EVENT_BYTES;
++			try {
++				bytes = new TextEncoder().encode(JSON.stringify(message)).byteLength;
++			} catch {}
++			totalBytes += bytes;
++			return { key, bytes };
++		});
++		const deleteKeys = [];
++		while (entries.length > DurableObjectEventStore.MAX_EVENTS_PER_STREAM || totalBytes > DurableObjectEventStore.MAX_BYTES_PER_STREAM) {
++			const evicted = entries.shift();
++			if (!evicted) break;
++			deleteKeys.push(evicted.key);
++			totalBytes -= evicted.bytes;
++		}
++		for (let i = 0; i < deleteKeys.length; i += DurableObjectEventStore.DELETE_CHUNK) await this.storage.delete(deleteKeys.slice(i, i + DurableObjectEventStore.DELETE_CHUNK));
++	}
+ 	/**
+ 	* Drop the event log for a single stream. Called by the transport
+ 	* immediately after a POST's final response has been written to the
+@@ -973,6 +1233,9 @@ DurableObjectEventStore.EVENT_KEY_PREFIX = "__mcp_event__:";
+ DurableObjectEventStore.SEQ_PAD = 16;
+ DurableObjectEventStore.DELETE_CHUNK = 128;
+ DurableObjectEventStore.REPLAY_LIMIT = 1e3;
++DurableObjectEventStore.MAX_EVENTS_PER_STREAM = 64;
++DurableObjectEventStore.MAX_BYTES_PER_STREAM = 2 * 1024 * 1024;
++DurableObjectEventStore.MAX_EVENT_BYTES = 2 * 1024 * 1024;
+ //#endregion
+ //#region src/mcp/client-transports.ts
+ /**
+@@ -1381,6 +1644,47 @@ var McpAgent = class McpAgent extends Agent {
+ 	async deleteStreamRequestIds(streamId) {
+ 		await this.ctx.storage.delete(`${McpAgent.STREAM_REQS_KEY_PREFIX}${streamId}`);
+ 	}
++	async markStreamUndelivered(streamId) {
++		await this.ctx.storage.put(`${McpAgent.UNDELIVERED_STREAM_KEY_PREFIX}${streamId}`, true);
++	}
++	async deleteUndeliveredStream(streamId) {
++		await this.ctx.storage.delete(`${McpAgent.UNDELIVERED_STREAM_KEY_PREFIX}${streamId}`);
++	}
++	async getUndeliveredStreamIds() {
++		const rows = await this.ctx.storage.list({
++			prefix: McpAgent.UNDELIVERED_STREAM_KEY_PREFIX,
++			limit: 1e3
++		});
++		return [...rows.keys()].map((key) => key.slice(McpAgent.UNDELIVERED_STREAM_KEY_PREFIX.length));
++	}
++	/** List persisted POST stream request ids for replay and idle accounting. @internal */
++	async getOpenStreamRequestIds() {
++		const rows = await this.ctx.storage.list({
++			prefix: McpAgent.STREAM_REQS_KEY_PREFIX,
++			limit: 1e3
++		});
++		return [...rows].flatMap(([key, requestIds]) => Array.isArray(requestIds) && requestIds.length > 0 ? [{
++			streamId: key.slice(McpAgent.STREAM_REQS_KEY_PREFIX.length),
++			requestIds
++		}] : []);
++	}
++	async acknowledgeDeliveredStream(streamId) {
++		await this.deleteStreamRequestIds(streamId);
++		await this.deleteUndeliveredStream(streamId);
++		const eventStore = this._transport?.["_eventStore"];
++		if (eventStore && isClearableEventStore(eventStore)) await eventStore.clearStream(streamId);
++	}
++	async onMessage(connection, message) {
++		if (typeof message !== "string") return super.onMessage(connection, message);
++		try {
++			const parsed = JSON.parse(message);
++			if (parsed?.type === "cf_mcp_delivery_ack" && typeof parsed.streamId === "string") {
++				await this.acknowledgeDeliveredStream(parsed.streamId);
++				return;
++			}
++		} catch {}
++		return super.onMessage(connection, message);
++	}
+ 	/**
+ 	* Reverse lookup: find which POST stream a given `requestId` belongs
+ 	* to, and return the stream's full `requestIds` list in the same
+@@ -1697,7 +2001,8 @@ var McpAgent = class McpAgent extends Agent {
+ 	}
  };
  McpAgent.STREAM_REQS_KEY_PREFIX = "__mcp_stream_reqs__:";
++McpAgent.UNDELIVERED_STREAM_KEY_PREFIX = "__mcp_undelivered_stream__:";
  //#endregion
 -export { DurableObjectEventStore, ElicitRequestSchema, MCP_SERVER_ID_MAX_LENGTH, McpAgent, RPCClientTransport, RPCServerTransport, RPC_DO_PREFIX, SSEEdgeClientTransport, StreamableHTTPEdgeClientTransport, WorkerTransport, createMcpHandler, experimental_createMcpHandler, getMcpAuthContext, normalizeServerId };
 +export { DurableObjectEventStore, ElicitRequestSchema, MAX_SSE_AGE_MS, MCP_SERVER_ID_MAX_LENGTH, McpAgent, RPCClientTransport, RPCServerTransport, RPC_DO_PREFIX, SSEEdgeClientTransport, StreamableHTTPEdgeClientTransport, WorkerTransport, createMcpHandler, experimental_createMcpHandler, getMcpAuthContext, normalizeServerId };


### PR DESCRIPTION
MCP tool results were delivered on a single SSE stream with no persistence. If that stream died mid-call (client disconnect, stream rotation, session recycling), the completed result was written into a dead pipe and dropped, and the client waited on the call indefinitely. Reproduced against production.

Tool responses are now persisted in the session DO until delivery is confirmed, and replayed on the session's next GET stream. The session idle alarm no longer disposes runtimes with in-flight calls or open streams, and disposal closes websockets cleanly.

Verified with e2e scenarios plus a raw streamable-HTTP harness covering stream-abort, replay, and idle-disposal paths.