### PR TITLE
Add a host-side timeout backstop for unresponsive sandbox executions

### DIFF
--- a/.changeset/host-evaluate-timeout.md
+++ b/.changeset/host-evaluate-timeout.md
@@ -1,0 +1,5 @@
+---
+"executor": patch
+---
+
+Back-stop code execution with a host-side timeout so a wedged sandbox delivers a descriptive error instead of hanging silently.

--- a/packages/kernel/core/src/effect-errors.ts
+++ b/packages/kernel/core/src/effect-errors.ts
@@ -56,3 +56,26 @@ export class SandboxRuntimeError extends Data.TaggedError("SandboxRuntimeError")
   readonly message: string;
   readonly cause?: unknown;
 }> {}
+
+/**
+ * Raised on the host side when a sandbox execution never settles within its
+ * effective timeout bound (plus a grace margin) AND is not merely blocked in a
+ * host round-trip (a tool call or an approval pause). This is the backstop for
+ * a wedged isolate: if the isolate is evicted / OOM-killed in a way that hangs
+ * the cross-isolate RPC without rejecting, the in-sandbox timer never fires and
+ * the host would otherwise wait forever, surfacing to the client as pure
+ * silence. Like `SandboxRuntimeError`, this is a safe-to-report condition (the
+ * execution is unrecoverable but the failure is descriptive, not an internal
+ * defect), so runtimes surface its `message` through the descriptive
+ * `ExecuteResult.error` channel rather than collapsing it to an opaque internal
+ * error. The host clock is suspended while the sandbox is blocked in a host
+ * round-trip, so a long-running tool call or a minutes-long approval pause does
+ * NOT trip it: it fires only when the sandbox is supposed to be computing on
+ * its own and has gone unresponsive.
+ */
+export class SandboxHostTimeoutError extends Data.TaggedError("SandboxHostTimeoutError")<{
+  readonly runtime: string;
+  readonly message: string;
+  readonly timeoutMs: number;
+  readonly elapsedMs: number;
+}> {}

--- a/packages/kernel/core/src/types.ts
+++ b/packages/kernel/core/src/types.ts
@@ -56,6 +56,14 @@ export type ExecuteResult = {
  */
 export interface CodeExecutor<E extends Cause.YieldableError = CodeExecutionError> {
   execute(code: string, toolInvoker: SandboxToolInvoker): Effect.Effect<ExecuteResult, E>;
+  /**
+   * The effective in-sandbox execution timeout, in milliseconds, that this
+   * runtime enforces on the code it runs. Exposed so a host can derive its own
+   * outer backstop (e.g. this bound plus a grace margin) for the case where the
+   * in-sandbox timer itself is defeated by a wedged isolate. Optional: runtimes
+   * that do not bound execution leave it undefined and hosts skip the backstop.
+   */
+  readonly timeoutMs?: number;
 }
 
 /** Accept-anything schema for tools with no input validation */

--- a/packages/kernel/runtime-dynamic-worker/src/executor.ts
+++ b/packages/kernel/runtime-dynamic-worker/src/executor.ts
@@ -16,6 +16,7 @@ import * as Effect from "effect/Effect";
 import {
   CodeCompilationError,
   recoverExecutionBody,
+  SandboxHostTimeoutError,
   SandboxRuntimeError,
   stripTypeScript,
   type CodeExecutor,
@@ -44,6 +45,20 @@ export type DynamicWorkerExecutorOptions = {
    * Timeout in milliseconds for code execution. Defaults to 5 minutes.
    */
   readonly timeoutMs?: number;
+  /**
+   * Extra wall-clock the host waits beyond `timeoutMs` before declaring the
+   * isolate wedged and delivering a `SandboxHostTimeoutError`. Defaults to 30s.
+   * The in-sandbox timer should always fire first for a healthy isolate; this
+   * margin only covers the case where that timer is defeated by a wedged RPC.
+   * Exposed primarily so tests can shrink the backstop; production leaves it
+   * unset.
+   */
+  readonly hostTimeoutGraceMs?: number;
+  /**
+   * Poll interval for the host-timeout watchdog, in milliseconds. Defaults to
+   * 1s. Exposed for tests; production leaves it unset.
+   */
+  readonly hostTimeoutPollMs?: number;
   /**
    * Controls outbound network access from sandboxed code.
    * - `null` (default): `fetch()` and `connect()` throw — fully isolated.
@@ -87,6 +102,14 @@ type WorkerRpcResponse = WorkerRpcSuccess | WorkerRpcFailure;
 // ---------------------------------------------------------------------------
 
 const DEFAULT_TIMEOUT_MS = 5 * 60_000;
+/**
+ * Extra wall-clock the host waits beyond the effective in-sandbox timeout
+ * before declaring the isolate wedged. The in-sandbox timer should always fire
+ * first for a healthy isolate; this margin covers scheduling jitter and the RPC
+ * unwind so a normally-timing-out execution reports its own descriptive timeout
+ * rather than this backstop.
+ */
+const HOST_TIMEOUT_GRACE_MS = 30_000;
 const ENTRY_MODULE = "executor.js";
 
 const normalizeErrorObject = (error: Error) => ({
@@ -467,6 +490,14 @@ export type RunPromise = <A, E>(effect: Effect.Effect<A, E>) => Promise<A>;
 export class ToolDispatcher extends RpcTarget {
   readonly #invoker: SandboxToolInvoker;
   readonly #runPromise: RunPromise;
+  // Number of tool round-trips currently in flight. The host-side execution
+  // timeout is suspended while this is > 0: whenever the sandbox is blocked
+  // here it is demonstrably not wedged (the host owns the continuation and
+  // will resume it), so neither a slow tool call nor a minutes-long approval
+  // pause (which manifests as an in-flight dispatch awaiting an elicitation
+  // response) should count against the unresponsive-sandbox backstop.
+  #inFlight = 0;
+  #lastReturnedAt = Date.now();
 
   constructor(invoker: SandboxToolInvoker, runPromise: RunPromise) {
     super();
@@ -474,7 +505,32 @@ export class ToolDispatcher extends RpcTarget {
     this.#runPromise = runPromise;
   }
 
+  /** True while at least one tool round-trip is awaiting the host. */
+  get isDispatching(): boolean {
+    return this.#inFlight > 0;
+  }
+
+  /**
+   * Epoch millis when the most recent tool round-trip returned control to the
+   * sandbox (or dispatcher construction time if none has). Combined with
+   * `isDispatching`, lets the host measure only the stretches where the sandbox
+   * is expected to be computing on its own.
+   */
+  get lastReturnedAt(): number {
+    return this.#lastReturnedAt;
+  }
+
   async call(path: string, args: unknown): Promise<WorkerRpcResponse> {
+    this.#inFlight += 1;
+    try {
+      return await this.#dispatch(path, args);
+    } finally {
+      this.#inFlight -= 1;
+      this.#lastReturnedAt = Date.now();
+    }
+  }
+
+  #dispatch(path: string, args: unknown): Promise<WorkerRpcResponse> {
     return this.#runPromise(
       Effect.try({
         try: () => rehydrateBinary(args),
@@ -592,13 +648,101 @@ const startDynamicWorker = (
     }),
   );
 
+// ---------------------------------------------------------------------------
+// Host-side execution timeout (unresponsive-sandbox backstop)
+// ---------------------------------------------------------------------------
+
+/** The subset of `ToolDispatcher` state the host watchdog observes. */
+export type DispatcherActivity = {
+  readonly isDispatching: boolean;
+  readonly lastReturnedAt: number;
+};
+
+export type HostTimeoutOptions = {
+  /** Effective in-sandbox timeout bound the sandbox itself enforces. */
+  readonly timeoutMs: number;
+  /** Extra wall-clock beyond the bound before declaring the isolate wedged. */
+  readonly graceMs: number;
+  /** Dispatcher activity — the host clock is suspended while it is dispatching. */
+  readonly dispatcher: DispatcherActivity;
+  /** Poll interval for the watchdog. Defaults to 1s. */
+  readonly pollMs?: number;
+  /** Emitted once when the backstop fires. */
+  readonly onTimeout?: (info: { readonly elapsedMs: number }) => void;
+  /** Clock injection for tests. Defaults to `Date.now`. */
+  readonly now?: () => number;
+};
+
+/**
+ * Race a (typed) evaluate Effect against a host-side watchdog that fires only
+ * when the sandbox has gone unresponsive: no result and no host round-trip for
+ * `timeoutMs + graceMs` of continuous compute time. The watchdog's reference
+ * point advances every time a tool round-trip returns and is held at `now`
+ * while a round-trip is in flight (a slow tool call or an approval pause), so
+ * those never trip it. A true wedge (isolate evicted / OOM, RPC hung without
+ * rejecting, no further dispatch) leaves the reference point stationary and the
+ * watchdog fires, failing with a `SandboxHostTimeoutError`.
+ *
+ * Takes the evaluate step as a pre-built Effect (not a raw promise) so the
+ * caller keeps its own error classification, and so a test can drive it with an
+ * Effect wrapping a never-settling promise (no live WorkerLoader needed).
+ */
+export const runEvaluateWithHostTimeout = <A, E>(
+  evaluated: Effect.Effect<A, E>,
+  options: HostTimeoutOptions,
+): Effect.Effect<A, E | SandboxHostTimeoutError> =>
+  Effect.gen(function* () {
+    const now = options.now ?? Date.now;
+    const bound = Math.max(0, options.timeoutMs) + Math.max(0, options.graceMs);
+    const pollMs = Math.max(1, options.pollMs ?? 1_000);
+    const start = now();
+
+    const completion = evaluated.pipe(
+      Effect.map((value): TimeoutRace<A> => ({ kind: "done", value })),
+    );
+
+    // Poll the dispatcher's activity. `reference` is the latest instant from
+    // which the sandbox is expected to be computing on its own: execution
+    // start, bumped forward to each round-trip's return, and pinned to `now`
+    // for as long as a round-trip is outstanding. The watchdog fires when the
+    // sandbox has been on its own for `bound` ms without producing a result.
+    const watchdog: Effect.Effect<TimeoutRace<A>> = Effect.gen(function* () {
+      for (;;) {
+        yield* Effect.sleep(pollMs);
+        const current = now();
+        const reference = options.dispatcher.isDispatching
+          ? current
+          : Math.max(start, options.dispatcher.lastReturnedAt);
+        if (current - reference >= bound) {
+          return { kind: "timeout", elapsedMs: current - start };
+        }
+      }
+    });
+
+    const outcome = yield* Effect.raceFirst(completion, watchdog);
+    if (outcome.kind === "timeout") {
+      options.onTimeout?.({ elapsedMs: outcome.elapsedMs });
+      return yield* new SandboxHostTimeoutError({
+        runtime: "dynamic-worker",
+        message: `execution exceeded ${bound}ms (sandbox unresponsive)`,
+        timeoutMs: bound,
+        elapsedMs: outcome.elapsedMs,
+      });
+    }
+    return outcome.value;
+  });
+
+type TimeoutRace<A> =
+  | { readonly kind: "done"; readonly value: A }
+  | { readonly kind: "timeout"; readonly elapsedMs: number };
+
 const evaluate = (
   options: DynamicWorkerExecutorOptions,
   code: string,
   toolInvoker: SandboxToolInvoker,
 ): Effect.Effect<
   ExecuteResult,
-  DynamicWorkerExecutionError | CodeCompilationError | SandboxRuntimeError
+  DynamicWorkerExecutionError | CodeCompilationError | SandboxRuntimeError | SandboxHostTimeoutError
 > => {
   const timeoutMs = Math.max(100, options.timeoutMs ?? DEFAULT_TIMEOUT_MS);
 
@@ -606,13 +750,32 @@ const evaluate = (
     const context = yield* Effect.context<never>();
     const dispatcher = new ToolDispatcher(toolInvoker, Effect.runPromiseWith(context));
     const entrypoint = yield* startDynamicWorker(options, code, timeoutMs);
-    const response = yield* Effect.tryPromise({
+    // The evaluate RPC rejects for module compile failures that escaped the
+    // strip step, non-serializable return values, isolate resource limits, and
+    // capacity. All are the user's concern or transient, so classify and
+    // surface them descriptively rather than opaquely.
+    const evaluated = Effect.tryPromise({
       try: () => entrypoint.evaluate(dispatcher),
-      // The evaluate RPC rejects for module compile failures that escaped
-      // the strip step, non-serializable return values, isolate resource
-      // limits, and capacity. All are the user's concern or transient, so
-      // classify and surface them descriptively rather than opaquely.
       catch: toSandboxFailure,
+    });
+    const graceMs = Math.max(0, options.hostTimeoutGraceMs ?? HOST_TIMEOUT_GRACE_MS);
+    const response = yield* runEvaluateWithHostTimeout(evaluated, {
+      timeoutMs,
+      graceMs,
+      pollMs: options.hostTimeoutPollMs,
+      dispatcher,
+      onTimeout: ({ elapsedMs }) => {
+        // Structured, greppable event for the alerting workstream. Kept off the
+        // trace span (which is interrupted by the race) so it always lands.
+        // oxlint-disable-next-line no-console -- boundary: structured host-timeout telemetry event
+        console.error(
+          JSON.stringify({
+            event: "mcp_execution_host_timeout",
+            elapsedMs,
+            timeoutMs: timeoutMs + graceMs,
+          }),
+        );
+      },
     }).pipe(
       Effect.withSpan("executor.runtime.evaluate", {
         attributes: { "executor.runtime": "dynamic-worker" },
@@ -652,6 +815,13 @@ const runInDynamicWorker = (
         Effect.succeed({ result: null, error: error.message } satisfies ExecuteResult),
       SandboxRuntimeError: (error) =>
         Effect.succeed({ result: null, error: error.message } satisfies ExecuteResult),
+      // A wedged isolate that the in-sandbox timer failed to catch is
+      // unrecoverable, but reporting it as a delivered, descriptive error beats
+      // the original symptom (open-ended silence). Fold it into the success
+      // channel like the other safe-to-report conditions so it reaches the
+      // model instead of collapsing to an opaque internal error.
+      SandboxHostTimeoutError: (error) =>
+        Effect.succeed({ result: null, error: error.message } satisfies ExecuteResult),
     }),
     Effect.withSpan("executor.code.exec.dynamic_worker", {
       attributes: { "executor.runtime": "dynamic-worker" },
@@ -667,4 +837,7 @@ export const makeDynamicWorkerExecutor = (
 ): CodeExecutor<DynamicWorkerExecutionError> => ({
   execute: (code: string, toolInvoker: SandboxToolInvoker) =>
     runInDynamicWorker(options, code, toolInvoker),
+  // The effective in-sandbox bound, exposed so hosts can reason about the
+  // execution budget. `evaluate` clamps to a 100ms floor identically.
+  timeoutMs: Math.max(100, options.timeoutMs ?? DEFAULT_TIMEOUT_MS),
 });

--- a/packages/kernel/runtime-dynamic-worker/src/host-timeout.test.ts
+++ b/packages/kernel/runtime-dynamic-worker/src/host-timeout.test.ts
@@ -1,0 +1,195 @@
+// ---------------------------------------------------------------------------
+// Host-side execution timeout — the unresponsive-sandbox backstop.
+//
+// The ONLY timeout on code execution used to be the in-SANDBOX Promise.race in
+// module-template.ts. If the isolate is evicted / OOM-killed in a way that
+// wedges the cross-isolate `evaluate` RPC WITHOUT rejecting, that timer never
+// fires and the host side awaited the RPC forever: the client saw pure silence
+// (SSE keepalives, no JSON-RPC frame) for the DO's whole running-work lease.
+//
+// These tests drive that exact shape through the PUBLIC executor path with a
+// fake WorkerLoader whose `evaluate()` never settles. On the unpatched code the
+// "delivers a typed timeout error" test HANGS and only fails via the bounded
+// vitest testTimeout (red-by-timeout repro); with the host backstop it delivers
+// a descriptive `ExecuteResult.error` well inside the bound. The pause-survival
+// test guards the correctness risk of the change: an execution blocked in a
+// host round-trip (a slow tool call or a minutes-long approval pause) must NOT
+// be killed by the backstop.
+// ---------------------------------------------------------------------------
+
+import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Fiber from "effect/Fiber";
+import * as Data from "effect/Data";
+import type { SandboxToolInvoker } from "@executor-js/codemode-core";
+
+import {
+  makeDynamicWorkerExecutor,
+  runEvaluateWithHostTimeout,
+  type DispatcherActivity,
+} from "./executor";
+
+// A never-invoked tool invoker — the wedge cases never reach a tool call.
+const idleInvoker: SandboxToolInvoker = {
+  invoke: () => Effect.succeed(undefined),
+};
+
+// Build a fake WorkerLoader whose loaded worker's `evaluate()` resolves with
+// `settle()` (or never, if `settle` is never called). Enough surface for
+// `startDynamicWorker` -> `worker.getEntrypoint().evaluate(dispatcher)`.
+const makeFakeLoader = (evaluate: () => Promise<unknown>) => {
+  const entrypoint = { evaluate };
+  const stub = { getEntrypoint: () => entrypoint };
+  // oxlint-disable-next-line executor/no-double-cast -- test double for the Cloudflare WorkerLoader binding; only get()/getEntrypoint()/evaluate() are exercised
+  return { get: () => stub, load: () => stub } as unknown as WorkerLoader;
+};
+
+// A dispatcher-activity double the watchdog observes directly.
+const activity = (init: Partial<DispatcherActivity> = {}): DispatcherActivity => ({
+  isDispatching: false,
+  lastReturnedAt: 0,
+  ...init,
+});
+
+class NeverError extends Data.TaggedError("NeverError")<{ readonly message: string }> {}
+
+// A promise that never settles — the wedged RPC.
+const never = <A>(): Promise<A> => new Promise<A>(() => {});
+
+describe("host execution timeout (public execute path)", () => {
+  it("delivers a descriptive timeout error when the evaluate RPC never settles", async () => {
+    // The wedge: evaluate() never resolves and never rejects.
+    const executor = makeDynamicWorkerExecutor({
+      loader: makeFakeLoader(() => never()),
+      timeoutMs: 200, // small in-sandbox bound so the backstop (bound + grace) is quick
+      hostTimeoutGraceMs: 100,
+      hostTimeoutPollMs: 20,
+    });
+
+    const started = Date.now();
+    // On UNPATCHED code this Effect never completes and the test fails only via
+    // the bounded vitest testTimeout. With the backstop it resolves with a
+    // delivered, descriptive error.
+    const result = await Effect.runPromise(executor.execute("return 1;", idleInvoker));
+    const elapsed = Date.now() - started;
+
+    expect(result.result).toBeNull();
+    expect(result.error).toBeDefined();
+    expect(result.error).toContain("unresponsive");
+    // bound = 200 (timeout) + 100 (grace). Must have fired, not hung forever.
+    expect(elapsed).toBeGreaterThanOrEqual(300);
+    expect(elapsed).toBeLessThan(10_000);
+  });
+
+  it("passes a fast result straight through without waiting on the backstop", async () => {
+    const executor = makeDynamicWorkerExecutor({
+      loader: makeFakeLoader(() => Promise.resolve({ result: 42, logs: [] })),
+      timeoutMs: 200,
+    });
+
+    const started = Date.now();
+    const result = await Effect.runPromise(executor.execute("return 42;", idleInvoker));
+    const elapsed = Date.now() - started;
+
+    expect(result.result).toBe(42);
+    expect(result.error).toBeUndefined();
+    expect(elapsed).toBeLessThan(1_000);
+  });
+});
+
+describe("runEvaluateWithHostTimeout", () => {
+  it("fires when the sandbox is on its own and produces nothing", async () => {
+    let fired = false;
+    const effect = runEvaluateWithHostTimeout(
+      Effect.tryPromise({
+        try: () => never<string>(),
+        catch: (c) => new NeverError({ message: String(c) }),
+      }),
+      {
+        timeoutMs: 50,
+        graceMs: 50,
+        pollMs: 10,
+        dispatcher: activity(),
+        onTimeout: () => {
+          fired = true;
+        },
+      },
+    );
+
+    const exit = await Effect.runPromiseExit(effect);
+    expect(Exit.isFailure(exit)).toBe(true);
+    expect(fired).toBe(true);
+  });
+
+  it("does NOT fire while a tool round-trip / approval pause is outstanding", async () => {
+    // The dispatcher reports it is dispatching for the entire window: the
+    // sandbox is blocked in the host (a slow tool, or an approval pause), so
+    // the backstop must hold its clock and never fire. The evaluate settles
+    // only AFTER a span far exceeding timeoutMs+graceMs.
+    const bound = 40; // timeoutMs 20 + graceMs 20
+    let resolveEvaluate!: (value: { result: number }) => void;
+    const pending = new Promise<{ result: number }>((resolve) => {
+      resolveEvaluate = resolve;
+    });
+
+    let fired = false;
+    const dispatcher = activity({ isDispatching: true, lastReturnedAt: Date.now() });
+    const effect = runEvaluateWithHostTimeout(
+      Effect.tryPromise({
+        try: () => pending,
+        catch: (c) => new NeverError({ message: String(c) }),
+      }),
+      {
+        timeoutMs: 20,
+        graceMs: 20,
+        pollMs: 5,
+        dispatcher,
+        onTimeout: () => {
+          fired = true;
+        },
+      },
+    );
+
+    const fiber = Effect.runFork(effect);
+
+    // Wait well past the bound while "paused" (dispatching). The watchdog must
+    // hold: no timeout should have fired.
+    await new Promise((r) => setTimeout(r, bound * 6));
+    expect(fired).toBe(false);
+
+    // The pause ends: the tool/approval returns, evaluate settles. Result must
+    // be delivered intact.
+    resolveEvaluate({ result: 7 });
+    const value = await Effect.runPromise(Fiber.join(fiber));
+    expect(value).toEqual({ result: 7 });
+    expect(fired).toBe(false);
+  });
+
+  it("fires after a dispatch returns and the sandbox then goes quiet", async () => {
+    // A round-trip returned at t0 (advancing lastReturnedAt), then the sandbox
+    // wedged with no further dispatch. The reference point is lastReturnedAt,
+    // so the backstop still fires bound ms after that return.
+    let fired = false;
+    const dispatcher = activity({ isDispatching: false, lastReturnedAt: Date.now() });
+    const effect = runEvaluateWithHostTimeout(
+      Effect.tryPromise({
+        try: () => never<string>(),
+        catch: (c) => new NeverError({ message: String(c) }),
+      }),
+      {
+        timeoutMs: 30,
+        graceMs: 30,
+        pollMs: 10,
+        dispatcher,
+        onTimeout: () => {
+          fired = true;
+        },
+      },
+    );
+
+    const exit = await Effect.runPromiseExit(effect);
+    expect(Exit.isFailure(exit)).toBe(true);
+    expect(fired).toBe(true);
+  });
+});

--- a/packages/kernel/runtime-dynamic-worker/src/index.ts
+++ b/packages/kernel/runtime-dynamic-worker/src/index.ts
@@ -2,9 +2,12 @@ export type { CodeExecutor, ExecuteResult, SandboxToolInvoker } from "@executor-
 
 export {
   makeDynamicWorkerExecutor,
+  runEvaluateWithHostTimeout,
   ToolDispatcher,
   DynamicWorkerExecutionError,
   type DynamicWorkerExecutorOptions,
+  type DispatcherActivity,
+  type HostTimeoutOptions,
 } from "./executor";
 
 export { buildExecutorModule } from "./module-template";

--- a/packages/kernel/runtime-dynamic-worker/src/wedge-repro.test.ts
+++ b/packages/kernel/runtime-dynamic-worker/src/wedge-repro.test.ts
@@ -1,0 +1,58 @@
+// ---------------------------------------------------------------------------
+// RED-ON-MAIN REPRO of the wedged-evaluate incident.
+//
+// A wedged `evaluate()` RPC (resolves never, rejects never) used to leave the
+// host awaiting forever: `execute()` never returned, so the MCP client saw pure
+// silence (SSE keepalives, no JSON-RPC frame) for the DO's whole running-work
+// lease. This test drives that exact shape through the PUBLIC executor path
+// with a fake WorkerLoader whose loaded worker's `evaluate` never settles.
+//
+// On UNPATCHED main this test HANGS and fails only via the bounded per-test
+// timeout below (verified: "Test timed out in 8000ms" on c46730b5). With the
+// host-timeout backstop it resolves with a delivered, descriptive error inside
+// the bound. The extra host-timeout knobs are passed through a widened options
+// value so this file still compiles against a checkout that predates them (they
+// are simply ignored there, and the test hangs → red).
+// ---------------------------------------------------------------------------
+
+import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import type { SandboxToolInvoker } from "@executor-js/codemode-core";
+
+import { makeDynamicWorkerExecutor, type DynamicWorkerExecutorOptions } from "./executor";
+
+const idleInvoker: SandboxToolInvoker = { invoke: () => Effect.succeed(undefined) };
+
+const makeFakeLoader = (evaluate: () => Promise<unknown>) => {
+  const entrypoint = { evaluate };
+  const stub = { getEntrypoint: () => entrypoint };
+  // oxlint-disable-next-line executor/no-double-cast -- test double for the Cloudflare WorkerLoader binding; only get()/getEntrypoint()/evaluate() are exercised
+  return { get: () => stub, load: () => stub } as unknown as WorkerLoader;
+};
+
+const never = <A>(): Promise<A> => new Promise<A>(() => {});
+
+describe("wedged evaluate RPC (public execute path)", () => {
+  it(
+    "delivers a descriptive timeout error instead of hanging forever",
+    { timeout: 8_000 },
+    async () => {
+      // Widened so the host-timeout knobs (absent on pre-fix checkouts) don't
+      // trip excess-property checks; they shrink the backstop on the fix and
+      // are ignored on main.
+      const options = {
+        loader: makeFakeLoader(() => never()),
+        timeoutMs: 200,
+        hostTimeoutGraceMs: 100,
+        hostTimeoutPollMs: 20,
+      } as DynamicWorkerExecutorOptions & Record<string, unknown>;
+
+      const executor = makeDynamicWorkerExecutor(options);
+      const result = await Effect.runPromise(executor.execute("return 1;", idleInvoker));
+
+      expect(result.result).toBeNull();
+      expect(result.error).toBeDefined();
+      expect(result.error).toContain("unresponsive");
+    },
+  );
+});


### PR DESCRIPTION
The only bound on dynamic-worker code execution was the in-sandbox timer. A sandbox whose evaluate RPC wedges without rejecting (isolate eviction, OOM kill) left the host waiting indefinitely and the client receiving only SSE keepalives with no result frame. Adds a pause-aware host-side watchdog that delivers a descriptive error when the sandbox goes unresponsive past the execution timeout plus grace. Approval pauses hold the watchdog open by design and are covered by tests, including a repro test that hangs on main.