### PR TITLE
Return streaming OpenAPI responses incrementally

### DIFF
--- a/packages/plugins/openapi/src/sdk/invoke.ts
+++ b/packages/plugins/openapi/src/sdk/invoke.ts
@@ -1,4 +1,4 @@
-import { Effect, Layer, Option } from "effect";
+import { Effect, Layer, Option, Stream } from "effect";
 import { HttpClient, HttpClientRequest } from "effect/unstable/http";
 import type { ToolFileValue } from "@executor-js/sdk/core";
 
@@ -151,6 +151,28 @@ const applyHeaders = (
 const normalizeContentType = (ct: string | null | undefined): string =>
   ct?.split(";")[0]?.trim().toLowerCase() ?? "";
 
+export const STREAM_MAX_BYTES = 1_000_000;
+export const STREAM_MAX_MS = 10_000;
+
+class StreamCapReached extends Error {
+  readonly _tag = "StreamCapReached";
+}
+
+export interface StreamingResponseCaps {
+  readonly maxBytes?: number;
+  readonly maxMs?: number;
+}
+
+const STREAMING_RESPONSE_CONTENT_TYPES = new Set([
+  "application/stream+json",
+  "application/x-ndjson",
+  "application/jsonl",
+  "text/event-stream",
+]);
+
+const isStreamingResponseContentType = (ct: string | null | undefined): boolean =>
+  STREAMING_RESPONSE_CONTENT_TYPES.has(normalizeContentType(ct));
+
 const isJsonContentType = (ct: string | null | undefined): boolean => {
   const normalized = normalizeContentType(ct);
   if (!normalized) return false;
@@ -178,6 +200,115 @@ const isTextContentType = (ct: string | null | undefined): boolean =>
 
 const isOctetStream = (ct: string | null | undefined): boolean =>
   normalizeContentType(ct) === "application/octet-stream";
+
+const parseStreamingJsonLines = (text: string, truncated: boolean): unknown => {
+  const lines = text.split(/\r?\n/);
+  let lastNonEmptyIndex = -1;
+  for (let index = lines.length - 1; index >= 0; index--) {
+    const line = lines[index];
+    if (line !== undefined && line.trim() !== "") {
+      lastNonEmptyIndex = index;
+      break;
+    }
+  }
+  const rows: unknown[] = [];
+
+  for (let index = 0; index < lines.length; index++) {
+    const line = lines[index];
+    if (line === undefined || line.trim() === "") continue;
+    try {
+      rows.push(JSON.parse(line));
+    } catch {
+      if (truncated && index === lastNonEmptyIndex) continue;
+      return text;
+    }
+  }
+
+  return rows;
+};
+
+const decodeStreamingResponseBody = (
+  contentType: string | null,
+  text: string,
+  truncated: boolean,
+): unknown => {
+  switch (normalizeContentType(contentType)) {
+    case "application/stream+json":
+    case "application/x-ndjson":
+    case "application/jsonl":
+      return parseStreamingJsonLines(text, truncated);
+    case "text/event-stream":
+    default:
+      return text;
+  }
+};
+
+export const collectStreamingBody = (
+  stream: Stream.Stream<Uint8Array, unknown, never>,
+  contentType: string | null,
+  caps: StreamingResponseCaps = {},
+) =>
+  Effect.gen(function* () {
+    const maxBytes = caps.maxBytes ?? STREAM_MAX_BYTES;
+    const maxMs = caps.maxMs ?? STREAM_MAX_MS;
+    const chunks: Uint8Array[] = [];
+    let bytes = 0;
+    let truncated = false;
+    const startedAt = Date.now();
+
+    const completed = yield* stream.pipe(
+      Stream.timeout(maxMs),
+      Stream.runForEach((chunk) =>
+        Effect.gen(function* () {
+          const remaining = maxBytes - bytes;
+          if (remaining <= 0) {
+            truncated = true;
+            return yield* Effect.fail(new StreamCapReached());
+          }
+
+          if (chunk.byteLength > remaining) {
+            chunks.push(chunk.subarray(0, remaining));
+            bytes += remaining;
+            truncated = true;
+            return yield* Effect.fail(new StreamCapReached());
+          }
+
+          chunks.push(chunk);
+          bytes += chunk.byteLength;
+          if (bytes >= maxBytes) {
+            truncated = true;
+            return yield* Effect.fail(new StreamCapReached());
+          }
+        }),
+      ),
+      Effect.timeoutOption(maxMs + 1_000),
+      Effect.catch((error: unknown) =>
+        error instanceof StreamCapReached
+          ? Effect.succeed(Option.some(undefined))
+          : Effect.fail(error),
+      ),
+    );
+    if (Option.isNone(completed)) truncated = true;
+
+    const durationMs = Date.now() - startedAt;
+    if (durationMs >= maxMs) truncated = true;
+    const collected = new Uint8Array(bytes);
+    let offset = 0;
+    for (const chunk of chunks) {
+      collected.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    const text = new TextDecoder("utf-8").decode(collected);
+
+    return {
+      data: decodeStreamingResponseBody(contentType, text, truncated),
+      headers: {
+        "x-executor-stream": truncated ? "truncated" : "complete",
+        "x-executor-stream-bytes": String(bytes),
+        "x-executor-stream-duration-ms": String(durationMs),
+      },
+    };
+  });
 
 const bytesToBase64 = (bytes: Uint8Array): string => {
   let binary = "";
@@ -861,6 +992,16 @@ export const invoke = Effect.fn("OpenApi.invoke")(function* (
     ? Option.getOrUndefined(responseBodyBinding.fileHint)
     : undefined;
   const ok = status >= 200 && status < 300;
+  const streamingBody =
+    ok &&
+    status !== 204 &&
+    fileHint?.kind !== "binaryResponse" &&
+    isStreamingResponseContentType(contentType)
+      ? yield* collectStreamingBody(response.stream, contentType).pipe(mapBodyError)
+      : null;
+  if (streamingBody) {
+    Object.assign(responseHeaders, streamingBody.headers);
+  }
   const responseBody: unknown =
     status === 204
       ? null
@@ -870,12 +1011,14 @@ export const invoke = Effect.fn("OpenApi.invoke")(function* (
             fileHint,
             contentType,
           )
-        : isJsonContentType(contentType)
-          ? yield* response.json.pipe(
-              Effect.catch(() => response.text),
-              mapBodyError,
-            )
-          : yield* response.text.pipe(mapBodyError);
+        : streamingBody
+          ? streamingBody.data
+          : isJsonContentType(contentType)
+            ? yield* response.json.pipe(
+                Effect.catch(() => response.text),
+                mapBodyError,
+              )
+            : yield* response.text.pipe(mapBodyError);
 
   const dataBody =
     ok && fileHint?.kind === "byteField"

--- a/packages/plugins/openapi/src/sdk/invoke.ts
+++ b/packages/plugins/openapi/src/sdk/invoke.ts
@@ -1,4 +1,4 @@
-import { Effect, Layer, Option, Stream } from "effect";
+import { Effect, Exit, Layer, Option, Schema, Stream } from "effect";
 import { HttpClient, HttpClientRequest } from "effect/unstable/http";
 import type { ToolFileValue } from "@executor-js/sdk/core";
 
@@ -201,6 +201,8 @@ const isTextContentType = (ct: string | null | undefined): boolean =>
 const isOctetStream = (ct: string | null | undefined): boolean =>
   normalizeContentType(ct) === "application/octet-stream";
 
+const decodeJsonLine = Schema.decodeUnknownExit(Schema.fromJsonString(Schema.Unknown));
+
 const parseStreamingJsonLines = (text: string, truncated: boolean): unknown => {
   const lines = text.split(/\r?\n/);
   let lastNonEmptyIndex = -1;
@@ -216,32 +218,34 @@ const parseStreamingJsonLines = (text: string, truncated: boolean): unknown => {
   for (let index = 0; index < lines.length; index++) {
     const line = lines[index];
     if (line === undefined || line.trim() === "") continue;
-    try {
-      rows.push(JSON.parse(line));
-    } catch {
-      if (truncated && index === lastNonEmptyIndex) continue;
-      return text;
+    const parsed = decodeJsonLine(line);
+    if (Exit.isSuccess(parsed)) {
+      rows.push(parsed.value);
+      continue;
     }
+    // A trailing fragment cut mid-line by the byte/time cap is expected; any
+    // other unparseable line means the body is not NDJSON after all.
+    if (truncated && index === lastNonEmptyIndex) continue;
+    return text;
   }
 
   return rows;
 };
 
+const NDJSON_CONTENT_TYPES = new Set([
+  "application/stream+json",
+  "application/x-ndjson",
+  "application/jsonl",
+]);
+
 const decodeStreamingResponseBody = (
   contentType: string | null,
   text: string,
   truncated: boolean,
-): unknown => {
-  switch (normalizeContentType(contentType)) {
-    case "application/stream+json":
-    case "application/x-ndjson":
-    case "application/jsonl":
-      return parseStreamingJsonLines(text, truncated);
-    case "text/event-stream":
-    default:
-      return text;
-  }
-};
+): unknown =>
+  NDJSON_CONTENT_TYPES.has(normalizeContentType(contentType))
+    ? parseStreamingJsonLines(text, truncated)
+    : text;
 
 export const collectStreamingBody = (
   stream: Stream.Stream<Uint8Array, unknown, never>,

--- a/packages/plugins/openapi/src/sdk/streaming-response.test.ts
+++ b/packages/plugins/openapi/src/sdk/streaming-response.test.ts
@@ -1,0 +1,276 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Exit, Schema, Stream } from "effect";
+import { FetchHttpClient } from "effect/unstable/http";
+import { HttpApi, HttpApiEndpoint, HttpApiGroup, OpenApi } from "effect/unstable/httpapi";
+import { createServer, type ServerResponse } from "node:http";
+import type { AddressInfo, Socket } from "node:net";
+
+import {
+  createExecutor,
+  AuthTemplateSlug,
+  ConnectionName,
+  IntegrationSlug,
+  ToolAddress,
+} from "@executor-js/sdk";
+import { makeTestConfig, memoryCredentialsPlugin } from "@executor-js/sdk/testing";
+import { makeOpenApiHttpApiTestSourceConfig, unwrapInvocation } from "../testing";
+
+import { collectStreamingBody, STREAM_MAX_BYTES } from "./invoke";
+import { openApiPlugin } from "./plugin";
+
+const testPlugins = () =>
+  [openApiPlugin({ httpClientLayer: FetchHttpClient.layer }), memoryCredentialsPlugin()] as const;
+
+const STREAM_TOOL = "logs.getLogs";
+
+const LogsGroup = HttpApiGroup.make("logs").add(
+  HttpApiEndpoint.get("getLogs", "/logs", {
+    success: Schema.Unknown,
+  }),
+);
+
+const StreamingApi = HttpApi.make("streamingResponseTest")
+  .add(LogsGroup)
+  .annotateMerge(OpenApi.annotations({ title: "StreamingResponseTest", version: "1.0.0" }));
+
+const buildExecutor = (baseUrl: string) =>
+  Effect.gen(function* () {
+    const executor = yield* createExecutor(makeTestConfig({ plugins: testPlugins() }));
+    yield* executor.openapi.addSpec(
+      makeOpenApiHttpApiTestSourceConfig(StreamingApi, { slug: "streaming", baseUrl }),
+    );
+    yield* executor.connections.create({
+      owner: "org",
+      name: ConnectionName.make("main"),
+      integration: IntegrationSlug.make("streaming"),
+      template: AuthTemplateSlug.make("apiKey"),
+      value: "token",
+    });
+    return {
+      executor,
+      address: ToolAddress.make(`tools.streaming.org.main.${STREAM_TOOL}`),
+    };
+  });
+
+const startRawServer = (handler: (res: ServerResponse) => void) =>
+  Effect.acquireRelease(
+    Effect.callback<{ baseUrl: string; close: () => void }>((resume) => {
+      const sockets = new Set<Socket>();
+      const server = createServer((req, res) => {
+        if (req.url?.split("?")[0] !== "/logs") {
+          res.writeHead(200, { "content-type": "application/json" });
+          res.end(JSON.stringify({ ok: true }));
+          return;
+        }
+        handler(res);
+      });
+      server.on("connection", (socket) => {
+        sockets.add(socket);
+        socket.on("close", () => sockets.delete(socket));
+      });
+      server.listen(0, "127.0.0.1", () => {
+        const port = (server.address() as AddressInfo).port;
+        resume(
+          Effect.succeed({
+            baseUrl: `http://127.0.0.1:${port}`,
+            close: () => {
+              for (const socket of sockets) socket.destroy();
+              server.close();
+            },
+          }),
+        );
+      });
+    }),
+    (server) => Effect.sync(() => server.close()),
+  );
+
+const encoder = new TextEncoder();
+
+const delayedReadableStream = (
+  chunks: readonly Uint8Array[],
+  delayMs: number,
+  options: { close: boolean },
+) =>
+  Stream.fromReadableStream({
+    evaluate: () => {
+      const timers: ReturnType<typeof setTimeout>[] = [];
+      return new ReadableStream<Uint8Array>({
+        start: (controller) => {
+          chunks.forEach((chunk, index) => {
+            timers.push(
+              setTimeout(() => {
+                controller.enqueue(chunk);
+                if (options.close && index === chunks.length - 1) {
+                  controller.close();
+                }
+              }, index * delayMs),
+            );
+          });
+        },
+        cancel: () => {
+          for (const timer of timers) clearTimeout(timer);
+        },
+      });
+    },
+    onError: (error) => error,
+  });
+
+describe("OpenAPI streaming responses", () => {
+  it.effect("returns from an oversized NDJSON stream with truncation metadata", () =>
+    Effect.gen(function* () {
+      const rows = Array.from(
+        { length: 6 },
+        (_, index) => `${JSON.stringify({ index, phase: "immediate" })}\n`,
+      ).join("");
+      const rowBytes = encoder.encode(rows);
+      const partialBytes = encoder.encode(`{"partial":"${"x".repeat(STREAM_MAX_BYTES)}"`);
+
+      const result = yield* collectStreamingBody(
+        Stream.make(rowBytes, partialBytes),
+        "application/stream+json",
+      );
+
+      expect(result.headers["x-executor-stream"]).toBe("truncated");
+      expect(result.headers["x-executor-stream-bytes"]).toBe(String(STREAM_MAX_BYTES));
+      expect(Array.isArray(result.data)).toBe(true);
+      const data = result.data as unknown[];
+      expect(data.slice(0, 6)).toEqual(
+        Array.from({ length: 6 }, (_, index) => ({ index, phase: "immediate" })),
+      );
+    }),
+  );
+
+  it.effect("collects every chunk from a delayed ReadableStream", () =>
+    Effect.gen(function* () {
+      const chunks = [
+        encoder.encode(`${JSON.stringify({ id: 1 })}\n`),
+        encoder.encode(`${JSON.stringify({ id: 2 })}\n`),
+        encoder.encode(`${JSON.stringify({ id: 3 })}\n`),
+      ];
+      const expectedBytes = chunks.reduce((sum, chunk) => sum + chunk.byteLength, 0);
+
+      const result = yield* collectStreamingBody(
+        delayedReadableStream(chunks, 75, { close: true }),
+        "application/x-ndjson",
+        { maxBytes: STREAM_MAX_BYTES, maxMs: 1_000 },
+      );
+
+      console.log(
+        JSON.stringify({
+          case: "delayed-readable-complete",
+          bytes: result.headers["x-executor-stream-bytes"],
+          rows: Array.isArray(result.data) ? result.data.length : 0,
+        }),
+      );
+      expect(result.headers["x-executor-stream"]).toBe("complete");
+      expect(result.headers["x-executor-stream-bytes"]).toBe(String(expectedBytes));
+      expect(result.data).toEqual([{ id: 1 }, { id: 2 }, { id: 3 }]);
+    }),
+  );
+
+  it("timeout truncation preserves all chunks received before interruption", async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const chunks = [
+          encoder.encode(`${JSON.stringify({ id: 1 })}\n`),
+          encoder.encode(`${JSON.stringify({ id: 2 })}\n`),
+        ];
+        const expectedBytes = chunks.reduce((sum, chunk) => sum + chunk.byteLength, 0);
+        const startedAt = Date.now();
+
+        const result = yield* collectStreamingBody(
+          delayedReadableStream(chunks, 100, { close: false }),
+          "application/stream+json",
+          { maxBytes: STREAM_MAX_BYTES, maxMs: 500 },
+        );
+        const elapsedMs = Date.now() - startedAt;
+
+        console.log(
+          JSON.stringify({
+            case: "delayed-readable-timeout",
+            elapsedMs,
+            bytes: result.headers["x-executor-stream-bytes"],
+            rows: Array.isArray(result.data) ? result.data.length : 0,
+          }),
+        );
+        expect(elapsedMs).toBeGreaterThanOrEqual(450);
+        expect(elapsedMs).toBeLessThan(1_500);
+        expect(result.headers["x-executor-stream"]).toBe("truncated");
+        expect(result.headers["x-executor-stream-bytes"]).toBe(String(expectedBytes));
+        expect(result.data).toEqual([{ id: 1 }, { id: 2 }]);
+      }),
+    );
+  });
+
+  it.effect("drops a trailing partial JSON line when the byte cap truncates", () =>
+    Effect.gen(function* () {
+      let body = "";
+      for (let index = 0; Buffer.byteLength(body) < STREAM_MAX_BYTES - 2_000; index++) {
+        body += `${JSON.stringify({ index, value: "x".repeat(512) })}\n`;
+      }
+      const encoded = encoder.encode(`${body}{"partial":"${"y".repeat(STREAM_MAX_BYTES)}"`);
+
+      const result = yield* collectStreamingBody(Stream.make(encoded), "application/x-ndjson");
+
+      expect(result.headers["x-executor-stream"]).toBe("truncated");
+      expect(Array.isArray(result.data)).toBe(true);
+      const data = result.data as unknown[];
+      expect(data.length).toBeGreaterThan(0);
+      expect(data.every((row: unknown) => typeof row === "object" && row !== null)).toBe(true);
+      expect(data.some((row: unknown) => "partial" in (row as Record<string, unknown>))).toBe(
+        false,
+      );
+    }),
+  );
+
+  it.effect("parses a completed short NDJSON stream", () =>
+    Effect.gen(function* () {
+      const server = yield* startRawServer((res) => {
+        res.writeHead(200, { "content-type": "application/jsonl" });
+        res.end(`${JSON.stringify({ id: 1 })}\n${JSON.stringify({ id: 2 })}\n`);
+      });
+      const { executor, address } = yield* buildExecutor(server.baseUrl);
+
+      const result = unwrapInvocation<unknown[]>(yield* executor.execute(address, {}));
+
+      expect(result.data).toEqual([{ id: 1 }, { id: 2 }]);
+      expect(result.headers?.["x-executor-stream"]).toBe("complete");
+    }),
+  );
+
+  it.effect("leaves ordinary JSON responses on the buffered path", () =>
+    Effect.gen(function* () {
+      const server = yield* startRawServer((res) => {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ ok: true }));
+      });
+      const { executor, address } = yield* buildExecutor(server.baseUrl);
+
+      const result = unwrapInvocation<Record<string, unknown>>(
+        yield* executor.execute(address, {}),
+      );
+
+      expect(result.data).toEqual({ ok: true });
+      expect(result.headers?.["x-executor-stream"]).toBeUndefined();
+    }),
+  );
+
+  it.effect("leaves non-2xx JSON error responses on the buffered path", () =>
+    Effect.gen(function* () {
+      const server = yield* startRawServer((res) => {
+        res.writeHead(422, { "content-type": "application/json" });
+        res.end('{"error":{"field":"name","reason":"too_short"}}');
+      });
+      const { executor, address } = yield* buildExecutor(server.baseUrl);
+
+      const exit = yield* executor.execute(address, {}).pipe(Effect.exit);
+      const text = Exit.match(exit, {
+        onFailure: (cause) => JSON.stringify(cause),
+        onSuccess: (value) => JSON.stringify(value),
+      });
+
+      expect(text).toMatch(/422|too_short|name|response|error/i);
+      expect(text).not.toMatch(/x-executor-stream/);
+    }),
+  );
+});


### PR DESCRIPTION
Streaming endpoints (application/stream+json, NDJSON, SSE) previously buffered until the upstream closed the connection. Live-tail endpoints like Vercel's runtime-logs never close, so cloud tool calls hung until the egress proxy timed out. Responses with a streaming content type are now read incrementally with a byte and time cap, parsed NDJSON rows are returned as an array, and truncation is signaled via x-executor-stream response headers.