### PR TITLE
Prime MCP POST streams with a replayable SSE event id

### DIFF
--- a/.changeset/mcp-priming-reconnect.md
+++ b/.changeset/mcp-priming-reconnect.md
@@ -1,0 +1,5 @@
+---
+"executor": patch
+---
+
+Let stock MCP clients auto-reconnect and recover a tool result when a POST stream drops mid-call.

--- a/apps/host-cloudflare/src/worker.e2e.node.test.ts
+++ b/apps/host-cloudflare/src/worker.e2e.node.test.ts
@@ -43,13 +43,33 @@ const readMcpJson = async <A>(response: JsonReadableResponse): Promise<A> => {
   if (contentType.includes("application/json")) {
     return (await response.json()) as A;
   }
+  // Parse the SSE stream properly instead of grabbing the first `data:` line:
+  // the server may legally interleave other events (e.g. the priming event a
+  // tools/call stream emits so clients can reconnect) before the JSON-RPC
+  // message. Only `message`-typed events (the SSE default) carry JSON-RPC.
   const text = await response.text();
-  const data = text
-    .split("\n")
-    .find((line) => line.startsWith("data: "))
-    ?.slice("data: ".length);
-  expect(data).toBeTruthy();
-  return decodeUnknownJson(data!) as A;
+  let responseMessage: unknown;
+  for (const block of text.split("\n\n")) {
+    let eventType = "message";
+    let data = "";
+    for (const line of block.replace(/\r/g, "").split("\n")) {
+      if (line.startsWith("event:")) eventType = line.slice("event:".length).trim();
+      if (line.startsWith("data:")) data += line.slice("data:".length).trimStart();
+    }
+    if (eventType !== "message" || data.length === 0) continue;
+    const parsed = decodeUnknownJson(data);
+    // Skip protocol-legal notifications; the tests want the response.
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      ("result" in parsed || "error" in parsed)
+    ) {
+      responseMessage = parsed;
+      break;
+    }
+  }
+  expect(responseMessage, "a JSON-RPC response arrives on the SSE stream").toBeTruthy();
+  return responseMessage as A;
 };
 
 describe("cloudflare host e2e (workerd/miniflare)", () => {

--- a/e2e/cloud/mcp-priming-reconnect.test.ts
+++ b/e2e/cloud/mcp-priming-reconnect.test.ts
@@ -1,0 +1,218 @@
+import {
+  request as httpRequest,
+  createServer,
+  type ClientRequest,
+  type ServerResponse,
+} from "node:http";
+import { randomUUID } from "node:crypto";
+import type { AddressInfo } from "node:net";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+import { scenario } from "../src/scenario";
+import { Mcp, Target } from "../src/services";
+import type { Identity } from "../src/target";
+
+const emailOf = (identity: Identity): string => identity.credentials?.email ?? identity.label;
+
+const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * A minimal HTTP relay that forwards to `origin` and, on `sever()`, destroys
+ * the in-flight POST tools/call socket. This models a real network cut of the
+ * POST tools/call SSE stream that the SDK observes as a stream read error, NOT
+ * a client-initiated fetch abort. The relay itself stays up so the SDK's own
+ * reconnect GET has something to connect back to.
+ *
+ * The cut is armed on a real event — the tools/call POST response headers — so
+ * the trigger is identical whether or not the server emits a priming event.
+ * `severPostMidCall()` waits for that stream to open, then cuts it a bounded
+ * grace later: after any priming event has flushed and been read, but well
+ * before the multi-second tool result.
+ */
+const startSeverableRelay = (
+  originUrl: string,
+): Promise<{
+  readonly url: (path: string) => string;
+  readonly severPostMidCall: () => Promise<void>;
+  readonly close: () => void;
+}> => {
+  const origin = new URL(originUrl);
+  // The tools/call POST hop, captured the moment its response headers arrive
+  // (before any body: this is independent of whether the server emits a priming
+  // event, so the trigger is identical on fixed and unfixed servers). The sever
+  // must land AFTER the stream opened but BEFORE the tool result, so it fires a
+  // bounded grace after the headers — long enough for a priming event to have
+  // flushed and been read by the SDK, far short of the multi-second tool call.
+  const SEVER_GRACE_MS = 2_000;
+  let toolCallHop: { readonly upstream: ClientRequest; readonly res: ServerResponse } | null = null;
+  let onToolCallOpen: (() => void) | null = null;
+  const toolCallOpened = new Promise<void>((resolve) => {
+    onToolCallOpen = resolve;
+  });
+
+  const server = createServer((req, res) => {
+    // Detect the tools/call POST by its request body (initialize also returns
+    // SSE, so a plain content-type check would arm on the wrong stream).
+    const bodyChunks: Buffer[] = [];
+    let isToolCall = false;
+    req.on("data", (chunk: Buffer) => {
+      bodyChunks.push(chunk);
+      if (!isToolCall && Buffer.concat(bodyChunks).toString("utf8").includes('"tools/call"')) {
+        isToolCall = true;
+      }
+    });
+    const upstream = httpRequest(
+      {
+        host: origin.hostname,
+        port: Number(origin.port),
+        path: req.url,
+        method: req.method,
+        headers: { ...req.headers, host: origin.host },
+      },
+      (upstreamRes) => {
+        res.writeHead(upstreamRes.statusCode ?? 502, upstreamRes.headers);
+        if (
+          isToolCall &&
+          (upstreamRes.headers["content-type"] ?? "").includes("text/event-stream")
+        ) {
+          toolCallHop = { upstream, res };
+          onToolCallOpen?.();
+        }
+        upstreamRes.pipe(res);
+      },
+    );
+    upstream.on("error", () => {
+      try {
+        res.destroy();
+      } catch {
+        /* already torn down */
+      }
+    });
+    req.pipe(upstream);
+    req.on("aborted", () => {
+      try {
+        upstream.destroy();
+      } catch {
+        /* already torn down */
+      }
+    });
+  });
+
+  const severPostMidCall = async (): Promise<void> => {
+    await toolCallOpened;
+    await delay(SEVER_GRACE_MS);
+    const hop = toolCallHop;
+    if (!hop) return;
+    // Destroy BOTH ends so every fetch client (undici and bun) observes a hard
+    // stream error: the client-facing response socket (what the SDK's reader is
+    // attached to) AND the upstream to the origin.
+    for (const destroy of [
+      () => hop.res.socket?.destroy(),
+      () => hop.res.destroy(),
+      () => hop.upstream.socket?.destroy(),
+      () => hop.upstream.destroy(),
+    ]) {
+      try {
+        destroy();
+      } catch {
+        /* already gone */
+      }
+    }
+  };
+
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const port = (server.address() as AddressInfo).port;
+      resolve({
+        url: (path: string) => `http://127.0.0.1:${port}${path}`,
+        severPostMidCall,
+        close: () => server.close(),
+      });
+    });
+  });
+};
+
+scenario(
+  "MCP streamable HTTP · a stock SDK client recovers a tool result after its POST stream is severed mid-call",
+  { timeout: 160_000 },
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const mcp = yield* Mcp;
+    const identity = yield* target.newIdentity();
+    const bearer = yield* mcp.mintBearer(emailOf(identity));
+
+    const mcpPath = new URL(target.mcpUrl).pathname;
+    const origin = new URL(target.mcpUrl).origin;
+    const relay = yield* Effect.promise(() => startSeverableRelay(origin));
+
+    // A fetch wrapper for the SDK transport that (1) records the SDK's own
+    // reconnect GET (with its last-event-id) so the test can assert the SDK
+    // actually reconnected, and (2) STRIPS the SDK's abort signal so a severed
+    // relay socket surfaces as a stream read error (the real churn scenario),
+    // not a client-side abort. Auth rides on the transport's requestInit.
+    const reconnectGetEventIds: string[] = [];
+    const drivenFetch: typeof fetch = (input, init) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      const method = init?.method ?? (input instanceof Request ? input.method : "GET");
+      const headers = new Headers(
+        init?.headers ?? (input instanceof Request ? input.headers : undefined),
+      );
+      const lastEventId = headers.get("last-event-id");
+      if (method === "GET" && lastEventId) reconnectGetEventIds.push(lastEventId);
+      const { signal: _stripped, ...rest } = init ?? {};
+      return fetch(url, rest);
+    };
+
+    const transport = new StreamableHTTPClientTransport(new URL(relay.url(mcpPath)), {
+      requestInit: { headers: { authorization: `Bearer ${bearer}` } },
+      fetch: drivenFetch,
+    });
+    const client = new Client({ name: "executor-e2e-priming-reconnect", version: "0.0.1" });
+
+    const result = yield* Effect.promise(async () => {
+      try {
+        await client.connect(transport);
+
+        const marker = `MARKER_PRIMING_RECONNECT_${randomUUID()}`;
+        const code = [
+          `const marker = ${JSON.stringify(marker)};`,
+          "await new Promise((resolve) => setTimeout(resolve, 15000));",
+          "return marker;",
+        ].join("\n");
+
+        // Arm the sever: the relay cuts the POST tools/call socket a short
+        // grace after the stream opens (see SEVER_GRACE_MS) — after any priming
+        // event has flushed and been read by the SDK, but ~13s before the tool
+        // result. The trigger (stream open) is identical on a fixed and an
+        // unfixed server, so the ONLY variable is whether the client saw a
+        // priming id to reconnect from.
+        void relay.severPostMidCall();
+        // Explicit request timeout > (call duration + reconnect backoff) so a
+        // successful recover resolves well inside it; the scenario timeout is
+        // the real ceiling.
+        const call = await client.callTool({ name: "execute", arguments: { code } }, undefined, {
+          timeout: 90_000,
+        });
+        return { marker, call, reconnected: reconnectGetEventIds.length > 0 };
+      } finally {
+        await client.close().catch(() => undefined);
+        await delay(200);
+        relay.close();
+      }
+    });
+
+    expect(
+      reconnectGetEventIds.length,
+      "the stock SDK issued a reconnect GET carrying a last-event-id (it had a priming id to resume from)",
+    ).toBeGreaterThan(0);
+    expect(
+      JSON.stringify(result.call),
+      "callTool resolves with the completed tool result after the mid-call sever",
+    ).toContain(result.marker);
+  }),
+);

--- a/packages/hosts/cloudflare/src/mcp/agents-priming-event.test.ts
+++ b/packages/hosts/cloudflare/src/mcp/agents-priming-event.test.ts
@@ -1,0 +1,212 @@
+// Unit coverage for the POST-stream priming SSE event (see
+// patches/agents@0.17.3.patch). Executor's POST tools/call stream used to emit
+// its first and only event `id:` together with the final result, so the MCP TS
+// SDK's StreamableHTTPClientTransport never set hasPrimingEvent and would not
+// auto-reconnect a stream that dropped mid-call: callTool hung while the DO
+// held the completed result. The patch writes a priming event as the first
+// frame on the POST stream, carrying a real event-store id that sorts before
+// the response so a `last-event-id: <primingId>` reconnect replays the result.
+//
+// Two properties are pinned here against real code:
+//   1. Event-store ordering + replay: with the real DurableObjectEventStore, a
+//      priming event stored before the response sorts first, and
+//      replayEventsAfter(primingId) yields exactly the response.
+//   2. Client contract: fed the exact priming frame the transport emits, the
+//      real SDK StreamableHTTPClientTransport records the priming id (so it
+//      would reconnect) WITHOUT dispatching it as a JSON-RPC message, then
+//      dispatches a following result frame normally.
+import { describe, expect, it } from "@effect/vitest";
+import { DurableObjectEventStore } from "agents/mcp";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
+
+type ListOptions = {
+  readonly prefix?: string;
+  readonly start?: string;
+  readonly limit?: number;
+  readonly reverse?: boolean;
+};
+
+/** Minimal in-memory stand-in for DurableObjectStorage's sorted KV surface. */
+const makeFakeStorage = () => {
+  const entries = new Map<string, unknown>();
+  return {
+    entries,
+    put: (key: string, value: unknown) => {
+      entries.set(key, value);
+      return Promise.resolve();
+    },
+    delete: (keys: string | ReadonlyArray<string>) => {
+      for (const key of Array.isArray(keys) ? keys : [keys]) entries.delete(key);
+      return Promise.resolve();
+    },
+    list: (options: ListOptions = {}) => {
+      const keys = [...entries.keys()]
+        .filter((key) => (options.prefix === undefined ? true : key.startsWith(options.prefix)))
+        .filter((key) => (options.start === undefined ? true : key >= options.start))
+        .sort();
+      if (options.reverse === true) keys.reverse();
+      const limited = options.limit === undefined ? keys : keys.slice(0, options.limit);
+      return Promise.resolve(new Map(limited.map((key) => [key, entries.get(key)])));
+    },
+  };
+};
+
+// The exact priming notification the patched transport persists, and the exact
+// SSE frame it writes to the client. Mirrors emitPrimingEvent /
+// writePrimingSSEEvent in patches/agents@0.17.3.patch: a benign JSON-RPC
+// notification stored (so a plain-GET replay via writeSSEEvent is ignorable),
+// framed live under a non-`message` event type so the SDK primes but does not
+// dispatch it.
+const PRIMING_MESSAGE = {
+  jsonrpc: "2.0" as const,
+  method: "notifications/message",
+  params: { level: "debug", data: "mcp-stream-priming" },
+};
+const primingFrame = (eventId: string): string =>
+  `event: mcp-priming\nid: ${eventId}\ndata: ${JSON.stringify(PRIMING_MESSAGE)}\n\n`;
+const messageFrame = (eventId: string, message: unknown): string =>
+  `event: message\nid: ${eventId}\ndata: ${JSON.stringify(message)}\n\n`;
+
+describe("POST-stream priming event: store ordering and replay", () => {
+  it("persists the priming event before the response so replayEventsAfter(primingId) yields the response", async () => {
+    const storage = makeFakeStorage();
+    const store = new DurableObjectEventStore(storage as never);
+    const streamId = "post-stream";
+
+    // Transport order: priming event first, then the tool response.
+    const primingId = await store.storeEvent(streamId, PRIMING_MESSAGE);
+    const response = {
+      jsonrpc: "2.0" as const,
+      id: 1,
+      result: { content: [{ type: "text", text: "MARKER" }] },
+    };
+    const responseId = await store.storeEvent(streamId, response);
+
+    expect(primingId, "priming event is seq 1 for the stream").toBe(`${streamId}:0000000000000001`);
+    expect(responseId, "response is seq 2, after the priming id").toBe(
+      `${streamId}:0000000000000002`,
+    );
+    expect(primingId < responseId, "priming id sorts strictly before the response id").toBe(true);
+
+    const replayed: Array<{ readonly eventId: string; readonly message: unknown }> = [];
+    await store.replayEventsAfter(primingId, {
+      send: async (eventId: string, message: unknown) => {
+        replayed.push({ eventId, message });
+      },
+    });
+
+    expect(
+      replayed.map((entry) => entry.eventId),
+      "a reconnect with last-event-id=<primingId> replays exactly the response",
+    ).toEqual([responseId]);
+    expect(replayed[0]?.message).toEqual(response);
+  });
+
+  it("does not replay the priming event itself on a last-event-id reconnect", async () => {
+    const storage = makeFakeStorage();
+    const store = new DurableObjectEventStore(storage as never);
+    const streamId = "post-stream";
+    const primingId = await store.storeEvent(streamId, PRIMING_MESSAGE);
+
+    const replayed: string[] = [];
+    await store.replayEventsAfter(primingId, {
+      send: async (eventId: string) => {
+        replayed.push(eventId);
+      },
+    });
+
+    expect(replayed, "nothing after the priming event yet, so replay is empty").toEqual([]);
+  });
+});
+
+describe("POST-stream priming event: SDK client contract", () => {
+  // Drive the real SDK StreamableHTTPClientTransport with a controlled fetch
+  // that returns a POST tools/call SSE stream: priming frame first, then the
+  // result. Assert the SDK records the priming id as a resumption token (so it
+  // would reconnect) but only dispatches the result as a JSON-RPC message.
+  const drivePostStream = async (frames: ReadonlyArray<string>) => {
+    const encoder = new TextEncoder();
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const frame of frames) controller.enqueue(encoder.encode(frame));
+        controller.close();
+      },
+    });
+    // oxlint-disable-next-line executor/no-double-cast -- boundary: a minimal fetch stub for a unit test; only the Response shape the SDK reads matters.
+    const fetchStub = (async () =>
+      new Response(body, {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      })) as unknown as typeof fetch;
+
+    const transport = new StreamableHTTPClientTransport(new URL("https://executor.sh/mcp"), {
+      fetch: fetchStub,
+    });
+
+    const messages: JSONRPCMessage[] = [];
+    const resumptionTokens: string[] = [];
+    transport.onmessage = (message) => {
+      messages.push(message);
+    };
+
+    await transport.start();
+    // POST a tools/call request; the stub returns the SSE stream above.
+    await transport.send(
+      { jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "execute", arguments: {} } },
+      {
+        onresumptiontoken: (token: string) => {
+          resumptionTokens.push(token);
+        },
+      },
+    );
+    // Let the SSE stream drain.
+    for (let i = 0; i < 20; i += 1) await Promise.resolve();
+    await transport.close();
+    return { messages, resumptionTokens };
+  };
+
+  it("records the priming id as a resumption token without dispatching it, then dispatches the result", async () => {
+    const primingId = "post-stream:0000000000000001";
+    const responseId = "post-stream:0000000000000002";
+    const result = {
+      jsonrpc: "2.0" as const,
+      id: 1,
+      result: { content: [{ type: "text", text: "MARKER" }] },
+    };
+
+    const { messages, resumptionTokens } = await drivePostStream([
+      primingFrame(primingId),
+      messageFrame(responseId, result),
+    ]);
+
+    expect(
+      resumptionTokens,
+      "the SDK records the priming id first (this is what sets hasPrimingEvent), then the response id",
+    ).toEqual([primingId, responseId]);
+    expect(
+      messages,
+      "the priming frame is NOT dispatched as a JSON-RPC message; only the result is",
+    ).toEqual([result]);
+  });
+
+  it("would not prime on a stream whose first event id arrives only with the result (the old behavior)", async () => {
+    // Sanity anchor for the fix: without a priming frame, the first recorded
+    // resumption token is the result's own id, which the SDK only sees at the
+    // same instant it receives the result. There is no earlier id to reconnect
+    // from, which is exactly the hang this patch removes.
+    const responseId = "post-stream:0000000000000001";
+    const result = {
+      jsonrpc: "2.0" as const,
+      id: 1,
+      result: { content: [{ type: "text", text: "MARKER" }] },
+    };
+
+    const { messages, resumptionTokens } = await drivePostStream([
+      messageFrame(responseId, result),
+    ]);
+
+    expect(resumptionTokens, "the only id ever seen is the result's own id").toEqual([responseId]);
+    expect(messages).toEqual([result]);
+  });
+});

--- a/patches/agents@0.17.3.patch
+++ b/patches/agents@0.17.3.patch
@@ -19,7 +19,7 @@ index c8fad448e8797b89690a99d93490d1363851b225..77f9fe3f6f2375eadc9f7a2974f0d202
    McpAgent,
    type McpAuthContext,
 diff --git a/dist/mcp/index.js b/dist/mcp/index.js
-index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..b0d1c55eda79324b6d76a1177519d26a62be2e41 100644
+index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..c3601bdb084bf82ebfea23cdabe1fab5f6d71fb3 100644
 --- a/dist/mcp/index.js
 +++ b/dist/mcp/index.js
 @@ -28,13 +28,17 @@ import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/
@@ -577,7 +577,7 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..b0d1c55eda79324b6d76a1177519d26a
  	}
  	/**
  	* Writes an event to the SSE stream with proper formatting
-@@ -689,6 +977,8 @@ var StreamableHTTPServerTransport = class {
+@@ -689,10 +977,65 @@ var StreamableHTTPServerTransport = class {
  		return connection.send(JSON.stringify({
  			type: "cf_mcp_agent_event",
  			event: eventData,
@@ -586,7 +586,82 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..b0d1c55eda79324b6d76a1177519d26a
  			close
  		}));
  	}
-@@ -777,9 +1067,11 @@ var StreamableHTTPServerTransport = class {
+ 	/**
++	* Persist and write the priming SSE event for a freshly opened POST
++	* stream. The stored message is a benign JSON-RPC notification so that
++	* if a plain recovery GET ever replays this stream via
++	* {@link writeSSEEvent} (which forces `event: message`), a compliant
++	* client parses and ignores it rather than erroring. The live priming
++	* frame, however, uses a non-`message` SSE event type so the SDK
++	* records the id (setting hasPrimingEvent / lastEventId) WITHOUT
++	* dispatching it as a JSON-RPC message: its SSE loop skips any event
++	* whose type is not `message`. A data line is required because the
++	* SDK's SSE parser drops events with empty data before recording the
++	* id, so an id-only frame would not prime.
++	*/
++	async emitPrimingEvent(agent, connection, streamId) {
++		if (!this._eventStore) return;
++		const primingMessage = {
++			jsonrpc: "2.0",
++			method: "notifications/message",
++			params: {
++				level: "debug",
++				data: "mcp-stream-priming"
++			}
++		};
++		let eventId;
++		try {
++			eventId = await this._eventStore.storeEvent(streamId, primingMessage);
++		} catch (error) {
++			this.onerror?.(error);
++			return;
++		}
++		if (!eventId) return;
++		try {
++			this.writePrimingSSEEvent(connection, primingMessage, eventId);
++		} catch (error) {
++			this.onerror?.(error);
++		}
++	}
++	/**
++	* Write a priming SSE frame: `event: mcp-priming`, an `id:` carrying a
++	* real replayable event-store id, and a data line the SDK ignores
++	* because the event type is not `message`. Never sets `close`.
++	*/
++	writePrimingSSEEvent(connection, message, eventId) {
++		let eventData = "event: mcp-priming\n";
++		eventData += `id: ${eventId}\n`;
++		eventData += `data: ${JSON.stringify(message)}\n\n`;
++		return connection.send(JSON.stringify({
++			type: "cf_mcp_agent_event",
++			event: eventData,
++			eventId,
++			streamId: eventId.slice(0, eventId.lastIndexOf(":"))
++		}));
++	}
++	/**
+ 	* Handles POST requests containing JSON-RPC messages
+ 	*/
+ 	async handlePostRequest(req, parsedBody) {
+@@ -733,6 +1076,17 @@ var StreamableHTTPServerTransport = class {
+ 			};
+ 			connection.setState(postState);
+ 			if (this._eventStore) await agent.setStreamRequestIds(streamId, requestIds);
++			// Emit a priming SSE event as the very first frame on this POST
++			// response stream, before dispatching the request(s). The MCP TS SDK
++			// only auto-reconnects a dropped POST SSE stream when it saw an event
++			// `id:` before the drop (hasPrimingEvent). Without this, a network
++			// blip or edge close mid-call leaves the SDK with hasPrimingEvent
++			// false, so it never issues the recovery GET that replays the
++			// persisted result, and callTool hangs forever. The priming event is
++			// a real event-store entry so its id sorts BEFORE the eventual
++			// response; a reconnect with `last-event-id: <primingId>` replays
++			// everything after it (i.e. the result). See patches/agents patch.
++			await this.emitPrimingEvent(agent, connection, streamId);
+ 			for (const message of messages) {
+ 				if (this.messageInterceptor) {
+ 					if (await this.messageInterceptor(message, {
+@@ -777,9 +1131,11 @@ var StreamableHTTPServerTransport = class {
  		} catch (error) {
  			this.onerror?.(error);
  		}
@@ -600,7 +675,7 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..b0d1c55eda79324b6d76a1177519d26a
  		}
  	}
  	async send(message, options) {
-@@ -861,12 +1153,10 @@ var StreamableHTTPServerTransport = class {
+@@ -861,12 +1217,10 @@ var StreamableHTTPServerTransport = class {
  *
  * ## Lifecycle
  *
@@ -617,7 +692,7 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..b0d1c55eda79324b6d76a1177519d26a
  *
  * Standalone GET stream events (`_GET_stream`) are *not* cleared
  * automatically; they accumulate for the lifetime of the DO. Bounded
-@@ -899,6 +1189,7 @@ var DurableObjectEventStore = class DurableObjectEventStore {
+@@ -899,6 +1253,7 @@ var DurableObjectEventStore = class DurableObjectEventStore {
  		const eventId = `${streamId}:${seq.toString(16).padStart(DurableObjectEventStore.SEQ_PAD, "0")}`;
  		const eventKey = `${DurableObjectEventStore.EVENT_KEY_PREFIX}${eventId}`;
  		await this.storage.put(eventKey, message);
@@ -625,7 +700,7 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..b0d1c55eda79324b6d76a1177519d26a
  		return eventId;
  	}
  	async getStreamIdForEventId(eventId) {
-@@ -915,9 +1206,59 @@ var DurableObjectEventStore = class DurableObjectEventStore {
+@@ -915,9 +1270,59 @@ var DurableObjectEventStore = class DurableObjectEventStore {
  			start: startKey,
  			limit: DurableObjectEventStore.REPLAY_LIMIT
  		});
@@ -686,7 +761,7 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..b0d1c55eda79324b6d76a1177519d26a
  	/**
  	* Drop the event log for a single stream. Called by the transport
  	* immediately after a POST's final response has been written to the
-@@ -973,6 +1314,9 @@ DurableObjectEventStore.EVENT_KEY_PREFIX = "__mcp_event__:";
+@@ -973,6 +1378,9 @@ DurableObjectEventStore.EVENT_KEY_PREFIX = "__mcp_event__:";
  DurableObjectEventStore.SEQ_PAD = 16;
  DurableObjectEventStore.DELETE_CHUNK = 128;
  DurableObjectEventStore.REPLAY_LIMIT = 1e3;
@@ -696,7 +771,7 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..b0d1c55eda79324b6d76a1177519d26a
  //#endregion
  //#region src/mcp/client-transports.ts
  /**
-@@ -1381,6 +1725,47 @@ var McpAgent = class McpAgent extends Agent {
+@@ -1381,6 +1789,47 @@ var McpAgent = class McpAgent extends Agent {
  	async deleteStreamRequestIds(streamId) {
  		await this.ctx.storage.delete(`${McpAgent.STREAM_REQS_KEY_PREFIX}${streamId}`);
  	}
@@ -744,7 +819,7 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..b0d1c55eda79324b6d76a1177519d26a
  	/**
  	* Reverse lookup: find which POST stream a given `requestId` belongs
  	* to, and return the stream's full `requestIds` list in the same
-@@ -1697,7 +2082,8 @@ var McpAgent = class McpAgent extends Agent {
+@@ -1697,7 +2146,8 @@ var McpAgent = class McpAgent extends Agent {
  	}
  };
  McpAgent.STREAM_REQS_KEY_PREFIX = "__mcp_stream_reqs__:";

--- a/patches/agents@0.17.3.patch
+++ b/patches/agents@0.17.3.patch
@@ -19,7 +19,7 @@ index c8fad448e8797b89690a99d93490d1363851b225..77f9fe3f6f2375eadc9f7a2974f0d202
    McpAgent,
    type McpAuthContext,
 diff --git a/dist/mcp/index.js b/dist/mcp/index.js
-index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..c3601bdb084bf82ebfea23cdabe1fab5f6d71fb3 100644
+index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..32d52598b42a4062d09020f0a1abfd67dbf3c266 100644
 --- a/dist/mcp/index.js
 +++ b/dist/mcp/index.js
 @@ -28,13 +28,17 @@ import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/
@@ -643,7 +643,7 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..c3601bdb084bf82ebfea23cdabe1fab5
  	* Handles POST requests containing JSON-RPC messages
  	*/
  	async handlePostRequest(req, parsedBody) {
-@@ -733,6 +1076,17 @@ var StreamableHTTPServerTransport = class {
+@@ -733,6 +1076,22 @@ var StreamableHTTPServerTransport = class {
  			};
  			connection.setState(postState);
  			if (this._eventStore) await agent.setStreamRequestIds(streamId, requestIds);
@@ -657,11 +657,16 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..c3601bdb084bf82ebfea23cdabe1fab5
 +			// a real event-store entry so its id sorts BEFORE the eventual
 +			// response; a reconnect with `last-event-id: <primingId>` replays
 +			// everything after it (i.e. the result). See patches/agents patch.
-+			await this.emitPrimingEvent(agent, connection, streamId);
++			// Scoped to tools/call streams: reconnect-with-replay only matters
++			// where the result can outlive the connection (long-running tool
++			// calls). initialize/tools/list resolve in milliseconds and clients
++			// retry them; priming those streams adds a storage write and an
++			// extra SSE frame per request for nothing.
++			if (messages.some((message) => isJSONRPCRequest(message) && message.method === "tools/call")) await this.emitPrimingEvent(agent, connection, streamId);
  			for (const message of messages) {
  				if (this.messageInterceptor) {
  					if (await this.messageInterceptor(message, {
-@@ -777,9 +1131,11 @@ var StreamableHTTPServerTransport = class {
+@@ -777,9 +1136,11 @@ var StreamableHTTPServerTransport = class {
  		} catch (error) {
  			this.onerror?.(error);
  		}
@@ -675,7 +680,7 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..c3601bdb084bf82ebfea23cdabe1fab5
  		}
  	}
  	async send(message, options) {
-@@ -861,12 +1217,10 @@ var StreamableHTTPServerTransport = class {
+@@ -861,12 +1222,10 @@ var StreamableHTTPServerTransport = class {
  *
  * ## Lifecycle
  *
@@ -692,7 +697,7 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..c3601bdb084bf82ebfea23cdabe1fab5
  *
  * Standalone GET stream events (`_GET_stream`) are *not* cleared
  * automatically; they accumulate for the lifetime of the DO. Bounded
-@@ -899,6 +1253,7 @@ var DurableObjectEventStore = class DurableObjectEventStore {
+@@ -899,6 +1258,7 @@ var DurableObjectEventStore = class DurableObjectEventStore {
  		const eventId = `${streamId}:${seq.toString(16).padStart(DurableObjectEventStore.SEQ_PAD, "0")}`;
  		const eventKey = `${DurableObjectEventStore.EVENT_KEY_PREFIX}${eventId}`;
  		await this.storage.put(eventKey, message);
@@ -700,7 +705,7 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..c3601bdb084bf82ebfea23cdabe1fab5
  		return eventId;
  	}
  	async getStreamIdForEventId(eventId) {
-@@ -915,9 +1270,59 @@ var DurableObjectEventStore = class DurableObjectEventStore {
+@@ -915,9 +1275,59 @@ var DurableObjectEventStore = class DurableObjectEventStore {
  			start: startKey,
  			limit: DurableObjectEventStore.REPLAY_LIMIT
  		});
@@ -761,7 +766,7 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..c3601bdb084bf82ebfea23cdabe1fab5
  	/**
  	* Drop the event log for a single stream. Called by the transport
  	* immediately after a POST's final response has been written to the
-@@ -973,6 +1378,9 @@ DurableObjectEventStore.EVENT_KEY_PREFIX = "__mcp_event__:";
+@@ -973,6 +1383,9 @@ DurableObjectEventStore.EVENT_KEY_PREFIX = "__mcp_event__:";
  DurableObjectEventStore.SEQ_PAD = 16;
  DurableObjectEventStore.DELETE_CHUNK = 128;
  DurableObjectEventStore.REPLAY_LIMIT = 1e3;
@@ -771,7 +776,7 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..c3601bdb084bf82ebfea23cdabe1fab5
  //#endregion
  //#region src/mcp/client-transports.ts
  /**
-@@ -1381,6 +1789,47 @@ var McpAgent = class McpAgent extends Agent {
+@@ -1381,6 +1794,47 @@ var McpAgent = class McpAgent extends Agent {
  	async deleteStreamRequestIds(streamId) {
  		await this.ctx.storage.delete(`${McpAgent.STREAM_REQS_KEY_PREFIX}${streamId}`);
  	}
@@ -819,7 +824,7 @@ index 1edcf0c8c9e67aa211ae515e7672cdf79912101e..c3601bdb084bf82ebfea23cdabe1fab5
  	/**
  	* Reverse lookup: find which POST stream a given `requestId` belongs
  	* to, and return the stream's full `requestIds` list in the same
-@@ -1697,7 +2146,8 @@ var McpAgent = class McpAgent extends Agent {
+@@ -1697,7 +2151,8 @@ var McpAgent = class McpAgent extends Agent {
  	}
  };
  McpAgent.STREAM_REQS_KEY_PREFIX = "__mcp_stream_reqs__:";


### PR DESCRIPTION
MCP clients only auto-reconnect a dropped POST stream when they saw an SSE event id before the drop. Tool-call responses carried their first id together with the final result, so a mid-call disconnect or long-call stream rotation left standard SDK clients unable to recover results the server had persisted. Each tool call response stream now opens with a benign priming event carrying a replayable id, so stock clients reconnect with last-event-id and receive the replayed result. Includes an e2e that severs the stream at the socket level with a real SDK client and fails without the fix.