### PR TITLE
Classify transient WorkOS failures as retryable during MCP auth

### DIFF
--- a/.changeset/workos-blip-session-survival.md
+++ b/.changeset/workos-blip-session-survival.md
@@ -1,0 +1,5 @@
+---
+"executor": patch
+---
+
+Treat a transient WorkOS outage during the MCP live-membership check as a retryable 503 instead of a Forbidden that destroys the session.

--- a/apps/cloud/src/auth/errors.test.ts
+++ b/apps/cloud/src/auth/errors.test.ts
@@ -1,0 +1,68 @@
+// The WorkOS failure-classification boundary: the service adapter must thread
+// the SDK exception's HTTP status onto the public `WorkOSError`, and the
+// definitive-denial predicate must split 401/403/404 (WorkOS answered "no" —
+// fail closed) from 429/5xx/no-status (transient — retryable). This split is
+// what keeps a WorkOS blip from condemning MCP sessions AND a revoked key from
+// being mistaken for a blip.
+import { describe, expect, it } from "@effect/vitest";
+import {
+  GenericServerException,
+  NotFoundException,
+  RateLimitExceededException,
+  UnauthorizedException,
+} from "@workos-inc/node/worker";
+
+import {
+  ServiceAdapterError,
+  isDefinitiveWorkOSDenial,
+  isDefinitiveWorkOSDenialStatus,
+  workosErrorFromFailure,
+} from "./errors";
+
+describe("workosErrorFromFailure", () => {
+  it("reads the status off the real SDK exceptions through the adapter wrapper", () => {
+    const cases: ReadonlyArray<readonly [unknown, number]> = [
+      [new UnauthorizedException("req_1"), 401],
+      [
+        new NotFoundException({ code: "not_found", message: "gone", path: "/x", requestID: "r" }),
+        404,
+      ],
+      [new RateLimitExceededException("slow down", "req_2", 1), 429],
+      [new GenericServerException(503, "upstream", {}, "req_3"), 503],
+    ];
+    for (const [sdkError, status] of cases) {
+      const wrapped = workosErrorFromFailure(new ServiceAdapterError({ cause: sdkError }));
+      expect(wrapped.status, `status for ${String(sdkError)}`).toBe(status);
+    }
+  });
+
+  it("leaves status unset for non-HTTP failures (network error, timeout)", () => {
+    // The shape fetch/undici raise on a network failure: an error value with a
+    // message and no HTTP status (statusless by construction, unlike the SDK's
+    // typed HTTP exceptions).
+    const networkFailure: unknown = { name: "TypeError", message: "fetch failed" };
+    const wrapped = workosErrorFromFailure(new ServiceAdapterError({ cause: networkFailure }));
+    expect(wrapped.status).toBeUndefined();
+  });
+});
+
+describe("isDefinitiveWorkOSDenial", () => {
+  it("treats 401/403/404 as definitive and everything else as transient", () => {
+    expect(isDefinitiveWorkOSDenialStatus(401)).toBe(true);
+    expect(isDefinitiveWorkOSDenialStatus(403)).toBe(true);
+    expect(isDefinitiveWorkOSDenialStatus(404)).toBe(true);
+    expect(isDefinitiveWorkOSDenialStatus(429)).toBe(false);
+    expect(isDefinitiveWorkOSDenialStatus(500)).toBe(false);
+    expect(isDefinitiveWorkOSDenialStatus(503)).toBe(false);
+    expect(isDefinitiveWorkOSDenialStatus(undefined)).toBe(false);
+  });
+
+  it("only claims WorkOSError instances, never arbitrary errors with a status", () => {
+    expect(isDefinitiveWorkOSDenial({ status: 403 })).toBe(false);
+    expect(
+      isDefinitiveWorkOSDenial(
+        workosErrorFromFailure(new ServiceAdapterError({ cause: new UnauthorizedException("r") })),
+      ),
+    ).toBe(true);
+  });
+});

--- a/apps/cloud/src/auth/errors.ts
+++ b/apps/cloud/src/auth/errors.ts
@@ -1,4 +1,4 @@
-import { Data, Effect, Schema } from "effect";
+import { Data, Effect, Option, Predicate, Schema } from "effect";
 
 export class UserStoreError extends Schema.TaggedErrorClass<UserStoreError>()(
   "UserStoreError",
@@ -8,9 +8,68 @@ export class UserStoreError extends Schema.TaggedErrorClass<UserStoreError>()(
 
 export class WorkOSError extends Schema.TaggedErrorClass<WorkOSError>()(
   "WorkOSError",
-  {},
+  {
+    /**
+     * The upstream HTTP status WorkOS answered with, when the failure WAS an
+     * HTTP answer (the SDK sets `.status` on all its typed exceptions).
+     * Absent for network errors / timeouts. Consumers that must distinguish
+     * "WorkOS said no" (definitive 4xx) from "WorkOS was unreachable"
+     * (transient) branch on this — see `isDefinitiveWorkOSDenialStatus`.
+     */
+    status: Schema.optional(Schema.Number),
+  },
   { httpApiStatus: 500 },
 ) {}
+
+// Statuses that are a DEFINITIVE denial from WorkOS — a deterministic "this
+// request cannot be authorized" answer (invalid/revoked API key, forbidden,
+// resource gone), not a blip. Retrying does not help, and auth decisions built
+// on them must fail CLOSED. Everything else (429, 5xx, or no status at all —
+// network error/timeout) is transient and must stay retryable.
+const DEFINITIVE_DENIAL_STATUSES: ReadonlySet<number> = new Set([401, 403, 404]);
+
+export const isDefinitiveWorkOSDenialStatus = (status: number | undefined): boolean =>
+  status !== undefined && DEFINITIVE_DENIAL_STATUSES.has(status);
+
+// Tag-based guards (same pattern as `isOAuth2Error` in core/sdk/oauth-helpers):
+// the untyped failure channels these run against carry values that crossed
+// layer boundaries, so the discriminant is the `_tag`, not the prototype chain.
+const isWorkOSError = Predicate.isTagged("WorkOSError") as (error: unknown) => error is WorkOSError;
+
+/** A `WorkOSError` that is a definitive denial (see above), typed on `unknown`
+ *  so auth code holding an untyped failure channel can branch safely. */
+export const isDefinitiveWorkOSDenial = (error: unknown): boolean =>
+  isWorkOSError(error) && isDefinitiveWorkOSDenialStatus(error.status);
+
+// Every typed exception the WorkOS node SDK throws for an HTTP answer carries a
+// numeric `.status` (UnauthorizedException 401, NotFoundException 404,
+// RateLimitExceededException 429, GenericServerException/OauthException with the
+// live status, ...). Network errors and timeouts throw non-SDK errors with no
+// status. Same extraction pattern as the workos-vault plugin's
+// `statusFromWorkOSCause` (packages/plugins/workos-vault/src/sdk/client.ts).
+const CauseWithStatusSchema = Schema.Struct({ status: Schema.Number });
+const decodeCauseWithStatusOption = Schema.decodeUnknownOption(CauseWithStatusSchema);
+
+export const statusFromWorkOSCause = (cause: unknown): number | undefined =>
+  Option.match(decodeCauseWithStatusOption(cause), {
+    onNone: () => undefined,
+    onSome: (decoded) => decoded.status,
+  });
+
+/**
+ * Build the public `WorkOSError` for a WorkOS service-adapter failure,
+ * threading the upstream HTTP status through when the underlying SDK exception
+ * carried one. The failure is normally the `ServiceAdapterError` wrapper from
+ * `tryPromiseService` (SDK exception in `.cause`); a bare cause also works.
+ */
+const isServiceAdapterError = Predicate.isTagged("ServiceAdapterError") as (
+  failure: unknown,
+) => failure is ServiceAdapterError;
+
+export const workosErrorFromFailure = (failure: unknown): WorkOSError =>
+  new WorkOSError({
+    status: statusFromWorkOSCause(isServiceAdapterError(failure) ? failure.cause : failure),
+  });
 
 export class ApiKeyManagementError extends Schema.TaggedErrorClass<ApiKeyManagementError>()(
   "ApiKeyManagementError",
@@ -47,7 +106,11 @@ export const tryPromiseService = <A>(fn: () => Promise<A>): Effect.Effect<A, Ser
  */
 export const withServiceLogging = <A, E, R>(
   name: string,
-  publicError: () => E,
+  // Receives the raw failure (for service adapters: the `ServiceAdapterError`
+  // whose `.cause` is the SDK exception) so the public error can carry safe
+  // classification fields (e.g. `WorkOSError.status`). Zero-arg callers that
+  // ignore the failure keep working unchanged.
+  publicError: (failure: unknown) => E,
   effect: Effect.Effect<A, unknown, R>,
 ): Effect.Effect<A, E, R> =>
   effect.pipe(

--- a/apps/cloud/src/auth/organization.ts
+++ b/apps/cloud/src/auth/organization.ts
@@ -57,9 +57,19 @@ export const resolveOrganization = (organizationId: string) =>
 // until their access token naturally expires (~10 min).
 //
 // To close that gap we verify membership live on every protected request.
-// `listUserMemberships` is one WorkOS call per request. If this becomes a
-// hot path we can layer a short per-(user, org) TTL cache underneath, or
-// swap it for a local memberships table fed by the WorkOS Events API.
+// `listUserMemberships` is one WorkOS call per request.
+//
+// Caching decision (2026-07): we deliberately do NOT add a positive TTL cache
+// here. A positive cache is exactly what would re-open the revocation gap this
+// live check exists to close — a revoked member would keep access for the cache
+// TTL. Negative caching is worse still (a transient WorkOS blip would get
+// pinned as "no access"), so it is out too. The rate-limit amplification a
+// shared-API-key org can cause under a WorkOS slowdown is mitigated instead by
+// the classification fix at the MCP call site (a blip now yields a retryable
+// 503, so it no longer condemns sessions or triggers reconnect storms). If per-
+// request WorkOS load later proves to be the bottleneck, the right structural
+// fix is a local memberships table fed by the WorkOS Events API (authoritative,
+// no staleness window), not a TTL cache over this call — tracked as follow-up.
 //
 // Returns the resolved organization (via resolveOrganization) if the user
 // currently holds an *active* membership in it, otherwise null. Callers

--- a/apps/cloud/src/auth/workos.ts
+++ b/apps/cloud/src/auth/workos.ts
@@ -6,7 +6,7 @@ import { env } from "cloudflare:workers";
 import { Context, Data, Effect, Layer, Option, Schema } from "effect";
 import { GeneratePortalLinkIntent, WorkOS } from "@workos-inc/node/worker";
 import { parseCookie } from "./cookies";
-import { WorkOSError, tryPromiseService, withServiceLogging } from "./errors";
+import { tryPromiseService, withServiceLogging, workosErrorFromFailure } from "./errors";
 
 const COOKIE_NAME = "wos-session";
 const INVALID_COOKIE_PASSWORD_MESSAGE = "WORKOS_COOKIE_PASSWORD must be at least 32 characters";
@@ -147,10 +147,14 @@ const make = Effect.gen(function* () {
 
   const workos = new WorkOS({ apiKey, clientId, ...workosApiUrlOptions(env.WORKOS_API_URL) });
 
+  // The public `WorkOSError` carries the upstream HTTP status when the SDK
+  // exception had one (all its typed exceptions do), so consumers can tell a
+  // definitive WorkOS denial (401/403/404 — fail closed) from a transient
+  // failure (429/5xx/network — retryable).
   const use = <A>(fn: (wos: WorkOS) => Promise<A>) =>
     withServiceLogging(
       "workos",
-      () => new WorkOSError(),
+      workosErrorFromFailure,
       tryPromiseService(() => fn(workos)),
     );
 

--- a/apps/cloud/src/mcp/agent-handler.ts
+++ b/apps/cloud/src/mcp/agent-handler.ts
@@ -19,6 +19,11 @@ import { wrapMcpSseResponse } from "../observability/memory-metrics";
 import { cloudMcpAuth } from "./auth-provider";
 import { McpSessionDOSqlite } from "./session-durable-object";
 
+// Advertised on transient-auth 503s so clients back off before retrying. Short:
+// WorkOS blips are typically sub-second, and the JSON-RPC transport surfaces the
+// non-200 as a retryable error the agent can re-issue.
+const UNAVAILABLE_RETRY_AFTER_SECONDS = 2;
+
 const corsPreflightResponse = (): Response =>
   new Response(null, {
     status: 204,
@@ -57,7 +62,14 @@ const renderAuthError = (
   if (Predicate.isTagged(outcome, "Forbidden")) {
     return jsonRpcResponse(403, outcome.code ?? -32001, outcome.message);
   }
-  return jsonRpcResponse(503, -32001, outcome.message);
+  // Unavailable: a transient auth-infra failure (JWKS blip OR a WorkOS
+  // membership-lookup 429/5xx/timeout). Both are retryable, so advertise a
+  // Retry-After so the client (and any polite retry layer) backs off instead of
+  // hammering. Crucially, this path NEVER reaches the session-destroy branch
+  // below — a transient failure must not condemn a live session.
+  const response = jsonRpcResponse(503, -32001, outcome.message);
+  response.headers.set("retry-after", String(UNAVAILABLE_RETRY_AFTER_SECONDS));
+  return response;
 };
 
 const authenticate = (request: Request) =>
@@ -99,7 +111,10 @@ const propsForPrincipal = (
   });
 
 export const makeCloudMcpAgentHandler = () => {
-  const serveOptions = { binding: "MCP_SESSION", transport: "streamable-http" } as const;
+  const serveOptions = {
+    binding: "MCP_SESSION",
+    transport: "streamable-http",
+  } as const;
   // The agents SDK builds an exact-match `URLPattern` from the path handed to
   // `serve` (see `createStreamingHttpHandler` in `agents/dist/mcp/index.js`) —
   // a single `/mcp` handler never matches `/mcp/toolkits/<slug>` and falls
@@ -126,6 +141,11 @@ export const makeCloudMcpAgentHandler = () => {
 
     const { auth, outcome } = await Effect.runPromise(authenticate(request));
     if (!Predicate.isTagged(outcome, "Authenticated")) {
+      // Destroying a live session on auth grounds requires a POSITIVE
+      // determination that access is genuinely gone — only `Forbidden` carries
+      // that (valid bearer, org absent/revoked). `Unavailable` (transient WorkOS
+      // / JWKS failure) and `Unauthorized` (retry with a fresh token) must leave
+      // the session intact, so the condemn path is gated on `Forbidden` alone.
       if (Predicate.isTagged(outcome, "Forbidden") && sessionId) {
         await Effect.runPromise(
           Effect.ignore(
@@ -142,7 +162,10 @@ export const makeCloudMcpAgentHandler = () => {
       // Matches the old envelope's contract (@modelcontextprotocol/sdk's
       // `WebStandardStreamableHTTPServerTransport.handleDeleteRequest`): 200,
       // not 204 — see e2e/cloud/mcp-protocol.test.ts.
-      return new Response(null, { status: 200, headers: { "access-control-allow-origin": "*" } });
+      return new Response(null, {
+        status: 200,
+        headers: { "access-control-allow-origin": "*" },
+      });
     }
 
     if (sessionId) {

--- a/apps/cloud/src/mcp/agent-handler.ts
+++ b/apps/cloud/src/mcp/agent-handler.ts
@@ -4,6 +4,7 @@ import {
   McpAuthProvider,
   jsonRpcErrorBody,
   defaultMcpResource,
+  UNAVAILABLE_RETRY_AFTER_SECONDS,
   type AuthOutcome,
   type McpResource,
 } from "@executor-js/host-mcp";
@@ -18,11 +19,6 @@ import { mcpSessionStub } from "@executor-js/cloudflare/mcp/session-stub";
 import { wrapMcpSseResponse } from "../observability/memory-metrics";
 import { cloudMcpAuth } from "./auth-provider";
 import { McpSessionDOSqlite } from "./session-durable-object";
-
-// Advertised on transient-auth 503s so clients back off before retrying. Short:
-// WorkOS blips are typically sub-second, and the JSON-RPC transport surfaces the
-// non-200 as a retryable error the agent can re-issue.
-const UNAVAILABLE_RETRY_AFTER_SECONDS = 2;
 
 const corsPreflightResponse = (): Response =>
   new Response(null, {
@@ -65,11 +61,18 @@ const renderAuthError = (
   // Unavailable: a transient auth-infra failure (JWKS blip OR a WorkOS
   // membership-lookup 429/5xx/timeout). Both are retryable, so advertise a
   // Retry-After so the client (and any polite retry layer) backs off instead of
-  // hammering. Crucially, this path NEVER reaches the session-destroy branch
-  // below — a transient failure must not condemn a live session.
-  const response = jsonRpcResponse(503, -32001, outcome.message);
-  response.headers.set("retry-after", String(UNAVAILABLE_RETRY_AFTER_SECONDS));
-  return response;
+  // hammering (same rendering as the shared envelope's Unavailable branch).
+  // Crucially, this path NEVER reaches the session-destroy branch below — a
+  // transient failure must not condemn a live session.
+  //
+  // Note this 503 shares JSON-RPC code -32001 with the terminated-session 404
+  // ("Session timed out, please reconnect"); that is intentional — -32001 is
+  // the generic auth/session envelope code, and the HTTP STATUS is the
+  // discriminator clients act on: 503 = retry the SAME session id, 404 = the
+  // id is dead, reconnect.
+  return jsonRpcErrorBody(503, -32001, outcome.message, {
+    retryAfterSeconds: UNAVAILABLE_RETRY_AFTER_SECONDS,
+  });
 };
 
 const authenticate = (request: Request) =>

--- a/apps/cloud/src/mcp/auth-provider.test.ts
+++ b/apps/cloud/src/mcp/auth-provider.test.ts
@@ -1,0 +1,114 @@
+// ---------------------------------------------------------------------------
+// The cloud MCP auth provider's organization-authorization branch.
+//
+// The load-bearing property under test: a TRANSIENT WorkOS failure during the
+// live membership lookup must resolve to a retryable `Unavailable` (503), NOT a
+// `Forbidden`. Only `Forbidden` reaches the session-destroy path in
+// agent-handler, so misclassifying a WorkOS blip as Forbidden permanently
+// condemns a live session DO. A lookup that SUCCEEDS with no membership is a
+// genuine `Forbidden` (destroy allowed); a lookup that succeeds with an org id
+// is `Authenticated`.
+// ---------------------------------------------------------------------------
+
+import { describe, expect, it } from "@effect/vitest";
+import { Data, Effect, Layer, Predicate } from "effect";
+
+import { McpAuthProvider } from "@executor-js/host-mcp";
+
+import { cloudMcpAuthProviderLayer } from "./auth-provider";
+import {
+  MCP_ORGANIZATION_HEADER,
+  McpAuth,
+  McpOrganizationAuth,
+  mcpAuthorized,
+  mcpUnauthorized,
+} from "./auth";
+
+const ACCOUNT_ID = "user_test";
+const ORG_ID = "org_test";
+
+const request = () =>
+  new Request("https://executor.sh/mcp", {
+    method: "POST",
+    headers: {
+      authorization: "Bearer token_fixture",
+      [MCP_ORGANIZATION_HEADER]: ORG_ID,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ jsonrpc: "2.0", method: "tools/list", id: 1 }),
+  });
+
+// A verified bearer that carries an account + org — the org-authorize branch is
+// what we exercise, so verifyBearer succeeds here.
+const stubAuth = Layer.succeed(McpAuth)({
+  verifyBearer: () =>
+    Effect.succeed(mcpAuthorized({ accountId: ACCOUNT_ID, organizationId: ORG_ID })),
+});
+
+const stubAuthMissingBearer = Layer.succeed(McpAuth)({
+  verifyBearer: () => Effect.succeed(mcpUnauthorized("missing_bearer")),
+});
+
+// Mirrors the real failure channel: `authorizeOrganization`'s WorkOS call maps
+// upstream 429/5xx/timeout to a tagged `WorkOSError` before it reaches here.
+class StubWorkOSError extends Data.TaggedError("StubWorkOSError")<{
+  readonly detail: string;
+}> {}
+
+// `authorize` FAILS (transient WorkOS error) — the blip we must classify as 503.
+const stubOrgAuthTransientFailure = Layer.succeed(McpOrganizationAuth)({
+  authorize: () => Effect.fail(new StubWorkOSError({ detail: "workos 503: upstream timeout" })),
+});
+
+// `authorize` SUCCEEDS with `null` — the caller genuinely holds no membership.
+const stubOrgAuthNoMembership = Layer.succeed(McpOrganizationAuth)({
+  authorize: () => Effect.succeed(null),
+});
+
+// `authorize` SUCCEEDS with an org id — active membership.
+const stubOrgAuthActive = Layer.succeed(McpOrganizationAuth)({
+  authorize: () => Effect.succeed(ORG_ID),
+});
+
+const authenticateWith = (
+  orgAuth: Layer.Layer<McpOrganizationAuth>,
+  auth: Layer.Layer<McpAuth> = stubAuth,
+) =>
+  Effect.gen(function* () {
+    const provider = yield* McpAuthProvider;
+    return yield* provider.authenticate(request());
+  }).pipe(
+    Effect.provide(cloudMcpAuthProviderLayer.pipe(Layer.provide(Layer.mergeAll(auth, orgAuth)))),
+  );
+
+describe("cloud MCP org-authorization classification", () => {
+  it.effect("transient WorkOS failure -> Unavailable (retryable 503, session preserved)", () =>
+    Effect.gen(function* () {
+      const outcome = yield* authenticateWith(stubOrgAuthTransientFailure);
+      expect(Predicate.isTagged(outcome, "Unavailable")).toBe(true);
+    }),
+  );
+
+  it.effect("lookup succeeds with no membership -> Forbidden (destroy allowed)", () =>
+    Effect.gen(function* () {
+      const outcome = yield* authenticateWith(stubOrgAuthNoMembership);
+      expect(Predicate.isTagged(outcome, "Forbidden")).toBe(true);
+    }),
+  );
+
+  it.effect("active membership -> Authenticated (principal carries the resolved org)", () =>
+    Effect.gen(function* () {
+      const outcome = yield* authenticateWith(stubOrgAuthActive);
+      const principal = Predicate.isTagged(outcome, "Authenticated") ? outcome.principal : null;
+      expect(principal?.accountId).toBe(ACCOUNT_ID);
+      expect(principal?.organizationId).toBe(ORG_ID);
+    }),
+  );
+
+  it.effect("missing bearer still short-circuits to Unauthorized", () =>
+    Effect.gen(function* () {
+      const outcome = yield* authenticateWith(stubOrgAuthActive, stubAuthMissingBearer);
+      expect(Predicate.isTagged(outcome, "Unauthorized")).toBe(true);
+    }),
+  );
+});

--- a/apps/cloud/src/mcp/auth-provider.test.ts
+++ b/apps/cloud/src/mcp/auth-provider.test.ts
@@ -1,13 +1,22 @@
 // ---------------------------------------------------------------------------
 // The cloud MCP auth provider's organization-authorization branch.
 //
-// The load-bearing property under test: a TRANSIENT WorkOS failure during the
-// live membership lookup must resolve to a retryable `Unavailable` (503), NOT a
-// `Forbidden`. Only `Forbidden` reaches the session-destroy path in
-// agent-handler, so misclassifying a WorkOS blip as Forbidden permanently
-// condemns a live session DO. A lookup that SUCCEEDS with no membership is a
-// genuine `Forbidden` (destroy allowed); a lookup that succeeds with an org id
-// is `Authenticated`.
+// The load-bearing property under test is the failure CLASSIFICATION, in both
+// directions:
+//
+//   - a TRANSIENT WorkOS failure (429/5xx/timeout/network — retrying can help)
+//     must resolve to a retryable `Unavailable` (503), NOT a `Forbidden`. Only
+//     `Forbidden` reaches the session-destroy path in agent-handler, so
+//     misclassifying a blip as Forbidden permanently condemns a live session DO.
+//   - a DEFINITIVE WorkOS denial (401 revoked/invalid API key, 403, 404 deleted
+//     org — WorkOS answered and said no) must fail CLOSED as `Forbidden`, NOT
+//     be misread as transient. Misclassifying it as Unavailable would preserve
+//     sessions indefinitely for a revoked customer (fail-open inversion).
+//
+// The definitive/transient split rides on `WorkOSError.status`, threaded from
+// the WorkOS SDK exception at the service boundary (auth/workos.ts). A lookup
+// that SUCCEEDS with no membership is a genuine `Forbidden` (destroy allowed);
+// a lookup that succeeds with an org id is `Authenticated`.
 // ---------------------------------------------------------------------------
 
 import { describe, expect, it } from "@effect/vitest";
@@ -15,6 +24,7 @@ import { Data, Effect, Layer, Predicate } from "effect";
 
 import { McpAuthProvider } from "@executor-js/host-mcp";
 
+import { WorkOSError } from "../auth/errors";
 import { cloudMcpAuthProviderLayer } from "./auth-provider";
 import {
   MCP_ORGANIZATION_HEADER,
@@ -49,16 +59,11 @@ const stubAuthMissingBearer = Layer.succeed(McpAuth)({
   verifyBearer: () => Effect.succeed(mcpUnauthorized("missing_bearer")),
 });
 
-// Mirrors the real failure channel: `authorizeOrganization`'s WorkOS call maps
-// upstream 429/5xx/timeout to a tagged `WorkOSError` before it reaches here.
-class StubWorkOSError extends Data.TaggedError("StubWorkOSError")<{
-  readonly detail: string;
-}> {}
-
-// `authorize` FAILS (transient WorkOS error) — the blip we must classify as 503.
-const stubOrgAuthTransientFailure = Layer.succeed(McpOrganizationAuth)({
-  authorize: () => Effect.fail(new StubWorkOSError({ detail: "workos 503: upstream timeout" })),
-});
+// `authorize` failing with the REAL `WorkOSError` the service boundary mints:
+// with `status` when WorkOS answered (its SDK exceptions all carry one), without
+// when the failure never reached WorkOS (network error / timeout).
+const stubOrgAuthFailing = (error: unknown): Layer.Layer<McpOrganizationAuth> =>
+  Layer.succeed(McpOrganizationAuth)({ authorize: () => Effect.fail(error) });
 
 // `authorize` SUCCEEDS with `null` — the caller genuinely holds no membership.
 const stubOrgAuthNoMembership = Layer.succeed(McpOrganizationAuth)({
@@ -69,6 +74,12 @@ const stubOrgAuthNoMembership = Layer.succeed(McpOrganizationAuth)({
 const stubOrgAuthActive = Layer.succeed(McpOrganizationAuth)({
   authorize: () => Effect.succeed(ORG_ID),
 });
+
+// A failure that is not a WorkOSError at all (e.g. the per-request DB layer
+// failing before the WorkOS call) — no status to read, must stay transient.
+class StubInfraError extends Data.TaggedError("StubInfraError")<{
+  readonly detail: string;
+}> {}
 
 const authenticateWith = (
   orgAuth: Layer.Layer<McpOrganizationAuth>,
@@ -82,10 +93,58 @@ const authenticateWith = (
   );
 
 describe("cloud MCP org-authorization classification", () => {
-  it.effect("transient WorkOS failure -> Unavailable (retryable 503, session preserved)", () =>
+  it.effect("WorkOS 5xx -> Unavailable (retryable 503, session preserved)", () =>
     Effect.gen(function* () {
-      const outcome = yield* authenticateWith(stubOrgAuthTransientFailure);
+      const outcome = yield* authenticateWith(stubOrgAuthFailing(new WorkOSError({ status: 503 })));
       expect(Predicate.isTagged(outcome, "Unavailable")).toBe(true);
+    }),
+  );
+
+  it.effect("WorkOS 429 rate limit -> Unavailable (retryable, session preserved)", () =>
+    Effect.gen(function* () {
+      const outcome = yield* authenticateWith(stubOrgAuthFailing(new WorkOSError({ status: 429 })));
+      expect(Predicate.isTagged(outcome, "Unavailable")).toBe(true);
+    }),
+  );
+
+  it.effect("WorkOS unreachable (no HTTP status) -> Unavailable (session preserved)", () =>
+    Effect.gen(function* () {
+      const outcome = yield* authenticateWith(stubOrgAuthFailing(new WorkOSError({})));
+      expect(Predicate.isTagged(outcome, "Unavailable")).toBe(true);
+    }),
+  );
+
+  it.effect("non-WorkOS infra failure -> Unavailable (no status to read, stay retryable)", () =>
+    Effect.gen(function* () {
+      const outcome = yield* authenticateWith(
+        stubOrgAuthFailing(new StubInfraError({ detail: "db layer failed" })),
+      );
+      expect(Predicate.isTagged(outcome, "Unavailable")).toBe(true);
+    }),
+  );
+
+  it.effect(
+    "WorkOS 401 (revoked/invalid API key) -> Forbidden (fail closed, destroy allowed)",
+    () =>
+      Effect.gen(function* () {
+        const outcome = yield* authenticateWith(
+          stubOrgAuthFailing(new WorkOSError({ status: 401 })),
+        );
+        expect(Predicate.isTagged(outcome, "Forbidden")).toBe(true);
+      }),
+  );
+
+  it.effect("WorkOS 403 -> Forbidden (fail closed, destroy allowed)", () =>
+    Effect.gen(function* () {
+      const outcome = yield* authenticateWith(stubOrgAuthFailing(new WorkOSError({ status: 403 })));
+      expect(Predicate.isTagged(outcome, "Forbidden")).toBe(true);
+    }),
+  );
+
+  it.effect("WorkOS 404 (deleted org/user) -> Forbidden (fail closed, destroy allowed)", () =>
+    Effect.gen(function* () {
+      const outcome = yield* authenticateWith(stubOrgAuthFailing(new WorkOSError({ status: 404 })));
+      expect(Predicate.isTagged(outcome, "Forbidden")).toBe(true);
     }),
   );
 

--- a/apps/cloud/src/mcp/auth-provider.ts
+++ b/apps/cloud/src/mcp/auth-provider.ts
@@ -42,6 +42,7 @@ import {
 } from "@executor-js/host-mcp";
 
 import { ApiKeyService } from "../auth/api-keys";
+import { isDefinitiveWorkOSDenial } from "../auth/errors";
 import { CoreSharedServices } from "../auth/workos";
 import {
   bearerChallengeFor,
@@ -67,14 +68,20 @@ const TOOLKIT_PROTECTED_RESOURCE_METADATA_PATH = `${PROTECTED_RESOURCE_METADATA_
 
 const NO_ORGANIZATION_MESSAGE = "No organization in session — log in via the web app first";
 
-// A transient WorkOS failure (429 / 5xx / timeout) during the live membership
-// lookup must NOT masquerade as "org revoked". The two are indistinguishable in
-// outcome value alone (`authorize` yields `null` for a genuinely-absent org),
-// but they differ in the Effect CHANNEL: a genuine absence SUCCEEDS with `null`,
-// while a WorkOS error FAILS. We branch on that below so a WorkOS blip becomes a
-// retryable 503 (session preserved) rather than a Forbidden (session condemned).
-// This mirrors the JWKS/api-key `reason: "system"` classification already used
-// on the verify path.
+// A transient WorkOS failure (429 / 5xx / timeout / network) during the live
+// membership lookup must NOT masquerade as "org revoked" — but the failure
+// channel alone is not enough to tell them apart: WorkOS also answers with
+// DEFINITIVE 4xx denials (401 revoked/invalid API key, 403, 404 deleted org)
+// that the SDK throws as typed exceptions. So the classification is:
+//   - lookup SUCCEEDS with `null`            -> genuine absence -> Forbidden
+//   - lookup FAILS with WorkOS 401/403/404   -> definitive denial -> Forbidden
+//       (fail CLOSED: WorkOS answered and said no; retrying cannot help)
+//   - lookup FAILS any other way (429/5xx/timeout/network/no status)
+//       -> transient -> retryable 503, session preserved
+// The status rides on `WorkOSError.status` (threaded from the SDK exception at
+// the service boundary in auth/workos.ts); `isDefinitiveWorkOSDenial` is the
+// single predicate. This mirrors the JWKS/api-key `reason: "system"`
+// classification already used on the verify path.
 const ORGANIZATION_AUTHORIZE_UNAVAILABLE =
   "Organization authorization temporarily unavailable - please retry";
 
@@ -172,9 +179,10 @@ export const cloudMcpAuthProviderLayer: Layer.Layer<
         }
 
         // Capture success-vs-failure explicitly instead of collapsing both into
-        // `null`. A FAILURE here is a transient WorkOS error (429/5xx/timeout) —
-        // NOT evidence the org is gone — so it must become a retryable 503 with
-        // the session left intact, never a Forbidden that condemns the DO.
+        // `null`, then classify the failure (see the classification table on
+        // ORGANIZATION_AUTHORIZE_UNAVAILABLE above): a definitive WorkOS 4xx
+        // denial fails CLOSED as Forbidden, anything else is a transient error
+        // that must become a retryable 503 with the session left intact.
         const authorizeResult = yield* orgAuth
           .authorize(token.accountId, organizationSelector)
           .pipe(
@@ -189,6 +197,19 @@ export const cloudMcpAuthProviderLayer: Layer.Layer<
         yield* annotateMcpRequest(request, { token, parseBody });
 
         if (Result.isFailure(authorizeResult)) {
+          if (isDefinitiveWorkOSDenial(authorizeResult.failure)) {
+            // WorkOS ANSWERED and said no (revoked key, forbidden, deleted
+            // org). Deterministic denial — same as a successful lookup with no
+            // membership, so the Forbidden/condemn path applies.
+            yield* Effect.annotateCurrentSpan({
+              "mcp.auth.outcome": "denied",
+              "mcp.auth.organization_authorize_error": String(authorizeResult.failure).slice(
+                0,
+                500,
+              ),
+            });
+            return forbidden(NO_ORGANIZATION_MESSAGE, -32001);
+          }
           yield* Effect.annotateCurrentSpan({
             "mcp.auth.outcome": "system_error",
             "mcp.auth.system_error.reason": "organization_authorize",

--- a/apps/cloud/src/mcp/auth-provider.ts
+++ b/apps/cloud/src/mcp/auth-provider.ts
@@ -9,11 +9,16 @@
 // AuthOutcome:
 //   - missing bearer       -> Unauthorized (challenge: Bearer resource_metadata=…)
 //   - invalid token/api key -> Unauthorized (challenge: Bearer error="invalid_token" …)
-//   - transient JWKS infra  -> Unavailable (caught here; envelope renders 503 -32001)
+//   - transient JWKS OR membership-lookup infra -> Unavailable (caught here;
+//       envelope renders a retryable 503 -32001). A WorkOS blip during the live
+//       org check is a TRANSIENT failure, not evidence the org is gone, so it
+//       must NOT reach the Forbidden/destroy path below.
 //   - no org / revoked org  -> Forbidden ("No organization in session …", -32001).
-//       Because authenticate reads the mcp-session-id header to do the live org
-//       check, the envelope's dispose-on-Forbidden-with-sessionId path reproduces
-//       the old inline clearExistingSession.
+//       This requires a POSITIVE determination (the lookup SUCCEEDED and the org
+//       is absent), never a failed lookup. Because authenticate reads the
+//       mcp-session-id header to do the live org check, the envelope's
+//       dispose-on-Forbidden-with-sessionId path reproduces the old inline
+//       clearExistingSession.
 //   - verified + org allowed -> Authenticated(principal)
 //
 // The rich `mcp.request.annotate` client-fingerprint span (cloud-specific, no
@@ -23,7 +28,7 @@
 // live at WorkOS/AuthKit (external); only the two discovery docs are mounted.
 // ---------------------------------------------------------------------------
 
-import { Cause, Effect, Layer, Predicate, Result } from "effect";
+import { Effect, Layer, Predicate, Result } from "effect";
 
 import {
   authenticated,
@@ -61,6 +66,17 @@ const AUTHORIZATION_SERVER_METADATA_PATH = "/.well-known/oauth-authorization-ser
 const TOOLKIT_PROTECTED_RESOURCE_METADATA_PATH = `${PROTECTED_RESOURCE_METADATA_PATH}/toolkits/:toolkitSlug`;
 
 const NO_ORGANIZATION_MESSAGE = "No organization in session — log in via the web app first";
+
+// A transient WorkOS failure (429 / 5xx / timeout) during the live membership
+// lookup must NOT masquerade as "org revoked". The two are indistinguishable in
+// outcome value alone (`authorize` yields `null` for a genuinely-absent org),
+// but they differ in the Effect CHANNEL: a genuine absence SUCCEEDS with `null`,
+// while a WorkOS error FAILS. We branch on that below so a WorkOS blip becomes a
+// retryable 503 (session preserved) rather than a Forbidden (session condemned).
+// This mirrors the JWKS/api-key `reason: "system"` classification already used
+// on the verify path.
+const ORGANIZATION_AUTHORIZE_UNAVAILABLE =
+  "Organization authorization temporarily unavailable - please retry";
 
 /**
  * Enrich a cloud {@link VerifiedToken} (which carries only accountId +
@@ -155,22 +171,37 @@ export const cloudMcpAuthProviderLayer: Layer.Layer<
           return forbidden(NO_ORGANIZATION_MESSAGE, -32001);
         }
 
-        const organizationId = yield* orgAuth.authorize(token.accountId, organizationSelector).pipe(
-          Effect.catchCause((error) =>
-            Effect.gen(function* () {
-              yield* Effect.annotateCurrentSpan({
-                "mcp.auth.organization_authorize_error": Cause.pretty(error),
-              });
-              return null;
+        // Capture success-vs-failure explicitly instead of collapsing both into
+        // `null`. A FAILURE here is a transient WorkOS error (429/5xx/timeout) —
+        // NOT evidence the org is gone — so it must become a retryable 503 with
+        // the session left intact, never a Forbidden that condemns the DO.
+        const authorizeResult = yield* orgAuth
+          .authorize(token.accountId, organizationSelector)
+          .pipe(
+            Effect.result,
+            Effect.withSpan("mcp.auth.authorize_organization", {
+              attributes: {
+                "mcp.auth.organization_selector": organizationSelector,
+              },
             }),
-          ),
-          Effect.withSpan("mcp.auth.authorize_organization", {
-            attributes: { "mcp.auth.organization_selector": organizationSelector },
-          }),
-        );
+          );
 
         yield* annotateMcpRequest(request, { token, parseBody });
 
+        if (Result.isFailure(authorizeResult)) {
+          yield* Effect.annotateCurrentSpan({
+            "mcp.auth.outcome": "system_error",
+            "mcp.auth.system_error.reason": "organization_authorize",
+            "mcp.auth.organization_authorize_error": String(authorizeResult.failure).slice(0, 500),
+          });
+          return unavailable(ORGANIZATION_AUTHORIZE_UNAVAILABLE);
+        }
+
+        // Positive determination: the lookup succeeded. `null` here means the
+        // caller genuinely holds no active membership (revoked / never a member)
+        // — a real Forbidden, which the handler may act on by condemning the
+        // session.
+        const organizationId = authorizeResult.success;
         if (!organizationId) return forbidden(NO_ORGANIZATION_MESSAGE, -32001);
         return authenticated(principalFromToken(token, organizationId));
       });
@@ -179,7 +210,10 @@ export const cloudMcpAuthProviderLayer: Layer.Layer<
       if (Predicate.isTagged(result, "Authorized")) {
         return finishAuthorized(request, result.token);
       }
-      return annotateMcpRequest(request, { token: null, parseBody: false }).pipe(
+      return annotateMcpRequest(request, {
+        token: null,
+        parseBody: false,
+      }).pipe(
         Effect.as(
           unauthorized(
             bearerChallengeFor(
@@ -202,7 +236,10 @@ export const cloudMcpAuthProviderLayer: Layer.Layer<
         Effect.result,
         Effect.flatMap((result) =>
           Result.isFailure(result)
-            ? annotateMcpRequest(request, { token: null, parseBody: false }).pipe(
+            ? annotateMcpRequest(request, {
+                token: null,
+                parseBody: false,
+              }).pipe(
                 Effect.flatMap(() =>
                   Effect.annotateCurrentSpan({
                     "mcp.auth.outcome": "system_error",

--- a/e2e/cloud/mcp-workos-blip-session-survival.test.ts
+++ b/e2e/cloud/mcp-workos-blip-session-survival.test.ts
@@ -1,22 +1,25 @@
-// Cloud: a TRANSIENT WorkOS outage during the per-request live-membership check
-// must NOT destroy a live MCP session. This is the churn-risk defect: every
-// /mcp request re-verifies org membership against WorkOS, and a WorkOS
-// 429/5xx/timeout used to be indistinguishable from a genuinely revoked
-// membership — it collapsed to Forbidden, and a Forbidden carrying a session id
-// schedules the session Durable Object for destruction (in-flight executions,
-// paused approvals, undelivered results — all gone). For a shared-API-key org a
-// single WorkOS blip could mass-condemn every session at once.
+// Cloud: how the per-request live-membership check classifies WorkOS failures,
+// pinned in BOTH directions at the real upstream (faults armed on the WorkOS
+// emulator's membership endpoint — the same emulator the product's real WorkOS
+// SDK talks to; no product code or stubs touched):
 //
-// The contract this pins: during the blip the request fails RETRYABLY (503),
-// the session is left intact, and once WorkOS recovers the SAME session id keeps
-// serving requests. We inject the outage at the real upstream by arming a fault
-// on the WorkOS emulator's membership endpoint (the same emulator the product's
-// real WorkOS SDK talks to) — no product code or stubs touched.
+// 1. A TRANSIENT WorkOS outage (5xx/timeout) must NOT destroy a live MCP
+//    session. This is the churn-risk defect: a WorkOS blip used to collapse to
+//    Forbidden, and a Forbidden carrying a session id schedules the session
+//    Durable Object for destruction (in-flight executions, paused approvals,
+//    undelivered results — all gone). For a shared-API-key org a single blip
+//    could mass-condemn every session at once. Contract: the blip request fails
+//    RETRYABLY (503 + Retry-After), and once WorkOS recovers the SAME session
+//    id keeps serving requests.
 //
-// Red/green: on the pre-fix code the outage request returns a session-destroying
-// Forbidden, so the post-outage request gets 404 "reconnect" (the session is
-// dead). With the fix the outage request is a 503 and the post-outage request is
-// a clean 200.
+// 2. A DEFINITIVE WorkOS denial (401 — the revoked/invalid API key answer) must
+//    fail CLOSED: Forbidden, session condemned. Retrying cannot help; treating
+//    it as transient would preserve sessions indefinitely for a revoked
+//    customer (the fail-open inversion the adversarial review caught).
+//
+// Red/green for (1): pre-fix, the outage request returns a session-destroying
+// Forbidden and the post-outage request gets 404 "reconnect". With the fix the
+// outage request is a 503 and the post-outage request is a clean 200.
 import { expect } from "@effect/vitest";
 import { Effect } from "effect";
 
@@ -116,6 +119,20 @@ const MEMBERSHIP_FAULT = {
   times: 8,
 } as const;
 
+// The definitive-denial counterpart: WorkOS ANSWERS the membership lookup with
+// 401 — the shape of a revoked/invalid API key. Not a blip; must fail closed.
+const MEMBERSHIP_DENIAL_FAULT = {
+  match: {
+    method: "GET",
+    pathPattern: "/user_management/organization_memberships*",
+  },
+  response: {
+    status: 401,
+    body: { message: "Could not authorize the request. Maybe your API key is invalid?" },
+  },
+  times: 8,
+} as const;
+
 scenario(
   "MCP sessions · a transient WorkOS outage 503s retryably and leaves the session alive",
   {},
@@ -181,5 +198,59 @@ scenario(
       "the session survived the blip and resumes work once WorkOS recovers",
     ).toBe(200);
     yield* Effect.promise(() => afterOutage.text());
+  }),
+);
+
+scenario(
+  "MCP sessions · a definitive WorkOS denial fails closed and condemns the session",
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const mcp = yield* Mcp;
+    const identity = yield* target.newIdentity();
+    const bearer = yield* mcp.mintBearer(emailOf(identity));
+
+    const workos = yield* Effect.promise(() =>
+      connectEmulator({ baseUrl: `http://127.0.0.1:${WORKOS_EMULATOR_PORT}` }),
+    );
+
+    // A healthy session doing real work before the denial.
+    const sessionId = yield* Effect.promise(() => openSession(target.mcpUrl, bearer));
+    const healthy = yield* Effect.promise(() =>
+      mcpPost(target.mcpUrl, { bearer, sessionId, body: toolsList(2) }),
+    );
+    expect(healthy.status, "the session serves requests before the denial").toBe(200);
+    yield* Effect.promise(() => healthy.text());
+
+    yield* Effect.gen(function* () {
+      // WorkOS starts ANSWERING the membership lookup with 401 — the
+      // revoked/invalid API key shape. Deterministic denial, not a blip.
+      yield* Effect.promise(() => workos.faults.arm(MEMBERSHIP_DENIAL_FAULT));
+
+      const denied = yield* Effect.promise(() =>
+        mcpPost(target.mcpUrl, { bearer, sessionId, body: toolsList(3) }),
+      );
+      const deniedBody = (yield* Effect.promise(() => denied.json())) as JsonRpcError;
+      expect(
+        denied.status,
+        "a definitive WorkOS denial fails closed as Forbidden, never a retryable 503",
+      ).toBe(403);
+      expect(deniedBody.error.code, "the denial is a JSON-RPC error envelope").toBe(-32001);
+    }).pipe(Effect.ensuring(Effect.promise(() => workos.faults.clear())));
+
+    // The Forbidden carried the session id, so the session was condemned: the
+    // id must NOT serve requests once WorkOS recovers. If this returned 200 the
+    // fail-closed contract is broken (a revoked customer kept a live session).
+    const afterDenial = yield* Effect.promise(() =>
+      mcpPost(target.mcpUrl, { bearer, sessionId, body: toolsList(4) }),
+    );
+    expect(
+      afterDenial.status,
+      "the condemned session id is dead after a definitive denial (reconnect required)",
+    ).toBe(404);
+    const afterBody = (yield* Effect.promise(() => afterDenial.json())) as JsonRpcError;
+    expect(afterBody.error.message, "the client is told to reconnect").toMatch(
+      /timed out|reconnect|not found/i,
+    );
   }),
 );

--- a/e2e/cloud/mcp-workos-blip-session-survival.test.ts
+++ b/e2e/cloud/mcp-workos-blip-session-survival.test.ts
@@ -1,0 +1,185 @@
+// Cloud: a TRANSIENT WorkOS outage during the per-request live-membership check
+// must NOT destroy a live MCP session. This is the churn-risk defect: every
+// /mcp request re-verifies org membership against WorkOS, and a WorkOS
+// 429/5xx/timeout used to be indistinguishable from a genuinely revoked
+// membership — it collapsed to Forbidden, and a Forbidden carrying a session id
+// schedules the session Durable Object for destruction (in-flight executions,
+// paused approvals, undelivered results — all gone). For a shared-API-key org a
+// single WorkOS blip could mass-condemn every session at once.
+//
+// The contract this pins: during the blip the request fails RETRYABLY (503),
+// the session is left intact, and once WorkOS recovers the SAME session id keeps
+// serving requests. We inject the outage at the real upstream by arming a fault
+// on the WorkOS emulator's membership endpoint (the same emulator the product's
+// real WorkOS SDK talks to) — no product code or stubs touched.
+//
+// Red/green: on the pre-fix code the outage request returns a session-destroying
+// Forbidden, so the post-outage request gets 404 "reconnect" (the session is
+// dead). With the fix the outage request is a 503 and the post-outage request is
+// a clean 200.
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+
+import { connectEmulator } from "@executor-js/emulate";
+
+import { scenario } from "../src/scenario";
+import { Mcp, Target } from "../src/services";
+import type { Identity } from "../src/target";
+import { WORKOS_EMULATOR_PORT } from "../targets/cloud";
+
+const JSON_AND_SSE = "application/json, text/event-stream";
+const PROTOCOL_VERSION = "2025-03-26";
+
+const INITIALIZE_REQUEST = {
+  jsonrpc: "2.0" as const,
+  id: 1,
+  method: "initialize",
+  params: {
+    protocolVersion: PROTOCOL_VERSION,
+    capabilities: {},
+    clientInfo: { name: "executor-e2e-workos-blip", version: "0.0.1" },
+  },
+};
+
+const INITIALIZED_NOTIFICATION = {
+  jsonrpc: "2.0" as const,
+  method: "notifications/initialized",
+};
+
+const toolsList = (id: number) => ({
+  jsonrpc: "2.0" as const,
+  id,
+  method: "tools/list",
+  params: {},
+});
+
+type JsonRpcError = {
+  readonly jsonrpc: string;
+  readonly error: { readonly code: number; readonly message: string };
+};
+
+const emailOf = (identity: Identity): string => identity.credentials?.email ?? identity.label;
+
+const mcpPost = (
+  url: string,
+  init: {
+    readonly bearer?: string;
+    readonly sessionId?: string;
+    readonly body: unknown;
+  },
+): Promise<Response> =>
+  fetch(url, {
+    method: "POST",
+    headers: {
+      accept: JSON_AND_SSE,
+      "content-type": "application/json",
+      ...(init.bearer ? { authorization: `Bearer ${init.bearer}` } : {}),
+      ...(init.sessionId ? { "mcp-session-id": init.sessionId } : {}),
+    },
+    body: JSON.stringify(init.body),
+  });
+
+/** initialize → session id → notifications/initialized. */
+const openSession = async (mcpUrl: string, bearer: string): Promise<string> => {
+  const initialize = await mcpPost(mcpUrl, {
+    bearer,
+    body: INITIALIZE_REQUEST,
+  });
+  const sessionId = initialize.headers.get("mcp-session-id");
+  await initialize.text();
+  if (initialize.status !== 200 || !sessionId) {
+    throw new Error(`openSession: initialize failed (${initialize.status})`);
+  }
+  const initialized = await mcpPost(mcpUrl, {
+    bearer,
+    sessionId,
+    body: INITIALIZED_NOTIFICATION,
+  });
+  await initialized.text();
+  if (initialized.status !== 202) {
+    throw new Error(`openSession: notifications/initialized failed (${initialized.status})`);
+  }
+  return sessionId;
+};
+
+// The live membership check is `GET /user_management/organization_memberships`
+// (WorkOS `listOrganizationMemberships`). A bounded count covers the outage
+// request without leaking into later (post-clear) requests; we also clear
+// explicitly. `times` is generous so any internal retry inside the one faulted
+// request still sees the outage, but the finalizer removes whatever remains.
+const MEMBERSHIP_FAULT = {
+  match: {
+    method: "GET",
+    pathPattern: "/user_management/organization_memberships*",
+  },
+  response: { status: 503, body: { error: "temporary upstream failure" } },
+  times: 8,
+} as const;
+
+scenario(
+  "MCP sessions · a transient WorkOS outage 503s retryably and leaves the session alive",
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const mcp = yield* Mcp;
+    const identity = yield* target.newIdentity();
+    const bearer = yield* mcp.mintBearer(emailOf(identity));
+
+    const workos = yield* Effect.promise(() =>
+      connectEmulator({ baseUrl: `http://127.0.0.1:${WORKOS_EMULATOR_PORT}` }),
+    );
+
+    // A healthy session doing real work before the outage.
+    const sessionId = yield* Effect.promise(() => openSession(target.mcpUrl, bearer));
+    const healthy = yield* Effect.promise(() =>
+      mcpPost(target.mcpUrl, { bearer, sessionId, body: toolsList(2) }),
+    );
+    expect(healthy.status, "the session serves requests before the blip").toBe(200);
+    yield* Effect.promise(() => healthy.text());
+
+    yield* Effect.gen(function* () {
+      // The blip: WorkOS membership lookups start failing with 503.
+      yield* Effect.promise(() => workos.faults.arm(MEMBERSHIP_FAULT));
+
+      // A request issued DURING the outage. The membership lookup fails
+      // transiently — this must be a retryable 503, NOT a Forbidden (which
+      // would condemn the session).
+      const duringOutage = yield* Effect.promise(() =>
+        mcpPost(target.mcpUrl, { bearer, sessionId, body: toolsList(3) }),
+      );
+      const outageBody = (yield* Effect.promise(() => duringOutage.json())) as JsonRpcError;
+      expect(
+        duringOutage.status,
+        "a WorkOS blip is a retryable 503, not a session-destroying error",
+      ).toBe(503);
+      expect(
+        duringOutage.status,
+        "the blip is NOT surfaced as a 404 reconnect (which would mean the session was destroyed)",
+      ).not.toBe(404);
+      expect(
+        outageBody.error.code,
+        "the 503 is a JSON-RPC error envelope the transport retries",
+      ).toBe(-32001);
+      expect(
+        duringOutage.headers.get("retry-after"),
+        "the 503 advertises a Retry-After so clients back off",
+      ).toEqual(expect.any(String));
+    }).pipe(
+      // Always lift the outage, even if an assertion above fails, so the
+      // recovery request runs against a healthy WorkOS.
+      Effect.ensuring(Effect.promise(() => workos.faults.clear())),
+    );
+
+    // WorkOS has recovered. The SAME session id must still serve requests: the
+    // blip left it untouched. On the pre-fix code this is a 404 (the outage
+    // request destroyed the DO); with the fix it is a clean 200.
+    const afterOutage = yield* Effect.promise(() =>
+      mcpPost(target.mcpUrl, { bearer, sessionId, body: toolsList(4) }),
+    );
+    expect(
+      afterOutage.status,
+      "the session survived the blip and resumes work once WorkOS recovers",
+    ).toBe(200);
+    yield* Effect.promise(() => afterOutage.text());
+  }),
+);

--- a/packages/hosts/mcp/src/envelope.ts
+++ b/packages/hosts/mcp/src/envelope.ts
@@ -87,10 +87,15 @@ export const jsonRpcErrorBody = (
   status: number,
   code: number,
   message: string,
-  opts?: { readonly cors?: boolean; readonly challenge?: string },
+  opts?: {
+    readonly cors?: boolean;
+    readonly challenge?: string;
+    readonly retryAfterSeconds?: number;
+  },
 ): Response => {
   const cors = opts?.cors ?? true;
   const challenge = opts?.challenge;
+  const retryAfterSeconds = opts?.retryAfterSeconds;
   return new Response(JSON.stringify({ jsonrpc: "2.0", error: { code, message }, id: null }), {
     status,
     headers: {
@@ -102,9 +107,17 @@ export const jsonRpcErrorBody = (
             "access-control-expose-headers": "WWW-Authenticate",
           }
         : {}),
+      ...(retryAfterSeconds === undefined ? {} : { "retry-after": String(retryAfterSeconds) }),
     },
   });
 };
+
+/**
+ * Advertised on transient-auth 503s (`Unavailable` outcomes) so clients back
+ * off before retrying. Short: upstream auth-infra blips (JWKS fetch, IdP
+ * membership lookups) are typically sub-second.
+ */
+export const UNAVAILABLE_RETRY_AFTER_SECONDS = 2;
 
 /** The envelope's own CORS-on JSON-RPC error `Response`, optionally carrying a challenge. */
 const jsonRpcResponse = (
@@ -147,7 +160,12 @@ const discoveryRoute = (handler: (request: Request) => Effect.Effect<Response>) 
  *   Unauthorized -> 401 + RFC 9728 challenge (outcome's own, else a default
  *                   built from the provider's `resourceMetadataUrl`)
  *   Forbidden    -> 403 JSON-RPC (default code -32001)
- *   Unavailable  -> 503 JSON-RPC -32001
+ *   Unavailable  -> 503 JSON-RPC -32001 + Retry-After
+ *
+ * The transient 503 and the session-lifecycle 404 both use JSON-RPC code
+ * -32001 (the shared "auth/session envelope error" code); clients discriminate
+ * on the HTTP status, which is the contract — 503 means retry the SAME
+ * session, 404 means the session id is dead and the client must reconnect.
  */
 const renderAuthError = (
   auth: McpAuthProvider["Service"],
@@ -164,7 +182,11 @@ const renderAuthError = (
       ),
     ),
     Match.tag("Forbidden", (f) => jsonRpcResponse(403, f.code ?? -32001, f.message)),
-    Match.tag("Unavailable", (u) => jsonRpcResponse(503, -32001, u.message)),
+    Match.tag("Unavailable", (u) =>
+      jsonRpcErrorBody(503, -32001, u.message, {
+        retryAfterSeconds: UNAVAILABLE_RETRY_AFTER_SECONDS,
+      }),
+    ),
     Match.exhaustive,
   );
 

--- a/packages/hosts/mcp/src/index.ts
+++ b/packages/hosts/mcp/src/index.ts
@@ -36,4 +36,9 @@ export {
   type McpResource,
 } from "./seams";
 
-export { McpServingRoutes, McpDiscoveryRoutes, jsonRpcErrorBody } from "./envelope";
+export {
+  McpServingRoutes,
+  McpDiscoveryRoutes,
+  jsonRpcErrorBody,
+  UNAVAILABLE_RETRY_AFTER_SECONDS,
+} from "./envelope";


### PR DESCRIPTION
The per-request membership check treated every WorkOS failure as a revoked membership, and a revoked-looking failure on a request carrying a session id destroys the session. A transient WorkOS 429/5xx/timeout therefore permanently destroyed live sessions, including all in-flight work — org-wide for teams sharing one identity. Transient failures now return a retryable 503 with the session preserved, while definitive denials (401/403/404) and confirmed absent memberships still fail closed and condemn the session. Covered by emulator fault-injection e2e scenarios in both directions.