### PR TITLE
Surface user-actionable tool errors to agents

### DIFF
--- a/packages/core/execution/src/tool-invoker.test.ts
+++ b/packages/core/execution/src/tool-invoker.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "@effect/vitest";
-import { Effect, Fiber, Schema } from "effect";
+import { Data, Effect, Fiber, Schema } from "effect";
 
 import {
   AuthTemplateSlug,
@@ -8,6 +8,7 @@ import {
   FormElicitation,
   IntegrationSlug,
   OAuthClientSlug,
+  OAuthRegisterDynamicError,
   ProviderItemId,
   ProviderKey,
   ToolName,
@@ -27,6 +28,7 @@ import {
 } from "@executor-js/sdk/testing";
 import { makeQuickJsExecutor } from "@executor-js/runtime-quickjs";
 import { createExecutionEngine } from "./engine";
+import { ExecutionToolError } from "./errors";
 import {
   describeTool,
   makeExecutorToolInvoker,
@@ -262,6 +264,43 @@ const errorPlugin = makeTestPlugin({
             message: 'Field with name "DisplayName" does not exist',
           }),
         ),
+    },
+  ],
+});
+
+class UnmarkedTestError extends Data.TaggedError("UnmarkedTestError")<{
+  readonly message: string;
+}> {}
+
+const userActionableErrorPlugin = makeTestPlugin({
+  pluginId: "user-actionable-error-test",
+  integration: "guided",
+  tools: [
+    {
+      name: "setup",
+      description: "Setup",
+      inputJsonSchema: EmptyInputJson,
+      validator: EmptyValidator,
+      handler: () =>
+        Effect.fail(
+          new OAuthRegisterDynamicError({
+            message: "Automatic OAuth setup failed: register an OAuth app manually.",
+          }),
+        ),
+    },
+  ],
+});
+
+const unmarkedErrorPlugin = makeTestPlugin({
+  pluginId: "unmarked-error-test",
+  integration: "unmarked",
+  tools: [
+    {
+      name: "explode",
+      description: "Explode",
+      inputJsonSchema: EmptyInputJson,
+      validator: EmptyValidator,
+      handler: () => Effect.fail(new UnmarkedTestError({ message: "internal detail" })),
     },
   ],
 });
@@ -948,6 +987,107 @@ describe("tool discovery", () => {
         },
       });
     }),
+  );
+
+  it.effect("returns user-actionable typed errors as ToolResult.fail", () =>
+    Effect.gen(function* () {
+      const executor = yield* makeExecutorWith([userActionableErrorPlugin] as const);
+      yield* provision(executor as never, [
+        { pluginId: "user-actionable-error-test", integration: "guided" },
+      ]);
+      const invoker = makeExecutorToolInvoker(executor, {
+        invokeOptions: { onElicitation: acceptAll },
+      });
+
+      const result = yield* invoker.invoke({ path: "guided.org.main.setup", args: {} });
+
+      expect(result).toEqual({
+        ok: false,
+        error: {
+          code: "oauth_register_dynamic_error",
+          message: "Automatic OAuth setup failed: register an OAuth app manually.",
+        },
+      });
+    }),
+  );
+
+  it.effect("keeps unmarked typed errors opaque", () =>
+    Effect.gen(function* () {
+      const executor = yield* makeExecutorWith([unmarkedErrorPlugin] as const);
+      yield* provision(executor as never, [
+        { pluginId: "unmarked-error-test", integration: "unmarked" },
+      ]);
+      const invoker = makeExecutorToolInvoker(executor, {
+        invokeOptions: { onElicitation: acceptAll },
+      });
+
+      const err = yield* Effect.flip(
+        invoker.invoke({ path: "unmarked.org.main.explode", args: {} }),
+      );
+      // oxlint-disable-next-line executor/no-unknown-error-message -- boundary: test inspects the rendered ExecutionToolError message to assert opaque redaction
+      const message = (err as ExecutionToolError).message;
+
+      expect(message).toMatch(/^Internal tool error \[[0-9a-f]{8}\]$/);
+      expect(message).not.toContain("internal detail");
+    }),
+  );
+
+  it.effect("surfaces DCR redirect guidance from the core registerDynamic tool", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const server = yield* serveOAuthTestServer({
+          scopes: ["read"],
+          approveRedirectUri: (uri) =>
+            uri.startsWith("http://localhost") || uri.startsWith("http://127."),
+        });
+        const executor = yield* createExecutor(
+          makeTestConfig({
+            plugins: [memoryCredentialsPlugin()] as const,
+            coreTools: {},
+          }),
+        );
+        const probe = yield* executor.oauth.probe({ url: server.mcpResourceUrl });
+        const invoker = makeExecutorToolInvoker(executor, {
+          invokeOptions: { onElicitation: acceptAll },
+        });
+        const nonLoopback = "https://app.example.com/api/oauth/callback";
+        const expectedMessage =
+          "Automatic OAuth setup failed: this server only approves loopback redirect " +
+          "URLs (http://localhost or http://127.0.0.1) for automatic registration, but " +
+          `Executor is using ${nonLoopback}. Register an OAuth app manually with that ` +
+          "redirect URL approved by the server, or run Executor on http://localhost.";
+
+        const result = yield* invoker.invoke({
+          path: "executor.coreTools.oauth.clients.registerDynamic",
+          args: {
+            owner: "org",
+            slug: "acme-dcr",
+            issuer: probe.issuer,
+            registrationEndpoint: probe.registrationEndpoint,
+            authorizationUrl: probe.authorizationUrl,
+            tokenUrl: probe.tokenUrl,
+            resource: probe.resource,
+            scopes: ["read"],
+            tokenEndpointAuthMethodsSupported: probe.tokenEndpointAuthMethodsSupported,
+            clientName: "Acme DCR",
+            redirectUri: nonLoopback,
+          },
+        });
+
+        expect(result).toEqual({
+          ok: false,
+          error: {
+            code: "oauth_register_dynamic_error",
+            message: expectedMessage,
+          },
+        });
+        const failure = result as {
+          readonly ok: false;
+          readonly error: { readonly message: string };
+        };
+        expect(failure.error.message).not.toContain("Internal tool error");
+      }),
+    ),
   );
 
   it.effect("returns OAuth reauth failures as ToolResult.fail instead of throwing", () =>

--- a/packages/core/execution/src/tool-invoker.ts
+++ b/packages/core/execution/src/tool-invoker.ts
@@ -11,6 +11,7 @@ import type {
 import {
   annotateToolResultOutcome,
   authToolFailure,
+  isUserActionableError,
   isToolResult,
   ToolResult,
   ToolAddress,
@@ -189,6 +190,12 @@ const credentialResolutionToolFailure = (input: {
   });
 
 const expectedToolFailure = (value: unknown): ToolError | null => {
+  if (isUserActionableError(value)) {
+    return {
+      code: value.code,
+      message: value.userMessage,
+    };
+  }
   if (Predicate.isTagged(value, "ToolNotFoundError") && "address" in value) {
     const suggestions =
       "suggestions" in value && Array.isArray(value.suggestions)
@@ -210,6 +217,12 @@ const expectedToolFailure = (value: unknown): ToolError | null => {
   }
   if (Predicate.isTagged(value, "ToolInvocationError")) {
     const cause = (value as { readonly cause?: unknown }).cause;
+    if (isUserActionableError(cause)) {
+      return {
+        code: cause.code,
+        message: cause.userMessage,
+      };
+    }
     const issues = validationIssues(cause);
     if (issues) {
       return {

--- a/packages/core/sdk/src/errors.ts
+++ b/packages/core/sdk/src/errors.ts
@@ -4,6 +4,24 @@ import { ElicitationDeclinedError } from "./elicitation";
 import type { StorageFailure } from "./fuma-runtime";
 import { ConnectionName, IntegrationSlug, Owner, ProviderKey, ToolAddress } from "./ids";
 
+export interface UserActionableError {
+  readonly __executorUserActionable: true;
+  readonly userMessage: string;
+  readonly code: string;
+}
+
+export const isUserActionableError = (value: unknown): value is UserActionableError =>
+  typeof value === "object" &&
+  value !== null &&
+  "__executorUserActionable" in value &&
+  value.__executorUserActionable === true &&
+  "userMessage" in value &&
+  typeof value.userMessage === "string" &&
+  value.userMessage.length > 0 &&
+  "code" in value &&
+  typeof value.code === "string" &&
+  value.code.length > 0;
+
 /* The failure set the SDK surfaces. `execute`'s invoke failures are ported from
  * v1 but re-keyed by `address` (the full `tools.<integration>.<owner>.<connection>.<tool>`
  * handle) instead of an opaque tool id. Storage failures reuse fuma-runtime's

--- a/packages/core/sdk/src/index.ts
+++ b/packages/core/sdk/src/index.ts
@@ -71,8 +71,10 @@ export {
   ConnectionNotFoundError,
   CredentialProviderNotRegisteredError,
   CredentialResolutionError,
+  isUserActionableError,
   type ExecuteError,
   type ExecutorError,
+  type UserActionableError,
 } from "./errors";
 
 // Integration / connection / tool domain contracts.

--- a/packages/core/sdk/src/oauth-client.ts
+++ b/packages/core/sdk/src/oauth-client.ts
@@ -2,6 +2,7 @@ import type { Effect } from "effect";
 import { Schema } from "effect";
 
 import type { Connection } from "./connection";
+import type { UserActionableError } from "./errors";
 import type { StorageFailure } from "./fuma-runtime";
 import {
   type AuthTemplateSlug,
@@ -188,27 +189,63 @@ export interface RegisterDynamicClientInput {
   readonly originIntegration?: IntegrationSlug | null;
 }
 
-export class OAuthStartError extends Schema.TaggedErrorClass<OAuthStartError>()("OAuthStartError", {
-  message: Schema.String,
-}) {}
+export class OAuthStartError
+  extends Schema.TaggedErrorClass<OAuthStartError>()("OAuthStartError", {
+    message: Schema.String,
+  })
+  implements UserActionableError
+{
+  readonly __executorUserActionable = true;
+  readonly code = "oauth_start_error";
 
-export class OAuthCompleteError extends Schema.TaggedErrorClass<OAuthCompleteError>()(
-  "OAuthCompleteError",
-  {
+  get userMessage(): string {
+    return this.message;
+  }
+}
+
+export class OAuthCompleteError
+  extends Schema.TaggedErrorClass<OAuthCompleteError>()("OAuthCompleteError", {
     message: Schema.String,
     /** True when the auth-code exchange failed in a way the user must restart. */
     restartRequired: Schema.optional(Schema.Boolean),
-  },
-) {}
+  })
+  implements UserActionableError
+{
+  readonly __executorUserActionable = true;
+  readonly code = "oauth_complete_error";
 
-export class OAuthProbeError extends Schema.TaggedErrorClass<OAuthProbeError>()("OAuthProbeError", {
-  message: Schema.String,
-}) {}
+  get userMessage(): string {
+    return this.message;
+  }
+}
 
-export class OAuthRegisterDynamicError extends Schema.TaggedErrorClass<OAuthRegisterDynamicError>()(
-  "OAuthRegisterDynamicError",
-  { message: Schema.String },
-) {}
+export class OAuthProbeError
+  extends Schema.TaggedErrorClass<OAuthProbeError>()("OAuthProbeError", {
+    message: Schema.String,
+  })
+  implements UserActionableError
+{
+  readonly __executorUserActionable = true;
+  readonly code = "oauth_probe_error";
+
+  get userMessage(): string {
+    return this.message;
+  }
+}
+
+export class OAuthRegisterDynamicError
+  extends Schema.TaggedErrorClass<OAuthRegisterDynamicError>()("OAuthRegisterDynamicError", {
+    message: Schema.String,
+  })
+  implements UserActionableError
+{
+  readonly __executorUserActionable = true;
+  readonly code = "oauth_register_dynamic_error";
+
+  get userMessage(): string {
+    return this.message;
+  }
+}
 
 export class OAuthSessionNotFoundError extends Schema.TaggedErrorClass<OAuthSessionNotFoundError>()(
   "OAuthSessionNotFoundError",

--- a/packages/core/sdk/src/shared.ts
+++ b/packages/core/sdk/src/shared.ts
@@ -62,8 +62,10 @@ export {
   InvalidConnectionInputError,
   CredentialProviderNotRegisteredError,
   CredentialResolutionError,
+  isUserActionableError,
   type ExecuteError,
   type ExecutorError,
+  type UserActionableError,
 } from "./errors";
 
 // Elicitation wire schemas.


### PR DESCRIPTION
Typed errors whose messages are written for the user (like the OAuth dynamic-registration guidance) were masked by the defect catch-all and reached agents as an opaque internal error with a correlation id. Errors can now opt into a user-actionable contract; the tool invoker surfaces their authored message and a stable code. Everything else keeps the opaque behavior.