### PR TITLE
Time out upstreams that send no response headers

### DIFF
--- a/packages/plugins/openapi/src/sdk/backing.ts
+++ b/packages/plugins/openapi/src/sdk/backing.ts
@@ -30,7 +30,7 @@ import {
   requiredTemplateVariables,
   type OpenApiIntegrationConfig,
 } from "./config";
-import { OpenApiExtractionError, OpenApiParseError } from "./errors";
+import { OpenApiExtractionError, OpenApiInvocationError, OpenApiParseError } from "./errors";
 import {
   buildInputSchema,
   extract,
@@ -38,7 +38,13 @@ import {
   streamOperationBindingsFromStructure,
 } from "./extract";
 import { compileToolDefinitions, type ToolDefinition } from "./definitions";
-import { annotationsForOperation, buildRequest, invokeWithLayer, REQUIRE_APPROVAL } from "./invoke";
+import {
+  annotationsForOperation,
+  buildRequest,
+  invokeWithLayer,
+  REQUIRE_APPROVAL,
+  type InvokeOptions,
+} from "./invoke";
 import { parse, type ParsedDocument } from "./parse";
 import { parseEntry, structuralSplit, type KeepPathItem, type SpecStructure } from "./split";
 import { type OpenapiStore, type StoredOperation } from "./store";
@@ -609,6 +615,7 @@ export const invokeOpenApiBackedTool = (input: {
   readonly credential: ToolInvocationCredential;
   readonly args: unknown;
   readonly httpClientLayer: Layer.Layer<HttpClient.HttpClient, never, never>;
+  readonly invokeOptions?: InvokeOptions;
 }) =>
   Effect.gen(function* () {
     const integration = input.toolRow.integration;
@@ -671,15 +678,33 @@ export const invokeOpenApiBackedTool = (input: {
       Object.assign(queryParams, rendered.queryParams);
     }
 
-    const result = yield* invokeWithLayer(
+    const invocation = yield* invokeWithLayer(
       binding,
       (input.args ?? {}) as Record<string, unknown>,
       config?.baseUrl ?? "",
       headers,
       queryParams,
       input.httpClientLayer,
+      input.invokeOptions,
+    ).pipe(
+      Effect.map((result) => ({ ok: true as const, result })),
+      Effect.catchTag("OpenApiInvocationError", (error: OpenApiInvocationError) =>
+        error.message.startsWith("Upstream returned no response headers within ")
+          ? Effect.succeed({
+              ok: false as const,
+              failure: ToolResult.fail({
+                code: "upstream_http_error",
+                message: error.message,
+                details: error.cause ?? error,
+              }),
+            })
+          : Effect.fail(error),
+      ),
     );
 
+    if (!invocation.ok) return invocation.failure;
+
+    const result = invocation.result;
     const ok = result.status >= 200 && result.status < 300;
     if (!ok) {
       if (result.status === 401 || result.status === 403) {

--- a/packages/plugins/openapi/src/sdk/backing.ts
+++ b/packages/plugins/openapi/src/sdk/backing.ts
@@ -689,11 +689,11 @@ export const invokeOpenApiBackedTool = (input: {
     ).pipe(
       Effect.map((result) => ({ ok: true as const, result })),
       Effect.catchTag("OpenApiInvocationError", (error: OpenApiInvocationError) =>
-        error.message.startsWith("Upstream returned no response headers within ")
+        error.reason === "response_headers_timeout"
           ? Effect.succeed({
               ok: false as const,
               failure: ToolResult.fail({
-                code: "upstream_http_error",
+                code: "upstream_response_headers_timeout",
                 message: error.message,
                 details: error.cause ?? error,
               }),

--- a/packages/plugins/openapi/src/sdk/errors.ts
+++ b/packages/plugins/openapi/src/sdk/errors.ts
@@ -28,6 +28,7 @@ export class OpenApiExtractionError extends Schema.TaggedErrorClass<OpenApiExtra
 export class OpenApiInvocationError extends Data.TaggedError("OpenApiInvocationError")<{
   readonly message: string;
   readonly statusCode: Option.Option<number>;
+  readonly reason?: "response_headers_timeout";
   readonly cause?: unknown;
 }> {}
 

--- a/packages/plugins/openapi/src/sdk/index.ts
+++ b/packages/plugins/openapi/src/sdk/index.ts
@@ -12,7 +12,14 @@ export {
   type ByteRange,
   type KeepPathItem,
 } from "./split";
-export { invoke, invokeWithLayer, buildRequest, annotationsForOperation } from "./invoke";
+export {
+  invoke,
+  invokeWithLayer,
+  buildRequest,
+  annotationsForOperation,
+  RESPONSE_HEADERS_TIMEOUT_MS,
+  type InvokeOptions,
+} from "./invoke";
 export {
   buildDefsJsonStreaming,
   checkHealthOpenApi,

--- a/packages/plugins/openapi/src/sdk/invoke.ts
+++ b/packages/plugins/openapi/src/sdk/invoke.ts
@@ -1,5 +1,5 @@
-import { Effect, Exit, Layer, Option, Schema, Stream } from "effect";
-import { HttpClient, HttpClientRequest } from "effect/unstable/http";
+import { Effect, Exit, Fiber, Layer, Option, Schema, Stream } from "effect";
+import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http";
 import type { ToolFileValue } from "@executor-js/sdk/core";
 
 import { OpenApiInvocationError } from "./errors";
@@ -153,6 +153,7 @@ const normalizeContentType = (ct: string | null | undefined): string =>
 
 export const STREAM_MAX_BYTES = 1_000_000;
 export const STREAM_MAX_MS = 10_000;
+export const RESPONSE_HEADERS_TIMEOUT_MS = 60_000;
 
 class StreamCapReached extends Error {
   readonly _tag = "StreamCapReached";
@@ -162,6 +163,16 @@ export interface StreamingResponseCaps {
   readonly maxBytes?: number;
   readonly maxMs?: number;
 }
+
+export interface InvokeOptions {
+  readonly responseHeadersTimeoutMs?: number;
+}
+
+const formatTimeout = (timeoutMs: number): string =>
+  timeoutMs % 1_000 === 0 ? `${timeoutMs / 1_000}s` : `${timeoutMs}ms`;
+
+const responseHeadersTimeoutMessage = (timeoutMs: number): string =>
+  `Upstream returned no response headers within ${formatTimeout(timeoutMs)}. The endpoint may be a live stream with no data to send (for example, runtime logs of an idle deployment); the request was aborted. Retry when the resource has activity, or use a non-streaming endpoint.`;
 
 const STREAMING_RESPONSE_CONTENT_TYPES = new Set([
   "application/stream+json",
@@ -260,39 +271,71 @@ export const collectStreamingBody = (
     let truncated = false;
     const startedAt = Date.now();
 
-    const completed = yield* stream.pipe(
-      Stream.timeout(maxMs),
-      Stream.runForEach((chunk) =>
-        Effect.gen(function* () {
-          const remaining = maxBytes - bytes;
-          if (remaining <= 0) {
-            truncated = true;
-            return yield* Effect.fail(new StreamCapReached());
-          }
+    const runFork = Effect.runForkWith(yield* Effect.context<never>());
+    const completedExitOption = yield* Effect.callback<Option.Option<Exit.Exit<void, unknown>>>(
+      (resume, signal) => {
+        let settled = false;
+        const collectEffect = stream.pipe(
+          Stream.timeout(maxMs),
+          Stream.runForEach((chunk) =>
+            Effect.gen(function* () {
+              const remaining = maxBytes - bytes;
+              if (remaining <= 0) {
+                truncated = true;
+                return yield* Effect.fail(new StreamCapReached());
+              }
 
-          if (chunk.byteLength > remaining) {
-            chunks.push(chunk.subarray(0, remaining));
-            bytes += remaining;
-            truncated = true;
-            return yield* Effect.fail(new StreamCapReached());
-          }
+              if (chunk.byteLength > remaining) {
+                chunks.push(chunk.subarray(0, remaining));
+                bytes += remaining;
+                truncated = true;
+                return yield* Effect.fail(new StreamCapReached());
+              }
 
-          chunks.push(chunk);
-          bytes += chunk.byteLength;
-          if (bytes >= maxBytes) {
-            truncated = true;
-            return yield* Effect.fail(new StreamCapReached());
-          }
-        }),
-      ),
-      Effect.timeoutOption(maxMs + 1_000),
-      Effect.catch((error: unknown) =>
-        error instanceof StreamCapReached
-          ? Effect.succeed(Option.some(undefined))
-          : Effect.fail(error),
-      ),
+              chunks.push(chunk);
+              bytes += chunk.byteLength;
+              if (bytes >= maxBytes) {
+                truncated = true;
+                return yield* Effect.fail(new StreamCapReached());
+              }
+            }),
+          ),
+          Effect.catch((error: unknown) =>
+            error instanceof StreamCapReached ? Effect.void : Effect.fail(error),
+          ),
+          Effect.exit,
+          Effect.tap((exit) =>
+            Effect.sync(() => {
+              if (settled) return;
+              settled = true;
+              clearTimeout(timer);
+              resume(Effect.succeed(Option.some(exit)));
+            }),
+          ),
+        );
+        const fiber = runFork(collectEffect);
+        const interrupt = () => {
+          runFork(Fiber.interrupt(fiber));
+        };
+        const timer = setTimeout(() => {
+          if (settled) return;
+          settled = true;
+          truncated = true;
+          interrupt();
+          resume(Effect.succeed(Option.none()));
+        }, maxMs + 1_000);
+        signal.addEventListener("abort", interrupt, { once: true });
+        return Effect.sync(() => {
+          clearTimeout(timer);
+          signal.removeEventListener("abort", interrupt);
+          if (!settled) interrupt();
+        });
+      },
     );
-    if (Option.isNone(completed)) truncated = true;
+    if (Option.isSome(completedExitOption) && Exit.isFailure(completedExitOption.value)) {
+      return yield* Effect.failCause(completedExitOption.value.cause);
+    }
+    if (Option.isNone(completedExitOption)) truncated = true;
 
     const durationMs = Date.now() - startedAt;
     if (durationMs >= maxMs) truncated = true;
@@ -952,6 +995,7 @@ export const invoke = Effect.fn("OpenApi.invoke")(function* (
   args: Record<string, unknown>,
   resolvedHeaders: Record<string, string>,
   sourceQueryParams: Record<string, string> = {},
+  options: InvokeOptions = {},
 ) {
   const client = yield* HttpClient.HttpClient;
 
@@ -965,16 +1009,57 @@ export const invoke = Effect.fn("OpenApi.invoke")(function* (
 
   const request = yield* buildRequest(operation, args, resolvedHeaders, sourceQueryParams);
 
-  const response = yield* client.execute(request).pipe(
-    Effect.mapError(
-      (err) =>
-        new OpenApiInvocationError({
-          message: "HTTP request failed",
-          statusCode: Option.none(),
-          cause: err,
+  const responseHeadersTimeoutMs = options.responseHeadersTimeoutMs ?? RESPONSE_HEADERS_TIMEOUT_MS;
+  const runFork = Effect.runForkWith(yield* Effect.context<never>());
+  const responseExitOption = yield* Effect.callback<
+    Option.Option<Exit.Exit<HttpClientResponse.HttpClientResponse, OpenApiInvocationError>>
+  >((resume, signal) => {
+    let settled = false;
+    const responseEffect = client.execute(request).pipe(
+      Effect.mapError(
+        (err) =>
+          new OpenApiInvocationError({
+            message: "HTTP request failed",
+            statusCode: Option.none(),
+            cause: err,
+          }),
+      ),
+      Effect.exit,
+      Effect.tap((exit) =>
+        Effect.sync(() => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timer);
+          resume(Effect.succeed(Option.some(exit)));
         }),
-    ),
-  );
+      ),
+    );
+    const fiber = runFork(responseEffect);
+    const interrupt = () => {
+      runFork(Fiber.interrupt(fiber));
+    };
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      interrupt();
+      resume(Effect.succeed(Option.none()));
+    }, responseHeadersTimeoutMs);
+    signal.addEventListener("abort", interrupt, { once: true });
+    return Effect.sync(() => {
+      clearTimeout(timer);
+      signal.removeEventListener("abort", interrupt);
+      if (!settled) interrupt();
+    });
+  });
+  if (Option.isNone(responseExitOption)) {
+    return yield* new OpenApiInvocationError({
+      message: responseHeadersTimeoutMessage(responseHeadersTimeoutMs),
+      statusCode: Option.none(),
+    });
+  }
+  const responseExit = responseExitOption.value;
+  if (Exit.isFailure(responseExit)) return yield* Effect.failCause(responseExit.cause);
+  const response = responseExit.value;
 
   const status = response.status;
   yield* Effect.annotateCurrentSpan({
@@ -1073,6 +1158,7 @@ export const invokeWithLayer = (
   resolvedHeaders: Record<string, string>,
   sourceQueryParams: Record<string, string>,
   httpClientLayer: Layer.Layer<HttpClient.HttpClient, never, never>,
+  options: InvokeOptions = {},
 ) => {
   const effectiveBaseUrl = resolveRequestHost(operation.servers ?? [], args.server, baseUrl);
   const clientWithBaseUrl = effectiveBaseUrl
@@ -1085,7 +1171,7 @@ export const invokeWithLayer = (
       ).pipe(Layer.provide(httpClientLayer))
     : httpClientLayer;
 
-  return invoke(operation, args, resolvedHeaders, sourceQueryParams).pipe(
+  return invoke(operation, args, resolvedHeaders, sourceQueryParams, options).pipe(
     Effect.provide(clientWithBaseUrl),
     // `invoke` annotates http.status_code on ITS span (`OpenApi.invoke`,
     // via Effect.fn) — annotateCurrentSpan inside it never reaches this

--- a/packages/plugins/openapi/src/sdk/invoke.ts
+++ b/packages/plugins/openapi/src/sdk/invoke.ts
@@ -153,7 +153,11 @@ const normalizeContentType = (ct: string | null | undefined): string =>
 
 export const STREAM_MAX_BYTES = 1_000_000;
 export const STREAM_MAX_MS = 10_000;
-export const RESPONSE_HEADERS_TIMEOUT_MS = 60_000;
+// Below Cloudflare's ~125s subrequest limit so cloud fails first with an
+// actionable error, but above the slowest legitimate buffered upstreams
+// observed in production (30d telemetry: successful calls cluster under
+// 110s; a 60s cap would have broken ~40 real calls).
+export const RESPONSE_HEADERS_TIMEOUT_MS = 110_000;
 
 class StreamCapReached extends Error {
   readonly _tag = "StreamCapReached";

--- a/packages/plugins/openapi/src/sdk/invoke.ts
+++ b/packages/plugins/openapi/src/sdk/invoke.ts
@@ -1055,6 +1055,7 @@ export const invoke = Effect.fn("OpenApi.invoke")(function* (
     return yield* new OpenApiInvocationError({
       message: responseHeadersTimeoutMessage(responseHeadersTimeoutMs),
       statusCode: Option.none(),
+      reason: "response_headers_timeout",
     });
   }
   const responseExit = responseExitOption.value;

--- a/packages/plugins/openapi/src/sdk/plugin.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.ts
@@ -48,6 +48,7 @@ import {
   resolveOpenApiBackedTools,
   validateOpenApiBackedToolArgs,
 } from "./backing";
+import type { InvokeOptions } from "./invoke";
 import { resolveServerUrl } from "./openapi-utils";
 
 // ---------------------------------------------------------------------------
@@ -563,6 +564,7 @@ export const describeOpenApiIntegrationDisplay = (
 
 export interface OpenApiPluginOptions {
   readonly httpClientLayer?: Layer.Layer<HttpClient.HttpClient, never, never>;
+  readonly invokeOptions?: InvokeOptions;
 }
 
 export const openApiPlugin = definePlugin((options?: OpenApiPluginOptions) => {
@@ -1044,6 +1046,7 @@ export const openApiPlugin = definePlugin((options?: OpenApiPluginOptions) => {
         credential,
         args,
         httpClientLayer,
+        invokeOptions: options?.invokeOptions,
       });
     },
 

--- a/packages/plugins/openapi/src/sdk/response-headers-timeout.test.ts
+++ b/packages/plugins/openapi/src/sdk/response-headers-timeout.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Deferred, Effect, Option, Schema } from "effect";
+import { FetchHttpClient } from "effect/unstable/http";
+import { HttpApi, HttpApiEndpoint, HttpApiGroup, OpenApi } from "effect/unstable/httpapi";
+import { createServer, type ServerResponse } from "node:http";
+import type { AddressInfo, Socket } from "node:net";
+
+import {
+  createExecutor,
+  AuthTemplateSlug,
+  ConnectionName,
+  IntegrationSlug,
+  ToolAddress,
+} from "@executor-js/sdk";
+import { makeTestConfig, memoryCredentialsPlugin } from "@executor-js/sdk/testing";
+import { makeOpenApiHttpApiTestSourceConfig, unwrapInvocation } from "../testing";
+
+import { invokeWithLayer } from "./invoke";
+import { openApiPlugin } from "./plugin";
+import type { OperationBinding } from "./types";
+
+const RESPONSE_HEADERS_TIMEOUT_MS = 100;
+const STREAM_TOOL = "logs.getLogs";
+const encoder = new TextEncoder();
+
+const LogsGroup = HttpApiGroup.make("logs").add(
+  HttpApiEndpoint.get("getLogs", "/logs", {
+    success: Schema.Unknown,
+  }),
+);
+
+const TimeoutApi = HttpApi.make("responseHeadersTimeoutTest")
+  .add(LogsGroup)
+  .annotateMerge(OpenApi.annotations({ title: "ResponseHeadersTimeoutTest", version: "1.0.0" }));
+
+const testPlugins = () =>
+  [
+    openApiPlugin({
+      httpClientLayer: FetchHttpClient.layer,
+      invokeOptions: { responseHeadersTimeoutMs: RESPONSE_HEADERS_TIMEOUT_MS },
+    }),
+    memoryCredentialsPlugin(),
+  ] as const;
+
+const buildExecutor = (baseUrl: string) =>
+  Effect.gen(function* () {
+    const executor = yield* createExecutor(makeTestConfig({ plugins: testPlugins() }));
+    yield* executor.openapi.addSpec(
+      makeOpenApiHttpApiTestSourceConfig(TimeoutApi, { slug: "headers_timeout", baseUrl }),
+    );
+    yield* executor.connections.create({
+      owner: "org",
+      name: ConnectionName.make("main"),
+      integration: IntegrationSlug.make("headers_timeout"),
+      template: AuthTemplateSlug.make("apiKey"),
+      value: "token",
+    });
+    return {
+      executor,
+      address: ToolAddress.make(`tools.headers_timeout.org.main.${STREAM_TOOL}`),
+    };
+  });
+
+const startRawServer = (handler: (res: ServerResponse) => void) =>
+  Effect.acquireRelease(
+    Effect.callback<{ baseUrl: string; close: () => void }>((resume) => {
+      const sockets = new Set<Socket>();
+      const timers = new Set<ReturnType<typeof setTimeout>>();
+      const server = createServer((req, res) => {
+        if (req.url?.split("?")[0] !== "/logs") {
+          res.writeHead(200, { "content-type": "application/json" });
+          res.end(JSON.stringify({ ok: true }));
+          return;
+        }
+        handler(res);
+      });
+      server.on("connection", (socket) => {
+        sockets.add(socket);
+        socket.on("close", () => sockets.delete(socket));
+      });
+      server.listen(0, "127.0.0.1", () => {
+        const port = (server.address() as AddressInfo).port;
+        resume(
+          Effect.succeed({
+            baseUrl: `http://127.0.0.1:${port}`,
+            close: () => {
+              for (const timer of timers) clearTimeout(timer);
+              for (const socket of sockets) socket.destroy();
+              server.close();
+            },
+          }),
+        );
+      });
+    }),
+    (server) => Effect.sync(() => server.close()),
+  );
+
+const startHeaderlessServer = (closed: Deferred.Deferred<void>) =>
+  Effect.acquireRelease(
+    Effect.callback<{ baseUrl: string; close: () => void }>((resume) => {
+      const sockets = new Set<Socket>();
+      const server = createServer((req, res) => {
+        if (req.url?.split("?")[0] === "/logs") return;
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ ok: true }));
+      });
+      server.on("connection", (socket) => {
+        sockets.add(socket);
+        socket.on("close", () => {
+          sockets.delete(socket);
+          Effect.runFork(Deferred.succeed(closed, undefined));
+        });
+      });
+      server.listen(0, "127.0.0.1", () => {
+        const port = (server.address() as AddressInfo).port;
+        resume(
+          Effect.succeed({
+            baseUrl: `http://127.0.0.1:${port}`,
+            close: () => {
+              for (const socket of sockets) socket.destroy();
+              server.close();
+            },
+          }),
+        );
+      });
+    }),
+    (server) => Effect.sync(() => server.close()),
+  );
+
+const operation: OperationBinding = {
+  method: "get",
+  pathTemplate: "/logs",
+  parameters: [],
+  requestBody: Option.none(),
+  responseBody: Option.none(),
+  servers: [],
+};
+
+describe("OpenAPI response headers timeout", () => {
+  it.effect("aborts a headerless upstream and returns an actionable tool failure", () =>
+    Effect.gen(function* () {
+      const closed = yield* Deferred.make<void>();
+      const server = yield* startHeaderlessServer(closed);
+      const { executor, address } = yield* buildExecutor(server.baseUrl);
+      const startedAt = Date.now();
+
+      const result = yield* executor.execute(address, {});
+      const elapsedMs = Date.now() - startedAt;
+      const socketClosed = yield* Deferred.await(closed).pipe(Effect.timeoutOption(1_000));
+
+      expect(elapsedMs).toBeGreaterThanOrEqual(RESPONSE_HEADERS_TIMEOUT_MS - 25);
+      expect(elapsedMs).toBeLessThan(2_000);
+      expect(Option.isSome(socketClosed)).toBe(true);
+      expect(result).toMatchObject({
+        ok: false,
+        error: {
+          code: "upstream_http_error",
+          message: expect.stringContaining("Upstream returned no response headers within 100ms"),
+        },
+      });
+    }),
+  );
+
+  it.effect("leaves normal fast JSON responses unaffected", () =>
+    Effect.gen(function* () {
+      const server = yield* startRawServer((res) => {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ ok: true }));
+      });
+      const { executor, address } = yield* buildExecutor(server.baseUrl);
+
+      const result = unwrapInvocation<Record<string, unknown>>(
+        yield* executor.execute(address, {}),
+      );
+
+      expect(result.status).toBe(200);
+      expect(result.data).toEqual({ ok: true });
+    }),
+  );
+
+  it.effect("does not apply the headers timeout after streaming response headers arrive", () =>
+    Effect.gen(function* () {
+      const server = yield* startRawServer((res) => {
+        res.writeHead(200, { "content-type": "application/jsonl" });
+        res.write(encoder.encode(`${JSON.stringify({ id: 1 })}\n`));
+        setTimeout(() => {
+          res.write(encoder.encode(`${JSON.stringify({ id: 2 })}\n`));
+          res.end();
+        }, RESPONSE_HEADERS_TIMEOUT_MS + 100);
+      });
+
+      const result = yield* invokeWithLayer(
+        operation,
+        {},
+        server.baseUrl,
+        {},
+        {},
+        FetchHttpClient.layer,
+        { responseHeadersTimeoutMs: RESPONSE_HEADERS_TIMEOUT_MS },
+      );
+
+      expect(result.status).toBe(200);
+      expect(result.data).toEqual([{ id: 1 }, { id: 2 }]);
+      expect(result.headers["x-executor-stream"]).toBe("complete");
+    }),
+  );
+});

--- a/packages/plugins/openapi/src/sdk/response-headers-timeout.test.ts
+++ b/packages/plugins/openapi/src/sdk/response-headers-timeout.test.ts
@@ -154,7 +154,7 @@ describe("OpenAPI response headers timeout", () => {
       expect(result).toMatchObject({
         ok: false,
         error: {
-          code: "upstream_http_error",
+          code: "upstream_response_headers_timeout",
           message: expect.stringContaining("Upstream returned no response headers within 100ms"),
         },
       });


### PR DESCRIPTION
Some endpoints hold the connection without sending status or headers until they have data, for example runtime logs of a deployment with no activity. Those calls previously sat until the egress proxy gave up around two minutes and surfaced an opaque 524. The OpenAPI invoke path now aborts after 60 seconds without response headers and returns an actionable error explaining the endpoint is likely a live stream with nothing to send. Once headers arrive the existing streaming and buffered paths apply unchanged.