### PR TITLE
Extend the plugin seam for virtual-tool plugins

### DIFF
--- a/packages/core/execution/src/tool-invoker.test.ts
+++ b/packages/core/execution/src/tool-invoker.test.ts
@@ -305,6 +305,27 @@ const unmarkedErrorPlugin = makeTestPlugin({
   ],
 });
 
+const bindingErrorPlugin = makeTestPlugin({
+  pluginId: "binding-error-test",
+  integration: "binding",
+  tools: [
+    {
+      name: "sync",
+      description: "Sync with a caller-selected connection",
+      inputJsonSchema: EmptyInputJson,
+      validator: EmptyValidator,
+      handler: () =>
+        Effect.fail({
+          _tag: "BindingError",
+          message: 'unknown connection "personal" for role "github" (github)',
+          role: "github",
+          integration: "github",
+          requestedConnection: "personal",
+        }),
+    },
+  ],
+});
+
 const oauthErrorPlugin = definePlugin(() => ({
   id: "oauth-error-test" as const,
   storage: () => ({}),
@@ -1209,6 +1230,33 @@ describe("tool discovery", () => {
               expect.objectContaining({ path: ["owner"], message: "Missing key" }),
               expect.objectContaining({ path: ["repo"], message: "Missing key" }),
             ]),
+          },
+        },
+      });
+    }),
+  );
+
+  it.effect("returns binding errors as ToolResult.fail", () =>
+    Effect.gen(function* () {
+      const executor = yield* makeExecutorWith([bindingErrorPlugin] as const);
+      yield* provision(executor as never, [
+        { pluginId: "binding-error-test", integration: "binding" },
+      ]);
+      const invoker = makeExecutorToolInvoker(executor, {
+        invokeOptions: { onElicitation: acceptAll },
+      });
+
+      const result = yield* invoker.invoke({ path: "binding.org.main.sync", args: {} });
+
+      expect(result).toEqual({
+        ok: false,
+        error: {
+          code: "binding_error",
+          message: 'unknown connection "personal" for role "github" (github)',
+          details: {
+            role: "github",
+            integration: "github",
+            requestedConnection: "personal",
           },
         },
       });

--- a/packages/core/execution/src/tool-invoker.ts
+++ b/packages/core/execution/src/tool-invoker.ts
@@ -189,6 +189,28 @@ const credentialResolutionToolFailure = (input: {
     },
   });
 
+const bindingToolFailure = (value: unknown): ToolError | null => {
+  if (!Predicate.isTagged(value, "BindingError")) return null;
+  const maybeBinding = value as {
+    readonly message?: unknown;
+    readonly role?: unknown;
+    readonly integration?: unknown;
+    readonly requestedConnection?: unknown;
+  };
+  const details: Record<string, string> = {};
+  if (typeof maybeBinding.role === "string") details.role = maybeBinding.role;
+  if (typeof maybeBinding.integration === "string") details.integration = maybeBinding.integration;
+  if (typeof maybeBinding.requestedConnection === "string") {
+    details.requestedConnection = maybeBinding.requestedConnection;
+  }
+  return {
+    code: "binding_error",
+    message:
+      typeof maybeBinding.message === "string" ? maybeBinding.message : "Tool binding failed.",
+    ...(Object.keys(details).length > 0 ? { details } : {}),
+  };
+};
+
 const expectedToolFailure = (value: unknown): ToolError | null => {
   if (isUserActionableError(value)) {
     return {
@@ -223,6 +245,8 @@ const expectedToolFailure = (value: unknown): ToolError | null => {
         message: cause.userMessage,
       };
     }
+    const binding = bindingToolFailure(cause);
+    if (binding) return binding;
     const issues = validationIssues(cause);
     if (issues) {
       return {

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -1944,6 +1944,19 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
           if (!existing.can_remove) {
             return yield* new IntegrationRemovalNotAllowedError({ slug });
           }
+          const runtime = runtimes.get(existing.plugin_id);
+          if (runtime?.plugin.removeIntegration) {
+            yield* runtime.plugin
+              .removeIntegration({
+                ctx: runtime.ctx,
+                integration: rowToIntegrationRecord(existing, describeAuthMethodsForRow(existing)),
+              })
+              .pipe(
+                Effect.mapError((cause) =>
+                  pluginStorageFailure(existing.plugin_id, "removeIntegration", cause),
+                ),
+              );
+          }
           // Drop owned connections / tools / definitions for this integration.
           const where = (b: AnyCb) => b("integration", "=", String(slug));
           yield* core.deleteMany("tool", { where });
@@ -2121,6 +2134,7 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
 
         const result: ResolveToolsResult = yield* runtime.plugin
           .resolveTools({
+            ctx: runtime.ctx,
             integration: rowToIntegration(integrationRow),
             config: decodeJsonColumn(integrationRow.config),
             httpClientLayer: runtime.ctx.httpClientLayer,
@@ -3212,6 +3226,30 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
         );
         if (effective.action === "block") return null;
 
+        const runtime = runtimes.get(row.plugin_id);
+        const projected = runtime?.plugin.projectToolSchema
+          ? yield* runtime.plugin
+              .projectToolSchema({
+                ctx: runtime.ctx,
+                toolRow: row,
+                inputSchema: tool.inputSchema,
+                outputSchema: tool.outputSchema,
+              })
+              .pipe(
+                Effect.mapError((cause) =>
+                  pluginStorageFailure(row.plugin_id, "projectToolSchema", cause),
+                ),
+              )
+          : null;
+        const inputSchema =
+          projected && Object.prototype.hasOwnProperty.call(projected, "inputSchema")
+            ? projected.inputSchema
+            : tool.inputSchema;
+        const outputSchema =
+          projected && Object.prototype.hasOwnProperty.call(projected, "outputSchema")
+            ? projected.outputSchema
+            : tool.outputSchema;
+
         const definitionRows = yield* core.findMany("definition", {
           where: (b: AnyCb) =>
             b.and(
@@ -3223,15 +3261,12 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
         const defs = new Map<string, unknown>();
         for (const def of definitionRows) defs.set(def.name, decodeJsonColumn(def.schema));
 
-        const referenced = collectReferencedDefinitions(
-          [tool.inputSchema, tool.outputSchema],
-          defs,
-        );
+        const referenced = collectReferencedDefinitions([inputSchema, outputSchema], defs);
         const preview = yield* Effect.tryPromise({
           try: () =>
             buildToolTypeScriptPreview({
-              inputSchema: tool.inputSchema,
-              outputSchema: tool.outputSchema,
+              inputSchema,
+              outputSchema,
               defs,
             }),
           catch: (cause) =>
@@ -3243,8 +3278,8 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
           address,
           name: tool.name,
           description: tool.description,
-          inputSchema: tool.inputSchema,
-          outputSchema: tool.outputSchema,
+          inputSchema,
+          outputSchema,
           schemaDefinitions:
             Object.keys(referenced).length > 0
               ? (referenced as Record<string, unknown>)
@@ -3269,6 +3304,53 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
         const provider = credentialProviders.get(String(key));
         if (!provider || !provider.list) return [];
         return yield* provider.list();
+      });
+
+    const providersGet = (
+      key: ProviderKey,
+      id: ProviderItemId,
+    ): Effect.Effect<string | null, StorageFailure> =>
+      Effect.gen(function* () {
+        const provider = credentialProviders.get(String(key));
+        if (!provider) return null;
+        return yield* provider.get(id);
+      });
+
+    const providersHas = (
+      key: ProviderKey,
+      id: ProviderItemId,
+    ): Effect.Effect<boolean, StorageFailure> =>
+      Effect.gen(function* () {
+        const provider = credentialProviders.get(String(key));
+        if (!provider) return false;
+        if (provider.has) return yield* provider.has(id);
+        const value = yield* provider.get(id);
+        return value !== null;
+      });
+
+    const providersSetDefault = (
+      id: ProviderItemId,
+      value: string,
+    ): Effect.Effect<ProviderKey, CredentialProviderNotRegisteredError | StorageFailure> =>
+      Effect.gen(function* () {
+        const provider = defaultWritableProvider();
+        if (!provider || !provider.set) {
+          return yield* new CredentialProviderNotRegisteredError({
+            provider: ProviderKey.make("default"),
+          });
+        }
+        yield* provider.set(id, value);
+        return provider.key;
+      });
+
+    const providersRemove = (
+      key: ProviderKey,
+      id: ProviderItemId,
+    ): Effect.Effect<void, StorageFailure> =>
+      Effect.gen(function* () {
+        const provider = credentialProviders.get(String(key));
+        if (!provider || !provider.delete) return;
+        yield* provider.delete(id);
       });
 
     // ------------------------------------------------------------------
@@ -3700,6 +3782,7 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
             credential,
             args,
             elicit: buildElicit(address, args, handler),
+            invokeOptions: options,
           }),
         );
       }).pipe(
@@ -3854,8 +3937,13 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
         providers: {
           list: () => providersList(),
           items: (key) => providersItems(key),
+          get: (key, id) => providersGet(key, id),
+          has: (key, id) => providersHas(key, id),
+          setDefault: (id, value) => providersSetDefault(id, value),
+          remove: (key, id) => providersRemove(key, id),
         },
         oauth,
+        execute: (address, args, options) => execute(address, args, options),
         transaction: <A, E>(effect: Effect.Effect<A, E>) => transaction(effect),
       };
 

--- a/packages/core/sdk/src/plugin.ts
+++ b/packages/core/sdk/src/plugin.ts
@@ -26,9 +26,11 @@ import type {
   ConnectionName,
   IntegrationSlug,
   Owner,
+  ProviderItemId,
   ProviderKey,
   Subject,
   Tenant,
+  ToolAddress,
 } from "./ids";
 import type { IntegrationDetectionResult } from "./types";
 import type {
@@ -36,8 +38,10 @@ import type {
   ElicitationHandler,
   ElicitationRequest,
   ElicitationResponse,
+  InvokeOptions,
 } from "./elicitation";
 import type {
+  ExecuteError,
   ConnectionNotFoundError,
   CredentialProviderNotRegisteredError,
   IntegrationNotFoundError,
@@ -244,10 +248,40 @@ export interface PluginCtx<TStore = unknown> {
     readonly items: (
       provider: ProviderKey,
     ) => Effect.Effect<readonly ProviderEntry[], StorageFailure>;
+    /** Read an opaque item from a provider. Plugins use this for secret values
+     *  they own that are not modeled as connections. */
+    readonly get: (
+      provider: ProviderKey,
+      id: ProviderItemId,
+    ) => Effect.Effect<string | null, StorageFailure>;
+    readonly has: (
+      provider: ProviderKey,
+      id: ProviderItemId,
+    ) => Effect.Effect<boolean, StorageFailure>;
+    /** Write through the executor's default writable provider and return the
+     *  provider key that owns the item. */
+    readonly setDefault: (
+      id: ProviderItemId,
+      value: string,
+    ) => Effect.Effect<ProviderKey, CredentialProviderNotRegisteredError | StorageFailure>;
+    readonly remove: (
+      provider: ProviderKey,
+      id: ProviderItemId,
+    ) => Effect.Effect<void, StorageFailure>;
   };
 
   /** Shared OAuth service. */
   readonly oauth: OAuthService;
+
+  /** Invoke another catalog tool through the same executor request context:
+   *  policy, approval, credential resolution, and plugin dispatch all stay in
+   *  the core path. Intended for plugin sandboxes that expose higher-level
+   *  virtual tools over existing integration tools. */
+  readonly execute: (
+    address: ToolAddress,
+    args: unknown,
+    options?: InvokeOptions,
+  ) => Effect.Effect<unknown, ExecuteError>;
 
   /** Run `effect` inside a FumaDB transaction (atomic across plugin storage +
    *  core integration/tool writes). */
@@ -261,6 +295,7 @@ export interface PluginCtx<TStore = unknown> {
 // ---------------------------------------------------------------------------
 
 export interface ResolveToolsInput<TStore = unknown> {
+  readonly ctx?: PluginCtx<TStore>;
   /** The catalog record (public projection) whose connection is being resolved. */
   readonly integration: Integration;
   /** The plugin's stored opaque config for that integration. */
@@ -300,6 +335,18 @@ export interface ResolveToolsResult {
   /** Human-readable reason for an incomplete listing. Persisted by core when it
    *  preserves the prior catalog so operators can see why data is stale. */
   readonly incompleteReason?: string;
+}
+
+export interface ProjectToolSchemaInput<TStore = unknown> {
+  readonly ctx: PluginCtx<TStore>;
+  readonly toolRow: ToolInvocationRow;
+  readonly inputSchema?: unknown;
+  readonly outputSchema?: unknown;
+}
+
+export interface ProjectToolSchemaResult {
+  readonly inputSchema?: unknown;
+  readonly outputSchema?: unknown;
 }
 
 // ---------------------------------------------------------------------------
@@ -457,6 +504,8 @@ export interface InvokeToolInput<TStore = unknown> {
   readonly credential: ToolInvocationCredential;
   readonly args: unknown;
   readonly elicit: Elicit;
+  /** Original caller options for nested same-request tool calls. */
+  readonly invokeOptions?: InvokeOptions;
 }
 
 /** Input for `validateToolArgs` — no credential/elicit: validation runs
@@ -475,6 +524,11 @@ export interface ConnectionLifecycleInput<TStore = unknown> {
   readonly ctx: PluginCtx<TStore>;
   readonly integration: IntegrationSlug;
   readonly connection: ConnectionRef;
+}
+
+export interface IntegrationLifecycleInput<TStore = unknown> {
+  readonly ctx: PluginCtx<TStore>;
+  readonly integration: IntegrationRecord;
 }
 
 export interface ConfigureIntegrationHandlerInput<TStore = unknown> {
@@ -615,6 +669,13 @@ export interface PluginSpec<
    *  for catalogs derived purely from stored state (specs, static config). */
   readonly remoteToolCatalog?: boolean;
 
+  /** Project a persisted tool row's stable schemas into the request-visible
+   *  schema view. Use this only for volatile presentation data that should be
+   *  current at read time, not persisted at catalog-refresh time. */
+  readonly projectToolSchema?: (
+    input: ProjectToolSchemaInput<TStore>,
+  ) => Effect.Effect<ProjectToolSchemaResult, unknown>;
+
   /** Invoke a dynamic tool. Called when the static-handler map doesn't have the
    *  address. The plugin applies `input.credential` to the outbound request. */
   readonly invokeTool?: (input: InvokeToolInput<TStore>) => Effect.Effect<unknown, unknown>;
@@ -640,6 +701,12 @@ export interface PluginSpec<
   /** Plugin-side cleanup when a connection is removed. */
   readonly removeConnection?: (
     input: ConnectionLifecycleInput<TStore>,
+  ) => Effect.Effect<void, unknown>;
+
+  /** Plugin-side cleanup when a removable integration is removed. Core still
+   *  owns deleting the integration, connection, tool, and definition rows. */
+  readonly removeIntegration?: (
+    input: IntegrationLifecycleInput<TStore>,
   ) => Effect.Effect<void, unknown>;
 
   /** Core-dispatched integration configuration (beyond auth). */


### PR DESCRIPTION
Plugins that publish higher-level tools over existing integrations (custom tools, upcoming apps work) need a few things the plugin seam did not offer: invoking another catalog tool inside the same request context via ctx.execute, opaque provider-item storage, a schema projection hook, and an integration-removal hook.

Binding failures now surface as a binding_error tool result naming the role and integration instead of an opaque internal error.

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. **#1361** 👈 current
2. #1362
3. #1363
4. #1365
<!-- stack:links:end -->