### PR TITLE
Apps engine: custom tool authoring, publish pipeline, and catalog plugin

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -772,6 +772,23 @@
         "effect": "catalog:",
       },
     },
+    "packages/plugins/apps": {
+      "name": "@executor-js/plugin-apps",
+      "version": "0.1.0",
+      "dependencies": {
+        "@executor-js/sdk": "workspace:*",
+        "esbuild": "^0.27.3",
+        "zod": "4.3.6",
+      },
+      "devDependencies": {
+        "@effect/vitest": "catalog:",
+        "@types/node": "catalog:",
+        "bun-types": "catalog:",
+        "effect": "catalog:",
+        "tsup": "catalog:",
+        "vitest": "catalog:",
+      },
+    },
     "packages/plugins/desktop-settings": {
       "name": "@executor-js/plugin-desktop-settings",
       "version": "1.5.29",
@@ -1709,6 +1726,8 @@
     "@executor-js/mcporter": ["@executor-js/mcporter@0.11.4", "", { "dependencies": { "@iarna/toml": "^2.2.5", "@modelcontextprotocol/sdk": "^1.29.0", "acorn": "^8.16.0", "commander": "^14.0.3", "es-toolkit": "^1.47.0", "jsonc-parser": "^3.3.1", "ora": "^9.4.0", "rolldown": "1.0.1", "zod": "^4.3.6" }, "bin": { "mcporter": "dist/cli.js" } }, "sha512-KewlNnqmzSkJAH7JS/2le9WxPWzL/ND7Pt/G5KGgfrSK9K9cE8UPIsEYZYZUJYoFnbCBzhlU9ugg59ptv1h3Ow=="],
 
     "@executor-js/motel": ["@executor-js/motel@0.2.5-executor.1", "", { "dependencies": { "@effect/atom-react": "^4.0.0-beta.49", "@effect/opentelemetry": "^4.0.0-beta.49", "@effect/platform-bun": "^4.0.0-beta.50", "@opentelemetry/api": "^1.9.0", "@opentelemetry/exporter-logs-otlp-http": "^0.214.0", "@opentelemetry/exporter-trace-otlp-http": "^0.211.0", "@opentelemetry/sdk-logs": "^0.214.0", "@opentelemetry/sdk-node": "^0.214.0", "@opentelemetry/sdk-trace-base": "^2.5.0", "@opentelemetry/sdk-trace-node": "^2.6.1", "@opentui/core": "^0.1.99", "@opentui/react": "^0.1.99", "effect": "^4.0.0-beta.49", "react": "^19.2.5", "scheduler": "^0.27.0" }, "bin": { "motel": "src/motel.ts", "motel-mcp": "src/mcp.ts" } }, "sha512-fLGJ5FIIBYd+4L2OurpYFjWzvcCbACvmdNofh6THXQJE1Gku93EKURtgn27/XddyM9SKGST6/znTRcmwKiYdXw=="],
+
+    "@executor-js/plugin-apps": ["@executor-js/plugin-apps@workspace:packages/plugins/apps"],
 
     "@executor-js/plugin-desktop-settings": ["@executor-js/plugin-desktop-settings@workspace:packages/plugins/desktop-settings"],
 

--- a/packages/plugins/apps/CHANGELOG.md
+++ b/packages/plugins/apps/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @executor-js/plugin-apps

--- a/packages/plugins/apps/package.json
+++ b/packages/plugins/apps/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@executor-js/plugin-apps",
+  "version": "0.1.0",
+  "homepage": "https://github.com/UsefulSoftwareCo/executor/tree/main/packages/plugins/apps",
+  "bugs": {
+    "url": "https://github.com/UsefulSoftwareCo/executor/issues"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/UsefulSoftwareCo/executor.git",
+    "directory": "packages/plugins/apps"
+  },
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./api": "./src/api.ts",
+    "./authoring": "./src/authoring.ts",
+    "./testing": "./src/testing/index.ts"
+  },
+  "scripts": {
+    "build": "tsup && (tsc --declaration --emitDeclarationOnly --outDir dist --rootDir src || true)",
+    "typecheck": "tsgo --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck:slow": "bunx tsc --noEmit -p tsconfig.json"
+  },
+  "dependencies": {
+    "@executor-js/sdk": "workspace:*",
+    "esbuild": "^0.27.3",
+    "zod": "4.3.6"
+  },
+  "devDependencies": {
+    "@effect/vitest": "catalog:",
+    "@types/node": "catalog:",
+    "bun-types": "catalog:",
+    "effect": "catalog:",
+    "tsup": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/plugins/apps/src/api.ts
+++ b/packages/plugins/apps/src/api.ts
@@ -1,0 +1,3 @@
+export type { PublishInput, PublishResult } from "./pipeline/publish";
+export { publish } from "./pipeline/publish";
+export { makeAppsPlugin, appsPlugin } from "./plugin/apps-plugin";

--- a/packages/plugins/apps/src/authoring.test.ts
+++ b/packages/plugins/apps/src/authoring.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import { integration } from "./authoring";
+
+describe("authoring integration builder", () => {
+  it("returns immutable fluent declarations", () => {
+    const base = integration("gmail");
+    const many = base.array().describe("Inbox accounts");
+    const all = many.all();
+
+    expect(Object.isFrozen(base)).toBe(true);
+    expect(Object.isFrozen(many)).toBe(true);
+    expect(base).toMatchObject({
+      kind: "integration",
+      slug: "gmail",
+      mode: "one",
+      allConnections: false,
+    });
+    expect(many).toMatchObject({
+      kind: "integration",
+      slug: "gmail",
+      mode: "many",
+      allConnections: false,
+      description: "Inbox accounts",
+    });
+    expect(all).toMatchObject({
+      kind: "integration",
+      slug: "gmail",
+      mode: "many",
+      allConnections: true,
+      description: "Inbox accounts",
+    });
+    expect(base).not.toBe(many);
+    expect(many).not.toBe(all);
+  });
+});

--- a/packages/plugins/apps/src/authoring.test.ts
+++ b/packages/plugins/apps/src/authoring.test.ts
@@ -6,7 +6,6 @@ describe("authoring integration builder", () => {
   it("returns immutable fluent declarations", () => {
     const base = integration("gmail");
     const many = base.array().describe("Inbox accounts");
-    const all = many.all();
 
     expect(Object.isFrozen(base)).toBe(true);
     expect(Object.isFrozen(many)).toBe(true);
@@ -14,23 +13,13 @@ describe("authoring integration builder", () => {
       kind: "integration",
       slug: "gmail",
       mode: "one",
-      allConnections: false,
     });
     expect(many).toMatchObject({
       kind: "integration",
       slug: "gmail",
       mode: "many",
-      allConnections: false,
-      description: "Inbox accounts",
-    });
-    expect(all).toMatchObject({
-      kind: "integration",
-      slug: "gmail",
-      mode: "many",
-      allConnections: true,
       description: "Inbox accounts",
     });
     expect(base).not.toBe(many);
-    expect(many).not.toBe(all);
   });
 });

--- a/packages/plugins/apps/src/authoring.ts
+++ b/packages/plugins/apps/src/authoring.ts
@@ -1,0 +1,82 @@
+import { z } from "zod";
+
+import type { StandardSchemaV1 } from "./standard-schema";
+
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue = JsonPrimitive | JsonObject | readonly JsonValue[];
+export interface JsonObject {
+  readonly [key: string]: JsonValue;
+}
+
+export type ToolSchema<TOutput = unknown> = StandardSchemaV1<unknown, TOutput> | JsonObject;
+
+export type AppIntegrationClient = {
+  readonly [key: string]: AppIntegrationClient;
+} & ((...args: readonly unknown[]) => Promise<unknown>);
+
+export const EXECUTOR_INTEGRATION_META = "~executor";
+
+export interface IntegrationMarker<Slug extends string = string> {
+  readonly kind: "integration";
+  readonly slug: Slug;
+}
+
+export type IntegrationSchema<Slug extends string = string> = z.ZodType<AppIntegrationClient> & {
+  readonly [EXECUTOR_INTEGRATION_META]?: IntegrationMarker<Slug>;
+};
+
+type InferToolInput<TSchema> = TSchema extends StandardSchemaV1
+  ? StandardSchemaV1.InferOutput<TSchema>
+  : unknown;
+
+type InferToolOutput<TSchema> = TSchema extends StandardSchemaV1
+  ? StandardSchemaV1.InferOutput<TSchema>
+  : unknown;
+
+export interface DefineToolOptions<
+  TInputSchema extends ToolSchema,
+  TOutputSchema extends ToolSchema | undefined = undefined,
+> {
+  readonly description: string;
+  readonly input: TInputSchema;
+  readonly output?: TOutputSchema;
+  readonly annotations?: {
+    readonly readOnly?: boolean;
+    readonly destructive?: boolean;
+    readonly requiresApproval?: boolean;
+  };
+  readonly handler: (
+    input: InferToolInput<TInputSchema>,
+    context: Record<string, never>,
+  ) =>
+    | Promise<TOutputSchema extends ToolSchema ? InferToolOutput<TOutputSchema> : unknown>
+    | (TOutputSchema extends ToolSchema ? InferToolOutput<TOutputSchema> : unknown);
+}
+
+export interface DefinedTool<
+  TInputSchema extends ToolSchema = ToolSchema,
+  TOutputSchema extends ToolSchema | undefined = ToolSchema | undefined,
+> extends DefineToolOptions<TInputSchema, TOutputSchema> {
+  readonly "~executorAppTool": true;
+}
+
+export const integration = <Slug extends string>(slug: Slug): IntegrationSchema<Slug> => {
+  const schema = z.custom<AppIntegrationClient>().meta({
+    [EXECUTOR_INTEGRATION_META]: { kind: "integration", slug },
+  }) as IntegrationSchema<Slug>;
+  Object.defineProperty(schema, EXECUTOR_INTEGRATION_META, {
+    value: { kind: "integration", slug },
+    enumerable: false,
+  });
+  return schema;
+};
+
+export const defineTool = <
+  TInputSchema extends ToolSchema,
+  TOutputSchema extends ToolSchema | undefined = undefined,
+>(
+  definition: DefineToolOptions<TInputSchema, TOutputSchema>,
+): DefinedTool<TInputSchema, TOutputSchema> => ({
+  ...definition,
+  "~executorAppTool": true,
+});

--- a/packages/plugins/apps/src/authoring.ts
+++ b/packages/plugins/apps/src/authoring.ts
@@ -21,6 +21,11 @@ export interface IntegrationDeclaration<Slug extends string = string> {
   readonly allConnections: boolean;
   readonly description?: string;
   readonly array: () => IntegrationDeclaration<Slug>;
+  /**
+   * Bind every visible connection for this integration. This does not project a caller field:
+   * optional fields are suggestions, and model callers under-fill them. Tools that search
+   * everything must not expose a connections parameter.
+   */
   readonly all: () => IntegrationDeclaration<Slug>;
   readonly describe: (text: string) => IntegrationDeclaration<Slug>;
 }

--- a/packages/plugins/apps/src/authoring.ts
+++ b/packages/plugins/apps/src/authoring.ts
@@ -14,18 +14,21 @@ export type AppIntegrationClient = {
 
 export type IntegrationMode = "one" | "many";
 
-export interface IntegrationDeclaration<Slug extends string = string> {
+export interface IntegrationDeclaration<
+  Slug extends string = string,
+  Mode extends IntegrationMode = IntegrationMode,
+> {
   readonly kind: "integration";
   readonly slug: Slug;
-  readonly mode: IntegrationMode;
+  readonly mode: Mode;
   readonly description?: string;
   /**
    * Ask the caller to choose a set of connections. Future author-chosen binding modes should not
    * project optional caller fields: optional fields are suggestions, and model callers under-fill
    * them.
    */
-  readonly array: () => IntegrationDeclaration<Slug>;
-  readonly describe: (text: string) => IntegrationDeclaration<Slug>;
+  readonly array: () => IntegrationDeclaration<Slug, "many">;
+  readonly describe: (text: string) => IntegrationDeclaration<Slug, Mode>;
 }
 
 export type IntegrationClients<TIntegrations> =
@@ -41,9 +44,12 @@ export type IntegrationClients<TIntegrations> =
 
 export type IntegrationDeclarations = Readonly<Record<string, IntegrationDeclaration>>;
 
-interface IntegrationDeclarationState<Slug extends string = string> {
+interface IntegrationDeclarationState<
+  Slug extends string = string,
+  Mode extends IntegrationMode = IntegrationMode,
+> {
   readonly slug: Slug;
-  readonly mode: IntegrationMode;
+  readonly mode: Mode;
   readonly description?: string;
 }
 
@@ -53,15 +59,15 @@ export interface SerializedIntegrationDeclaration {
   readonly description?: string;
 }
 
-const makeIntegrationDeclaration = <Slug extends string>(
-  state: IntegrationDeclarationState<Slug>,
-): IntegrationDeclaration<Slug> => {
+const makeIntegrationDeclaration = <Slug extends string, Mode extends IntegrationMode>(
+  state: IntegrationDeclarationState<Slug, Mode>,
+): IntegrationDeclaration<Slug, Mode> => {
   const declaration = {
     kind: "integration" as const,
     slug: state.slug,
     mode: state.mode,
     ...(state.description !== undefined ? { description: state.description } : {}),
-    array: () => makeIntegrationDeclaration({ ...state, mode: "many" }),
+    array: () => makeIntegrationDeclaration({ ...state, mode: "many" as const }),
     describe: (text: string) => makeIntegrationDeclaration({ ...state, description: text }),
   };
   return Object.freeze(declaration);
@@ -105,8 +111,8 @@ export interface DefinedTool<
   readonly "~executorAppTool": true;
 }
 
-export const integration = <Slug extends string>(slug: Slug): IntegrationDeclaration<Slug> =>
-  makeIntegrationDeclaration({ slug, mode: "one" });
+export const integration = <Slug extends string>(slug: Slug): IntegrationDeclaration<Slug, "one"> =>
+  makeIntegrationDeclaration({ slug, mode: "one" as const });
 
 export const defineTool = <
   TInputSchema extends ToolSchema,

--- a/packages/plugins/apps/src/authoring.ts
+++ b/packages/plugins/apps/src/authoring.ts
@@ -1,5 +1,3 @@
-import { z } from "zod";
-
 import type { StandardSchemaV1 } from "./standard-schema";
 
 export type JsonPrimitive = string | number | boolean | null;
@@ -14,15 +12,60 @@ export type AppIntegrationClient = {
   readonly [key: string]: AppIntegrationClient;
 } & ((...args: readonly unknown[]) => Promise<unknown>);
 
-export const EXECUTOR_INTEGRATION_META = "~executor";
+export type IntegrationMode = "one" | "many";
 
-export interface IntegrationMarker<Slug extends string = string> {
+export interface IntegrationDeclaration<Slug extends string = string> {
   readonly kind: "integration";
   readonly slug: Slug;
+  readonly mode: IntegrationMode;
+  readonly allConnections: boolean;
+  readonly description?: string;
+  readonly array: () => IntegrationDeclaration<Slug>;
+  readonly all: () => IntegrationDeclaration<Slug>;
+  readonly describe: (text: string) => IntegrationDeclaration<Slug>;
 }
 
-export type IntegrationSchema<Slug extends string = string> = z.ZodType<AppIntegrationClient> & {
-  readonly [EXECUTOR_INTEGRATION_META]?: IntegrationMarker<Slug>;
+export type IntegrationClients<TIntegrations> =
+  TIntegrations extends Readonly<Record<string, IntegrationDeclaration>>
+    ? {
+        readonly [K in keyof TIntegrations]: TIntegrations[K] extends {
+          readonly mode: "many";
+        }
+          ? readonly AppIntegrationClient[]
+          : AppIntegrationClient;
+      }
+    : Record<string, never>;
+
+export type IntegrationDeclarations = Readonly<Record<string, IntegrationDeclaration>>;
+
+interface IntegrationDeclarationState<Slug extends string = string> {
+  readonly slug: Slug;
+  readonly mode: IntegrationMode;
+  readonly allConnections: boolean;
+  readonly description?: string;
+}
+
+export interface SerializedIntegrationDeclaration {
+  readonly slug: string;
+  readonly mode: IntegrationMode;
+  readonly all: boolean;
+  readonly description?: string;
+}
+
+const makeIntegrationDeclaration = <Slug extends string>(
+  state: IntegrationDeclarationState<Slug>,
+): IntegrationDeclaration<Slug> => {
+  const declaration = {
+    kind: "integration" as const,
+    slug: state.slug,
+    mode: state.mode,
+    allConnections: state.allConnections,
+    ...(state.description !== undefined ? { description: state.description } : {}),
+    array: () => makeIntegrationDeclaration({ ...state, mode: "many" }),
+    all: () => makeIntegrationDeclaration({ ...state, allConnections: true }),
+    describe: (text: string) => makeIntegrationDeclaration({ ...state, description: text }),
+  };
+  return Object.freeze(declaration);
 };
 
 type InferToolInput<TSchema> = TSchema extends StandardSchemaV1
@@ -36,8 +79,10 @@ type InferToolOutput<TSchema> = TSchema extends StandardSchemaV1
 export interface DefineToolOptions<
   TInputSchema extends ToolSchema,
   TOutputSchema extends ToolSchema | undefined = undefined,
+  TIntegrations extends IntegrationDeclarations | undefined = undefined,
 > {
   readonly description: string;
+  readonly integrations?: TIntegrations;
   readonly input: TInputSchema;
   readonly output?: TOutputSchema;
   readonly annotations?: {
@@ -47,7 +92,7 @@ export interface DefineToolOptions<
   };
   readonly handler: (
     input: InferToolInput<TInputSchema>,
-    context: Record<string, never>,
+    context: IntegrationClients<TIntegrations>,
   ) =>
     | Promise<TOutputSchema extends ToolSchema ? InferToolOutput<TOutputSchema> : unknown>
     | (TOutputSchema extends ToolSchema ? InferToolOutput<TOutputSchema> : unknown);
@@ -56,27 +101,21 @@ export interface DefineToolOptions<
 export interface DefinedTool<
   TInputSchema extends ToolSchema = ToolSchema,
   TOutputSchema extends ToolSchema | undefined = ToolSchema | undefined,
-> extends DefineToolOptions<TInputSchema, TOutputSchema> {
+  TIntegrations extends IntegrationDeclarations | undefined = IntegrationDeclarations | undefined,
+> extends DefineToolOptions<TInputSchema, TOutputSchema, TIntegrations> {
   readonly "~executorAppTool": true;
 }
 
-export const integration = <Slug extends string>(slug: Slug): IntegrationSchema<Slug> => {
-  const schema = z.custom<AppIntegrationClient>().meta({
-    [EXECUTOR_INTEGRATION_META]: { kind: "integration", slug },
-  }) as IntegrationSchema<Slug>;
-  Object.defineProperty(schema, EXECUTOR_INTEGRATION_META, {
-    value: { kind: "integration", slug },
-    enumerable: false,
-  });
-  return schema;
-};
+export const integration = <Slug extends string>(slug: Slug): IntegrationDeclaration<Slug> =>
+  makeIntegrationDeclaration({ slug, mode: "one", allConnections: false });
 
 export const defineTool = <
   TInputSchema extends ToolSchema,
   TOutputSchema extends ToolSchema | undefined = undefined,
+  TIntegrations extends IntegrationDeclarations | undefined = undefined,
 >(
-  definition: DefineToolOptions<TInputSchema, TOutputSchema>,
-): DefinedTool<TInputSchema, TOutputSchema> => ({
+  definition: DefineToolOptions<TInputSchema, TOutputSchema, TIntegrations>,
+): DefinedTool<TInputSchema, TOutputSchema, TIntegrations> => ({
   ...definition,
   "~executorAppTool": true,
 });

--- a/packages/plugins/apps/src/authoring.ts
+++ b/packages/plugins/apps/src/authoring.ts
@@ -18,15 +18,13 @@ export interface IntegrationDeclaration<Slug extends string = string> {
   readonly kind: "integration";
   readonly slug: Slug;
   readonly mode: IntegrationMode;
-  readonly allConnections: boolean;
   readonly description?: string;
-  readonly array: () => IntegrationDeclaration<Slug>;
   /**
-   * Bind every visible connection for this integration. This does not project a caller field:
-   * optional fields are suggestions, and model callers under-fill them. Tools that search
-   * everything must not expose a connections parameter.
+   * Ask the caller to choose a set of connections. Future author-chosen binding modes should not
+   * project optional caller fields: optional fields are suggestions, and model callers under-fill
+   * them.
    */
-  readonly all: () => IntegrationDeclaration<Slug>;
+  readonly array: () => IntegrationDeclaration<Slug>;
   readonly describe: (text: string) => IntegrationDeclaration<Slug>;
 }
 
@@ -46,14 +44,12 @@ export type IntegrationDeclarations = Readonly<Record<string, IntegrationDeclara
 interface IntegrationDeclarationState<Slug extends string = string> {
   readonly slug: Slug;
   readonly mode: IntegrationMode;
-  readonly allConnections: boolean;
   readonly description?: string;
 }
 
 export interface SerializedIntegrationDeclaration {
   readonly slug: string;
   readonly mode: IntegrationMode;
-  readonly all: boolean;
   readonly description?: string;
 }
 
@@ -64,10 +60,8 @@ const makeIntegrationDeclaration = <Slug extends string>(
     kind: "integration" as const,
     slug: state.slug,
     mode: state.mode,
-    allConnections: state.allConnections,
     ...(state.description !== undefined ? { description: state.description } : {}),
     array: () => makeIntegrationDeclaration({ ...state, mode: "many" }),
-    all: () => makeIntegrationDeclaration({ ...state, allConnections: true }),
     describe: (text: string) => makeIntegrationDeclaration({ ...state, description: text }),
   };
   return Object.freeze(declaration);
@@ -112,7 +106,7 @@ export interface DefinedTool<
 }
 
 export const integration = <Slug extends string>(slug: Slug): IntegrationDeclaration<Slug> =>
-  makeIntegrationDeclaration({ slug, mode: "one", allConnections: false });
+  makeIntegrationDeclaration({ slug, mode: "one" });
 
 export const defineTool = <
   TInputSchema extends ToolSchema,

--- a/packages/plugins/apps/src/executor/app-tool-executor.conformance.test.ts
+++ b/packages/plugins/apps/src/executor/app-tool-executor.conformance.test.ts
@@ -1,0 +1,4 @@
+import { makeInProcessAppToolExecutor } from "./app-tool-executor";
+import { appToolExecutorConformance } from "../testing/conformance";
+
+appToolExecutorConformance("in-process", makeInProcessAppToolExecutor);

--- a/packages/plugins/apps/src/executor/app-tool-executor.test.ts
+++ b/packages/plugins/apps/src/executor/app-tool-executor.test.ts
@@ -13,16 +13,17 @@ const bundle = (source: string) =>
   });
 
 describe("in-process app tool executor", () => {
-  it.effect("detects top-level integration fields", () =>
+  it.effect("detects integration declarations and merges projected input fields", () =>
     Effect.gen(function* () {
       const bundled = yield* bundle(`
         import { z } from "zod";
         import { defineTool, integration } from "executor:app";
         export default defineTool({
           description: "Refresh deals",
-          input: z.object({ crm: integration("dealcloud"), updatedSince: z.string().optional() }),
+          integrations: { crm: integration("dealcloud").describe("CRM account") },
+          input: z.object({ updatedSince: z.string().optional() }),
           output: z.object({ synced: z.number() }),
-          async handler(input) {
+          async handler(input, { crm }) {
             return { synced: 1 };
           },
         });
@@ -31,21 +32,53 @@ describe("in-process app tool executor", () => {
         fileSlug: "sync-deals",
         sourcePath: "tools/sync-deals.ts",
       });
-      expect(collected.tools[0]?.integrations).toEqual({ crm: { slug: "dealcloud" } });
+      expect(collected.tools[0]?.integrations).toEqual({
+        crm: { slug: "dealcloud", mode: "one", all: false, description: "CRM account" },
+      });
       expect(collected.tools[0]?.inputSchema).toMatchObject({
-        properties: { crm: { type: "string" } },
+        properties: { crm: { type: "string", description: "CRM account" } },
+        required: ["crm"],
       });
     }),
   );
 
-  it.effect("rejects nested integration fields with a named diagnostic", () =>
+  it.effect("keeps many all declarations optional and round-trips the flag", () =>
     Effect.gen(function* () {
       const bundled = yield* bundle(`
         import { z } from "zod";
         import { defineTool, integration } from "executor:app";
         export default defineTool({
-          description: "Bad nesting",
-          input: z.object({ nested: z.object({ crm: integration("dealcloud") }) }),
+          description: "Fan out",
+          integrations: { inboxes: integration("gmail").array().all() },
+          input: z.object({ q: z.string() }),
+          async handler(input, { inboxes }) {
+            return { count: inboxes.length };
+          },
+        });
+      `);
+      const collected = yield* makeInProcessAppToolExecutor().collect(bundled.code, {
+        fileSlug: "sync-deals",
+        sourcePath: "tools/sync-deals.ts",
+      });
+      expect(collected.tools[0]?.integrations).toEqual({
+        inboxes: { slug: "gmail", mode: "many", all: true },
+      });
+      expect(collected.tools[0]?.inputSchema).toMatchObject({
+        properties: { inboxes: { type: "array", items: { type: "string" } } },
+        required: ["q"],
+      });
+    }),
+  );
+
+  it.effect("rejects integration keys that collide with input fields", () =>
+    Effect.gen(function* () {
+      const bundled = yield* bundle(`
+        import { z } from "zod";
+        import { defineTool, integration } from "executor:app";
+        export default defineTool({
+          description: "Bad collision",
+          integrations: { crm: integration("dealcloud") },
+          input: z.object({ crm: z.string() }),
           async handler(input) {
             return input;
           },
@@ -57,7 +90,31 @@ describe("in-process app tool executor", () => {
           sourcePath: "tools/sync-deals.ts",
         })
         .pipe(Effect.flip);
-      expect(error).toMatchObject({ message: expect.stringContaining("nested.crm") });
+      expect(error).toMatchObject({ message: expect.stringContaining("collides") });
+    }),
+  );
+
+  it.effect("rejects all on single integration declarations", () =>
+    Effect.gen(function* () {
+      const bundled = yield* bundle(`
+        import { z } from "zod";
+        import { defineTool, integration } from "executor:app";
+        export default defineTool({
+          description: "Bad all",
+          integrations: { crm: integration("dealcloud").all() },
+          input: z.object({}),
+          async handler(input) {
+            return input;
+          },
+        });
+      `);
+      const error = yield* makeInProcessAppToolExecutor()
+        .collect(bundled.code, {
+          fileSlug: "sync-deals",
+          sourcePath: "tools/sync-deals.ts",
+        })
+        .pipe(Effect.flip);
+      expect(error).toMatchObject({ message: expect.stringContaining(".all()") });
     }),
   );
 
@@ -120,10 +177,11 @@ describe("in-process app tool executor", () => {
         import { defineTool, integration } from "executor:app";
         export default defineTool({
           description: "Refresh deals",
-          input: z.object({ crm: integration("dealcloud") }),
+          integrations: { crm: integration("dealcloud") },
+          input: z.object({ updatedSince: z.string().optional() }),
           output: z.object({ synced: z.number() }),
-          async handler(input) {
-            const deals = await input.crm.deals.list({ limit: 2 });
+          async handler({ updatedSince }, { crm }) {
+            const deals = await crm.deals.list({ limit: 2, updatedSince });
             return { synced: deals.length };
           },
         });
@@ -142,7 +200,49 @@ describe("in-process app tool executor", () => {
         { timeoutMs: 1000 },
       );
       expect(result.output).toEqual({ synced: 2 });
-      expect(calls).toEqual([{ toolPath: "crm.deals.list", args: { limit: 2 } }]);
+      expect(calls).toEqual([
+        { toolPath: "crm.deals.list", args: { limit: 2, updatedSince: undefined } },
+      ]);
+    }),
+  );
+
+  it.effect("passes fan-out integrations as arrays of proxies", () =>
+    Effect.gen(function* () {
+      const bundled = yield* bundle(`
+        import { z } from "zod";
+        import { defineTool, integration } from "executor:app";
+        export default defineTool({
+          description: "Fan out",
+          integrations: { inboxes: integration("gmail").array() },
+          input: z.object({ q: z.string() }),
+          output: z.object({ seen: z.number() }),
+          async handler({ q }, { inboxes }) {
+            const batches = await Promise.all(inboxes.map((inbox) => inbox.messages.list({ q })));
+            return { seen: batches.flat().length };
+          },
+        });
+      `);
+      const calls: unknown[] = [];
+      const result = yield* makeInProcessAppToolExecutor().invoke(
+        bundled.code,
+        { toolName: "sync-deals" },
+        {
+          q: "unread",
+          inboxes: ["tools.gmail.org.work", "tools.gmail.user.personal"],
+        },
+        {
+          call: async (toolPath, args) => {
+            calls.push({ toolPath, args });
+            return toolPath.startsWith("inboxes#0.") ? [{ id: 1 }] : [{ id: 2 }, { id: 3 }];
+          },
+        },
+        { timeoutMs: 1000 },
+      );
+      expect(result.output).toEqual({ seen: 3 });
+      expect(calls).toEqual([
+        { toolPath: "inboxes#0.messages.list", args: { q: "unread" } },
+        { toolPath: "inboxes#1.messages.list", args: { q: "unread" } },
+      ]);
     }),
   );
 

--- a/packages/plugins/apps/src/executor/app-tool-executor.test.ts
+++ b/packages/plugins/apps/src/executor/app-tool-executor.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
 
 import { bundleEntry } from "../pipeline/bundle";
+import { buildBridge, resolveIntegrationBindings, type ClientResolver } from "../plugin/bindings";
 import { makeInProcessAppToolExecutor } from "./app-tool-executor";
 
 const bytes = (value: string): string => value;
@@ -42,7 +43,7 @@ describe("in-process app tool executor", () => {
     }),
   );
 
-  it.effect("keeps many all declarations optional and round-trips the flag", () =>
+  it.effect("omits many all declarations from projected input and round-trips the flag", () =>
     Effect.gen(function* () {
       const bundled = yield* bundle(`
         import { z } from "zod";
@@ -64,9 +65,13 @@ describe("in-process app tool executor", () => {
         inboxes: { slug: "gmail", mode: "many", all: true },
       });
       expect(collected.tools[0]?.inputSchema).toMatchObject({
-        properties: { inboxes: { type: "array", items: { type: "string" } } },
+        properties: { q: { type: "string" } },
         required: ["q"],
       });
+      const inputSchema = collected.tools[0]?.inputSchema as
+        | { readonly properties?: Record<string, unknown> }
+        | undefined;
+      expect(inputSchema?.properties?.inboxes).toBeUndefined();
     }),
   );
 
@@ -242,6 +247,62 @@ describe("in-process app tool executor", () => {
       expect(calls).toEqual([
         { toolPath: "inboxes#0.messages.list", args: { q: "unread" } },
         { toolPath: "inboxes#1.messages.list", args: { q: "unread" } },
+      ]);
+    }),
+  );
+
+  it.effect("expands all integrations before invoke and passes every proxy to the handler", () =>
+    Effect.gen(function* () {
+      const bundled = yield* bundle(`
+        import { z } from "zod";
+        import { defineTool, integration } from "executor:app";
+        export default defineTool({
+          description: "Search all inboxes",
+          integrations: { inboxes: integration("gmail").array().all() },
+          input: z.object({ q: z.string() }),
+          output: z.object({ seen: z.number() }),
+          async handler({ q }, { inboxes }) {
+            const batches = await Promise.all(inboxes.map((inbox) => inbox.messages.list({ q })));
+            return { seen: batches.flat().length };
+          },
+        });
+      `);
+      const calls: unknown[] = [];
+      const resolver: ClientResolver = {
+        listConnections: ({ integration }) =>
+          Effect.succeed([
+            { integration, address: "tools.gmail.org.work" },
+            { integration, address: "tools.gmail.user.personal" },
+            { integration, address: "tools.gmail.org.shared" },
+          ]),
+        resolveConnection: () => Effect.succeed(null),
+        call: (input) =>
+          Effect.sync(() => {
+            calls.push(input);
+            return [{ id: input.connection }];
+          }),
+      };
+      const bindings = yield* resolveIntegrationBindings(
+        { inboxes: { slug: "gmail", mode: "many", all: true } },
+        { q: "unread" },
+        resolver,
+      );
+      const result = yield* makeInProcessAppToolExecutor().invoke(
+        bundled.code,
+        { toolName: "sync-deals" },
+        { ...bindings.input, ...bindings.bindings },
+        buildBridge({
+          declared: { inboxes: { slug: "gmail", mode: "many", all: true } },
+          bindings: bindings.bindings,
+          resolver,
+        }),
+        { timeoutMs: 1000 },
+      );
+      expect(result.output).toEqual({ seen: 3 });
+      expect(calls).toMatchObject([
+        { connection: "tools.gmail.org.work", path: ["messages", "list"] },
+        { connection: "tools.gmail.user.personal", path: ["messages", "list"] },
+        { connection: "tools.gmail.org.shared", path: ["messages", "list"] },
       ]);
     }),
   );

--- a/packages/plugins/apps/src/executor/app-tool-executor.test.ts
+++ b/packages/plugins/apps/src/executor/app-tool-executor.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+
+import { bundleEntry } from "../pipeline/bundle";
+import { makeInProcessAppToolExecutor } from "./app-tool-executor";
+
+const bytes = (value: string): string => value;
+
+const bundle = (source: string) =>
+  bundleEntry({
+    files: new Map([["tools/sync-deals.ts", bytes(source)]]),
+    entry: "tools/sync-deals.ts",
+  });
+
+describe("in-process app tool executor", () => {
+  it.effect("detects top-level integration fields", () =>
+    Effect.gen(function* () {
+      const bundled = yield* bundle(`
+        import { z } from "zod";
+        import { defineTool, integration } from "executor:app";
+        export default defineTool({
+          description: "Refresh deals",
+          input: z.object({ crm: integration("dealcloud"), updatedSince: z.string().optional() }),
+          output: z.object({ synced: z.number() }),
+          async handler(input) {
+            return { synced: 1 };
+          },
+        });
+      `);
+      const collected = yield* makeInProcessAppToolExecutor().collect(bundled.code, {
+        fileSlug: "sync-deals",
+        sourcePath: "tools/sync-deals.ts",
+      });
+      expect(collected.tools[0]?.integrations).toEqual({ crm: { slug: "dealcloud" } });
+      expect(collected.tools[0]?.inputSchema).toMatchObject({
+        properties: { crm: { type: "string" } },
+      });
+    }),
+  );
+
+  it.effect("rejects nested integration fields with a named diagnostic", () =>
+    Effect.gen(function* () {
+      const bundled = yield* bundle(`
+        import { z } from "zod";
+        import { defineTool, integration } from "executor:app";
+        export default defineTool({
+          description: "Bad nesting",
+          input: z.object({ nested: z.object({ crm: integration("dealcloud") }) }),
+          async handler(input) {
+            return input;
+          },
+        });
+      `);
+      const exit = yield* makeInProcessAppToolExecutor()
+        .collect(bundled.code, {
+          fileSlug: "sync-deals",
+          sourcePath: "tools/sync-deals.ts",
+        })
+        .pipe(Effect.exit);
+      expect(exit._tag).toBe("Failure");
+      if (exit._tag === "Failure") {
+        expect(String(exit.cause)).toContain("nested.crm");
+      }
+    }),
+  );
+
+  it.effect("collects record and factory exports with file-prefixed names", () =>
+    Effect.gen(function* () {
+      const bundled = yield* bundle(`
+        import { z } from "zod";
+        import { defineTool } from "executor:app";
+        export default async () => ({
+          first: defineTool({
+            description: "First",
+            input: z.object({ value: z.string() }),
+            handler(input) { return input; },
+          }),
+          second: defineTool({
+            description: "Second",
+            input: z.object({ value: z.string() }),
+            handler(input) { return input; },
+          }),
+        });
+      `);
+      const collected = yield* makeInProcessAppToolExecutor().collect(bundled.code, {
+        fileSlug: "sync-deals",
+        sourcePath: "tools/sync-deals.ts",
+      });
+      expect(collected.tools.map((tool) => tool.toolName)).toEqual([
+        "sync-deals__first",
+        "sync-deals__second",
+      ]);
+    }),
+  );
+
+  it.effect("rejects record keys that collide with the single export slug", () =>
+    Effect.gen(function* () {
+      const bundled = yield* bundle(`
+        import { z } from "zod";
+        import { defineTool } from "executor:app";
+        export default {
+          "sync-deals": defineTool({
+            description: "Collides",
+            input: z.object({ value: z.string() }),
+            handler(input) { return input; },
+          }),
+        };
+      `);
+      const exit = yield* makeInProcessAppToolExecutor()
+        .collect(bundled.code, {
+          fileSlug: "sync-deals",
+          sourcePath: "tools/sync-deals.ts",
+        })
+        .pipe(Effect.exit);
+      expect(exit._tag).toBe("Failure");
+      if (exit._tag === "Failure") expect(String(exit.cause)).toContain("collides");
+    }),
+  );
+
+  it.effect("routes integration method calls through the bridge", () =>
+    Effect.gen(function* () {
+      const bundled = yield* bundle(`
+        import { z } from "zod";
+        import { defineTool, integration } from "executor:app";
+        export default defineTool({
+          description: "Refresh deals",
+          input: z.object({ crm: integration("dealcloud") }),
+          output: z.object({ synced: z.number() }),
+          async handler(input) {
+            const deals = await input.crm.deals.list({ limit: 2 });
+            return { synced: deals.length };
+          },
+        });
+      `);
+      const calls: unknown[] = [];
+      const result = yield* makeInProcessAppToolExecutor().invoke(
+        bundled.code,
+        { toolName: "sync-deals" },
+        { crm: "tools.dealcloud.org.main" },
+        {
+          call: async (toolPath, args) => {
+            calls.push({ toolPath, args });
+            return [{ id: 1 }, { id: 2 }];
+          },
+        },
+        { timeoutMs: 1000 },
+      );
+      expect(result.output).toEqual({ synced: 2 });
+      expect(calls).toEqual([{ toolPath: "crm.deals.list", args: { limit: 2 } }]);
+    }),
+  );
+
+  it.effect("classifies input validation failure", () =>
+    Effect.gen(function* () {
+      const bundled = yield* bundle(`
+        import { z } from "zod";
+        import { defineTool } from "executor:app";
+        export default defineTool({
+          description: "Validate",
+          input: z.object({ value: z.string() }),
+          handler(input) { return input; },
+        });
+      `);
+      const exit = yield* makeInProcessAppToolExecutor()
+        .invoke(
+          bundled.code,
+          { toolName: "sync-deals" },
+          { value: 1 },
+          { call: async () => null },
+          {
+            timeoutMs: 1000,
+          },
+        )
+        .pipe(Effect.exit);
+      expect(exit._tag).toBe("Failure");
+      if (exit._tag === "Failure") expect(String(exit.cause)).toContain("validation failed");
+    }),
+  );
+
+  it.effect("enforces timeout", () =>
+    Effect.gen(function* () {
+      const bundled = yield* bundle(`
+        import { z } from "zod";
+        import { defineTool } from "executor:app";
+        export default defineTool({
+          description: "Slow",
+          input: z.object({}),
+          async handler() {
+            await new Promise((resolve) => setTimeout(resolve, 50));
+            return {};
+          },
+        });
+      `);
+      const exit = yield* makeInProcessAppToolExecutor()
+        .invoke(
+          bundled.code,
+          { toolName: "sync-deals" },
+          {},
+          { call: async () => null },
+          {
+            timeoutMs: 1,
+          },
+        )
+        .pipe(Effect.exit);
+      expect(exit._tag).toBe("Failure");
+      if (exit._tag === "Failure") expect(String(exit.cause)).toContain("timed out");
+    }),
+  );
+});

--- a/packages/plugins/apps/src/executor/app-tool-executor.test.ts
+++ b/packages/plugins/apps/src/executor/app-tool-executor.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
 
 import { bundleEntry } from "../pipeline/bundle";
-import { buildBridge, resolveIntegrationBindings, type ClientResolver } from "../plugin/bindings";
 import { makeInProcessAppToolExecutor } from "./app-tool-executor";
 
 const bytes = (value: string): string => value;
@@ -34,44 +33,12 @@ describe("in-process app tool executor", () => {
         sourcePath: "tools/sync-deals.ts",
       });
       expect(collected.tools[0]?.integrations).toEqual({
-        crm: { slug: "dealcloud", mode: "one", all: false, description: "CRM account" },
+        crm: { slug: "dealcloud", mode: "one", description: "CRM account" },
       });
       expect(collected.tools[0]?.inputSchema).toMatchObject({
         properties: { crm: { type: "string", description: "CRM account" } },
         required: ["crm"],
       });
-    }),
-  );
-
-  it.effect("omits many all declarations from projected input and round-trips the flag", () =>
-    Effect.gen(function* () {
-      const bundled = yield* bundle(`
-        import { z } from "zod";
-        import { defineTool, integration } from "executor:app";
-        export default defineTool({
-          description: "Fan out",
-          integrations: { inboxes: integration("gmail").array().all() },
-          input: z.object({ q: z.string() }),
-          async handler(input, { inboxes }) {
-            return { count: inboxes.length };
-          },
-        });
-      `);
-      const collected = yield* makeInProcessAppToolExecutor().collect(bundled.code, {
-        fileSlug: "sync-deals",
-        sourcePath: "tools/sync-deals.ts",
-      });
-      expect(collected.tools[0]?.integrations).toEqual({
-        inboxes: { slug: "gmail", mode: "many", all: true },
-      });
-      expect(collected.tools[0]?.inputSchema).toMatchObject({
-        properties: { q: { type: "string" } },
-        required: ["q"],
-      });
-      const inputSchema = collected.tools[0]?.inputSchema as
-        | { readonly properties?: Record<string, unknown> }
-        | undefined;
-      expect(inputSchema?.properties?.inboxes).toBeUndefined();
     }),
   );
 
@@ -96,30 +63,6 @@ describe("in-process app tool executor", () => {
         })
         .pipe(Effect.flip);
       expect(error).toMatchObject({ message: expect.stringContaining("collides") });
-    }),
-  );
-
-  it.effect("rejects all on single integration declarations", () =>
-    Effect.gen(function* () {
-      const bundled = yield* bundle(`
-        import { z } from "zod";
-        import { defineTool, integration } from "executor:app";
-        export default defineTool({
-          description: "Bad all",
-          integrations: { crm: integration("dealcloud").all() },
-          input: z.object({}),
-          async handler(input) {
-            return input;
-          },
-        });
-      `);
-      const error = yield* makeInProcessAppToolExecutor()
-        .collect(bundled.code, {
-          fileSlug: "sync-deals",
-          sourcePath: "tools/sync-deals.ts",
-        })
-        .pipe(Effect.flip);
-      expect(error).toMatchObject({ message: expect.stringContaining(".all()") });
     }),
   );
 
@@ -247,62 +190,6 @@ describe("in-process app tool executor", () => {
       expect(calls).toEqual([
         { toolPath: "inboxes#0.messages.list", args: { q: "unread" } },
         { toolPath: "inboxes#1.messages.list", args: { q: "unread" } },
-      ]);
-    }),
-  );
-
-  it.effect("expands all integrations before invoke and passes every proxy to the handler", () =>
-    Effect.gen(function* () {
-      const bundled = yield* bundle(`
-        import { z } from "zod";
-        import { defineTool, integration } from "executor:app";
-        export default defineTool({
-          description: "Search all inboxes",
-          integrations: { inboxes: integration("gmail").array().all() },
-          input: z.object({ q: z.string() }),
-          output: z.object({ seen: z.number() }),
-          async handler({ q }, { inboxes }) {
-            const batches = await Promise.all(inboxes.map((inbox) => inbox.messages.list({ q })));
-            return { seen: batches.flat().length };
-          },
-        });
-      `);
-      const calls: unknown[] = [];
-      const resolver: ClientResolver = {
-        listConnections: ({ integration }) =>
-          Effect.succeed([
-            { integration, address: "tools.gmail.org.work" },
-            { integration, address: "tools.gmail.user.personal" },
-            { integration, address: "tools.gmail.org.shared" },
-          ]),
-        resolveConnection: () => Effect.succeed(null),
-        call: (input) =>
-          Effect.sync(() => {
-            calls.push(input);
-            return [{ id: input.connection }];
-          }),
-      };
-      const bindings = yield* resolveIntegrationBindings(
-        { inboxes: { slug: "gmail", mode: "many", all: true } },
-        { q: "unread" },
-        resolver,
-      );
-      const result = yield* makeInProcessAppToolExecutor().invoke(
-        bundled.code,
-        { toolName: "sync-deals" },
-        { ...bindings.input, ...bindings.bindings },
-        buildBridge({
-          declared: { inboxes: { slug: "gmail", mode: "many", all: true } },
-          bindings: bindings.bindings,
-          resolver,
-        }),
-        { timeoutMs: 1000 },
-      );
-      expect(result.output).toEqual({ seen: 3 });
-      expect(calls).toMatchObject([
-        { connection: "tools.gmail.org.work", path: ["messages", "list"] },
-        { connection: "tools.gmail.user.personal", path: ["messages", "list"] },
-        { connection: "tools.gmail.org.shared", path: ["messages", "list"] },
       ]);
     }),
   );

--- a/packages/plugins/apps/src/executor/app-tool-executor.test.ts
+++ b/packages/plugins/apps/src/executor/app-tool-executor.test.ts
@@ -51,16 +51,13 @@ describe("in-process app tool executor", () => {
           },
         });
       `);
-      const exit = yield* makeInProcessAppToolExecutor()
+      const error = yield* makeInProcessAppToolExecutor()
         .collect(bundled.code, {
           fileSlug: "sync-deals",
           sourcePath: "tools/sync-deals.ts",
         })
-        .pipe(Effect.exit);
-      expect(exit._tag).toBe("Failure");
-      if (exit._tag === "Failure") {
-        expect(String(exit.cause)).toContain("nested.crm");
-      }
+        .pipe(Effect.flip);
+      expect(error).toMatchObject({ message: expect.stringContaining("nested.crm") });
     }),
   );
 
@@ -106,14 +103,13 @@ describe("in-process app tool executor", () => {
           }),
         };
       `);
-      const exit = yield* makeInProcessAppToolExecutor()
+      const error = yield* makeInProcessAppToolExecutor()
         .collect(bundled.code, {
           fileSlug: "sync-deals",
           sourcePath: "tools/sync-deals.ts",
         })
-        .pipe(Effect.exit);
-      expect(exit._tag).toBe("Failure");
-      if (exit._tag === "Failure") expect(String(exit.cause)).toContain("collides");
+        .pipe(Effect.flip);
+      expect(error).toMatchObject({ message: expect.stringContaining("collides") });
     }),
   );
 
@@ -161,7 +157,7 @@ describe("in-process app tool executor", () => {
           handler(input) { return input; },
         });
       `);
-      const exit = yield* makeInProcessAppToolExecutor()
+      const error = yield* makeInProcessAppToolExecutor()
         .invoke(
           bundled.code,
           { toolName: "sync-deals" },
@@ -171,9 +167,8 @@ describe("in-process app tool executor", () => {
             timeoutMs: 1000,
           },
         )
-        .pipe(Effect.exit);
-      expect(exit._tag).toBe("Failure");
-      if (exit._tag === "Failure") expect(String(exit.cause)).toContain("validation failed");
+        .pipe(Effect.flip);
+      expect(error).toMatchObject({ message: expect.stringContaining("validation failed") });
     }),
   );
 
@@ -191,7 +186,7 @@ describe("in-process app tool executor", () => {
           },
         });
       `);
-      const exit = yield* makeInProcessAppToolExecutor()
+      const error = yield* makeInProcessAppToolExecutor()
         .invoke(
           bundled.code,
           { toolName: "sync-deals" },
@@ -201,9 +196,8 @@ describe("in-process app tool executor", () => {
             timeoutMs: 1,
           },
         )
-        .pipe(Effect.exit);
-      expect(exit._tag).toBe("Failure");
-      if (exit._tag === "Failure") expect(String(exit.cause)).toContain("timed out");
+        .pipe(Effect.flip);
+      expect(error).toMatchObject({ message: expect.stringContaining("timed out") });
     }),
   );
 });

--- a/packages/plugins/apps/src/executor/app-tool-executor.ts
+++ b/packages/plugins/apps/src/executor/app-tool-executor.ts
@@ -26,7 +26,17 @@ export interface CollectedTool {
   readonly description: string;
   readonly inputSchema?: unknown;
   readonly outputSchema?: unknown;
-  readonly integrations: Readonly<Record<string, { readonly slug: string }>>;
+  readonly integrations: Readonly<
+    Record<
+      string,
+      {
+        readonly slug: string;
+        readonly mode: "one" | "many";
+        readonly all: boolean;
+        readonly description?: string;
+      }
+    >
+  >;
   readonly annotations?: {
     readonly readOnly?: boolean;
     readonly destructive?: boolean;
@@ -59,8 +69,6 @@ export interface AppToolExecutor {
     limits: { readonly timeoutMs: number },
   ) => Effect.Effect<InvokeOutcome, AppExecutorError>;
 }
-
-const EXECUTOR_INTEGRATION_META = "~executor";
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   value !== null && typeof value === "object" && !Array.isArray(value);
@@ -119,104 +127,111 @@ const jsonSchemaFor = (schema: unknown): unknown => {
   return schema;
 };
 
-const integrationMarker = (value: unknown): { readonly slug: string } | null => {
+type CollectedIntegrationDecl = CollectedTool["integrations"][string];
+
+const integrationDeclaration = (value: unknown): CollectedIntegrationDecl | null => {
   if (!isRecord(value)) return null;
-  const direct = value[EXECUTOR_INTEGRATION_META];
-  if (isRecord(direct) && direct.kind === "integration" && typeof direct.slug === "string") {
-    return { slug: direct.slug };
+  if (value.kind !== "integration") return null;
+  if (typeof value.slug !== "string" || (value.mode !== "one" && value.mode !== "many")) {
+    return null;
   }
-  const meta = isRecord(value._def) ? value._def.metadata : undefined;
-  const marker = isRecord(meta) ? meta[EXECUTOR_INTEGRATION_META] : undefined;
-  return isRecord(marker) && marker.kind === "integration" && typeof marker.slug === "string"
-    ? { slug: marker.slug }
-    : null;
-};
-
-const shapeOf = (schema: unknown): Record<string, unknown> | null => {
-  if (!isRecord(schema)) return null;
-  const shape = schema.shape;
-  if (isRecord(shape)) return shape;
-  if (typeof shape === "function") {
-    const out = shape();
-    return isRecord(out) ? out : null;
-  }
-  return null;
-};
-
-const findNestedIntegration = (
-  value: unknown,
-  path: readonly string[],
-): readonly string[] | null => {
-  if (integrationMarker(value)) return path;
-  const shape = shapeOf(value);
-  if (shape) {
-    for (const [key, child] of Object.entries(shape)) {
-      const nested = findNestedIntegration(child, [...path, key]);
-      if (nested) return nested;
-    }
-  }
-  return null;
+  return {
+    slug: value.slug,
+    mode: value.mode,
+    all: value.allConnections === true,
+    ...(typeof value.description === "string" ? { description: value.description } : {}),
+  };
 };
 
 const collectIntegrations = (
   toolName: string,
   sourcePath: string,
-  input: unknown,
-): Readonly<Record<string, { readonly slug: string }>> => {
-  const shape = shapeOf(input);
-  if (!shape) return {};
-  const out: Record<string, { readonly slug: string }> = {};
-  for (const [field, fieldSchema] of Object.entries(shape)) {
-    const marker = integrationMarker(fieldSchema);
-    if (marker) {
-      out[field] = marker;
-      continue;
-    }
-    const nested = findNestedIntegration(fieldSchema, [field]);
-    if (nested) {
+  declarations: unknown,
+  inputJsonSchema: unknown,
+): CollectedTool["integrations"] => {
+  if (declarations === undefined) return {};
+  if (!isRecord(declarations)) {
+    throw new AppExecutorError({
+      kind: "collect",
+      message: `tool "${toolName}" integrations must be a record`,
+      diagnostics: [{ path: sourcePath, message: "integrations must be a record" }],
+    });
+  }
+  const inputProperties =
+    isRecord(inputJsonSchema) && isRecord(inputJsonSchema.properties)
+      ? inputJsonSchema.properties
+      : {};
+  const out: Record<string, CollectedIntegrationDecl> = {};
+  for (const [field, raw] of Object.entries(declarations)) {
+    if (Object.prototype.hasOwnProperty.call(inputProperties, field)) {
       throw new AppExecutorError({
         kind: "collect",
-        message: `tool "${toolName}" declares nested integration at "${nested.join(".")}"`,
+        message: `tool "${toolName}" integration key "${field}" collides with input field`,
         diagnostics: [
-          {
-            path: sourcePath,
-            message: `integration() fields must be top-level input fields: ${nested.join(".")}`,
-          },
+          { path: sourcePath, message: `integration key collides with input: ${field}` },
         ],
       });
     }
+    const decl = integrationDeclaration(raw);
+    if (!decl) {
+      throw new AppExecutorError({
+        kind: "collect",
+        message: `tool "${toolName}" integration "${field}" is not a valid declaration`,
+        diagnostics: [{ path: sourcePath, message: `invalid integration declaration: ${field}` }],
+      });
+    }
+    if (decl.mode === "one" && decl.all) {
+      throw new AppExecutorError({
+        kind: "collect",
+        message: `tool "${toolName}" integration "${field}" calls .all() without .array()`,
+        diagnostics: [{ path: sourcePath, message: `.all() requires .array(): ${field}` }],
+      });
+    }
+    out[field] = decl;
   }
   return out;
 };
 
-const projectInputSchema = (schema: unknown): unknown => {
-  const shape = shapeOf(schema);
-  if (!shape) return jsonSchemaFor(schema);
-  const properties: Record<string, unknown> = {};
-  const required: string[] = [];
-  for (const [field, fieldSchema] of Object.entries(shape)) {
-    const marker = integrationMarker(fieldSchema);
-    if (marker) {
+const projectInputSchema = (
+  inputJsonSchema: unknown,
+  integrations: CollectedTool["integrations"],
+): unknown => {
+  const base = isRecord(inputJsonSchema) ? inputJsonSchema : {};
+  const properties = isRecord(base.properties) ? { ...base.properties } : {};
+  const required = Array.isArray(base.required) ? [...base.required] : [];
+  for (const [field, decl] of Object.entries(integrations)) {
+    if (decl.mode === "one") {
       properties[field] = {
         type: "string",
-        description: `Connection address for ${marker.slug}`,
+        description: decl.description ?? `Connection for ${decl.slug}`,
       };
       required.push(field);
     } else {
-      properties[field] = jsonSchemaFor(fieldSchema);
+      properties[field] = {
+        type: "array",
+        items: { type: "string" },
+        description: decl.description ?? `Connections for ${decl.slug}`,
+      };
+      if (!decl.all) required.push(field);
     }
   }
-  return { type: "object", properties, ...(required.length > 0 ? { required } : {}) };
+  return {
+    ...base,
+    type: "object",
+    properties,
+    ...(required.length > 0 ? { required: [...new Set(required)] } : {}),
+  };
 };
 
 const isDefinedTool = (
   value: unknown,
 ): value is {
   readonly description: string;
+  readonly integrations?: unknown;
   readonly input: unknown;
   readonly output?: unknown;
   readonly annotations?: CollectedTool["annotations"];
-  readonly handler: (input: unknown, ctx: Record<string, never>) => unknown;
+  readonly handler: (input: unknown, ctx: Record<string, unknown>) => unknown;
 } =>
   isRecord(value) &&
   value["~executorAppTool"] === true &&
@@ -230,13 +245,20 @@ const collectFromExport = (
   sourcePath: string,
 ): CollectedModule => {
   if (isDefinedTool(exported)) {
+    const inputJsonSchema = jsonSchemaFor(exported.input);
+    const integrations = collectIntegrations(
+      fileSlug,
+      sourcePath,
+      exported.integrations,
+      inputJsonSchema,
+    );
     return {
       tools: [
         {
           toolName: fileSlug,
           description: exported.description,
-          integrations: collectIntegrations(fileSlug, sourcePath, exported.input),
-          inputSchema: projectInputSchema(exported.input),
+          integrations,
+          inputSchema: projectInputSchema(inputJsonSchema, integrations),
           outputSchema: jsonSchemaFor(exported.output),
           annotations: exported.annotations,
         },
@@ -276,13 +298,20 @@ const collectFromExport = (
         diagnostics: [{ path: sourcePath, message: `duplicate tool name "${toolName}"` }],
       });
     }
+    const inputJsonSchema = jsonSchemaFor(value.input);
+    const integrations = collectIntegrations(
+      toolName,
+      sourcePath,
+      value.integrations,
+      inputJsonSchema,
+    );
     seen.add(toolName);
     tools.push({
       toolName,
       exportKey: key,
       description: value.description,
-      integrations: collectIntegrations(toolName, sourcePath, value.input),
-      inputSchema: projectInputSchema(value.input),
+      integrations,
+      inputSchema: projectInputSchema(inputJsonSchema, integrations),
       outputSchema: jsonSchemaFor(value.output),
       annotations: value.annotations,
     });
@@ -323,16 +352,53 @@ const timeout = <A>(promise: Promise<A>, timeoutMs: number): Promise<A> =>
     }),
   ]);
 
-const makeClient = (prefix: readonly string[], bridge: AppToolBridge): unknown =>
+const makeClient = (root: string, prefix: readonly string[], bridge: AppToolBridge): unknown =>
   new Proxy(() => undefined, {
     get(_target, prop) {
       if (prop === "then" || typeof prop === "symbol") return undefined;
-      return makeClient([...prefix, String(prop)], bridge);
+      return makeClient(root, [...prefix, String(prop)], bridge);
     },
     apply(_target, _thisArg, args) {
-      return bridge.call(prefix.join("."), args[0] ?? {});
+      return bridge.call(`${root}.${prefix.join(".")}`, args[0] ?? {});
     },
   });
+
+const splitInvokeInput = (
+  toolName: string,
+  input: unknown,
+  integrations: CollectedTool["integrations"],
+  bridge: AppToolBridge,
+): { readonly input: Record<string, unknown>; readonly integrations: Record<string, unknown> } => {
+  const payload = isRecord(input) ? input : {};
+  const dataInput: Record<string, unknown> = { ...payload };
+  const handles: Record<string, unknown> = {};
+  for (const [field, decl] of Object.entries(integrations)) {
+    const raw = payload[field];
+    delete dataInput[field];
+    if (decl.mode === "one") {
+      if (typeof raw !== "string" || raw.length === 0) {
+        throw new AppExecutorError({
+          kind: "input_validation",
+          message: `tool "${toolName}" integration "${field}" must be a connection address`,
+        });
+      }
+      handles[field] = makeClient(field, [], bridge);
+      continue;
+    }
+    if (raw === undefined && decl.all) {
+      handles[field] = [];
+      continue;
+    }
+    if (!Array.isArray(raw) || raw.some((item) => typeof item !== "string" || item.length === 0)) {
+      throw new AppExecutorError({
+        kind: "input_validation",
+        message: `tool "${toolName}" integration "${field}" must be connection addresses`,
+      });
+    }
+    handles[field] = raw.map((_address, index) => makeClient(`${field}#${index}`, [], bridge));
+  }
+  return { input: dataInput, integrations: handles };
+};
 
 /** In-process backing for unit tests only. It is not a security boundary. */
 export const makeInProcessAppToolExecutor = (): AppToolExecutor => ({
@@ -382,18 +448,16 @@ export const makeInProcessAppToolExecutor = (): AppToolExecutor => ({
                 message: `tool not found in bundle: ${entry.toolName}`,
               });
             }
-            const integrations = collectIntegrations(entry.toolName, entry.toolName, tool.input);
-            const decoded = (await validateStandard(tool.input, input, "input")) as Record<
-              string,
-              unknown
-            >;
-            const handlerInput = { ...decoded };
-            for (const field of Object.keys(integrations)) {
-              handlerInput[field] = makeClient([], {
-                call: (toolPath, args) => bridge.call(`${field}.${toolPath}`, args),
-              });
-            }
-            const output = await tool.handler(handlerInput, {});
+            const inputJsonSchema = jsonSchemaFor(tool.input);
+            const integrations = collectIntegrations(
+              entry.toolName,
+              entry.toolName,
+              tool.integrations,
+              inputJsonSchema,
+            );
+            const split = splitInvokeInput(entry.toolName, input, integrations, bridge);
+            const decoded = await validateStandard(tool.input, split.input, "input");
+            const output = await tool.handler(decoded, split.integrations);
             return { output: await validateStandard(tool.output, output, "output") };
           })(),
           limits.timeoutMs,

--- a/packages/plugins/apps/src/executor/app-tool-executor.ts
+++ b/packages/plugins/apps/src/executor/app-tool-executor.ts
@@ -1,0 +1,405 @@
+import { Buffer } from "node:buffer";
+import { Data, Effect } from "effect";
+import { z } from "zod";
+
+import { validToolKey } from "../pipeline/discover";
+import { stableStringify } from "../pipeline/descriptor";
+
+export class AppExecutorError extends Data.TaggedError("AppExecutorError")<{
+  readonly message: string;
+  readonly kind:
+    | "bundle"
+    | "collect"
+    | "invoke"
+    | "timeout"
+    | "nondeterministic"
+    | "input_validation"
+    | "output_validation";
+  readonly diagnostics?: readonly { readonly path: string; readonly message: string }[];
+  readonly cause?: unknown;
+}> {}
+
+export interface CollectedTool {
+  readonly toolName: string;
+  readonly exportKey?: string;
+  readonly description: string;
+  readonly inputSchema?: unknown;
+  readonly outputSchema?: unknown;
+  readonly integrations: Readonly<Record<string, { readonly slug: string }>>;
+  readonly annotations?: {
+    readonly readOnly?: boolean;
+    readonly destructive?: boolean;
+    readonly requiresApproval?: boolean;
+  };
+}
+
+export interface CollectedModule {
+  readonly tools: readonly CollectedTool[];
+}
+
+export interface AppToolBridge {
+  readonly call: (toolPath: string, args: unknown) => Promise<unknown>;
+}
+
+export interface InvokeOutcome {
+  readonly output: unknown;
+}
+
+export interface AppToolExecutor {
+  readonly collect: (
+    bundle: string,
+    input: { readonly fileSlug: string; readonly sourcePath: string },
+  ) => Effect.Effect<CollectedModule, AppExecutorError>;
+  readonly invoke: (
+    bundle: string,
+    entry: { readonly toolName: string },
+    input: unknown,
+    bridge: AppToolBridge,
+    limits: { readonly timeoutMs: number },
+  ) => Effect.Effect<InvokeOutcome, AppExecutorError>;
+}
+
+const EXECUTOR_INTEGRATION_META = "~executor";
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object" && !Array.isArray(value);
+
+const moduleUrl = (bundle: string): string =>
+  `data:text/javascript;base64,${Buffer.from(bundle, "utf8").toString("base64")}#${crypto.randomUUID()}`;
+
+const importBundle = (bundle: string): Promise<unknown> => import(moduleUrl(bundle));
+
+const resolveDefault = async (bundle: string): Promise<unknown> => {
+  const mod = (await importBundle(bundle)) as { readonly default?: unknown };
+  const value = mod.default;
+  return typeof value === "function" ? await (value as () => unknown | Promise<unknown>)() : value;
+};
+
+const toIssue = (
+  issue: unknown,
+): { readonly message: string; readonly path?: readonly unknown[] } => {
+  if (isRecord(issue) && typeof issue.message === "string") {
+    return {
+      message: issue.message,
+      ...(Array.isArray(issue.path) ? { path: issue.path } : {}),
+    };
+  }
+  return { message: String(issue) };
+};
+
+const validateStandard = async (
+  schema: unknown,
+  value: unknown,
+  field: "input" | "output",
+): Promise<unknown> => {
+  if (!isRecord(schema) || !isRecord(schema["~standard"])) return value;
+  const validate = schema["~standard"].validate;
+  if (typeof validate !== "function") return value;
+  const result = await validate(value);
+  if (isRecord(result) && "issues" in result && Array.isArray(result.issues)) {
+    throw new AppExecutorError({
+      kind: field === "input" ? "input_validation" : "output_validation",
+      message: `${field} validation failed`,
+      cause: result.issues.map(toIssue),
+    });
+  }
+  return isRecord(result) && "value" in result ? result.value : value;
+};
+
+const jsonSchemaFor = (schema: unknown): unknown => {
+  if (schema === undefined) return undefined;
+  if (isRecord(schema) && isRecord(schema["~standard"])) {
+    try {
+      return z.toJSONSchema(schema as unknown as z.ZodType);
+    } catch {
+      return {};
+    }
+  }
+  return schema;
+};
+
+const integrationMarker = (value: unknown): { readonly slug: string } | null => {
+  if (!isRecord(value)) return null;
+  const direct = value[EXECUTOR_INTEGRATION_META];
+  if (isRecord(direct) && direct.kind === "integration" && typeof direct.slug === "string") {
+    return { slug: direct.slug };
+  }
+  const meta = isRecord(value._def) ? value._def.metadata : undefined;
+  const marker = isRecord(meta) ? meta[EXECUTOR_INTEGRATION_META] : undefined;
+  return isRecord(marker) && marker.kind === "integration" && typeof marker.slug === "string"
+    ? { slug: marker.slug }
+    : null;
+};
+
+const shapeOf = (schema: unknown): Record<string, unknown> | null => {
+  if (!isRecord(schema)) return null;
+  const shape = schema.shape;
+  if (isRecord(shape)) return shape;
+  if (typeof shape === "function") {
+    const out = shape();
+    return isRecord(out) ? out : null;
+  }
+  return null;
+};
+
+const findNestedIntegration = (
+  value: unknown,
+  path: readonly string[],
+): readonly string[] | null => {
+  if (integrationMarker(value)) return path;
+  const shape = shapeOf(value);
+  if (shape) {
+    for (const [key, child] of Object.entries(shape)) {
+      const nested = findNestedIntegration(child, [...path, key]);
+      if (nested) return nested;
+    }
+  }
+  return null;
+};
+
+const collectIntegrations = (
+  toolName: string,
+  sourcePath: string,
+  input: unknown,
+): Readonly<Record<string, { readonly slug: string }>> => {
+  const shape = shapeOf(input);
+  if (!shape) return {};
+  const out: Record<string, { readonly slug: string }> = {};
+  for (const [field, fieldSchema] of Object.entries(shape)) {
+    const marker = integrationMarker(fieldSchema);
+    if (marker) {
+      out[field] = marker;
+      continue;
+    }
+    const nested = findNestedIntegration(fieldSchema, [field]);
+    if (nested) {
+      throw new AppExecutorError({
+        kind: "collect",
+        message: `tool "${toolName}" declares nested integration at "${nested.join(".")}"`,
+        diagnostics: [
+          {
+            path: sourcePath,
+            message: `integration() fields must be top-level input fields: ${nested.join(".")}`,
+          },
+        ],
+      });
+    }
+  }
+  return out;
+};
+
+const projectInputSchema = (schema: unknown): unknown => {
+  const shape = shapeOf(schema);
+  if (!shape) return jsonSchemaFor(schema);
+  const properties: Record<string, unknown> = {};
+  const required: string[] = [];
+  for (const [field, fieldSchema] of Object.entries(shape)) {
+    const marker = integrationMarker(fieldSchema);
+    if (marker) {
+      properties[field] = {
+        type: "string",
+        description: `Connection address for ${marker.slug}`,
+      };
+      required.push(field);
+    } else {
+      properties[field] = jsonSchemaFor(fieldSchema);
+    }
+  }
+  return { type: "object", properties, ...(required.length > 0 ? { required } : {}) };
+};
+
+const isDefinedTool = (
+  value: unknown,
+): value is {
+  readonly description: string;
+  readonly input: unknown;
+  readonly output?: unknown;
+  readonly annotations?: CollectedTool["annotations"];
+  readonly handler: (input: unknown, ctx: Record<string, never>) => unknown;
+} =>
+  isRecord(value) &&
+  value["~executorAppTool"] === true &&
+  typeof value.description === "string" &&
+  "input" in value &&
+  typeof value.handler === "function";
+
+const collectFromExport = (
+  exported: unknown,
+  fileSlug: string,
+  sourcePath: string,
+): CollectedModule => {
+  if (isDefinedTool(exported)) {
+    return {
+      tools: [
+        {
+          toolName: fileSlug,
+          description: exported.description,
+          integrations: collectIntegrations(fileSlug, sourcePath, exported.input),
+          inputSchema: projectInputSchema(exported.input),
+          outputSchema: jsonSchemaFor(exported.output),
+          annotations: exported.annotations,
+        },
+      ],
+    };
+  }
+  if (!isRecord(exported)) {
+    throw new AppExecutorError({
+      kind: "collect",
+      message: `default export in ${sourcePath} must be a tool, record, or factory`,
+      diagnostics: [{ path: sourcePath, message: "unsupported default export" }],
+    });
+  }
+  const tools: CollectedTool[] = [];
+  const seen = new Set<string>();
+  if (isDefinedTool(exported[fileSlug])) {
+    throw new AppExecutorError({
+      kind: "collect",
+      message: `record export key "${fileSlug}" collides with single tool name`,
+      diagnostics: [{ path: sourcePath, message: `record key "${fileSlug}" is reserved` }],
+    });
+  }
+  for (const [key, value] of Object.entries(exported)) {
+    if (!isDefinedTool(value)) continue;
+    if (!validToolKey(key)) {
+      throw new AppExecutorError({
+        kind: "collect",
+        message: `record export key "${key}" is not a valid tool slug`,
+        diagnostics: [{ path: sourcePath, message: `invalid record key "${key}"` }],
+      });
+    }
+    const toolName = `${fileSlug}__${key}`;
+    if (seen.has(toolName)) {
+      throw new AppExecutorError({
+        kind: "collect",
+        message: `duplicate tool name "${toolName}"`,
+        diagnostics: [{ path: sourcePath, message: `duplicate tool name "${toolName}"` }],
+      });
+    }
+    seen.add(toolName);
+    tools.push({
+      toolName,
+      exportKey: key,
+      description: value.description,
+      integrations: collectIntegrations(toolName, sourcePath, value.input),
+      inputSchema: projectInputSchema(value.input),
+      outputSchema: jsonSchemaFor(value.output),
+      annotations: value.annotations,
+    });
+  }
+  if (tools.length === 0) {
+    throw new AppExecutorError({
+      kind: "collect",
+      message: `record export in ${sourcePath} contains no defineTool entries`,
+      diagnostics: [{ path: sourcePath, message: "no tools found" }],
+    });
+  }
+  return { tools };
+};
+
+const selectTool = (exported: unknown, entry: string): unknown => {
+  if (isDefinedTool(exported)) return exported;
+  if (!isRecord(exported)) return null;
+  const marker = "__";
+  const index = entry.indexOf(marker);
+  if (index === -1) return null;
+  return exported[entry.slice(index + marker.length)];
+};
+
+const timeout = <A>(promise: Promise<A>, timeoutMs: number): Promise<A> =>
+  Promise.race([
+    promise,
+    new Promise<A>((_, reject) => {
+      setTimeout(
+        () =>
+          reject(
+            new AppExecutorError({
+              kind: "timeout",
+              message: `app tool timed out after ${timeoutMs}ms`,
+            }),
+          ),
+        timeoutMs,
+      );
+    }),
+  ]);
+
+const makeClient = (prefix: readonly string[], bridge: AppToolBridge): unknown =>
+  new Proxy(() => undefined, {
+    get(_target, prop) {
+      if (prop === "then" || typeof prop === "symbol") return undefined;
+      return makeClient([...prefix, String(prop)], bridge);
+    },
+    apply(_target, _thisArg, args) {
+      return bridge.call(prefix.join("."), args[0] ?? {});
+    },
+  });
+
+/** In-process backing for unit tests only. It is not a security boundary. */
+export const makeInProcessAppToolExecutor = (): AppToolExecutor => ({
+  collect: (bundle, input) =>
+    Effect.tryPromise({
+      try: async () => {
+        const first = collectFromExport(
+          await resolveDefault(bundle),
+          input.fileSlug,
+          input.sourcePath,
+        );
+        const second = collectFromExport(
+          await resolveDefault(bundle),
+          input.fileSlug,
+          input.sourcePath,
+        );
+        if (stableStringify(first) !== stableStringify(second)) {
+          throw new AppExecutorError({
+            kind: "nondeterministic",
+            message: `collect for ${input.sourcePath} is nondeterministic`,
+            diagnostics: [
+              { path: input.sourcePath, message: "factory output changed between runs" },
+            ],
+          });
+        }
+        return first;
+      },
+      catch: (cause) =>
+        cause instanceof AppExecutorError
+          ? cause
+          : new AppExecutorError({
+              kind: "collect",
+              message: `collect failed for ${input.sourcePath}`,
+              cause,
+            }),
+    }),
+  invoke: (bundle, entry, input, bridge, limits) =>
+    Effect.tryPromise({
+      try: async () =>
+        timeout(
+          (async () => {
+            const exported = await resolveDefault(bundle);
+            const tool = selectTool(exported, entry.toolName);
+            if (!isDefinedTool(tool)) {
+              throw new AppExecutorError({
+                kind: "invoke",
+                message: `tool not found in bundle: ${entry.toolName}`,
+              });
+            }
+            const integrations = collectIntegrations(entry.toolName, entry.toolName, tool.input);
+            const decoded = (await validateStandard(tool.input, input, "input")) as Record<
+              string,
+              unknown
+            >;
+            const handlerInput = { ...decoded };
+            for (const field of Object.keys(integrations)) {
+              handlerInput[field] = makeClient([], {
+                call: (toolPath, args) => bridge.call(`${field}.${toolPath}`, args),
+              });
+            }
+            const output = await tool.handler(handlerInput, {});
+            return { output: await validateStandard(tool.output, output, "output") };
+          })(),
+          limits.timeoutMs,
+        ),
+      catch: (cause) =>
+        cause instanceof AppExecutorError
+          ? cause
+          : new AppExecutorError({ kind: "invoke", message: "app tool invocation failed", cause }),
+    }),
+});

--- a/packages/plugins/apps/src/executor/app-tool-executor.ts
+++ b/packages/plugins/apps/src/executor/app-tool-executor.ts
@@ -1,6 +1,6 @@
 /* oxlint-disable executor/no-try-catch-or-throw, executor/no-double-cast, executor/no-promise-reject, executor/no-instanceof-tagged-error -- boundary: in-process dynamic-import backing converts JavaScript exceptions into typed AppExecutorError */
 import { Buffer } from "node:buffer";
-import { Data, Effect } from "effect";
+import { Data, Effect, Predicate } from "effect";
 import { z } from "zod";
 
 import { validToolKey } from "../pipeline/discover";
@@ -124,6 +124,13 @@ const jsonSchemaFor = (schema: unknown): unknown => {
     }
   }
   return schema;
+};
+
+const innerToolFailureMessage = (cause: unknown): string | null => {
+  if (!Predicate.isTagged("AppInnerToolError")(cause)) return null;
+  const error = cause as { readonly address?: unknown; readonly innerMessage?: unknown };
+  if (typeof error.address !== "string" || typeof error.innerMessage !== "string") return null;
+  return `Inner tool ${error.address} failed: "${error.innerMessage}"`;
 };
 
 type CollectedIntegrationDecl = CollectedTool["integrations"][string];
@@ -452,6 +459,10 @@ export const makeInProcessAppToolExecutor = (): AppToolExecutor => ({
       catch: (cause) =>
         cause instanceof AppExecutorError
           ? cause
-          : new AppExecutorError({ kind: "invoke", message: "app tool invocation failed", cause }),
+          : new AppExecutorError({
+              kind: "invoke",
+              message: innerToolFailureMessage(cause) ?? "app tool invocation failed",
+              cause,
+            }),
     }),
 });

--- a/packages/plugins/apps/src/executor/app-tool-executor.ts
+++ b/packages/plugins/apps/src/executor/app-tool-executor.ts
@@ -200,20 +200,21 @@ const projectInputSchema = (
   const properties = isRecord(base.properties) ? { ...base.properties } : {};
   const required = Array.isArray(base.required) ? [...base.required] : [];
   for (const [field, decl] of Object.entries(integrations)) {
+    if (decl.all) continue;
     if (decl.mode === "one") {
       properties[field] = {
         type: "string",
         description: decl.description ?? `Connection for ${decl.slug}`,
       };
       required.push(field);
-    } else {
-      properties[field] = {
-        type: "array",
-        items: { type: "string" },
-        description: decl.description ?? `Connections for ${decl.slug}`,
-      };
-      if (!decl.all) required.push(field);
+      continue;
     }
+    properties[field] = {
+      type: "array",
+      items: { type: "string" },
+      description: decl.description ?? `Connections for ${decl.slug}`,
+    };
+    required.push(field);
   }
   return {
     ...base,

--- a/packages/plugins/apps/src/executor/app-tool-executor.ts
+++ b/packages/plugins/apps/src/executor/app-tool-executor.ts
@@ -1,3 +1,4 @@
+/* oxlint-disable executor/no-try-catch-or-throw, executor/no-double-cast, executor/no-promise-reject, executor/no-instanceof-tagged-error -- boundary: in-process dynamic-import backing converts JavaScript exceptions into typed AppExecutorError */
 import { Buffer } from "node:buffer";
 import { Data, Effect } from "effect";
 import { z } from "zod";

--- a/packages/plugins/apps/src/executor/app-tool-executor.ts
+++ b/packages/plugins/apps/src/executor/app-tool-executor.ts
@@ -32,7 +32,6 @@ export interface CollectedTool {
       {
         readonly slug: string;
         readonly mode: "one" | "many";
-        readonly all: boolean;
         readonly description?: string;
       }
     >
@@ -138,7 +137,6 @@ const integrationDeclaration = (value: unknown): CollectedIntegrationDecl | null
   return {
     slug: value.slug,
     mode: value.mode,
-    all: value.allConnections === true,
     ...(typeof value.description === "string" ? { description: value.description } : {}),
   };
 };
@@ -180,13 +178,6 @@ const collectIntegrations = (
         diagnostics: [{ path: sourcePath, message: `invalid integration declaration: ${field}` }],
       });
     }
-    if (decl.mode === "one" && decl.all) {
-      throw new AppExecutorError({
-        kind: "collect",
-        message: `tool "${toolName}" integration "${field}" calls .all() without .array()`,
-        diagnostics: [{ path: sourcePath, message: `.all() requires .array(): ${field}` }],
-      });
-    }
     out[field] = decl;
   }
   return out;
@@ -200,7 +191,6 @@ const projectInputSchema = (
   const properties = isRecord(base.properties) ? { ...base.properties } : {};
   const required = Array.isArray(base.required) ? [...base.required] : [];
   for (const [field, decl] of Object.entries(integrations)) {
-    if (decl.all) continue;
     if (decl.mode === "one") {
       properties[field] = {
         type: "string",
@@ -384,10 +374,6 @@ const splitInvokeInput = (
         });
       }
       handles[field] = makeClient(field, [], bridge);
-      continue;
-    }
-    if (raw === undefined && decl.all) {
-      handles[field] = [];
       continue;
     }
     if (!Array.isArray(raw) || raw.some((item) => typeof item !== "string" || item.length === 0)) {

--- a/packages/plugins/apps/src/index.ts
+++ b/packages/plugins/apps/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./api";
+export * from "./authoring";

--- a/packages/plugins/apps/src/pipeline/bundle.ts
+++ b/packages/plugins/apps/src/pipeline/bundle.ts
@@ -1,0 +1,173 @@
+import { build, version as esbuildVersion } from "esbuild";
+import { Effect, Option, Schema } from "effect";
+
+import { AppExecutorError } from "../executor/app-tool-executor";
+import type { ToolchainRef } from "./descriptor";
+
+const BUNDLE_TARGET = "es2022";
+const FILESET_NS = "executor-apps-fileset";
+const VIRTUAL_NS = "executor-apps-virtual";
+const VIRTUAL_ENTRY = "executor-apps:entry";
+const VIRTUAL_APP = "executor:app";
+
+export const toolchainRef = (): ToolchainRef => ({
+  bundler: { name: "esbuild", version: esbuildVersion },
+  executor: { name: "in-process-data-url", version: "0.1.0" },
+  target: BUNDLE_TARGET,
+});
+
+export interface BundleInput {
+  readonly files: ReadonlyMap<string, string>;
+  readonly entry: string;
+}
+
+export interface BundleOutput {
+  readonly code: string;
+}
+
+const EsbuildDiagnostic = Schema.Struct({ text: Schema.String });
+const EsbuildFailure = Schema.Struct({ errors: Schema.Array(EsbuildDiagnostic) });
+const decodeEsbuildFailure = Schema.decodeUnknownOption(EsbuildFailure);
+
+const bundleFailureMessage = (entry: string, cause: unknown): string => {
+  const decoded = Option.getOrNull(decodeEsbuildFailure(cause));
+  const detail = decoded?.errors.map((error) => error.text).join("; ");
+  return detail ? `bundle failed for ${entry}: ${detail}` : `bundle failed for ${entry}`;
+};
+
+const resolveRelative = (base: string, rel: string): string => {
+  const parts = (base ? base.split("/") : []).concat(rel.split("/"));
+  const out: string[] = [];
+  for (const part of parts) {
+    if (part === "" || part === ".") continue;
+    if (part === "..") out.pop();
+    else out.push(part);
+  }
+  return out.join("/");
+};
+
+const candidates = (path: string): readonly string[] =>
+  /\.(tsx?|jsx?)$/.test(path)
+    ? [path]
+    : [
+        path,
+        `${path}.ts`,
+        `${path}.tsx`,
+        `${path}.js`,
+        `${path}.jsx`,
+        `${path}/index.ts`,
+        `${path}/index.tsx`,
+      ];
+
+const virtualEntrySource = (authorEntry: string): string => `
+import artifact from ${JSON.stringify(`/${authorEntry}`)};
+export default artifact;
+`;
+
+const executorAppSource = `
+import { z } from "zod";
+const EXECUTOR_INTEGRATION_META = "~executor";
+export const integration = (slug) => {
+  const schema = z.custom().meta({ [EXECUTOR_INTEGRATION_META]: { kind: "integration", slug } });
+  Object.defineProperty(schema, EXECUTOR_INTEGRATION_META, {
+    value: { kind: "integration", slug },
+    enumerable: false,
+  });
+  return schema;
+};
+export const defineTool = (definition) => ({ ...definition, "~executorAppTool": true });
+`;
+
+const isAllowedBare = (path: string): boolean => path === "zod" || path.startsWith("zod/");
+
+const fileSetPlugin = (files: ReadonlyMap<string, string>, authorEntry: string) => ({
+  name: "executor-apps-fileset",
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  setup(build2: any) {
+    const norm = (path: string) => path.replace(/^\.\//, "").replace(/\/\.\//g, "/");
+    build2.onResolve(
+      { filter: /.*/ },
+      (args: { path: string; importer: string; namespace?: string }) => {
+        if (args.path === VIRTUAL_ENTRY) return { path: VIRTUAL_ENTRY, namespace: VIRTUAL_NS };
+        if (args.path === VIRTUAL_APP) return { path: VIRTUAL_APP, namespace: VIRTUAL_NS };
+        const fromFileSet = args.namespace === FILESET_NS || args.namespace === VIRTUAL_NS;
+        if (!fromFileSet) return undefined;
+        if (isAllowedBare(args.path)) return undefined;
+        if (args.path.startsWith("/")) {
+          const joined = norm(args.path.slice(1));
+          for (const candidate of candidates(joined)) {
+            if (files.has(candidate)) return { path: candidate, namespace: FILESET_NS };
+          }
+          return { errors: [{ text: `cannot resolve "${args.path}" in the app file set` }] };
+        }
+        if (args.path.startsWith(".")) {
+          const base = args.importer.split("/").slice(0, -1).join("/");
+          const joined = norm(resolveRelative(base, args.path));
+          for (const candidate of candidates(joined)) {
+            if (files.has(candidate)) return { path: candidate, namespace: FILESET_NS };
+          }
+          return {
+            errors: [
+              { text: `cannot resolve "${args.path}" from "${args.importer}" in the app file set` },
+            ],
+          };
+        }
+        return { errors: [{ text: `bare import "${args.path}" is not allowed` }] };
+      },
+    );
+    build2.onLoad({ filter: /.*/, namespace: VIRTUAL_NS }, (args: { path: string }) => ({
+      contents: args.path === VIRTUAL_ENTRY ? virtualEntrySource(authorEntry) : executorAppSource,
+      loader: "ts",
+      resolveDir: process.cwd(),
+    }));
+    build2.onLoad({ filter: /.*/, namespace: FILESET_NS }, (args: { path: string }) => {
+      const contents = files.get(args.path);
+      if (contents === undefined)
+        return { errors: [{ text: `missing file in set: ${args.path}` }] };
+      const loader = args.path.endsWith(".tsx")
+        ? "tsx"
+        : args.path.endsWith(".ts")
+          ? "ts"
+          : args.path.endsWith(".jsx")
+            ? "jsx"
+            : "js";
+      return { contents, loader, resolveDir: process.cwd() };
+    });
+  },
+});
+
+export const bundleEntry = (input: BundleInput): Effect.Effect<BundleOutput, AppExecutorError> =>
+  Effect.tryPromise({
+    try: () =>
+      build({
+        entryPoints: [VIRTUAL_ENTRY],
+        bundle: true,
+        write: false,
+        format: "esm",
+        platform: "neutral",
+        target: BUNDLE_TARGET,
+        minify: false,
+        treeShaking: true,
+        jsx: "automatic",
+        logLevel: "silent",
+        plugins: [fileSetPlugin(input.files, input.entry) as never],
+      }),
+    catch: (cause) =>
+      new AppExecutorError({
+        kind: "bundle",
+        message: bundleFailureMessage(input.entry, cause),
+        cause,
+      }),
+  }).pipe(
+    Effect.flatMap((result) => {
+      const out = result.outputFiles?.[0]?.text;
+      return out === undefined
+        ? Effect.fail(
+            new AppExecutorError({
+              kind: "bundle",
+              message: `bundle failed for ${input.entry}: esbuild produced no output`,
+            }),
+          )
+        : Effect.succeed({ code: out });
+    }),
+  );

--- a/packages/plugins/apps/src/pipeline/bundle.ts
+++ b/packages/plugins/apps/src/pipeline/bundle.ts
@@ -65,16 +65,18 @@ export default artifact;
 `;
 
 const executorAppSource = `
-import { z } from "zod";
-const EXECUTOR_INTEGRATION_META = "~executor";
-export const integration = (slug) => {
-  const schema = z.custom().meta({ [EXECUTOR_INTEGRATION_META]: { kind: "integration", slug } });
-  Object.defineProperty(schema, EXECUTOR_INTEGRATION_META, {
-    value: { kind: "integration", slug },
-    enumerable: false,
-  });
-  return schema;
-};
+const makeIntegrationDeclaration = (state) => Object.freeze({
+  kind: "integration",
+  slug: state.slug,
+  mode: state.mode,
+  allConnections: state.allConnections,
+  ...(state.description !== undefined ? { description: state.description } : {}),
+  array: () => makeIntegrationDeclaration({ ...state, mode: "many" }),
+  all: () => makeIntegrationDeclaration({ ...state, allConnections: true }),
+  describe: (text) => makeIntegrationDeclaration({ ...state, description: text }),
+});
+export const integration = (slug) =>
+  makeIntegrationDeclaration({ slug, mode: "one", allConnections: false });
 export const defineTool = (definition) => ({ ...definition, "~executorAppTool": true });
 `;
 

--- a/packages/plugins/apps/src/pipeline/bundle.ts
+++ b/packages/plugins/apps/src/pipeline/bundle.ts
@@ -69,14 +69,12 @@ const makeIntegrationDeclaration = (state) => Object.freeze({
   kind: "integration",
   slug: state.slug,
   mode: state.mode,
-  allConnections: state.allConnections,
   ...(state.description !== undefined ? { description: state.description } : {}),
   array: () => makeIntegrationDeclaration({ ...state, mode: "many" }),
-  all: () => makeIntegrationDeclaration({ ...state, allConnections: true }),
   describe: (text) => makeIntegrationDeclaration({ ...state, description: text }),
 });
 export const integration = (slug) =>
-  makeIntegrationDeclaration({ slug, mode: "one", allConnections: false });
+  makeIntegrationDeclaration({ slug, mode: "one" });
 export const defineTool = (definition) => ({ ...definition, "~executorAppTool": true });
 `;
 

--- a/packages/plugins/apps/src/pipeline/descriptor.ts
+++ b/packages/plugins/apps/src/pipeline/descriptor.ts
@@ -19,6 +19,9 @@ export interface ToolchainRef {
 
 export interface IntegrationDecl {
   readonly slug: string;
+  readonly mode: "one" | "many";
+  readonly all: boolean;
+  readonly description?: string;
 }
 
 export interface ToolDescriptor {

--- a/packages/plugins/apps/src/pipeline/descriptor.ts
+++ b/packages/plugins/apps/src/pipeline/descriptor.ts
@@ -1,0 +1,74 @@
+export const DESCRIPTOR_VERSION = 6 as const;
+
+export interface ModuleSourceRef {
+  readonly path: string;
+  readonly sourceHash: string;
+}
+
+export interface ToolchainRef {
+  readonly bundler: {
+    readonly name: string;
+    readonly version: string;
+  };
+  readonly executor: {
+    readonly name: string;
+    readonly version: string;
+  };
+  readonly target: string;
+}
+
+export interface IntegrationDecl {
+  readonly slug: string;
+}
+
+export interface ToolDescriptor {
+  readonly name: string;
+  readonly sourcePath: string;
+  readonly bundleKey: string;
+  readonly source: ModuleSourceRef;
+  readonly description: string;
+  readonly integrations: Readonly<Record<string, IntegrationDecl>>;
+  readonly inputSchema?: unknown;
+  readonly outputSchema?: unknown;
+  readonly annotations?: {
+    readonly readOnly?: boolean;
+    readonly destructive?: boolean;
+    readonly requiresApproval?: boolean;
+  };
+}
+
+export interface DeferredDescriptor {
+  readonly path: string;
+  readonly reason: "not supported yet";
+}
+
+export interface AppDescriptor {
+  readonly version: typeof DESCRIPTOR_VERSION;
+  readonly app: string;
+  readonly sourceRef: string;
+  readonly descriptorKey: string;
+  readonly publishedAt: number;
+  readonly toolchain: ToolchainRef;
+  readonly tools: readonly ToolDescriptor[];
+  readonly workflows: readonly DeferredDescriptor[];
+  readonly ui: readonly DeferredDescriptor[];
+  readonly skills: readonly DeferredDescriptor[];
+  readonly skipped: readonly DeferredDescriptor[];
+}
+
+export const stableStringify = (value: unknown): string => {
+  const seen = new WeakSet<object>();
+  const walk = (v: unknown): unknown => {
+    if (v === null || typeof v !== "object") return v;
+    if (seen.has(v)) return "[Circular]";
+    seen.add(v);
+    if (Array.isArray(v)) return v.map(walk);
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(v as Record<string, unknown>).sort()) {
+      const inner = (v as Record<string, unknown>)[key];
+      if (inner !== undefined) out[key] = walk(inner);
+    }
+    return out;
+  };
+  return JSON.stringify(walk(value));
+};

--- a/packages/plugins/apps/src/pipeline/descriptor.ts
+++ b/packages/plugins/apps/src/pipeline/descriptor.ts
@@ -48,7 +48,6 @@ export interface AppDescriptor {
   readonly version: typeof DESCRIPTOR_VERSION;
   readonly app: string;
   readonly sourceRef: string;
-  readonly descriptorKey: string;
   readonly publishedAt: number;
   readonly toolchain: ToolchainRef;
   readonly tools: readonly ToolDescriptor[];

--- a/packages/plugins/apps/src/pipeline/descriptor.ts
+++ b/packages/plugins/apps/src/pipeline/descriptor.ts
@@ -20,7 +20,6 @@ export interface ToolchainRef {
 export interface IntegrationDecl {
   readonly slug: string;
   readonly mode: "one" | "many";
-  readonly all: boolean;
   readonly description?: string;
 }
 

--- a/packages/plugins/apps/src/pipeline/discover.ts
+++ b/packages/plugins/apps/src/pipeline/discover.ts
@@ -1,0 +1,68 @@
+import { Data } from "effect";
+
+export interface FileDiagnostic {
+  readonly path: string;
+  readonly message: string;
+}
+
+export class PublishError extends Data.TaggedError("PublishError")<{
+  readonly message: string;
+  readonly stage: "discover" | "bundle" | "collect" | "project";
+  readonly diagnostics: readonly FileDiagnostic[];
+}> {}
+
+export interface DiscoveredTool {
+  readonly name: string;
+  readonly entry: string;
+}
+
+export interface SkippedArtifact {
+  readonly path: string;
+  readonly reason: "not supported yet";
+}
+
+export interface DiscoverResult {
+  readonly tools: readonly DiscoveredTool[];
+  readonly skipped: readonly SkippedArtifact[];
+}
+
+const TOOL_RE = /^tools\/([a-z0-9][a-z0-9-]*)\.(ts|tsx|js|jsx)$/;
+const DEFERRED_RE = /^(workflows|ui|skills)\//;
+
+export const validToolKey = (key: string): boolean => /^[a-z0-9][a-z0-9-]*$/.test(key);
+
+export const discover = (files: ReadonlyMap<string, string>): DiscoverResult | PublishError => {
+  const diagnostics: FileDiagnostic[] = [];
+  const tools: DiscoveredTool[] = [];
+  const skipped: SkippedArtifact[] = [];
+  const seen = new Set<string>();
+
+  for (const [path] of files) {
+    if (path === "executor.json") continue;
+    const tool = path.match(TOOL_RE);
+    if (tool) {
+      const name = tool[1]!;
+      if (seen.has(name)) {
+        diagnostics.push({ path, message: `duplicate tool identity: ${name}` });
+      } else {
+        seen.add(name);
+        tools.push({ name, entry: path });
+      }
+      continue;
+    }
+    if (path.startsWith("tools/")) {
+      diagnostics.push({ path, message: "file does not match the expected layout for tools/" });
+      continue;
+    }
+    if (DEFERRED_RE.test(path)) skipped.push({ path, reason: "not supported yet" });
+  }
+
+  if (diagnostics.length > 0) {
+    return new PublishError({
+      message: `discover found ${diagnostics.length} problem(s)`,
+      stage: "discover",
+      diagnostics,
+    });
+  }
+  return { tools, skipped };
+};

--- a/packages/plugins/apps/src/pipeline/publish.test.ts
+++ b/packages/plugins/apps/src/pipeline/publish.test.ts
@@ -28,6 +28,7 @@ const makeMemoryStore = (): AppsStore & {
   const blobs = new Map<string, string>();
   const rows = new Map<string, unknown>();
   let descriptor: AppDescriptor | null = null;
+  let descriptorKey: string | null = null;
   return {
     rows,
     blobs,
@@ -40,11 +41,9 @@ const makeMemoryStore = (): AppsStore & {
     getBlob: (key) => Effect.sync(() => blobs.get(key) ?? null),
     getDescriptorRecord: () =>
       Effect.sync(() =>
-        descriptor
-          ? { sourceRef: descriptor.sourceRef, descriptorKey: descriptor.descriptorKey }
-          : null,
+        descriptor ? { sourceRef: descriptor.sourceRef, descriptorKey: descriptorKey ?? "" } : null,
       ),
-    putPublished: (next, _owner, expectedSourceRef) =>
+    putPublished: (next, nextDescriptorKey, _owner, expectedSourceRef) =>
       Effect.gen(function* () {
         const actualSourceRef = descriptor?.sourceRef ?? null;
         if (actualSourceRef !== expectedSourceRef) {
@@ -55,6 +54,7 @@ const makeMemoryStore = (): AppsStore & {
           });
         }
         descriptor = next;
+        descriptorKey = nextDescriptorKey;
         for (const key of rows.keys()) rows.delete(key);
         for (const item of next.tools) rows.set(item.name, item);
       }),
@@ -132,6 +132,7 @@ describe("publish", () => {
       expect(result.publishedTools).toEqual(["sync"]);
       expect(result.skipped).toEqual([{ path: "workflows/later.ts", reason: "not supported yet" }]);
       expect(result.descriptor.toolchain.executor.name).toBe("in-process-data-url");
+      expect(store.blobs.size).toBe(2);
     }),
   );
 

--- a/packages/plugins/apps/src/pipeline/publish.test.ts
+++ b/packages/plugins/apps/src/pipeline/publish.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "@effect/vitest";
-import { Effect } from "effect";
+import { Effect, Result } from "effect";
 
-import type { AppsStore } from "../plugin/store";
+import { AppPublishConflictError, type AppsStore } from "../plugin/store";
 import { makeInProcessAppToolExecutor } from "../executor/app-tool-executor";
 import type { AppDescriptor } from "./descriptor";
 import { discover } from "./discover";
@@ -21,12 +21,16 @@ const tool = (description = "Tool") => `
   });
 `;
 
-const makeMemoryStore = (): AppsStore & { readonly rows: Map<string, unknown> } => {
+const makeMemoryStore = (): AppsStore & {
+  readonly rows: Map<string, unknown>;
+  readonly blobs: Map<string, string>;
+} => {
   const blobs = new Map<string, string>();
   const rows = new Map<string, unknown>();
   let descriptor: AppDescriptor | null = null;
   return {
     rows,
+    blobs,
     putBlob: (body) =>
       Effect.sync(() => {
         const key = `blob:${body.length}:${blobs.size}`;
@@ -40,9 +44,18 @@ const makeMemoryStore = (): AppsStore & { readonly rows: Map<string, unknown> } 
           ? { sourceRef: descriptor.sourceRef, descriptorKey: descriptor.descriptorKey }
           : null,
       ),
-    putPublished: (next) =>
-      Effect.sync(() => {
+    putPublished: (next, _owner, expectedSourceRef) =>
+      Effect.gen(function* () {
+        const actualSourceRef = descriptor?.sourceRef ?? null;
+        if (actualSourceRef !== expectedSourceRef) {
+          return yield* new AppPublishConflictError({
+            app: next.app,
+            expectedSourceRef,
+            actualSourceRef,
+          });
+        }
         descriptor = next;
+        for (const key of rows.keys()) rows.delete(key);
         for (const item of next.tools) rows.set(item.name, item);
       }),
     listActiveTools: () => Effect.sync(() => descriptor?.tools ?? []),
@@ -62,6 +75,28 @@ const makeMemoryStore = (): AppsStore & { readonly rows: Map<string, unknown> } 
             }
           : null;
       }),
+  };
+};
+
+const makeBarrierStore = () => {
+  const store = makeMemoryStore();
+  let reads = 0;
+  let release: (() => void) | null = null;
+  const barrier = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  return {
+    ...store,
+    getDescriptorRecord: () =>
+      Effect.promise(async () => {
+        reads += 1;
+        if (reads === 2) release?.();
+        if (reads <= 2) await barrier;
+        return null;
+      }),
+  } satisfies AppsStore & {
+    readonly rows: Map<string, unknown>;
+    readonly blobs: Map<string, string>;
   };
 };
 
@@ -142,6 +177,61 @@ describe("publish", () => {
         },
       ).pipe(Effect.flip);
       expect(store.rows.size).toBe(0);
+    }),
+  );
+
+  it.effect("leaves no rows or blobs when one tool fails collect", () =>
+    Effect.gen(function* () {
+      const store = makeMemoryStore();
+      yield* publish(
+        { store, executor: makeInProcessAppToolExecutor() },
+        {
+          app: "crm",
+          sourceRef: "sha-1",
+          files: [
+            file("tools/ok.ts", tool("OK")),
+            file(
+              "tools/bad.ts",
+              `
+                import { z } from "zod";
+                import { defineTool, integration } from "executor:app";
+                export default defineTool({
+                  description: "Bad",
+                  integrations: { crm: integration("dealcloud").all() },
+                  input: z.object({}),
+                  handler(input) { return input; },
+                });
+              `,
+            ),
+          ],
+        },
+      ).pipe(Effect.flip);
+      expect(store.rows.size).toBe(0);
+      expect(store.blobs.size).toBe(0);
+    }),
+  );
+
+  it.effect("guards concurrent publishes for the same app", () =>
+    Effect.gen(function* () {
+      const store = makeBarrierStore();
+      const results = yield* Effect.all(
+        [
+          publish(
+            { store, executor: makeInProcessAppToolExecutor(), now: () => 1 },
+            { app: "crm", sourceRef: "sha-a", files: [file("tools/a.ts", tool("A"))] },
+          ).pipe(Effect.result),
+          publish(
+            { store, executor: makeInProcessAppToolExecutor(), now: () => 2 },
+            { app: "crm", sourceRef: "sha-b", files: [file("tools/b.ts", tool("B"))] },
+          ).pipe(Effect.result),
+        ],
+        { concurrency: "unbounded" },
+      );
+      const successes = results.filter(Result.isSuccess);
+      const failures = results.filter(Result.isFailure);
+      expect(successes).toHaveLength(1);
+      expect(failures).toHaveLength(1);
+      expect([...store.rows.keys()]).toHaveLength(1);
     }),
   );
 });

--- a/packages/plugins/apps/src/pipeline/publish.test.ts
+++ b/packages/plugins/apps/src/pipeline/publish.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+
+import type { AppsStore } from "../plugin/store";
+import { makeInProcessAppToolExecutor } from "../executor/app-tool-executor";
+import type { AppDescriptor } from "./descriptor";
+import { discover, PublishError } from "./discover";
+import { publish } from "./publish";
+
+const encoder = new TextEncoder();
+
+const file = (path: string, body: string) => ({ path, bytes: encoder.encode(body) });
+
+const tool = (description = "Tool") => `
+  import { z } from "zod";
+  import { defineTool } from "executor:app";
+  export default defineTool({
+    description: ${JSON.stringify(description)},
+    input: z.object({ value: z.string() }),
+    handler(input) { return input; },
+  });
+`;
+
+const makeMemoryStore = (): AppsStore & { readonly rows: Map<string, unknown> } => {
+  const blobs = new Map<string, string>();
+  const rows = new Map<string, unknown>();
+  let descriptor: AppDescriptor | null = null;
+  return {
+    rows,
+    putBlob: (body) =>
+      Effect.sync(() => {
+        const key = `blob:${body.length}:${blobs.size}`;
+        blobs.set(key, body);
+        return key;
+      }),
+    getBlob: (key) => Effect.sync(() => blobs.get(key) ?? null),
+    getDescriptorRecord: () =>
+      Effect.sync(() =>
+        descriptor
+          ? { sourceRef: descriptor.sourceRef, descriptorKey: descriptor.descriptorKey }
+          : null,
+      ),
+    putPublished: (next) =>
+      Effect.sync(() => {
+        descriptor = next;
+        for (const item of next.tools) rows.set(item.name, item);
+      }),
+    listActiveTools: () => Effect.sync(() => descriptor?.tools ?? []),
+    getTool: (name) =>
+      Effect.sync(() => {
+        const row = descriptor?.tools.find((item) => item.name === name);
+        return row
+          ? {
+              app: descriptor!.app,
+              name: row.name,
+              bundleKey: row.bundleKey,
+              description: row.description,
+              inputSchema: row.inputSchema,
+              outputSchema: row.outputSchema,
+              integrations: row.integrations,
+              annotations: row.annotations,
+            }
+          : null;
+      }),
+  };
+};
+
+describe("discover", () => {
+  it("reports non-tool files under tools and reserved folders", () => {
+    const result = discover(
+      new Map([
+        ["tools/readme.md", ""],
+        ["workflows/a.ts", ""],
+        ["ui/panel.tsx", ""],
+        ["skills/guide.md", ""],
+      ]),
+    );
+    expect(result).toBeInstanceOf(PublishError);
+    if (!(result instanceof PublishError)) return;
+    expect(result.diagnostics[0]?.path).toBe("tools/readme.md");
+  });
+});
+
+describe("publish", () => {
+  it.effect("publishes tools from an in-memory file set", () =>
+    Effect.gen(function* () {
+      const store = makeMemoryStore();
+      const result = yield* publish(
+        { store, executor: makeInProcessAppToolExecutor(), now: () => 10 },
+        {
+          app: "crm",
+          sourceRef: "sha-1",
+          files: [file("tools/sync.ts", tool()), file("workflows/later.ts", "")],
+        },
+      );
+      expect(result.publishedTools).toEqual(["sync"]);
+      expect(result.skipped).toEqual([{ path: "workflows/later.ts", reason: "not supported yet" }]);
+      expect(result.descriptor.toolchain.executor.name).toBe("in-process-data-url");
+    }),
+  );
+
+  it.effect("treats identical sourceRef as a no-op", () =>
+    Effect.gen(function* () {
+      const store = makeMemoryStore();
+      const input = {
+        app: "crm",
+        sourceRef: "sha-1",
+        files: [file("tools/sync.ts", tool())],
+      };
+      yield* publish({ store, executor: makeInProcessAppToolExecutor() }, input);
+      const second = yield* publish({ store, executor: makeInProcessAppToolExecutor() }, input);
+      expect(second.noop).toBe(true);
+      expect(second.publishedTools).toEqual([]);
+    }),
+  );
+
+  it.effect("rejects nondeterministic factories", () =>
+    Effect.gen(function* () {
+      const store = makeMemoryStore();
+      const exit = yield* publish(
+        { store, executor: makeInProcessAppToolExecutor() },
+        {
+          app: "crm",
+          sourceRef: "sha-1",
+          files: [
+            file(
+              "tools/sync.ts",
+              `
+                import { z } from "zod";
+                import { defineTool } from "executor:app";
+                export default () => ({
+                  [String(Math.random()).slice(2)]: defineTool({
+                    description: "Random",
+                    input: z.object({}),
+                    handler() { return {}; },
+                  }),
+                });
+              `,
+            ),
+          ],
+        },
+      ).pipe(Effect.exit);
+      expect(exit._tag).toBe("Failure");
+      expect(store.rows.size).toBe(0);
+    }),
+  );
+});

--- a/packages/plugins/apps/src/pipeline/publish.test.ts
+++ b/packages/plugins/apps/src/pipeline/publish.test.ts
@@ -4,7 +4,7 @@ import { Effect } from "effect";
 import type { AppsStore } from "../plugin/store";
 import { makeInProcessAppToolExecutor } from "../executor/app-tool-executor";
 import type { AppDescriptor } from "./descriptor";
-import { discover, PublishError } from "./discover";
+import { discover } from "./discover";
 import { publish } from "./publish";
 
 const encoder = new TextEncoder();
@@ -75,9 +75,10 @@ describe("discover", () => {
         ["skills/guide.md", ""],
       ]),
     );
-    expect(result).toBeInstanceOf(PublishError);
-    if (!(result instanceof PublishError)) return;
-    expect(result.diagnostics[0]?.path).toBe("tools/readme.md");
+    expect(result).toMatchObject({
+      _tag: "PublishError",
+      diagnostics: [{ path: "tools/readme.md" }],
+    });
   });
 });
 
@@ -117,7 +118,7 @@ describe("publish", () => {
   it.effect("rejects nondeterministic factories", () =>
     Effect.gen(function* () {
       const store = makeMemoryStore();
-      const exit = yield* publish(
+      yield* publish(
         { store, executor: makeInProcessAppToolExecutor() },
         {
           app: "crm",
@@ -139,8 +140,7 @@ describe("publish", () => {
             ),
           ],
         },
-      ).pipe(Effect.exit);
-      expect(exit._tag).toBe("Failure");
+      ).pipe(Effect.flip);
       expect(store.rows.size).toBe(0);
     }),
   );

--- a/packages/plugins/apps/src/pipeline/publish.test.ts
+++ b/packages/plugins/apps/src/pipeline/publish.test.ts
@@ -197,7 +197,7 @@ describe("publish", () => {
                 import { defineTool, integration } from "executor:app";
                 export default defineTool({
                   description: "Bad",
-                  integrations: { crm: integration("dealcloud").all() },
+                  integrations: { crm: { kind: "integration", slug: "dealcloud", mode: "bad" } },
                   input: z.object({}),
                   handler(input) { return input; },
                 });

--- a/packages/plugins/apps/src/pipeline/publish.ts
+++ b/packages/plugins/apps/src/pipeline/publish.ts
@@ -180,11 +180,10 @@ export const publish = (
       }
     }
 
-    const descriptorSeed = {
+    const descriptor: AppDescriptor = {
       version: DESCRIPTOR_VERSION,
       app: input.app,
       sourceRef: input.sourceRef,
-      descriptorKey: "",
       publishedAt: deps.now?.() ?? Date.now(),
       toolchain: toolchainRef(),
       tools,
@@ -193,8 +192,8 @@ export const publish = (
       skills: discovered.skipped.filter((item) => item.path.startsWith("skills/")),
       skipped: discovered.skipped,
     };
-    const descriptorBodyWithoutKey = stableStringify(descriptorSeed);
-    const descriptorKey = yield* deps.store.putBlob(descriptorBodyWithoutKey, owner).pipe(
+    const descriptorBody = stableStringify(descriptor);
+    const descriptorKey = yield* deps.store.putBlob(descriptorBody, owner).pipe(
       Effect.mapError(
         () =>
           new PublishError({
@@ -204,38 +203,27 @@ export const publish = (
           }),
       ),
     );
-    const descriptor: AppDescriptor = { ...descriptorSeed, descriptorKey };
-    const descriptorBody = stableStringify(descriptor);
-    const finalDescriptorKey = yield* deps.store.putBlob(descriptorBody, owner).pipe(
-      Effect.mapError(
-        () =>
-          new PublishError({
-            stage: "project",
-            message: "failed to write final descriptor blob",
-            diagnostics: [],
-          }),
-      ),
-    );
-    const finalDescriptor: AppDescriptor = { ...descriptor, descriptorKey: finalDescriptorKey };
-    yield* deps.store.putPublished(finalDescriptor, owner, existing?.sourceRef ?? null).pipe(
-      Effect.mapError((cause) => {
-        if (Predicate.isTagged("AppPublishConflictError")(cause)) {
+    yield* deps.store
+      .putPublished(descriptor, descriptorKey, owner, existing?.sourceRef ?? null)
+      .pipe(
+        Effect.mapError((cause) => {
+          if (Predicate.isTagged("AppPublishConflictError")(cause)) {
+            return new PublishError({
+              stage: "project",
+              message: `app "${input.app}" changed during publish`,
+              diagnostics: [{ path: "", message: "publish sourceRef changed during publish" }],
+            });
+          }
           return new PublishError({
             stage: "project",
-            message: `app "${input.app}" changed during publish`,
-            diagnostics: [{ path: "", message: "publish sourceRef changed during publish" }],
+            message: "failed to persist app publication",
+            diagnostics: [],
           });
-        }
-        return new PublishError({
-          stage: "project",
-          message: "failed to persist app publication",
-          diagnostics: [],
-        });
-      }),
-    );
+        }),
+      );
     return {
-      descriptor: finalDescriptor,
-      publishedTools: finalDescriptor.tools.map((tool) => tool.name),
+      descriptor,
+      publishedTools: descriptor.tools.map((tool) => tool.name),
       skipped: discovered.skipped,
       noop: false,
     };

--- a/packages/plugins/apps/src/pipeline/publish.ts
+++ b/packages/plugins/apps/src/pipeline/publish.ts
@@ -1,0 +1,214 @@
+import { Effect, Predicate, Schema } from "effect";
+import { sha256Hex, type Owner } from "@executor-js/sdk";
+
+import type { AppToolExecutor, CollectedTool } from "../executor/app-tool-executor";
+import type { AppsStore } from "../plugin/store";
+import { bundleEntry } from "./bundle";
+import {
+  DESCRIPTOR_VERSION,
+  stableStringify,
+  type AppDescriptor,
+  type ModuleSourceRef,
+  type ToolDescriptor,
+} from "./descriptor";
+import { toolchainRef } from "./bundle";
+import { discover, PublishError, type SkippedArtifact } from "./discover";
+
+export interface PublishFile {
+  readonly path: string;
+  readonly bytes: Uint8Array;
+}
+
+export interface PublishInput {
+  readonly app: string;
+  readonly owner?: Owner;
+  readonly files: readonly PublishFile[];
+  readonly sourceRef: string;
+}
+
+export interface PublishResult {
+  readonly descriptor: AppDescriptor;
+  readonly publishedTools: readonly string[];
+  readonly skipped: readonly SkippedArtifact[];
+  readonly noop: boolean;
+}
+
+export interface PublishDeps {
+  readonly store: AppsStore;
+  readonly executor: AppToolExecutor;
+  readonly now?: () => number;
+}
+
+const textDecoder = new TextDecoder();
+
+const fileMap = (files: readonly PublishFile[]): ReadonlyMap<string, string> => {
+  const out = new Map<string, string>();
+  for (const file of files) out.set(file.path, textDecoder.decode(file.bytes));
+  return out;
+};
+
+const sourceRef = (path: string, source: string): Effect.Effect<ModuleSourceRef> =>
+  sha256Hex(source).pipe(Effect.map((sourceHash) => ({ path, sourceHash })));
+
+const isPublishError = Predicate.isTagged("PublishError") as (
+  value: unknown,
+) => value is PublishError;
+
+const decodeJson = Schema.decodeUnknownSync(Schema.UnknownFromJsonString);
+
+const toPublishError = (
+  stage: PublishError["stage"],
+  path: string,
+  cause: {
+    readonly message: string;
+    readonly diagnostics?: readonly { readonly path: string; readonly message: string }[];
+  },
+): PublishError =>
+  new PublishError({
+    stage,
+    message: cause.message,
+    diagnostics:
+      cause.diagnostics && cause.diagnostics.length > 0
+        ? cause.diagnostics
+        : [{ path, message: cause.message }],
+  });
+
+const toolDescriptor = (input: {
+  readonly collected: CollectedTool;
+  readonly sourcePath: string;
+  readonly bundleKey: string;
+  readonly source: ModuleSourceRef;
+}): ToolDescriptor => ({
+  name: input.collected.toolName,
+  sourcePath: input.sourcePath,
+  bundleKey: input.bundleKey,
+  source: input.source,
+  description: input.collected.description,
+  integrations: input.collected.integrations,
+  inputSchema: input.collected.inputSchema,
+  outputSchema: input.collected.outputSchema,
+  annotations: input.collected.annotations,
+});
+
+export const publish = (
+  deps: PublishDeps,
+  input: PublishInput,
+): Effect.Effect<PublishResult, PublishError> =>
+  Effect.gen(function* () {
+    const owner = input.owner ?? "org";
+    const files = fileMap(input.files);
+    const discovered = discover(files);
+    if (isPublishError(discovered)) return yield* discovered;
+
+    const existing = yield* deps.store.getDescriptorRecord(input.app).pipe(
+      Effect.mapError(
+        (cause) =>
+          new PublishError({
+            stage: "project",
+            message: "failed to read existing app descriptor",
+            diagnostics: [],
+            cause,
+          } as never),
+      ),
+    );
+    if (existing?.sourceRef === input.sourceRef) {
+      const descriptorBody = yield* deps.store.getBlob(existing.descriptorKey).pipe(
+        Effect.mapError(
+          () =>
+            new PublishError({
+              stage: "project",
+              message: "failed to read existing descriptor blob",
+              diagnostics: [],
+            }),
+        ),
+      );
+      if (descriptorBody) {
+        return {
+          descriptor: decodeJson(descriptorBody) as AppDescriptor,
+          publishedTools: [],
+          skipped: discovered.skipped,
+          noop: true,
+        };
+      }
+    }
+
+    const tools: ToolDescriptor[] = [];
+    for (const artifact of discovered.tools) {
+      const bundled = yield* bundleEntry({ files, entry: artifact.entry }).pipe(
+        Effect.mapError((cause) => toPublishError("bundle", artifact.entry, cause)),
+      );
+      const bundleKey = yield* deps.store.putBlob(bundled.code, owner).pipe(
+        Effect.mapError(
+          () =>
+            new PublishError({
+              stage: "project",
+              message: `failed to write bundle for ${artifact.entry}`,
+              diagnostics: [{ path: artifact.entry, message: "bundle blob write failed" }],
+            }),
+        ),
+      );
+      const collected = yield* deps.executor
+        .collect(bundled.code, { fileSlug: artifact.name, sourcePath: artifact.entry })
+        .pipe(Effect.mapError((cause) => toPublishError("collect", artifact.entry, cause)));
+      const source = yield* sourceRef(artifact.entry, files.get(artifact.entry) ?? "");
+      for (const tool of collected.tools) {
+        tools.push(
+          toolDescriptor({ collected: tool, sourcePath: artifact.entry, bundleKey, source }),
+        );
+      }
+    }
+
+    const descriptorSeed = {
+      version: DESCRIPTOR_VERSION,
+      app: input.app,
+      sourceRef: input.sourceRef,
+      descriptorKey: "",
+      publishedAt: deps.now?.() ?? Date.now(),
+      toolchain: toolchainRef(),
+      tools,
+      workflows: discovered.skipped.filter((item) => item.path.startsWith("workflows/")),
+      ui: discovered.skipped.filter((item) => item.path.startsWith("ui/")),
+      skills: discovered.skipped.filter((item) => item.path.startsWith("skills/")),
+      skipped: discovered.skipped,
+    };
+    const descriptorBodyWithoutKey = stableStringify(descriptorSeed);
+    const descriptorKey = yield* deps.store.putBlob(descriptorBodyWithoutKey, owner).pipe(
+      Effect.mapError(
+        () =>
+          new PublishError({
+            stage: "project",
+            message: "failed to write descriptor blob",
+            diagnostics: [],
+          }),
+      ),
+    );
+    const descriptor: AppDescriptor = { ...descriptorSeed, descriptorKey };
+    const descriptorBody = stableStringify(descriptor);
+    const finalDescriptorKey = yield* deps.store.putBlob(descriptorBody, owner).pipe(
+      Effect.mapError(
+        () =>
+          new PublishError({
+            stage: "project",
+            message: "failed to write final descriptor blob",
+            diagnostics: [],
+          }),
+      ),
+    );
+    const finalDescriptor: AppDescriptor = { ...descriptor, descriptorKey: finalDescriptorKey };
+    yield* deps.store.putPublished(finalDescriptor, owner).pipe(
+      Effect.mapError(
+        () =>
+          new PublishError({
+            stage: "project",
+            message: "failed to persist app publication",
+            diagnostics: [],
+          }),
+      ),
+    );
+    return {
+      descriptor: finalDescriptor,
+      publishedTools: finalDescriptor.tools.map((tool) => tool.name),
+      skipped: discovered.skipped,
+      noop: false,
+    };
+  });

--- a/packages/plugins/apps/src/pipeline/publish.ts
+++ b/packages/plugins/apps/src/pipeline/publish.ts
@@ -134,12 +134,31 @@ export const publish = (
       }
     }
 
-    const tools: ToolDescriptor[] = [];
+    const staged: {
+      readonly entry: string;
+      readonly bundle: string;
+      readonly collected: readonly CollectedTool[];
+      readonly source: ModuleSourceRef;
+    }[] = [];
     for (const artifact of discovered.tools) {
       const bundled = yield* bundleEntry({ files, entry: artifact.entry }).pipe(
         Effect.mapError((cause) => toPublishError("bundle", artifact.entry, cause)),
       );
-      const bundleKey = yield* deps.store.putBlob(bundled.code, owner).pipe(
+      const collected = yield* deps.executor
+        .collect(bundled.code, { fileSlug: artifact.name, sourcePath: artifact.entry })
+        .pipe(Effect.mapError((cause) => toPublishError("collect", artifact.entry, cause)));
+      const source = yield* sourceRef(artifact.entry, files.get(artifact.entry) ?? "");
+      staged.push({
+        entry: artifact.entry,
+        bundle: bundled.code,
+        collected: collected.tools,
+        source,
+      });
+    }
+
+    const tools: ToolDescriptor[] = [];
+    for (const artifact of staged) {
+      const bundleKey = yield* deps.store.putBlob(artifact.bundle, owner).pipe(
         Effect.mapError(
           () =>
             new PublishError({
@@ -149,13 +168,14 @@ export const publish = (
             }),
         ),
       );
-      const collected = yield* deps.executor
-        .collect(bundled.code, { fileSlug: artifact.name, sourcePath: artifact.entry })
-        .pipe(Effect.mapError((cause) => toPublishError("collect", artifact.entry, cause)));
-      const source = yield* sourceRef(artifact.entry, files.get(artifact.entry) ?? "");
-      for (const tool of collected.tools) {
+      for (const tool of artifact.collected) {
         tools.push(
-          toolDescriptor({ collected: tool, sourcePath: artifact.entry, bundleKey, source }),
+          toolDescriptor({
+            collected: tool,
+            sourcePath: artifact.entry,
+            bundleKey,
+            source: artifact.source,
+          }),
         );
       }
     }
@@ -197,15 +217,21 @@ export const publish = (
       ),
     );
     const finalDescriptor: AppDescriptor = { ...descriptor, descriptorKey: finalDescriptorKey };
-    yield* deps.store.putPublished(finalDescriptor, owner).pipe(
-      Effect.mapError(
-        () =>
-          new PublishError({
+    yield* deps.store.putPublished(finalDescriptor, owner, existing?.sourceRef ?? null).pipe(
+      Effect.mapError((cause) => {
+        if (Predicate.isTagged("AppPublishConflictError")(cause)) {
+          return new PublishError({
             stage: "project",
-            message: "failed to persist app publication",
-            diagnostics: [],
-          }),
-      ),
+            message: `app "${input.app}" changed during publish`,
+            diagnostics: [{ path: "", message: "publish sourceRef changed during publish" }],
+          });
+        }
+        return new PublishError({
+          stage: "project",
+          message: "failed to persist app publication",
+          diagnostics: [],
+        });
+      }),
     );
     return {
       descriptor: finalDescriptor,

--- a/packages/plugins/apps/src/pipeline/publish.ts
+++ b/packages/plugins/apps/src/pipeline/publish.ts
@@ -66,11 +66,13 @@ const toPublishError = (
 ): PublishError =>
   new PublishError({
     stage,
+    // oxlint-disable-next-line executor/no-unknown-error-message -- typed AppExecutorError conversion keeps its stable diagnostic message
     message: cause.message,
     diagnostics:
       cause.diagnostics && cause.diagnostics.length > 0
         ? cause.diagnostics
-        : [{ path, message: cause.message }],
+        : // oxlint-disable-next-line executor/no-unknown-error-message -- typed AppExecutorError conversion keeps its stable diagnostic message
+          [{ path, message: cause.message }],
   });
 
 const toolDescriptor = (input: {

--- a/packages/plugins/apps/src/plugin/apps-plugin.test.ts
+++ b/packages/plugins/apps/src/plugin/apps-plugin.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+
+import { projectAppsToolSchema } from "./apps-plugin";
+import type { AppsStore } from "./store";
+
+describe("apps plugin schema projection", () => {
+  it.effect("narrows synthesized integration fields to connection address enums", () =>
+    Effect.gen(function* () {
+      const storage: AppsStore = {
+        putBlob: () => Effect.succeed("bundle"),
+        getBlob: () => Effect.succeed(null),
+        getDescriptorRecord: () => Effect.succeed(null),
+        putPublished: () => Effect.void,
+        listActiveTools: () => Effect.succeed([]),
+        getTool: () =>
+          Effect.succeed({
+            app: "crm",
+            name: "sync",
+            bundleKey: "bundle",
+            description: "Sync",
+            integrations: {
+              crm: { slug: "dealcloud", mode: "one", all: false },
+              inboxes: { slug: "gmail", mode: "many", all: false },
+            },
+          }),
+      };
+      const result = yield* projectAppsToolSchema(
+        {
+          storage,
+          connections: {
+            list: ({ integration }: { readonly integration?: unknown }) =>
+              Effect.succeed(
+                String(integration) === "dealcloud"
+                  ? [{ address: "tools.dealcloud.org.main" }]
+                  : [{ address: "tools.gmail.org.work" }, { address: "tools.gmail.user.personal" }],
+              ),
+          },
+        } as never,
+        "sync",
+        {
+          type: "object",
+          properties: {
+            updatedSince: { type: "string" },
+            crm: { type: "string" },
+            inboxes: { type: "array", items: { type: "string" } },
+          },
+          required: ["crm", "inboxes"],
+        },
+        undefined,
+      );
+      expect(result.inputSchema).toMatchObject({
+        properties: {
+          crm: { enum: ["tools.dealcloud.org.main"] },
+          inboxes: {
+            items: {
+              enum: ["tools.gmail.org.work", "tools.gmail.user.personal"],
+            },
+          },
+        },
+        required: ["crm", "inboxes"],
+      });
+    }),
+  );
+});

--- a/packages/plugins/apps/src/plugin/apps-plugin.test.ts
+++ b/packages/plugins/apps/src/plugin/apps-plugin.test.ts
@@ -1,8 +1,59 @@
 import { describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
+import { ToolResult } from "@executor-js/sdk";
 
-import { projectAppsToolSchema } from "./apps-plugin";
+import { bundleEntry } from "../pipeline/bundle";
+import { makeInProcessAppToolExecutor } from "../executor/app-tool-executor";
+import type { AppDescriptor } from "../pipeline/descriptor";
+import { makeAppsPlugin, projectAppsToolSchema } from "./apps-plugin";
 import type { AppsStore } from "./store";
+
+const bundle = (source: string) =>
+  bundleEntry({
+    files: new Map([["tools/sync.ts", source]]),
+    entry: "tools/sync.ts",
+  });
+
+const makeInvokeStore = (input: {
+  readonly bundle: string;
+  readonly integrations: AppDescriptor["tools"][number]["integrations"];
+}): AppsStore => ({
+  putBlob: () => Effect.succeed("bundle"),
+  getBlob: () => Effect.succeed(input.bundle),
+  getDescriptorRecord: () => Effect.succeed(null),
+  putPublished: () => Effect.void,
+  listActiveTools: () => Effect.succeed([]),
+  getTool: () =>
+    Effect.succeed({
+      app: "crm",
+      name: "sync",
+      bundleKey: "bundle",
+      description: "Sync",
+      integrations: input.integrations,
+    }),
+});
+
+const invokeCtx = (input: {
+  readonly bundle: string;
+  readonly execute: (address: string, args: unknown) => Effect.Effect<unknown, unknown>;
+}) =>
+  ({
+    storage: makeInvokeStore({
+      bundle: input.bundle,
+      integrations: { crm: { slug: "dealcloud", mode: "one" } },
+    }),
+    connections: {
+      list: () => Effect.succeed([]),
+      get: () =>
+        Effect.succeed({
+          address: "tools.dealcloud.org.main",
+          integration: "dealcloud",
+          owner: "org",
+          name: "main",
+        }),
+    },
+    execute: (address: string, args: unknown) => input.execute(String(address), args),
+  }) as never;
 
 describe("apps plugin schema projection", () => {
   it.effect("narrows synthesized integration fields to connection address enums", () =>
@@ -60,6 +111,86 @@ describe("apps plugin schema projection", () => {
         },
         required: ["crm", "inboxes"],
       });
+    }),
+  );
+});
+
+describe("apps plugin invocation", () => {
+  it.effect("surfaces uncaught inner tool failures without binding_error", () =>
+    Effect.gen(function* () {
+      const bundled = yield* bundle(`
+        import { z } from "zod";
+        import { defineTool, integration } from "executor:app";
+        export default defineTool({
+          description: "Sync",
+          integrations: { crm: integration("dealcloud") },
+          input: z.object({}),
+          async handler(_input, { crm }) {
+            await crm.deals.list({});
+            return { ok: true };
+          },
+        });
+      `);
+      const plugin = makeAppsPlugin({ executor: makeInProcessAppToolExecutor() });
+      const result = yield* plugin.invokeTool!({
+        ctx: invokeCtx({
+          bundle: bundled.code,
+          execute: () =>
+            Effect.succeed(
+              ToolResult.fail({ code: "upstream_failed", message: "CRM unavailable" }),
+            ),
+        }),
+        toolRow: { name: "sync" },
+        args: { crm: "tools.dealcloud.org.main" },
+      } as never);
+      expect(result).toMatchObject({
+        ok: false,
+        error: {
+          code: "upstream_failed",
+          message: expect.stringContaining("tools.dealcloud.org.main.deals.list"),
+        },
+      });
+      expect(result).toMatchObject({
+        error: { message: expect.stringContaining('"CRM unavailable"') },
+      });
+      expect((result as { readonly error: { readonly code: string } }).error.code).not.toBe(
+        "binding_error",
+      );
+    }),
+  );
+
+  it.effect("lets handlers catch inner tool failures and return a fallback", () =>
+    Effect.gen(function* () {
+      const bundled = yield* bundle(`
+        import { z } from "zod";
+        import { defineTool, integration } from "executor:app";
+        export default defineTool({
+          description: "Sync",
+          integrations: { crm: integration("dealcloud") },
+          input: z.object({}),
+          async handler(_input, { crm }) {
+            try {
+              await crm.deals.list({});
+              return { fallback: false };
+            } catch {
+              return { fallback: true };
+            }
+          },
+        });
+      `);
+      const plugin = makeAppsPlugin({ executor: makeInProcessAppToolExecutor() });
+      const result = yield* plugin.invokeTool!({
+        ctx: invokeCtx({
+          bundle: bundled.code,
+          execute: () =>
+            Effect.succeed(
+              ToolResult.fail({ code: "upstream_failed", message: "CRM unavailable" }),
+            ),
+        }),
+        toolRow: { name: "sync" },
+        args: { crm: "tools.dealcloud.org.main" },
+      } as never);
+      expect(result).toEqual({ fallback: true });
     }),
   );
 });

--- a/packages/plugins/apps/src/plugin/apps-plugin.test.ts
+++ b/packages/plugins/apps/src/plugin/apps-plugin.test.ts
@@ -62,4 +62,45 @@ describe("apps plugin schema projection", () => {
       });
     }),
   );
+
+  it.effect("omits all-bound integration fields from projected schemas", () =>
+    Effect.gen(function* () {
+      const storage: AppsStore = {
+        putBlob: () => Effect.succeed("bundle"),
+        getBlob: () => Effect.succeed(null),
+        getDescriptorRecord: () => Effect.succeed(null),
+        putPublished: () => Effect.void,
+        listActiveTools: () => Effect.succeed([]),
+        getTool: () =>
+          Effect.succeed({
+            app: "mail",
+            name: "search_all_mail",
+            bundleKey: "bundle",
+            description: "Search mail",
+            integrations: {
+              inboxes: { slug: "gmail", mode: "many", all: true },
+            },
+          }),
+      };
+      const inputSchema = {
+        type: "object",
+        properties: {
+          query: { type: "string" },
+        },
+        required: ["query"],
+      };
+      const result = yield* projectAppsToolSchema(
+        {
+          storage,
+          connections: {
+            list: () => Effect.succeed([{ address: "tools.gmail.org.work" }]),
+          },
+        } as never,
+        "search_all_mail",
+        inputSchema,
+        undefined,
+      );
+      expect(result.inputSchema).toEqual(inputSchema);
+    }),
+  );
 });

--- a/packages/plugins/apps/src/plugin/apps-plugin.test.ts
+++ b/packages/plugins/apps/src/plugin/apps-plugin.test.ts
@@ -20,8 +20,8 @@ describe("apps plugin schema projection", () => {
             bundleKey: "bundle",
             description: "Sync",
             integrations: {
-              crm: { slug: "dealcloud", mode: "one", all: false },
-              inboxes: { slug: "gmail", mode: "many", all: false },
+              crm: { slug: "dealcloud", mode: "one" },
+              inboxes: { slug: "gmail", mode: "many" },
             },
           }),
       };
@@ -60,47 +60,6 @@ describe("apps plugin schema projection", () => {
         },
         required: ["crm", "inboxes"],
       });
-    }),
-  );
-
-  it.effect("omits all-bound integration fields from projected schemas", () =>
-    Effect.gen(function* () {
-      const storage: AppsStore = {
-        putBlob: () => Effect.succeed("bundle"),
-        getBlob: () => Effect.succeed(null),
-        getDescriptorRecord: () => Effect.succeed(null),
-        putPublished: () => Effect.void,
-        listActiveTools: () => Effect.succeed([]),
-        getTool: () =>
-          Effect.succeed({
-            app: "mail",
-            name: "search_all_mail",
-            bundleKey: "bundle",
-            description: "Search mail",
-            integrations: {
-              inboxes: { slug: "gmail", mode: "many", all: true },
-            },
-          }),
-      };
-      const inputSchema = {
-        type: "object",
-        properties: {
-          query: { type: "string" },
-        },
-        required: ["query"],
-      };
-      const result = yield* projectAppsToolSchema(
-        {
-          storage,
-          connections: {
-            list: () => Effect.succeed([{ address: "tools.gmail.org.work" }]),
-          },
-        } as never,
-        "search_all_mail",
-        inputSchema,
-        undefined,
-      );
-      expect(result.inputSchema).toEqual(inputSchema);
     }),
   );
 });

--- a/packages/plugins/apps/src/plugin/apps-plugin.ts
+++ b/packages/plugins/apps/src/plugin/apps-plugin.ts
@@ -1,0 +1,139 @@
+import { Data, Effect } from "effect";
+import { ToolName, definePlugin, type PluginCtx, type ToolDef } from "@executor-js/sdk";
+
+import { makeInProcessAppToolExecutor, type AppToolExecutor } from "../executor/app-tool-executor";
+import { publish, type PublishInput } from "../pipeline/publish";
+import { buildBridge, resolveIntegrationBindings } from "./bindings";
+import { makePluginCtxAppsResolver } from "./resolver";
+import { descriptorCollection, makeAppsStore, toolCollection, type AppsStore } from "./store";
+
+export interface AppsExtension {
+  readonly publish: (input: PublishInput) => Effect.Effect<unknown, unknown>;
+}
+
+const APPS_INTEGRATION = "apps";
+const APPS_CONNECTION = "published";
+
+class AppPluginError extends Data.TaggedError("AppPluginError")<{
+  readonly message: string;
+}> {}
+
+interface ProjectedToolSchema {
+  readonly inputSchema?: unknown;
+  readonly outputSchema?: unknown;
+}
+
+export const makeAppsPlugin = (options?: { readonly executor?: AppToolExecutor }) =>
+  definePlugin(() => ({
+    id: "apps",
+    packageName: "@executor-js/plugin-apps",
+    pluginStorage: {
+      [descriptorCollection.name]: descriptorCollection,
+      [toolCollection.name]: toolCollection,
+    },
+    storage: ({ blobs, pluginStorage }) => makeAppsStore({ blobs, pluginStorage }),
+    extension: (ctx: PluginCtx<AppsStore>): AppsExtension => ({
+      publish: (input) =>
+        publish(
+          { store: ctx.storage, executor: options?.executor ?? makeInProcessAppToolExecutor() },
+          input,
+        ),
+    }),
+    staticSources: () => [
+      {
+        id: "apps",
+        kind: "apps",
+        name: "Apps",
+        canRemove: false,
+        canRefresh: false,
+        tools: [],
+      },
+    ],
+    resolveTools: ({ storage }) =>
+      storage.listActiveTools().pipe(
+        Effect.map((tools) => ({
+          tools: tools.map(
+            (tool): ToolDef => ({
+              name: ToolName.make(tool.name),
+              description: tool.description,
+              inputSchema: tool.inputSchema,
+              outputSchema: tool.outputSchema,
+              annotations: {
+                ...(tool.annotations?.requiresApproval !== undefined
+                  ? { requiresApproval: tool.annotations.requiresApproval }
+                  : {}),
+                ...(tool.annotations?.readOnly === true ? { requiresApproval: false } : {}),
+              },
+            }),
+          ),
+        })),
+      ),
+    projectToolSchema: ({ ctx, toolRow, inputSchema, outputSchema }) =>
+      projectAppsToolSchema(ctx, String(toolRow.name), inputSchema, outputSchema),
+    validateToolArgs: ({ ctx, toolRow, args }) =>
+      Effect.gen(function* () {
+        const tool = yield* ctx.storage.getTool(String(toolRow.name));
+        if (!tool) return;
+        const resolver = makePluginCtxAppsResolver({ ctx });
+        yield* resolveIntegrationBindings(tool.integrations, args, resolver);
+      }),
+    invokeTool: ({ ctx, toolRow, args, invokeOptions }) =>
+      Effect.gen(function* () {
+        const tool = yield* ctx.storage.getTool(String(toolRow.name));
+        if (!tool) {
+          return yield* new AppPluginError({ message: `app tool not found: ${toolRow.name}` });
+        }
+        const bundle = yield* ctx.storage.getBlob(tool.bundleKey);
+        if (!bundle) {
+          return yield* new AppPluginError({ message: `app tool bundle missing: ${tool.name}` });
+        }
+        const resolver = makePluginCtxAppsResolver({ ctx });
+        const bindings = yield* resolveIntegrationBindings(tool.integrations, args, resolver);
+        const bridge = buildBridge({
+          declared: tool.integrations,
+          bindings: bindings.bindings,
+          resolver,
+          invokeOptions,
+        });
+        const result = yield* (options?.executor ?? makeInProcessAppToolExecutor()).invoke(
+          bundle,
+          { toolName: tool.name },
+          { ...bindings.input, ...bindings.bindings },
+          bridge,
+          { timeoutMs: 30_000 },
+        );
+        return result.output;
+      }),
+  }))();
+
+const projectAppsToolSchema = (
+  ctx: PluginCtx<AppsStore>,
+  toolName: string,
+  inputSchema: unknown,
+  outputSchema: unknown,
+): Effect.Effect<ProjectedToolSchema, unknown> =>
+  Effect.gen(function* () {
+    const tool = yield* ctx.storage.getTool(toolName);
+    if (!tool || !inputSchema || typeof inputSchema !== "object" || Array.isArray(inputSchema)) {
+      return { inputSchema, outputSchema };
+    }
+    const schema = inputSchema as Record<string, unknown>;
+    const properties =
+      schema.properties &&
+      typeof schema.properties === "object" &&
+      !Array.isArray(schema.properties)
+        ? { ...(schema.properties as Record<string, unknown>) }
+        : {};
+    for (const [field, decl] of Object.entries(tool.integrations)) {
+      const connections = yield* ctx.connections.list({ integration: decl.slug as never });
+      properties[field] = {
+        type: "string",
+        enum: connections.map((connection) => String(connection.address)),
+      };
+    }
+    return { inputSchema: { ...schema, properties }, outputSchema };
+  });
+
+export const appsPlugin = makeAppsPlugin();
+
+export { APPS_INTEGRATION, APPS_CONNECTION };

--- a/packages/plugins/apps/src/plugin/apps-plugin.ts
+++ b/packages/plugins/apps/src/plugin/apps-plugin.ts
@@ -103,7 +103,7 @@ export const makeAppsPlugin = (options?: { readonly executor?: AppToolExecutor }
       }),
   }))();
 
-const projectAppsToolSchema = (
+export const projectAppsToolSchema = (
   ctx: PluginCtx<AppsStore>,
   toolName: string,
   inputSchema: unknown,
@@ -123,10 +123,11 @@ const projectAppsToolSchema = (
         : {};
     for (const [field, decl] of Object.entries(tool.integrations)) {
       const connections = yield* ctx.connections.list({ integration: decl.slug as never });
-      properties[field] = {
-        type: "string",
-        enum: connections.map((connection) => String(connection.address)),
-      };
+      const enumValues = connections.map((connection) => String(connection.address));
+      properties[field] =
+        decl.mode === "many"
+          ? { type: "array", items: { type: "string", enum: enumValues } }
+          : { type: "string", enum: enumValues };
     }
     return { inputSchema: { ...schema, properties }, outputSchema };
   });

--- a/packages/plugins/apps/src/plugin/apps-plugin.ts
+++ b/packages/plugins/apps/src/plugin/apps-plugin.ts
@@ -1,5 +1,5 @@
-import { Data, Effect } from "effect";
-import { ToolName, definePlugin, type PluginCtx, type ToolDef } from "@executor-js/sdk";
+import { Data, Effect, Predicate } from "effect";
+import { ToolName, ToolResult, definePlugin, type PluginCtx, type ToolDef } from "@executor-js/sdk";
 
 import { makeInProcessAppToolExecutor, type AppToolExecutor } from "../executor/app-tool-executor";
 import { publish } from "../pipeline/publish";
@@ -18,6 +18,43 @@ interface ProjectedToolSchema {
   readonly inputSchema?: unknown;
   readonly outputSchema?: unknown;
 }
+
+const innerToolError = (
+  cause: unknown,
+): { readonly address: string; readonly innerMessage: string; readonly code?: string } | null => {
+  const direct =
+    Predicate.isTagged("AppInnerToolError")(cause) && typeof cause === "object" && cause !== null
+      ? (cause as {
+          readonly address?: unknown;
+          readonly innerMessage?: unknown;
+          readonly code?: unknown;
+        })
+      : null;
+  const nested =
+    direct === null &&
+    cause !== null &&
+    typeof cause === "object" &&
+    "cause" in cause &&
+    Predicate.isTagged("AppInnerToolError")(cause.cause)
+      ? (cause.cause as {
+          readonly address?: unknown;
+          readonly innerMessage?: unknown;
+          readonly code?: unknown;
+        })
+      : direct;
+  if (
+    nested === null ||
+    typeof nested.address !== "string" ||
+    typeof nested.innerMessage !== "string"
+  ) {
+    return null;
+  }
+  return {
+    address: nested.address,
+    innerMessage: nested.innerMessage,
+    ...(typeof nested.code === "string" ? { code: nested.code } : {}),
+  };
+};
 
 const makeAppsExtension = (ctx: PluginCtx<AppsStore>, executor?: AppToolExecutor) => ({
   publish: (input: Parameters<typeof publish>[1]) =>
@@ -92,14 +129,28 @@ export const makeAppsPlugin = (options?: { readonly executor?: AppToolExecutor }
           resolver,
           invokeOptions,
         });
-        const result = yield* (options?.executor ?? makeInProcessAppToolExecutor()).invoke(
-          bundle,
-          { toolName: tool.name },
-          { ...bindings.input, ...bindings.bindings },
-          bridge,
-          { timeoutMs: 30_000 },
-        );
-        return result.output;
+        const result = yield* (options?.executor ?? makeInProcessAppToolExecutor())
+          .invoke(
+            bundle,
+            { toolName: tool.name },
+            { ...bindings.input, ...bindings.bindings },
+            bridge,
+            { timeoutMs: 30_000 },
+          )
+          .pipe(
+            Effect.catch((cause: unknown) => {
+              const inner = innerToolError(cause);
+              return inner
+                ? Effect.succeed(
+                    ToolResult.fail({
+                      code: inner.code ?? "inner_tool_error",
+                      message: `Inner tool ${inner.address} failed: "${inner.innerMessage}"`,
+                    }),
+                  )
+                : Effect.fail(cause);
+            }),
+          );
+        return "output" in result ? result.output : result;
       }),
   }))();
 

--- a/packages/plugins/apps/src/plugin/apps-plugin.ts
+++ b/packages/plugins/apps/src/plugin/apps-plugin.ts
@@ -122,6 +122,7 @@ export const projectAppsToolSchema = (
         ? { ...(schema.properties as Record<string, unknown>) }
         : {};
     for (const [field, decl] of Object.entries(tool.integrations)) {
+      if (decl.all) continue;
       const connections = yield* ctx.connections.list({ integration: decl.slug as never });
       const enumValues = connections.map((connection) => String(connection.address));
       properties[field] =

--- a/packages/plugins/apps/src/plugin/apps-plugin.ts
+++ b/packages/plugins/apps/src/plugin/apps-plugin.ts
@@ -122,7 +122,6 @@ export const projectAppsToolSchema = (
         ? { ...(schema.properties as Record<string, unknown>) }
         : {};
     for (const [field, decl] of Object.entries(tool.integrations)) {
-      if (decl.all) continue;
       const connections = yield* ctx.connections.list({ integration: decl.slug as never });
       const enumValues = connections.map((connection) => String(connection.address));
       properties[field] =

--- a/packages/plugins/apps/src/plugin/apps-plugin.ts
+++ b/packages/plugins/apps/src/plugin/apps-plugin.ts
@@ -2,14 +2,10 @@ import { Data, Effect } from "effect";
 import { ToolName, definePlugin, type PluginCtx, type ToolDef } from "@executor-js/sdk";
 
 import { makeInProcessAppToolExecutor, type AppToolExecutor } from "../executor/app-tool-executor";
-import { publish, type PublishInput } from "../pipeline/publish";
+import { publish } from "../pipeline/publish";
 import { buildBridge, resolveIntegrationBindings } from "./bindings";
 import { makePluginCtxAppsResolver } from "./resolver";
 import { descriptorCollection, makeAppsStore, toolCollection, type AppsStore } from "./store";
-
-export interface AppsExtension {
-  readonly publish: (input: PublishInput) => Effect.Effect<unknown, unknown>;
-}
 
 const APPS_INTEGRATION = "apps";
 const APPS_CONNECTION = "published";
@@ -23,6 +19,13 @@ interface ProjectedToolSchema {
   readonly outputSchema?: unknown;
 }
 
+const makeAppsExtension = (ctx: PluginCtx<AppsStore>, executor?: AppToolExecutor) => ({
+  publish: (input: Parameters<typeof publish>[1]) =>
+    publish({ store: ctx.storage, executor: executor ?? makeInProcessAppToolExecutor() }, input),
+});
+
+export type AppsExtension = ReturnType<typeof makeAppsExtension>;
+
 export const makeAppsPlugin = (options?: { readonly executor?: AppToolExecutor }) =>
   definePlugin(() => ({
     id: "apps",
@@ -32,13 +35,7 @@ export const makeAppsPlugin = (options?: { readonly executor?: AppToolExecutor }
       [toolCollection.name]: toolCollection,
     },
     storage: ({ blobs, pluginStorage }) => makeAppsStore({ blobs, pluginStorage }),
-    extension: (ctx: PluginCtx<AppsStore>): AppsExtension => ({
-      publish: (input) =>
-        publish(
-          { store: ctx.storage, executor: options?.executor ?? makeInProcessAppToolExecutor() },
-          input,
-        ),
-    }),
+    extension: (ctx: PluginCtx<AppsStore>) => makeAppsExtension(ctx, options?.executor),
     staticSources: () => [
       {
         id: "apps",

--- a/packages/plugins/apps/src/plugin/bindings.test.ts
+++ b/packages/plugins/apps/src/plugin/bindings.test.ts
@@ -19,6 +19,7 @@ const resolver: ClientResolver = {
 
 const one = (slug: string) => ({ slug, mode: "one" as const, all: false });
 const many = (slug: string) => ({ slug, mode: "many" as const, all: false });
+const manyAll = (slug: string) => ({ slug, mode: "many" as const, all: true });
 
 describe("integration bindings", () => {
   it.effect("resolves caller-supplied connection addresses", () =>
@@ -125,6 +126,59 @@ describe("integration bindings", () => {
       expect(result).toEqual({
         input: { q: "unread" },
         bindings: { inboxes: ["tools.gmail.org.work", "tools.gmail.user.personal"] },
+      });
+    }),
+  );
+
+  it.effect("expands all declarations to every visible connection", () =>
+    Effect.gen(function* () {
+      const result = yield* resolveIntegrationBindings(
+        { inboxes: manyAll("gmail") },
+        { q: "unread" },
+        {
+          ...resolver,
+          listConnections: ({ integration }) =>
+            Effect.succeed([
+              { integration, address: "tools.gmail.org.work" },
+              { integration, address: "tools.gmail.user.personal" },
+              { integration, address: "tools.gmail.org.shared" },
+            ]),
+        },
+      );
+      expect(result).toEqual({
+        input: { q: "unread" },
+        bindings: {
+          inboxes: ["tools.gmail.org.work", "tools.gmail.user.personal", "tools.gmail.org.shared"],
+        },
+      });
+    }),
+  );
+
+  it.effect("fails all declarations with no visible connections", () =>
+    Effect.gen(function* () {
+      const error = yield* resolveIntegrationBindings(
+        { inboxes: manyAll("gmail") },
+        { q: "unread" },
+        { ...resolver, listConnections: () => Effect.succeed([]) },
+      ).pipe(Effect.flip);
+      expect(error).toMatchObject({
+        _tag: "BindingError",
+        role: "inboxes",
+        integration: "gmail",
+      });
+    }),
+  );
+
+  it.effect("rejects caller-supplied fields for all declarations", () =>
+    Effect.gen(function* () {
+      const error = yield* resolveIntegrationBindings(
+        { inboxes: manyAll("gmail") },
+        { q: "unread", inboxes: ["tools.gmail.org.work"] },
+        resolver,
+      ).pipe(Effect.flip);
+      expect(error).toMatchObject({
+        _tag: "BindingError",
+        message: expect.stringContaining("binds all connections automatically"),
       });
     }),
   );

--- a/packages/plugins/apps/src/plugin/bindings.test.ts
+++ b/packages/plugins/apps/src/plugin/bindings.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+
+import {
+  BindingError,
+  buildBridge,
+  resolveIntegrationBindings,
+  type ClientResolver,
+} from "./bindings";
+
+const resolver: ClientResolver = {
+  listConnections: ({ integration }) =>
+    Effect.succeed([{ integration, address: `tools.${integration}.org.main` }]),
+  resolveConnection: ({ connection }) =>
+    Effect.succeed(
+      connection === "tools.dealcloud.org.main"
+        ? { integration: "dealcloud", address: connection }
+        : connection === "tools.github.org.main"
+          ? { integration: "github", address: connection }
+          : null,
+    ),
+  call: ({ path, args }) => Effect.succeed({ path, args }),
+};
+
+describe("integration bindings", () => {
+  it.effect("resolves caller-supplied connection addresses", () =>
+    Effect.gen(function* () {
+      const result = yield* resolveIntegrationBindings(
+        { crm: { slug: "dealcloud" } },
+        { crm: "tools.dealcloud.org.main", updatedSince: "today" },
+        resolver,
+      );
+      expect(result).toEqual({
+        input: { updatedSince: "today" },
+        bindings: { crm: "tools.dealcloud.org.main" },
+      });
+    }),
+  );
+
+  it.effect("fails unknown connection addresses as BindingError", () =>
+    Effect.gen(function* () {
+      const exit = yield* resolveIntegrationBindings(
+        { crm: { slug: "dealcloud" } },
+        { crm: "tools.dealcloud.org.missing" },
+        resolver,
+      ).pipe(Effect.exit);
+      expect(exit._tag).toBe("Failure");
+      if (exit._tag === "Failure") expect(String(exit.cause)).toContain("BindingError");
+    }),
+  );
+
+  it.effect("fails mismatched connection integrations as BindingError", () =>
+    Effect.gen(function* () {
+      const exit = yield* resolveIntegrationBindings(
+        { crm: { slug: "dealcloud" } },
+        { crm: "tools.github.org.main" },
+        resolver,
+      ).pipe(Effect.exit);
+      expect(exit._tag).toBe("Failure");
+      if (exit._tag === "Failure") expect(String(exit.cause)).toContain('not "dealcloud"');
+    }),
+  );
+
+  it("bridges method calls to the resolver", async () => {
+    const bridge = buildBridge({
+      declared: { crm: { slug: "dealcloud" } },
+      bindings: { crm: "tools.dealcloud.org.main" },
+      resolver,
+    });
+    await expect(bridge.call("crm.deals.list", { limit: 1 })).resolves.toEqual({
+      path: ["deals", "list"],
+      args: { limit: 1 },
+    });
+  });
+
+  it("rejects undeclared bridge calls", async () => {
+    const bridge = buildBridge({
+      declared: { crm: { slug: "dealcloud" } },
+      bindings: { crm: "tools.dealcloud.org.main" },
+      resolver,
+    });
+    await expect(bridge.call("github.repos.get", {})).rejects.toBeInstanceOf(BindingError);
+  });
+});

--- a/packages/plugins/apps/src/plugin/bindings.test.ts
+++ b/packages/plugins/apps/src/plugin/bindings.test.ts
@@ -17,11 +17,14 @@ const resolver: ClientResolver = {
   call: ({ path, args }) => Effect.succeed({ path, args }),
 };
 
+const one = (slug: string) => ({ slug, mode: "one" as const, all: false });
+const many = (slug: string) => ({ slug, mode: "many" as const, all: false });
+
 describe("integration bindings", () => {
   it.effect("resolves caller-supplied connection addresses", () =>
     Effect.gen(function* () {
       const result = yield* resolveIntegrationBindings(
-        { crm: { slug: "dealcloud" } },
+        { crm: one("dealcloud") },
         { crm: "tools.dealcloud.org.main", updatedSince: "today" },
         resolver,
       );
@@ -35,7 +38,7 @@ describe("integration bindings", () => {
   it.effect("fails unknown connection addresses as BindingError", () =>
     Effect.gen(function* () {
       const error = yield* resolveIntegrationBindings(
-        { crm: { slug: "dealcloud" } },
+        { crm: one("dealcloud") },
         { crm: "tools.dealcloud.org.missing" },
         resolver,
       ).pipe(Effect.flip);
@@ -46,7 +49,7 @@ describe("integration bindings", () => {
   it.effect("fails mismatched connection integrations as BindingError", () =>
     Effect.gen(function* () {
       const error = yield* resolveIntegrationBindings(
-        { crm: { slug: "dealcloud" } },
+        { crm: one("dealcloud") },
         { crm: "tools.github.org.main" },
         resolver,
       ).pipe(Effect.flip);
@@ -56,7 +59,7 @@ describe("integration bindings", () => {
 
   it("bridges method calls to the resolver", async () => {
     const bridge = buildBridge({
-      declared: { crm: { slug: "dealcloud" } },
+      declared: { crm: one("dealcloud") },
       bindings: { crm: "tools.dealcloud.org.main" },
       resolver,
     });
@@ -68,7 +71,7 @@ describe("integration bindings", () => {
 
   it("rejects undeclared bridge calls", async () => {
     const bridge = buildBridge({
-      declared: { crm: { slug: "dealcloud" } },
+      declared: { crm: one("dealcloud") },
       bindings: { crm: "tools.dealcloud.org.main" },
       resolver,
     });
@@ -76,4 +79,53 @@ describe("integration bindings", () => {
       _tag: "BindingError",
     });
   });
+
+  it("routes fan-out bridge calls to the indexed connection", async () => {
+    const calls: unknown[] = [];
+    const bridge = buildBridge({
+      declared: { inboxes: many("gmail") },
+      bindings: { inboxes: ["tools.gmail.org.work", "tools.gmail.user.personal"] },
+      resolver: {
+        ...resolver,
+        call: (input) =>
+          Effect.sync(() => {
+            calls.push(input);
+            return { ok: true };
+          }),
+      },
+    });
+    await expect(bridge.call("inboxes#1.messages.list", { q: "unread" })).resolves.toEqual({
+      ok: true,
+    });
+    expect(calls).toMatchObject([
+      {
+        integration: "gmail",
+        connection: "tools.gmail.user.personal",
+        path: ["messages", "list"],
+        args: { q: "unread" },
+      },
+    ]);
+  });
+
+  it.effect("resolves arrays of connection addresses for fan-out", () =>
+    Effect.gen(function* () {
+      const result = yield* resolveIntegrationBindings(
+        { inboxes: many("gmail") },
+        { inboxes: ["tools.gmail.org.work", "tools.gmail.user.personal"], q: "unread" },
+        {
+          ...resolver,
+          resolveConnection: ({ connection }) =>
+            Effect.succeed(
+              connection.startsWith("tools.gmail.")
+                ? { integration: "gmail", address: connection }
+                : null,
+            ),
+        },
+      );
+      expect(result).toEqual({
+        input: { q: "unread" },
+        bindings: { inboxes: ["tools.gmail.org.work", "tools.gmail.user.personal"] },
+      });
+    }),
+  );
 });

--- a/packages/plugins/apps/src/plugin/bindings.test.ts
+++ b/packages/plugins/apps/src/plugin/bindings.test.ts
@@ -17,9 +17,8 @@ const resolver: ClientResolver = {
   call: ({ path, args }) => Effect.succeed({ path, args }),
 };
 
-const one = (slug: string) => ({ slug, mode: "one" as const, all: false });
-const many = (slug: string) => ({ slug, mode: "many" as const, all: false });
-const manyAll = (slug: string) => ({ slug, mode: "many" as const, all: true });
+const one = (slug: string) => ({ slug, mode: "one" as const });
+const many = (slug: string) => ({ slug, mode: "many" as const });
 
 describe("integration bindings", () => {
   it.effect("resolves caller-supplied connection addresses", () =>
@@ -126,59 +125,6 @@ describe("integration bindings", () => {
       expect(result).toEqual({
         input: { q: "unread" },
         bindings: { inboxes: ["tools.gmail.org.work", "tools.gmail.user.personal"] },
-      });
-    }),
-  );
-
-  it.effect("expands all declarations to every visible connection", () =>
-    Effect.gen(function* () {
-      const result = yield* resolveIntegrationBindings(
-        { inboxes: manyAll("gmail") },
-        { q: "unread" },
-        {
-          ...resolver,
-          listConnections: ({ integration }) =>
-            Effect.succeed([
-              { integration, address: "tools.gmail.org.work" },
-              { integration, address: "tools.gmail.user.personal" },
-              { integration, address: "tools.gmail.org.shared" },
-            ]),
-        },
-      );
-      expect(result).toEqual({
-        input: { q: "unread" },
-        bindings: {
-          inboxes: ["tools.gmail.org.work", "tools.gmail.user.personal", "tools.gmail.org.shared"],
-        },
-      });
-    }),
-  );
-
-  it.effect("fails all declarations with no visible connections", () =>
-    Effect.gen(function* () {
-      const error = yield* resolveIntegrationBindings(
-        { inboxes: manyAll("gmail") },
-        { q: "unread" },
-        { ...resolver, listConnections: () => Effect.succeed([]) },
-      ).pipe(Effect.flip);
-      expect(error).toMatchObject({
-        _tag: "BindingError",
-        role: "inboxes",
-        integration: "gmail",
-      });
-    }),
-  );
-
-  it.effect("rejects caller-supplied fields for all declarations", () =>
-    Effect.gen(function* () {
-      const error = yield* resolveIntegrationBindings(
-        { inboxes: manyAll("gmail") },
-        { q: "unread", inboxes: ["tools.gmail.org.work"] },
-        resolver,
-      ).pipe(Effect.flip);
-      expect(error).toMatchObject({
-        _tag: "BindingError",
-        message: expect.stringContaining("binds all connections automatically"),
       });
     }),
   );

--- a/packages/plugins/apps/src/plugin/bindings.test.ts
+++ b/packages/plugins/apps/src/plugin/bindings.test.ts
@@ -1,12 +1,7 @@
 import { describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
 
-import {
-  BindingError,
-  buildBridge,
-  resolveIntegrationBindings,
-  type ClientResolver,
-} from "./bindings";
+import { buildBridge, resolveIntegrationBindings, type ClientResolver } from "./bindings";
 
 const resolver: ClientResolver = {
   listConnections: ({ integration }) =>
@@ -39,25 +34,23 @@ describe("integration bindings", () => {
 
   it.effect("fails unknown connection addresses as BindingError", () =>
     Effect.gen(function* () {
-      const exit = yield* resolveIntegrationBindings(
+      const error = yield* resolveIntegrationBindings(
         { crm: { slug: "dealcloud" } },
         { crm: "tools.dealcloud.org.missing" },
         resolver,
-      ).pipe(Effect.exit);
-      expect(exit._tag).toBe("Failure");
-      if (exit._tag === "Failure") expect(String(exit.cause)).toContain("BindingError");
+      ).pipe(Effect.flip);
+      expect(error).toMatchObject({ _tag: "BindingError" });
     }),
   );
 
   it.effect("fails mismatched connection integrations as BindingError", () =>
     Effect.gen(function* () {
-      const exit = yield* resolveIntegrationBindings(
+      const error = yield* resolveIntegrationBindings(
         { crm: { slug: "dealcloud" } },
         { crm: "tools.github.org.main" },
         resolver,
-      ).pipe(Effect.exit);
-      expect(exit._tag).toBe("Failure");
-      if (exit._tag === "Failure") expect(String(exit.cause)).toContain('not "dealcloud"');
+      ).pipe(Effect.flip);
+      expect(error).toMatchObject({ message: expect.stringContaining('not "dealcloud"') });
     }),
   );
 
@@ -79,6 +72,8 @@ describe("integration bindings", () => {
       bindings: { crm: "tools.dealcloud.org.main" },
       resolver,
     });
-    await expect(bridge.call("github.repos.get", {})).rejects.toBeInstanceOf(BindingError);
+    await expect(bridge.call("github.repos.get", {})).rejects.toMatchObject({
+      _tag: "BindingError",
+    });
   });
 });

--- a/packages/plugins/apps/src/plugin/bindings.ts
+++ b/packages/plugins/apps/src/plugin/bindings.ts
@@ -1,0 +1,125 @@
+import { Data, Effect } from "effect";
+import type { InvokeOptions } from "@executor-js/sdk";
+
+import type { AppToolBridge } from "../executor/app-tool-executor";
+import type { IntegrationDecl } from "../pipeline/descriptor";
+
+export class BindingError extends Data.TaggedError("BindingError")<{
+  readonly message: string;
+  readonly role: string;
+  readonly integration: string;
+  readonly requestedConnection?: string;
+}> {}
+
+export interface ConnectionCandidate {
+  readonly address: string;
+  readonly integration: string;
+}
+
+export interface ClientResolver {
+  readonly listConnections: (input: {
+    readonly integration: string;
+  }) => Effect.Effect<readonly ConnectionCandidate[], BindingError>;
+  readonly resolveConnection: (input: {
+    readonly connection: string;
+  }) => Effect.Effect<ConnectionCandidate | null, BindingError>;
+  readonly call: (input: {
+    readonly integration: string;
+    readonly connection: string;
+    readonly path: readonly string[];
+    readonly args: unknown;
+    readonly invokeOptions?: InvokeOptions;
+  }) => Effect.Effect<unknown, BindingError>;
+}
+
+export interface ResolvedBindings {
+  readonly input: Record<string, unknown>;
+  readonly bindings: Readonly<Record<string, string>>;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object" && !Array.isArray(value);
+
+const resolveRequested = (
+  field: string,
+  decl: IntegrationDecl,
+  requested: string,
+  resolver: ClientResolver,
+): Effect.Effect<string, BindingError> =>
+  Effect.gen(function* () {
+    const connection = yield* resolver.resolveConnection({ connection: requested });
+    if (!connection) {
+      const candidates = yield* resolver.listConnections({ integration: decl.slug });
+      return yield* new BindingError({
+        role: field,
+        integration: decl.slug,
+        requestedConnection: requested,
+        message: `unknown connection "${requested}" for integration field "${field}" (${decl.slug})${candidates.length > 0 ? `; choose one of ${candidates.map((candidate) => candidate.address).join(", ")}` : ""}`,
+      });
+    }
+    if (connection.integration !== decl.slug) {
+      return yield* new BindingError({
+        role: field,
+        integration: decl.slug,
+        requestedConnection: requested,
+        message: `connection "${requested}" belongs to integration "${connection.integration}", not "${decl.slug}"`,
+      });
+    }
+    return connection.address;
+  });
+
+export const resolveIntegrationBindings = (
+  declared: Readonly<Record<string, IntegrationDecl>>,
+  args: unknown,
+  resolver: ClientResolver,
+): Effect.Effect<ResolvedBindings, BindingError> =>
+  Effect.gen(function* () {
+    const payload = isRecord(args) ? args : {};
+    const input: Record<string, unknown> = { ...payload };
+    const bindings: Record<string, string> = {};
+    for (const [field, decl] of Object.entries(declared)) {
+      const raw = payload[field];
+      if (typeof raw !== "string" || raw.length === 0) {
+        return yield* new BindingError({
+          role: field,
+          integration: decl.slug,
+          message: `connection for integration field "${field}" (${decl.slug}) must be a non-empty string`,
+          ...(typeof raw === "string" ? { requestedConnection: raw } : {}),
+        });
+      }
+      bindings[field] = yield* resolveRequested(field, decl, raw, resolver);
+      delete input[field];
+    }
+    return { input, bindings };
+  });
+
+export const buildBridge = (input: {
+  readonly declared: Readonly<Record<string, IntegrationDecl>>;
+  readonly bindings: Readonly<Record<string, string>>;
+  readonly resolver: ClientResolver;
+  readonly invokeOptions?: InvokeOptions;
+}): AppToolBridge => ({
+  call: (toolPath, args) => {
+    const [field, ...path] = toolPath.split(".");
+    const decl = input.declared[field ?? ""];
+    const connection = input.bindings[field ?? ""];
+    if (!field || !decl || !connection || path.length === 0) {
+      return Promise.reject(
+        new BindingError({
+          role: field ?? "",
+          integration: decl?.slug ?? "",
+          message: `undeclared integration call: ${toolPath}`,
+        }),
+      );
+    }
+    return Effect.runPromise(
+      input.resolver.call({
+        integration: decl.slug,
+        connection,
+        path,
+        args,
+        invokeOptions: input.invokeOptions,
+      }),
+    );
+  },
+});

--- a/packages/plugins/apps/src/plugin/bindings.ts
+++ b/packages/plugins/apps/src/plugin/bindings.ts
@@ -34,7 +34,7 @@ export interface ClientResolver {
 
 export interface ResolvedBindings {
   readonly input: Record<string, unknown>;
-  readonly bindings: Readonly<Record<string, string>>;
+  readonly bindings: Readonly<Record<string, string | readonly string[]>>;
 }
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -68,6 +68,25 @@ const resolveRequested = (
     return connection.address;
   });
 
+const resolveManyRequested = (
+  field: string,
+  decl: IntegrationDecl,
+  requested: readonly unknown[],
+  resolver: ClientResolver,
+): Effect.Effect<readonly string[], BindingError> =>
+  Effect.forEach(requested, (item) => {
+    if (typeof item !== "string" || item.length === 0) {
+      return Effect.fail(
+        new BindingError({
+          role: field,
+          integration: decl.slug,
+          message: `connection set for integration field "${field}" (${decl.slug}) must contain non-empty strings`,
+        }),
+      );
+    }
+    return resolveRequested(field, decl, item, resolver);
+  });
+
 export const resolveIntegrationBindings = (
   declared: Readonly<Record<string, IntegrationDecl>>,
   args: unknown,
@@ -76,9 +95,25 @@ export const resolveIntegrationBindings = (
   Effect.gen(function* () {
     const payload = isRecord(args) ? args : {};
     const input: Record<string, unknown> = { ...payload };
-    const bindings: Record<string, string> = {};
+    const bindings: Record<string, string | readonly string[]> = {};
     for (const [field, decl] of Object.entries(declared)) {
       const raw = payload[field];
+      if (decl.mode === "many") {
+        if (raw === undefined && decl.all) {
+          bindings[field] = [];
+          continue;
+        }
+        if (!Array.isArray(raw)) {
+          return yield* new BindingError({
+            role: field,
+            integration: decl.slug,
+            message: `connection set for integration field "${field}" (${decl.slug}) must be an array`,
+          });
+        }
+        bindings[field] = yield* resolveManyRequested(field, decl, raw, resolver);
+        delete input[field];
+        continue;
+      }
       if (typeof raw !== "string" || raw.length === 0) {
         return yield* new BindingError({
           role: field,
@@ -95,14 +130,23 @@ export const resolveIntegrationBindings = (
 
 export const buildBridge = (input: {
   readonly declared: Readonly<Record<string, IntegrationDecl>>;
-  readonly bindings: Readonly<Record<string, string>>;
+  readonly bindings: Readonly<Record<string, string | readonly string[]>>;
   readonly resolver: ClientResolver;
   readonly invokeOptions?: InvokeOptions;
 }): AppToolBridge => ({
   call: (toolPath, args) => {
-    const [field, ...path] = toolPath.split(".");
+    const [root, ...path] = toolPath.split(".");
+    const [field, rawIndex] = (root ?? "").split("#");
     const decl = input.declared[field ?? ""];
-    const connection = input.bindings[field ?? ""];
+    const binding = input.bindings[field ?? ""];
+    const connection =
+      rawIndex === undefined
+        ? typeof binding === "string"
+          ? binding
+          : undefined
+        : Array.isArray(binding)
+          ? binding[Number(rawIndex)]
+          : undefined;
     if (!field || !decl || !connection || path.length === 0) {
       return Effect.runPromise(
         Effect.fail(

--- a/packages/plugins/apps/src/plugin/bindings.ts
+++ b/packages/plugins/apps/src/plugin/bindings.ts
@@ -11,6 +11,15 @@ export class BindingError extends Data.TaggedError("BindingError")<{
   readonly requestedConnection?: string;
 }> {}
 
+export class AppInnerToolError extends Data.TaggedError("AppInnerToolError")<{
+  readonly address: string;
+  readonly innerMessage: string;
+  readonly code?: string;
+}> {}
+
+export const appInnerToolFailureMessage = (error: AppInnerToolError): string =>
+  `Inner tool ${error.address} failed: "${error.innerMessage}"`;
+
 export interface ConnectionCandidate {
   readonly address: string;
   readonly integration: string;
@@ -29,7 +38,7 @@ export interface ClientResolver {
     readonly path: readonly string[];
     readonly args: unknown;
     readonly invokeOptions?: InvokeOptions;
-  }) => Effect.Effect<unknown, BindingError>;
+  }) => Effect.Effect<unknown, BindingError | AppInnerToolError>;
 }
 
 export interface ResolvedBindings {

--- a/packages/plugins/apps/src/plugin/bindings.ts
+++ b/packages/plugins/apps/src/plugin/bindings.ts
@@ -87,6 +87,26 @@ const resolveManyRequested = (
     return resolveRequested(field, decl, item, resolver);
   });
 
+const resolveAllConnections = (
+  field: string,
+  decl: IntegrationDecl,
+  resolver: ClientResolver,
+): Effect.Effect<readonly string[], BindingError> =>
+  Effect.gen(function* () {
+    const candidates = yield* resolver.listConnections({ integration: decl.slug });
+    const connections = candidates
+      .filter((candidate) => candidate.integration === decl.slug)
+      .map((candidate) => candidate.address);
+    if (connections.length === 0) {
+      return yield* new BindingError({
+        role: field,
+        integration: decl.slug,
+        message: `no connections available for integration field "${field}" (${decl.slug})`,
+      });
+    }
+    return connections;
+  });
+
 export const resolveIntegrationBindings = (
   declared: Readonly<Record<string, IntegrationDecl>>,
   args: unknown,
@@ -99,8 +119,15 @@ export const resolveIntegrationBindings = (
     for (const [field, decl] of Object.entries(declared)) {
       const raw = payload[field];
       if (decl.mode === "many") {
-        if (raw === undefined && decl.all) {
-          bindings[field] = [];
+        if (decl.all) {
+          if (Object.prototype.hasOwnProperty.call(payload, field)) {
+            return yield* new BindingError({
+              role: field,
+              integration: decl.slug,
+              message: `integration field "${field}" (${decl.slug}) binds all connections automatically`,
+            });
+          }
+          bindings[field] = yield* resolveAllConnections(field, decl, resolver);
           continue;
         }
         if (!Array.isArray(raw)) {

--- a/packages/plugins/apps/src/plugin/bindings.ts
+++ b/packages/plugins/apps/src/plugin/bindings.ts
@@ -87,26 +87,6 @@ const resolveManyRequested = (
     return resolveRequested(field, decl, item, resolver);
   });
 
-const resolveAllConnections = (
-  field: string,
-  decl: IntegrationDecl,
-  resolver: ClientResolver,
-): Effect.Effect<readonly string[], BindingError> =>
-  Effect.gen(function* () {
-    const candidates = yield* resolver.listConnections({ integration: decl.slug });
-    const connections = candidates
-      .filter((candidate) => candidate.integration === decl.slug)
-      .map((candidate) => candidate.address);
-    if (connections.length === 0) {
-      return yield* new BindingError({
-        role: field,
-        integration: decl.slug,
-        message: `no connections available for integration field "${field}" (${decl.slug})`,
-      });
-    }
-    return connections;
-  });
-
 export const resolveIntegrationBindings = (
   declared: Readonly<Record<string, IntegrationDecl>>,
   args: unknown,
@@ -119,17 +99,6 @@ export const resolveIntegrationBindings = (
     for (const [field, decl] of Object.entries(declared)) {
       const raw = payload[field];
       if (decl.mode === "many") {
-        if (decl.all) {
-          if (Object.prototype.hasOwnProperty.call(payload, field)) {
-            return yield* new BindingError({
-              role: field,
-              integration: decl.slug,
-              message: `integration field "${field}" (${decl.slug}) binds all connections automatically`,
-            });
-          }
-          bindings[field] = yield* resolveAllConnections(field, decl, resolver);
-          continue;
-        }
         if (!Array.isArray(raw)) {
           return yield* new BindingError({
             role: field,

--- a/packages/plugins/apps/src/plugin/bindings.ts
+++ b/packages/plugins/apps/src/plugin/bindings.ts
@@ -104,12 +104,14 @@ export const buildBridge = (input: {
     const decl = input.declared[field ?? ""];
     const connection = input.bindings[field ?? ""];
     if (!field || !decl || !connection || path.length === 0) {
-      return Promise.reject(
-        new BindingError({
-          role: field ?? "",
-          integration: decl?.slug ?? "",
-          message: `undeclared integration call: ${toolPath}`,
-        }),
+      return Effect.runPromise(
+        Effect.fail(
+          new BindingError({
+            role: field ?? "",
+            integration: decl?.slug ?? "",
+            message: `undeclared integration call: ${toolPath}`,
+          }),
+        ),
       );
     }
     return Effect.runPromise(

--- a/packages/plugins/apps/src/plugin/resolver.ts
+++ b/packages/plugins/apps/src/plugin/resolver.ts
@@ -1,0 +1,121 @@
+import { Effect } from "effect";
+import {
+  ConnectionName,
+  IntegrationSlug,
+  ToolAddress,
+  isToolResult,
+  type ConnectionRef,
+  type Owner,
+  type PluginCtx,
+} from "@executor-js/sdk";
+
+import { BindingError, type ClientResolver, type ConnectionCandidate } from "./bindings";
+
+export interface AppsResolverPluginCtx {
+  readonly connections: Pick<PluginCtx["connections"], "list" | "get">;
+  readonly execute: PluginCtx["execute"];
+}
+
+const parseConnectionAddress = (address: string): ConnectionRef | null => {
+  const parts = address.split(".");
+  if (parts.length !== 4 || parts[0] !== "tools") return null;
+  const [, integration, owner, name] = parts;
+  if (!integration || !name) return null;
+  if (owner !== "org" && owner !== "user") return null;
+  return {
+    owner: owner as Owner,
+    integration: IntegrationSlug.make(integration),
+    name: ConnectionName.make(name),
+  };
+};
+
+const toCandidate = (connection: {
+  readonly address?: unknown;
+  readonly integration: unknown;
+  readonly owner?: unknown;
+  readonly name?: unknown;
+}): ConnectionCandidate => ({
+  address:
+    typeof connection.address === "string"
+      ? connection.address
+      : `tools.${String(connection.integration)}.${String(connection.owner)}.${String(
+          connection.name,
+        )}`,
+  integration: String(connection.integration),
+});
+
+export const makePluginCtxAppsResolver = (input: {
+  readonly ctx: AppsResolverPluginCtx;
+}): ClientResolver => ({
+  listConnections: ({ integration }) =>
+    input.ctx.connections.list({ integration: IntegrationSlug.make(integration) }).pipe(
+      Effect.map((connections) => connections.map(toCandidate)),
+      Effect.mapError(
+        () =>
+          new BindingError({
+            role: integration,
+            integration,
+            message: `failed to list ${integration} connections`,
+          }),
+      ),
+    ),
+  resolveConnection: ({ connection }) =>
+    Effect.gen(function* () {
+      const ref = parseConnectionAddress(connection);
+      if (!ref) return null;
+      const row = yield* input.ctx.connections.get(ref).pipe(
+        Effect.mapError(
+          () =>
+            new BindingError({
+              role: String(ref.integration),
+              integration: String(ref.integration),
+              requestedConnection: connection,
+              message: `failed to resolve connection ${connection}`,
+            }),
+        ),
+      );
+      return row ? toCandidate(row) : null;
+    }),
+  call: ({ integration, connection, path, args, invokeOptions }) =>
+    Effect.gen(function* () {
+      const ref = parseConnectionAddress(connection);
+      if (!ref) {
+        return yield* new BindingError({
+          role: integration,
+          integration,
+          requestedConnection: connection,
+          message: `invalid connection address ${connection}`,
+        });
+      }
+      if (String(ref.integration) !== integration) {
+        return yield* new BindingError({
+          role: integration,
+          integration,
+          requestedConnection: connection,
+          message: `connection "${connection}" belongs to integration "${ref.integration}", not "${integration}"`,
+        });
+      }
+      const address = ToolAddress.make(`${connection}.${path.join(".")}`);
+      const result = yield* input.ctx.execute(address, args, invokeOptions).pipe(
+        Effect.mapError(
+          () =>
+            new BindingError({
+              role: integration,
+              integration,
+              requestedConnection: connection,
+              message: `failed to execute ${address}`,
+            }),
+        ),
+      );
+      if (isToolResult(result)) {
+        if (result.ok) return result.data;
+        return yield* new BindingError({
+          role: integration,
+          integration,
+          requestedConnection: connection,
+          message: result.error.message,
+        });
+      }
+      return result;
+    }),
+});

--- a/packages/plugins/apps/src/plugin/resolver.ts
+++ b/packages/plugins/apps/src/plugin/resolver.ts
@@ -1,15 +1,21 @@
-import { Effect } from "effect";
+import { Effect, Predicate } from "effect";
 import {
   ConnectionName,
   IntegrationSlug,
   ToolAddress,
   isToolResult,
+  type ExecuteError,
   type ConnectionRef,
   type Owner,
   type PluginCtx,
 } from "@executor-js/sdk";
 
-import { BindingError, type ClientResolver, type ConnectionCandidate } from "./bindings";
+import {
+  AppInnerToolError,
+  BindingError,
+  type ClientResolver,
+  type ConnectionCandidate,
+} from "./bindings";
 
 export interface AppsResolverPluginCtx {
   readonly connections: Pick<PluginCtx["connections"], "list" | "get">;
@@ -43,6 +49,34 @@ const toCandidate = (connection: {
         )}`,
   integration: String(connection.integration),
 });
+
+const innerMessageFromCause = (cause: ExecuteError): string => {
+  if (
+    Predicate.isTagged("ToolInvocationError")(cause) ||
+    Predicate.isTagged("CredentialResolutionError")(cause) ||
+    Predicate.isTagged("StorageError")(cause)
+  ) {
+    // oxlint-disable-next-line executor/no-unknown-error-message -- typed ExecuteError variants expose message as caller-facing failure text
+    return cause.message;
+  }
+  if (Predicate.isTagged("ToolNotFoundError")(cause)) return `Tool not found: ${cause.address}`;
+  if (Predicate.isTagged("ToolBlockedError")(cause)) return `Tool blocked: ${cause.address}`;
+  if (Predicate.isTagged("PluginNotLoadedError")(cause)) {
+    return `Plugin not loaded for tool: ${cause.address}`;
+  }
+  if (Predicate.isTagged("NoHandlerError")(cause)) return `No handler for tool: ${cause.address}`;
+  if (Predicate.isTagged("ConnectionNotFoundError")(cause)) {
+    return `Connection not found: ${cause.integration}.${cause.owner}.${cause.name}`;
+  }
+  if (Predicate.isTagged("CredentialProviderNotRegisteredError")(cause)) {
+    return `Credential provider not registered: ${cause.provider}`;
+  }
+  if (Predicate.isTagged("ElicitationDeclinedError")(cause)) {
+    return `Tool approval ${cause.action === "cancel" ? "cancelled" : "declined"}: ${cause.address}`;
+  }
+  if (Predicate.isTagged("UniqueViolationError")(cause)) return "storage unique violation";
+  return "inner tool failed";
+};
 
 export const makePluginCtxAppsResolver = (input: {
   readonly ctx: AppsResolverPluginCtx;
@@ -98,22 +132,19 @@ export const makePluginCtxAppsResolver = (input: {
       const address = ToolAddress.make(`${connection}.${path.join(".")}`);
       const result = yield* input.ctx.execute(address, args, invokeOptions).pipe(
         Effect.mapError(
-          () =>
-            new BindingError({
-              role: integration,
-              integration,
-              requestedConnection: connection,
-              message: `failed to execute ${address}`,
+          (cause) =>
+            new AppInnerToolError({
+              address,
+              innerMessage: innerMessageFromCause(cause),
             }),
         ),
       );
       if (isToolResult(result)) {
         if (result.ok) return result.data;
-        return yield* new BindingError({
-          role: integration,
-          integration,
-          requestedConnection: connection,
-          message: result.error.message,
+        return yield* new AppInnerToolError({
+          address,
+          code: result.error.code,
+          innerMessage: result.error.message,
         });
       }
       return result;

--- a/packages/plugins/apps/src/plugin/store.test.ts
+++ b/packages/plugins/apps/src/plugin/store.test.ts
@@ -139,7 +139,6 @@ const descriptor = (tools: readonly AppDescriptor["tools"][number][]): AppDescri
   version: 6,
   app: "crm",
   sourceRef: "sha-1",
-  descriptorKey: "descriptor",
   publishedAt: 1,
   toolchain: {
     bundler: { name: "esbuild", version: "0" },
@@ -169,8 +168,13 @@ describe("apps store", () => {
         blobs: pluginBlobStore(makeInMemoryBlobStore(), { org: "tenant", user: null }, "apps"),
         pluginStorage: makeMemoryPluginStorage(),
       });
-      yield* store.putPublished(descriptor([tool("first"), tool("second")]), "org", null);
-      yield* store.putPublished(descriptor([tool("first")]), "org", "sha-1");
+      yield* store.putPublished(
+        descriptor([tool("first"), tool("second")]),
+        "descriptor",
+        "org",
+        null,
+      );
+      yield* store.putPublished(descriptor([tool("first")]), "descriptor-2", "org", "sha-1");
       const active = yield* store.listActiveTools();
       expect(active.map((item) => item.name)).toEqual(["first"]);
     }),

--- a/packages/plugins/apps/src/plugin/store.test.ts
+++ b/packages/plugins/apps/src/plugin/store.test.ts
@@ -169,8 +169,8 @@ describe("apps store", () => {
         blobs: pluginBlobStore(makeInMemoryBlobStore(), { org: "tenant", user: null }, "apps"),
         pluginStorage: makeMemoryPluginStorage(),
       });
-      yield* store.putPublished(descriptor([tool("first"), tool("second")]), "org");
-      yield* store.putPublished(descriptor([tool("first")]), "org");
+      yield* store.putPublished(descriptor([tool("first"), tool("second")]), "org", null);
+      yield* store.putPublished(descriptor([tool("first")]), "org", "sha-1");
       const active = yield* store.listActiveTools();
       expect(active.map((item) => item.name)).toEqual(["first"]);
     }),

--- a/packages/plugins/apps/src/plugin/store.test.ts
+++ b/packages/plugins/apps/src/plugin/store.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+import {
+  makeInMemoryBlobStore,
+  pluginBlobStore,
+  type PluginStorageCollectionDefinition,
+  type PluginStorageEntry,
+  type PluginStorageFacade,
+} from "@executor-js/sdk";
+
+import type { AppDescriptor } from "../pipeline/descriptor";
+import { descriptorCollection, makeAppsStore, toolCollection } from "./store";
+
+const entry = <T>(input: {
+  owner: "org" | "user";
+  collection: string;
+  key: string;
+  data: T;
+}): PluginStorageEntry<T> => ({
+  id: `${input.collection}:${input.key}`,
+  owner: input.owner,
+  pluginId: "apps",
+  collection: input.collection,
+  key: input.key,
+  data: input.data,
+  createdAt: new Date(0),
+  updatedAt: new Date(0),
+});
+
+const makeMemoryPluginStorage = (): PluginStorageFacade => {
+  const rows = new Map<string, PluginStorageEntry<unknown>>();
+  const rowKey = (owner: string, collection: string, key: string) =>
+    `${owner}:${collection}:${key}`;
+  const put = (input: {
+    readonly owner: "org" | "user";
+    readonly collection: string;
+    readonly key: string;
+    readonly data: object;
+  }) =>
+    Effect.sync(() => {
+      const next = entry({
+        owner: input.owner,
+        collection: input.collection,
+        key: input.key,
+        data: input.data,
+      });
+      rows.set(rowKey(input.owner, input.collection, input.key), next);
+      return next;
+    });
+  return {
+    collection: <const TDefinition extends PluginStorageCollectionDefinition>(
+      definition: TDefinition,
+    ) => ({
+      get: ({ key }) =>
+        Effect.sync(() => {
+          for (const row of rows.values()) {
+            if (row.collection === definition.name && row.key === key) return row as never;
+          }
+          return null;
+        }),
+      getForOwner: ({ owner, key }) =>
+        Effect.sync(
+          () => (rows.get(rowKey(owner, definition.name, key)) as never | undefined) ?? null,
+        ),
+      list: ({ keyPrefix } = {}) =>
+        Effect.sync(
+          () =>
+            [...rows.values()].filter(
+              (row) =>
+                row.collection === definition.name &&
+                (keyPrefix === undefined || row.key.startsWith(keyPrefix)),
+            ) as never,
+        ),
+      put: (input) => put({ ...input, collection: definition.name }) as never,
+      query: (input = {}) =>
+        Effect.sync(() => {
+          let out = [...rows.values()].filter((row) => row.collection === definition.name);
+          if (input.where) {
+            out = out.filter((row) =>
+              Object.entries(input.where ?? {}).every(([field, expected]) => {
+                const actual = (row.data as Record<string, unknown>)[field];
+                return typeof expected === "object" && expected !== null && "eq" in expected
+                  ? actual === expected.eq
+                  : actual === expected;
+              }),
+            );
+          }
+          return (input.limit ? out.slice(0, input.limit) : out) as never;
+        }),
+      count: () => Effect.sync(() => 0),
+      remove: ({ owner, key }) =>
+        Effect.sync(() => {
+          rows.delete(rowKey(owner, definition.name, key));
+        }),
+    }),
+    get: ({ collection, key }) =>
+      Effect.sync(() => {
+        for (const row of rows.values()) {
+          if (row.collection === collection && row.key === key) return row as never;
+        }
+        return null;
+      }),
+    getForOwner: ({ owner, collection, key }) =>
+      Effect.sync(() => (rows.get(rowKey(owner, collection, key)) as never | undefined) ?? null),
+    list: ({ collection, keyPrefix }) =>
+      Effect.sync(
+        () =>
+          [...rows.values()].filter(
+            (row) =>
+              row.collection === collection &&
+              (keyPrefix === undefined || row.key.startsWith(keyPrefix)),
+          ) as never,
+      ),
+    put: (input) => put(input as never) as never,
+    putMany: ({ owner, entries }) =>
+      Effect.sync(() => {
+        for (const item of entries) {
+          const next = entry({
+            owner,
+            collection: item.collection,
+            key: item.key,
+            data: item.data,
+          });
+          rows.set(rowKey(owner, item.collection, item.key), next);
+        }
+      }),
+    remove: ({ owner, collection, key }) =>
+      Effect.sync(() => {
+        rows.delete(rowKey(owner, collection, key));
+      }),
+    removeMany: ({ owner, entries }) =>
+      Effect.sync(() => {
+        for (const item of entries) rows.delete(rowKey(owner, item.collection, item.key));
+      }),
+  };
+};
+
+const descriptor = (tools: readonly AppDescriptor["tools"][number][]): AppDescriptor => ({
+  version: 6,
+  app: "crm",
+  sourceRef: "sha-1",
+  descriptorKey: "descriptor",
+  publishedAt: 1,
+  toolchain: {
+    bundler: { name: "esbuild", version: "0" },
+    executor: { name: "test", version: "0" },
+    target: "es2022",
+  },
+  tools,
+  workflows: [],
+  ui: [],
+  skills: [],
+  skipped: [],
+});
+
+const tool = (name: string): AppDescriptor["tools"][number] => ({
+  name,
+  sourcePath: `tools/${name}.ts`,
+  bundleKey: `bundle:${name}`,
+  source: { path: `tools/${name}.ts`, sourceHash: name },
+  description: name,
+  integrations: {},
+});
+
+describe("apps store", () => {
+  it.effect("tombstones removed tools", () =>
+    Effect.gen(function* () {
+      const store = makeAppsStore({
+        blobs: pluginBlobStore(makeInMemoryBlobStore(), { org: "tenant", user: null }, "apps"),
+        pluginStorage: makeMemoryPluginStorage(),
+      });
+      yield* store.putPublished(descriptor([tool("first"), tool("second")]), "org");
+      yield* store.putPublished(descriptor([tool("first")]), "org");
+      const active = yield* store.listActiveTools();
+      expect(active.map((item) => item.name)).toEqual(["first"]);
+    }),
+  );
+
+  it.effect("keeps owner blob partitions isolated", () =>
+    Effect.gen(function* () {
+      const blobStore = makeInMemoryBlobStore();
+      const orgStore = makeAppsStore({
+        blobs: pluginBlobStore(blobStore, { org: "tenant-a", user: null }, "apps"),
+        pluginStorage: makeMemoryPluginStorage(),
+      });
+      const otherStore = makeAppsStore({
+        blobs: pluginBlobStore(blobStore, { org: "tenant-b", user: null }, "apps"),
+        pluginStorage: makeMemoryPluginStorage(),
+      });
+      const key = yield* orgStore.putBlob("same app", "org");
+      expect(yield* orgStore.getBlob(key)).toBe("same app");
+      expect(yield* otherStore.getBlob(key)).toBeNull();
+    }),
+  );
+
+  it("declares plugin storage collections", () => {
+    expect(descriptorCollection.name).toBe("apps_descriptors");
+    expect(toolCollection.name).toBe("apps_tools");
+  });
+});

--- a/packages/plugins/apps/src/plugin/store.ts
+++ b/packages/plugins/apps/src/plugin/store.ts
@@ -59,6 +59,7 @@ export interface AppsStore {
   >;
   readonly putPublished: (
     descriptor: AppDescriptor,
+    descriptorKey: string,
     owner: Owner,
     expectedSourceRef: string | null,
   ) => Effect.Effect<void, StorageFailure | AppPublishConflictError>;
@@ -113,7 +114,7 @@ export const makeAppsStore = (input: {
             : null,
         ),
       ),
-    putPublished: (descriptor, owner, expectedSourceRef) =>
+    putPublished: (descriptor, descriptorKey, owner, expectedSourceRef) =>
       Effect.gen(function* () {
         const current = yield* descriptors.get({ key: descriptor.app });
         const actualSourceRef = current?.data.sourceRef ?? null;
@@ -134,7 +135,7 @@ export const makeAppsStore = (input: {
             app: descriptor.app,
             name: tool.name,
             sourceRef: descriptor.sourceRef,
-            descriptorKey: descriptor.descriptorKey,
+            descriptorKey,
             bundleKey: tool.bundleKey,
             description: tool.description,
             inputSchema: tool.inputSchema,
@@ -161,7 +162,7 @@ export const makeAppsStore = (input: {
           data: {
             app: descriptor.app,
             sourceRef: descriptor.sourceRef,
-            descriptorKey: descriptor.descriptorKey,
+            descriptorKey,
             publishedAt: descriptor.publishedAt,
             toolchain: descriptor.toolchain,
           },

--- a/packages/plugins/apps/src/plugin/store.ts
+++ b/packages/plugins/apps/src/plugin/store.ts
@@ -1,4 +1,4 @@
-import { Effect } from "effect";
+import { Data, Effect } from "effect";
 import {
   definePluginStorageCollection,
   sha256Hex,
@@ -9,6 +9,12 @@ import {
 } from "@executor-js/sdk";
 
 import type { AppDescriptor } from "../pipeline/descriptor";
+
+export class AppPublishConflictError extends Data.TaggedError("AppPublishConflictError")<{
+  readonly app: string;
+  readonly expectedSourceRef: string | null;
+  readonly actualSourceRef: string | null;
+}> {}
 
 export const descriptorCollection = definePluginStorageCollection("apps_descriptors", {
   Type: {} as {
@@ -54,7 +60,8 @@ export interface AppsStore {
   readonly putPublished: (
     descriptor: AppDescriptor,
     owner: Owner,
-  ) => Effect.Effect<void, StorageFailure>;
+    expectedSourceRef: string | null,
+  ) => Effect.Effect<void, StorageFailure | AppPublishConflictError>;
   readonly listActiveTools: () => Effect.Effect<
     readonly AppDescriptor["tools"][number][],
     StorageFailure
@@ -106,8 +113,17 @@ export const makeAppsStore = (input: {
             : null,
         ),
       ),
-    putPublished: (descriptor, owner) =>
+    putPublished: (descriptor, owner, expectedSourceRef) =>
       Effect.gen(function* () {
+        const current = yield* descriptors.get({ key: descriptor.app });
+        const actualSourceRef = current?.data.sourceRef ?? null;
+        if (actualSourceRef !== expectedSourceRef) {
+          return yield* new AppPublishConflictError({
+            app: descriptor.app,
+            expectedSourceRef,
+            actualSourceRef,
+          });
+        }
         const now = descriptor.publishedAt;
         const existing = yield* tools.query({ where: { app: descriptor.app } });
         const activeNames = new Set(descriptor.tools.map((tool) => tool.name));

--- a/packages/plugins/apps/src/plugin/store.ts
+++ b/packages/plugins/apps/src/plugin/store.ts
@@ -1,0 +1,189 @@
+import { Effect } from "effect";
+import {
+  definePluginStorageCollection,
+  sha256Hex,
+  type Owner,
+  type PluginBlobStore,
+  type PluginStorageFacade,
+  type StorageFailure,
+} from "@executor-js/sdk";
+
+import type { AppDescriptor } from "../pipeline/descriptor";
+
+export const descriptorCollection = definePluginStorageCollection("apps_descriptors", {
+  Type: {} as {
+    readonly app: string;
+    readonly sourceRef: string;
+    readonly descriptorKey: string;
+    readonly publishedAt: number;
+    readonly toolchain: AppDescriptor["toolchain"];
+  },
+});
+
+export const toolCollection = definePluginStorageCollection(
+  "apps_tools",
+  {
+    Type: {} as {
+      readonly app: string;
+      readonly name: string;
+      readonly sourceRef: string;
+      readonly descriptorKey: string;
+      readonly bundleKey: string;
+      readonly description: string;
+      readonly inputSchema?: unknown;
+      readonly outputSchema?: unknown;
+      readonly integrations: AppDescriptor["tools"][number]["integrations"];
+      readonly annotations?: AppDescriptor["tools"][number]["annotations"];
+      readonly tombstoned: boolean;
+      readonly updatedAt: number;
+    },
+  },
+  { indexes: ["app", "name", "tombstoned"] },
+);
+
+export interface AppsStore {
+  readonly putBlob: (body: string, owner: Owner) => Effect.Effect<string, StorageFailure>;
+  readonly getBlob: (key: string) => Effect.Effect<string | null, StorageFailure>;
+  readonly getDescriptorRecord: (app: string) => Effect.Effect<
+    {
+      readonly sourceRef: string;
+      readonly descriptorKey: string;
+    } | null,
+    StorageFailure
+  >;
+  readonly putPublished: (
+    descriptor: AppDescriptor,
+    owner: Owner,
+  ) => Effect.Effect<void, StorageFailure>;
+  readonly listActiveTools: () => Effect.Effect<
+    readonly AppDescriptor["tools"][number][],
+    StorageFailure
+  >;
+  readonly getTool: (name: string) => Effect.Effect<
+    {
+      readonly app: string;
+      readonly name: string;
+      readonly bundleKey: string;
+      readonly description: string;
+      readonly inputSchema?: unknown;
+      readonly outputSchema?: unknown;
+      readonly integrations: AppDescriptor["tools"][number]["integrations"];
+      readonly annotations?: AppDescriptor["tools"][number]["annotations"];
+    } | null,
+    StorageFailure
+  >;
+}
+
+interface PutManyEntry {
+  readonly collection: string;
+  readonly key: string;
+  readonly data: unknown;
+}
+
+export const makeAppsStore = (input: {
+  readonly blobs: PluginBlobStore;
+  readonly pluginStorage: PluginStorageFacade;
+}): AppsStore => {
+  const descriptors = input.pluginStorage.collection(descriptorCollection);
+  const tools = input.pluginStorage.collection(toolCollection);
+  const keyForTool = (app: string, name: string) => `${app}:${name}`;
+  return {
+    putBlob: (body, owner) =>
+      sha256Hex(body).pipe(
+        Effect.flatMap((hash) =>
+          input.blobs.put(`apps/${hash}`, body, { owner }).pipe(Effect.as(`apps/${hash}`)),
+        ),
+      ),
+    getBlob: (key) => input.blobs.get(key),
+    getDescriptorRecord: (app) =>
+      descriptors.get({ key: app }).pipe(
+        Effect.map((entry) =>
+          entry
+            ? {
+                sourceRef: entry.data.sourceRef,
+                descriptorKey: entry.data.descriptorKey,
+              }
+            : null,
+        ),
+      ),
+    putPublished: (descriptor, owner) =>
+      Effect.gen(function* () {
+        const now = descriptor.publishedAt;
+        const existing = yield* tools.query({ where: { app: descriptor.app } });
+        const activeNames = new Set(descriptor.tools.map((tool) => tool.name));
+        const entries: PutManyEntry[] = descriptor.tools.map((tool) => ({
+          collection: toolCollection.name,
+          key: keyForTool(descriptor.app, tool.name),
+          data: {
+            app: descriptor.app,
+            name: tool.name,
+            sourceRef: descriptor.sourceRef,
+            descriptorKey: descriptor.descriptorKey,
+            bundleKey: tool.bundleKey,
+            description: tool.description,
+            inputSchema: tool.inputSchema,
+            outputSchema: tool.outputSchema,
+            integrations: tool.integrations,
+            annotations: tool.annotations,
+            tombstoned: false,
+            updatedAt: now,
+          },
+        }));
+        for (const entry of existing) {
+          if (!activeNames.has(entry.data.name) && !entry.data.tombstoned) {
+            entries.push({
+              collection: toolCollection.name,
+              key: entry.key,
+              data: { ...entry.data, tombstoned: true, updatedAt: now },
+            });
+          }
+        }
+        yield* input.pluginStorage.putMany({ owner, entries });
+        yield* descriptors.put({
+          owner,
+          key: descriptor.app,
+          data: {
+            app: descriptor.app,
+            sourceRef: descriptor.sourceRef,
+            descriptorKey: descriptor.descriptorKey,
+            publishedAt: descriptor.publishedAt,
+            toolchain: descriptor.toolchain,
+          },
+        });
+      }),
+    listActiveTools: () =>
+      tools.query({ where: { tombstoned: false } }).pipe(
+        Effect.map((entries) =>
+          entries.map((entry) => ({
+            name: entry.data.name,
+            sourcePath: "",
+            source: { path: "", sourceHash: "" },
+            bundleKey: entry.data.bundleKey,
+            description: entry.data.description,
+            integrations: entry.data.integrations,
+            inputSchema: entry.data.inputSchema,
+            outputSchema: entry.data.outputSchema,
+            annotations: entry.data.annotations,
+          })),
+        ),
+      ),
+    getTool: (name) =>
+      tools.query({ where: { name, tombstoned: false }, limit: 1 }).pipe(
+        Effect.map((entries) => {
+          const entry = entries[0];
+          return entry
+            ? {
+                app: entry.data.app,
+                name: entry.data.name,
+                bundleKey: entry.data.bundleKey,
+                description: entry.data.description,
+                inputSchema: entry.data.inputSchema,
+                outputSchema: entry.data.outputSchema,
+                integrations: entry.data.integrations,
+                annotations: entry.data.annotations,
+              }
+            : null;
+        }),
+      ),
+  };
+};

--- a/packages/plugins/apps/src/standard-schema.ts
+++ b/packages/plugins/apps/src/standard-schema.ts
@@ -1,0 +1,21 @@
+export type StandardSchemaIssue = {
+  readonly message: string;
+  readonly path?: readonly (PropertyKey | { readonly key: PropertyKey })[];
+};
+
+export interface StandardSchemaV1<Input = unknown, Output = Input> {
+  readonly "~standard": {
+    readonly version: 1;
+    readonly vendor: string;
+    readonly validate: (
+      value: Input,
+    ) =>
+      | { readonly value: Output }
+      | { readonly issues: readonly StandardSchemaIssue[] }
+      | Promise<{ readonly value: Output } | { readonly issues: readonly StandardSchemaIssue[] }>;
+  };
+}
+
+export namespace StandardSchemaV1 {
+  export type InferOutput<T> = T extends StandardSchemaV1<unknown, infer Output> ? Output : never;
+}

--- a/packages/plugins/apps/src/testing/conformance.ts
+++ b/packages/plugins/apps/src/testing/conformance.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+
+import { bundleEntry } from "../pipeline/bundle";
+import type { AppToolExecutor } from "../executor/app-tool-executor";
+
+const bundle = (source: string) =>
+  bundleEntry({
+    files: new Map([["tools/conformance.ts", source]]),
+    entry: "tools/conformance.ts",
+  });
+
+export const appToolExecutorConformance = (
+  name: string,
+  makeExecutor: () => AppToolExecutor,
+): void => {
+  describe(`${name} app tool executor conformance`, () => {
+    it.effect("collects descriptors deterministically", () =>
+      Effect.gen(function* () {
+        const bundled = yield* bundle(`
+          import { z } from "zod";
+          import { defineTool, integration } from "executor:app";
+          export default defineTool({
+            description: "Conformance",
+            integrations: { crm: integration("dealcloud") },
+            input: z.object({ value: z.string() }),
+            output: z.object({ ok: z.boolean() }),
+            handler() { return { ok: true }; },
+          });
+        `);
+        const collected = yield* makeExecutor().collect(bundled.code, {
+          fileSlug: "conformance",
+          sourcePath: "tools/conformance.ts",
+        });
+        expect(collected.tools).toMatchObject([
+          {
+            toolName: "conformance",
+            integrations: { crm: { slug: "dealcloud", mode: "one", all: false } },
+          },
+        ]);
+      }),
+    );
+
+    it.effect("invokes handlers with split input and integrations", () =>
+      Effect.gen(function* () {
+        const bundled = yield* bundle(`
+          import { z } from "zod";
+          import { defineTool, integration } from "executor:app";
+          export default defineTool({
+            description: "Conformance invoke",
+            integrations: { crm: integration("dealcloud") },
+            input: z.object({ value: z.string() }),
+            output: z.object({ result: z.string() }),
+            async handler({ value }, { crm }) {
+              const response = await crm.echo({ value });
+              return { result: response.value };
+            },
+          });
+        `);
+        const output = yield* makeExecutor().invoke(
+          bundled.code,
+          { toolName: "conformance" },
+          { crm: "tools.dealcloud.org.main", value: "ok" },
+          { call: async (_path, args) => args },
+          { timeoutMs: 1000 },
+        );
+        expect(output.output).toEqual({ result: "ok" });
+      }),
+    );
+  });
+};

--- a/packages/plugins/apps/src/testing/conformance.ts
+++ b/packages/plugins/apps/src/testing/conformance.ts
@@ -67,5 +67,52 @@ export const appToolExecutorConformance = (
         expect(output.output).toEqual({ result: "ok" });
       }),
     );
+
+    it.effect("invokes all-bound handlers with fan-out integration proxies", () =>
+      Effect.gen(function* () {
+        const bundled = yield* bundle(`
+          import { z } from "zod";
+          import { defineTool, integration } from "executor:app";
+          export default defineTool({
+            description: "Conformance all invoke",
+            integrations: { inboxes: integration("gmail").array().all() },
+            input: z.object({ query: z.string() }),
+            output: z.object({ count: z.number() }),
+            async handler({ query }, { inboxes }) {
+              const batches = await Promise.all(
+                inboxes.map((inbox) => inbox.messages.list({ query })),
+              );
+              return { count: batches.flat().length };
+            },
+          });
+        `);
+        const calls: unknown[] = [];
+        const output = yield* makeExecutor().invoke(
+          bundled.code,
+          { toolName: "conformance" },
+          {
+            query: "invoice",
+            inboxes: [
+              "tools.gmail.org.work",
+              "tools.gmail.user.personal",
+              "tools.gmail.org.shared",
+            ],
+          },
+          {
+            call: async (toolPath, args) => {
+              calls.push({ toolPath, args });
+              return [{ id: toolPath }];
+            },
+          },
+          { timeoutMs: 1000 },
+        );
+        expect(output.output).toEqual({ count: 3 });
+        expect(calls).toEqual([
+          { toolPath: "inboxes#0.messages.list", args: { query: "invoice" } },
+          { toolPath: "inboxes#1.messages.list", args: { query: "invoice" } },
+          { toolPath: "inboxes#2.messages.list", args: { query: "invoice" } },
+        ]);
+      }),
+    );
   });
 };

--- a/packages/plugins/apps/src/testing/conformance.ts
+++ b/packages/plugins/apps/src/testing/conformance.ts
@@ -35,7 +35,7 @@ export const appToolExecutorConformance = (
         expect(collected.tools).toMatchObject([
           {
             toolName: "conformance",
-            integrations: { crm: { slug: "dealcloud", mode: "one", all: false } },
+            integrations: { crm: { slug: "dealcloud", mode: "one" } },
           },
         ]);
       }),
@@ -65,53 +65,6 @@ export const appToolExecutorConformance = (
           { timeoutMs: 1000 },
         );
         expect(output.output).toEqual({ result: "ok" });
-      }),
-    );
-
-    it.effect("invokes all-bound handlers with fan-out integration proxies", () =>
-      Effect.gen(function* () {
-        const bundled = yield* bundle(`
-          import { z } from "zod";
-          import { defineTool, integration } from "executor:app";
-          export default defineTool({
-            description: "Conformance all invoke",
-            integrations: { inboxes: integration("gmail").array().all() },
-            input: z.object({ query: z.string() }),
-            output: z.object({ count: z.number() }),
-            async handler({ query }, { inboxes }) {
-              const batches = await Promise.all(
-                inboxes.map((inbox) => inbox.messages.list({ query })),
-              );
-              return { count: batches.flat().length };
-            },
-          });
-        `);
-        const calls: unknown[] = [];
-        const output = yield* makeExecutor().invoke(
-          bundled.code,
-          { toolName: "conformance" },
-          {
-            query: "invoice",
-            inboxes: [
-              "tools.gmail.org.work",
-              "tools.gmail.user.personal",
-              "tools.gmail.org.shared",
-            ],
-          },
-          {
-            call: async (toolPath, args) => {
-              calls.push({ toolPath, args });
-              return [{ id: toolPath }];
-            },
-          },
-          { timeoutMs: 1000 },
-        );
-        expect(output.output).toEqual({ count: 3 });
-        expect(calls).toEqual([
-          { toolPath: "inboxes#0.messages.list", args: { query: "invoice" } },
-          { toolPath: "inboxes#1.messages.list", args: { query: "invoice" } },
-          { toolPath: "inboxes#2.messages.list", args: { query: "invoice" } },
-        ]);
       }),
     );
   });

--- a/packages/plugins/apps/src/testing/index.ts
+++ b/packages/plugins/apps/src/testing/index.ts
@@ -1,0 +1,2 @@
+export { makeInProcessAppToolExecutor } from "../executor/app-tool-executor";
+export { makeAppsStore } from "../plugin/store";

--- a/packages/plugins/apps/src/testing/index.ts
+++ b/packages/plugins/apps/src/testing/index.ts
@@ -1,2 +1,3 @@
 export { makeInProcessAppToolExecutor } from "../executor/app-tool-executor";
 export { makeAppsStore } from "../plugin/store";
+export { appToolExecutorConformance } from "./conformance";

--- a/packages/plugins/apps/tsconfig.json
+++ b/packages/plugins/apps/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "lib": ["ES2022", "DOM"],
+    "types": ["bun-types", "node"],
+    "noUnusedLocals": true,
+    "noImplicitOverride": true,
+    "plugins": [
+      {
+        "name": "@effect/language-service",
+        "ignoreEffectSuggestionsInTscExitCode": true,
+        "ignoreEffectWarningsInTscExitCode": true,
+        "diagnosticSeverity": {}
+      }
+    ]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/plugins/apps/tsup.config.ts
+++ b/packages/plugins/apps/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: {
+    index: "src/index.ts",
+    api: "src/api.ts",
+    authoring: "src/authoring.ts",
+    "testing/index": "src/testing/index.ts",
+  },
+  format: ["esm"],
+  dts: false,
+  sourcemap: true,
+  clean: true,
+  external: [/^@executor-js\//, /^effect/, /^@effect\//, "esbuild", "zod"],
+});

--- a/packages/plugins/apps/vitest.config.ts
+++ b/packages/plugins/apps/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
+  },
+});


### PR DESCRIPTION
The engine for custom tools: authoring surface (defineTool with an integrations block, fluent integration() declarations, record and factory exports), the publish pipeline (discover, bundle, collect with a determinism gate, project), and the apps plugin that makes published tools catalog citizens with connection selection projected into their schemas.

Storage rides the existing BlobStore and plugin storage. Execution runs behind an executor-agnostic seam with an in-process test backing; the workerd backing arrives with the host wiring in the next PR against the same conformance suite. No hosts, routes, or UI in this PR.

Stacked on #1361.

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #1361
2. **#1362** 👈 current
3. #1363
4. #1365
<!-- stack:links:end -->