### PR TITLE
CLI: sign-in hint on 401 and a default login server

### DIFF
--- a/.changeset/cli-login-hints.md
+++ b/.changeset/cli-login-hints.md
@@ -1,0 +1,5 @@
+---
+"executor": patch
+---
+
+Explain 401s from a hosted server as a sign-in problem with the exact `executor login` command to run, instead of surfacing a raw decode error. `executor login` now defaults to https://executor.sh when no server is specified, and profile plumbing stays out of messages unless you address servers by name.

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -965,7 +965,7 @@ const executeCode = (input: {
 }): Effect.Effect<ExecuteCodeResult, Error, FileSystem.FileSystem | PlatformPath.Path> =>
   Effect.gen(function* () {
     const connection = yield* resolveExecutorServerConnection(input.target);
-    const client = yield* makeApiClient(connection);
+    const client = yield* makeApiClient(connection, input.target);
     const response = yield* client.executions.execute({
       payload: {
         code: input.code,
@@ -1054,7 +1054,7 @@ const printExecutionOutcome = (input: {
 // Typed API client
 // ---------------------------------------------------------------------------
 
-const makeApiClient = (connection: ExecutorServerConnection) => {
+const makeApiClient = (connection: ExecutorServerConnection, target: ServerTarget = {}) => {
   const authorization = getExecutorServerAuthorizationHeader(connection);
   return HttpApiClient.make(ExecutorApi, {
     baseUrl: connection.apiBaseUrl,
@@ -1074,7 +1074,8 @@ const makeApiClient = (connection: ExecutorServerConnection) => {
       Effect.catchIf(
         effect,
         (cause) => HttpClientError.isHttpClientError(cause) && cause.response?.status === 401,
-        () => Effect.fail(new Error(describeUnauthorizedCliServer({ connection, cliPrefix }))),
+        () =>
+          Effect.fail(new Error(describeUnauthorizedCliServer({ connection, cliPrefix, target }))),
       ),
   }).pipe(Effect.provide(FetchHttpClient.layer));
 };
@@ -1817,11 +1818,9 @@ const runCallHelp = (
   Effect.gen(function* () {
     if (args.scopeDir) process.env.EXECUTOR_SCOPE_DIR = resolve(args.scopeDir);
 
-    const connection = yield* resolveExecutorServerConnection({
-      baseUrl: args.baseUrl,
-      serverName: args.serverName,
-    });
-    const client = yield* makeApiClient(connection);
+    const target: ServerTarget = { baseUrl: args.baseUrl, serverName: args.serverName };
+    const connection = yield* resolveExecutorServerConnection(target);
+    const client = yield* makeApiClient(connection, target);
     const tools = yield* client.tools.list({ query: {} });
     const toolPaths = tools.map((tool) => tool.address);
 
@@ -2002,7 +2001,7 @@ const resumeCommand = Command.make(
 
       const contentObj = yield* parseOptionalJsonObject(Option.getOrUndefined(content));
 
-      const client = yield* makeApiClient(connection);
+      const client = yield* makeApiClient(connection, target);
       const result = yield* client.executions.resume({
         params: { executionId },
         payload: { action, content: contentObj },
@@ -2438,7 +2437,15 @@ const loginCommand = Command.make(
       });
 
       console.log("");
-      console.log(`Logged in to ${target.origin} (profile "${profileName}", now the default).`);
+      // Profile bookkeeping stays backstage unless the user works with named
+      // profiles (--name, or a store that already has several).
+      const mentionProfile =
+        explicitName !== undefined || (yield* readCliServerConnectionStore()).profiles.length > 1;
+      console.log(
+        mentionProfile
+          ? `Logged in to ${target.origin} (profile "${profileName}", now the default).`
+          : `Logged in to ${target.origin}.`,
+      );
       if (email) console.log(`Account: ${email}`);
       if (org) console.log(`Organization: ${org}`);
       else if (sub) console.log(`User: ${sub}`);
@@ -2463,8 +2470,14 @@ const logoutCommand = Command.make(
         console.log(`No stored login for ${target.origin}.`);
         return;
       }
+      // Profile bookkeeping stays backstage unless the user addressed one.
+      const mentionProfile = Option.isSome(server) || store.profiles.length > 1;
       if (!profile.connection.auth) {
-        console.log(`Profile "${profile.name}" has no stored credentials.`);
+        console.log(
+          mentionProfile
+            ? `Profile "${profile.name}" has no stored credentials.`
+            : `Not signed in to ${target.origin}.`,
+        );
         return;
       }
       yield* upsertCliServerConnectionProfile({
@@ -2477,7 +2490,9 @@ const logoutCommand = Command.make(
         makeDefault: store.defaultProfile === profile.name,
       });
       console.log(
-        `Logged out of ${profile.connection.origin} (cleared credentials for "${profile.name}").`,
+        mentionProfile
+          ? `Logged out of ${profile.connection.origin} (cleared credentials for "${profile.name}").`
+          : `Logged out of ${profile.connection.origin}.`,
       );
     }),
 ).pipe(Command.withDescription("Clear stored credentials for a server profile"));

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -64,7 +64,12 @@ if (sentryDsn) {
 import { Argument as Args, Command, Flag as Options } from "effect/unstable/cli";
 import { BunRuntime, BunServices } from "@effect/platform-bun";
 import { HttpApiClient } from "effect/unstable/httpapi";
-import { FetchHttpClient, HttpClient, HttpClientRequest } from "effect/unstable/http";
+import {
+  FetchHttpClient,
+  HttpClient,
+  HttpClientError,
+  HttpClientRequest,
+} from "effect/unstable/http";
 import { FileSystem, Path as PlatformPath } from "effect";
 import type { PlatformError } from "effect/PlatformError";
 import * as Effect from "effect/Effect";
@@ -131,7 +136,9 @@ import {
 import {
   canAutoStartCliServerConnection,
   chooseCliServerConnectionWithActiveLocal,
+  describeUnauthorizedCliServer,
   parseCliExecutorServerConnection,
+  profileNameFromConnectionKey,
   type CliServerConnectionSource,
   withCliServerAuthFallback,
 } from "./server-connection";
@@ -743,9 +750,6 @@ const resolveRequestedExecutorServerConnection = (
 // login. The refreshed tokens are written back to the originating profile.
 const OAUTH_REFRESH_SKEW_SECONDS = 60;
 
-const profileNameFromKey = (key: string): string | null =>
-  key.startsWith("profile:") ? key.slice("profile:".length) : null;
-
 const refreshOAuthConnection = (
   connection: ExecutorServerConnection,
 ): Effect.Effect<ExecutorServerConnection, never, FileSystem.FileSystem | PlatformPath.Path> =>
@@ -780,7 +784,7 @@ const refreshOAuthConnection = (
       },
     });
 
-    const profileName = profileNameFromKey(connection.key);
+    const profileName = profileNameFromConnectionKey(connection.key);
     if (profileName) {
       yield* upsertCliServerConnectionProfile({
         name: profileName,
@@ -1061,6 +1065,17 @@ const makeApiClient = (connection: ExecutorServerConnection) => {
           ),
         }
       : {}),
+    // A 401 on an endpoint that doesn't model it is a sign-in problem: rewrite
+    // the transport-level error into the login hint. Without this the client
+    // fails decoding the unexpected status and prints the opaque
+    // `Decode error (401 GET .../api/tools)`. Declared 401s (typed API errors)
+    // decode before this catch and pass through untouched.
+    transformResponse: (effect) =>
+      Effect.catchIf(
+        effect,
+        (cause) => HttpClientError.isHttpClientError(cause) && cause.response?.status === 401,
+        () => Effect.fail(new Error(describeUnauthorizedCliServer({ connection, cliPrefix }))),
+      ),
   }).pipe(Effect.provide(FetchHttpClient.layer));
 };
 
@@ -2307,9 +2322,13 @@ const chooseLoginProfileName = (
   }
 };
 
+/** Where `executor login` lands with no flags and no stored profiles. */
+const DEFAULT_LOGIN_ORIGIN = "https://executor.sh";
+
 // Resolve which server a login/logout targets: an existing profile (--server
-// or the default) or a bare origin (--base-url). The profile name is decided
-// later, from the authenticated account.
+// or the default), a bare origin (--base-url), or hosted Executor when
+// nothing is configured yet. The profile name is decided later, from the
+// authenticated account.
 const resolveLoginOrigin = (input: {
   readonly baseUrl: Option.Option<string>;
   readonly server: Option.Option<string>;
@@ -2337,11 +2356,7 @@ const resolveLoginOrigin = (input: {
     const store = yield* readCliServerConnectionStore();
     const profile = defaultCliServerConnectionProfile(store);
     if (profile) return { origin: profile.connection.origin, profile };
-    return yield* Effect.fail(
-      new Error(
-        "No server to log in to. Pass --base-url <https://your-host> or --server <profile>.",
-      ),
-    );
+    return { origin: DEFAULT_LOGIN_ORIGIN, profile: null };
   });
 
 const loginNameOption = Options.string("name").pipe(
@@ -2366,6 +2381,9 @@ const loginCommand = Command.make(
     Effect.gen(function* () {
       const target = yield* resolveLoginOrigin({ baseUrl, server });
       const explicitName = Option.getOrUndefined(name);
+      // The target may have been picked implicitly (default profile, or the
+      // hosted fallback): say where the login is going before the device flow.
+      console.log(`Signing in to ${target.origin}`);
       const discovery = yield* Effect.tryPromise({
         try: () => discoverCliLogin(target.origin),
         catch: toError,
@@ -2425,7 +2443,11 @@ const loginCommand = Command.make(
       if (org) console.log(`Organization: ${org}`);
       else if (sub) console.log(`User: ${sub}`);
     }),
-).pipe(Command.withDescription("Sign in to a hosted Executor server in the browser (device flow)"));
+).pipe(
+  Command.withDescription(
+    "Sign in to a hosted Executor server in the browser (device flow). Defaults to https://executor.sh.",
+  ),
+);
 
 const logoutCommand = Command.make(
   "logout",

--- a/apps/cli/src/server-connection.test.ts
+++ b/apps/cli/src/server-connection.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "@effect/vitest";
 
+import { normalizeExecutorServerConnection } from "@executor-js/sdk/shared";
+
 import {
   canAutoStartCliServerConnection,
   chooseCliServerConnectionWithActiveLocal,
+  describeUnauthorizedCliServer,
   parseCliExecutorServerConnection,
   withCliServerAuthFallback,
 } from "./server-connection";
@@ -133,5 +136,55 @@ describe("CLI server connection", () => {
         active,
       }).kind,
     ).toBe("conflict");
+  });
+});
+
+describe("describeUnauthorizedCliServer", () => {
+  it("names the profile and its login command for a stale oauth login", () => {
+    const connection = normalizeExecutorServerConnection({
+      key: "profile:work",
+      origin: "https://executor.example",
+      auth: { kind: "oauth", accessToken: "stale", expiresAt: 1 },
+    });
+
+    const message = describeUnauthorizedCliServer({ connection, cliPrefix: "executor" });
+    expect(message).toContain("You're signed out");
+    expect(message).toContain('profile "work"');
+    expect(message).toContain("executor login --server work");
+  });
+
+  it("points an unauthenticated origin at login --base-url", () => {
+    const connection = normalizeExecutorServerConnection({
+      origin: "https://executor.example",
+    });
+
+    const message = describeUnauthorizedCliServer({ connection, cliPrefix: "executor" });
+    expect(message).toContain("no credentials are stored");
+    expect(message).toContain("executor login --base-url https://executor.example");
+  });
+
+  it("mentions the env vars when a profile-less bearer key is rejected", () => {
+    const connection = normalizeExecutorServerConnection({
+      origin: "https://executor.example",
+      auth: { kind: "bearer", token: "key_bad" },
+    });
+
+    const message = describeUnauthorizedCliServer({ connection, cliPrefix: "executor" });
+    expect(message).toContain("rejected the stored bearer credentials");
+    expect(message).toContain("EXECUTOR_API_KEY");
+  });
+
+  it("uses the dev entrypoint prefix verbatim", () => {
+    const connection = normalizeExecutorServerConnection({
+      key: "profile:hosted",
+      origin: "https://executor.example",
+      auth: { kind: "oauth", accessToken: "stale" },
+    });
+
+    const message = describeUnauthorizedCliServer({
+      connection,
+      cliPrefix: "bun run apps/cli/src/main.ts",
+    });
+    expect(message).toContain("bun run apps/cli/src/main.ts login --server hosted");
   });
 });

--- a/apps/cli/src/server-connection.test.ts
+++ b/apps/cli/src/server-connection.test.ts
@@ -140,25 +140,51 @@ describe("CLI server connection", () => {
 });
 
 describe("describeUnauthorizedCliServer", () => {
-  it("names the profile and its login command for a stale oauth login", () => {
+  it("hints plain `executor login` when the server was picked implicitly", () => {
+    const connection = normalizeExecutorServerConnection({
+      key: "profile:rhys-executor.sh",
+      origin: "https://executor.sh",
+      auth: { kind: "oauth", accessToken: "stale", expiresAt: 1 },
+    });
+
+    const message = describeUnauthorizedCliServer({
+      connection,
+      cliPrefix: "executor",
+      target: {},
+    });
+    expect(message).toContain("You're signed out of https://executor.sh");
+    expect(message).toContain("Run `executor login` to sign in again.");
+    // Profile names are plumbing: never surfaced when the user didn't type one.
+    expect(message).not.toContain("--server");
+    expect(message).not.toContain("profile");
+  });
+
+  it("echoes --server back when the user targeted a named profile", () => {
     const connection = normalizeExecutorServerConnection({
       key: "profile:work",
       origin: "https://executor.example",
       auth: { kind: "oauth", accessToken: "stale", expiresAt: 1 },
     });
 
-    const message = describeUnauthorizedCliServer({ connection, cliPrefix: "executor" });
-    expect(message).toContain("You're signed out");
-    expect(message).toContain('profile "work"');
+    const message = describeUnauthorizedCliServer({
+      connection,
+      cliPrefix: "executor",
+      target: { serverName: "work" },
+    });
+    expect(message).toContain("You're signed out of https://executor.example");
     expect(message).toContain("executor login --server work");
   });
 
-  it("points an unauthenticated origin at login --base-url", () => {
+  it("echoes --base-url back when the user targeted an origin", () => {
     const connection = normalizeExecutorServerConnection({
       origin: "https://executor.example",
     });
 
-    const message = describeUnauthorizedCliServer({ connection, cliPrefix: "executor" });
+    const message = describeUnauthorizedCliServer({
+      connection,
+      cliPrefix: "executor",
+      target: { baseUrl: "https://executor.example" },
+    });
     expect(message).toContain("no credentials are stored");
     expect(message).toContain("executor login --base-url https://executor.example");
   });
@@ -169,7 +195,11 @@ describe("describeUnauthorizedCliServer", () => {
       auth: { kind: "bearer", token: "key_bad" },
     });
 
-    const message = describeUnauthorizedCliServer({ connection, cliPrefix: "executor" });
+    const message = describeUnauthorizedCliServer({
+      connection,
+      cliPrefix: "executor",
+      target: {},
+    });
     expect(message).toContain("rejected the stored bearer credentials");
     expect(message).toContain("EXECUTOR_API_KEY");
   });
@@ -184,7 +214,8 @@ describe("describeUnauthorizedCliServer", () => {
     const message = describeUnauthorizedCliServer({
       connection,
       cliPrefix: "bun run apps/cli/src/main.ts",
+      target: {},
     });
-    expect(message).toContain("bun run apps/cli/src/main.ts login --server hosted");
+    expect(message).toContain("bun run apps/cli/src/main.ts login");
   });
 });

--- a/apps/cli/src/server-connection.ts
+++ b/apps/cli/src/server-connection.ts
@@ -52,6 +52,50 @@ export const canAutoStartCliServerConnection = (connection: ExecutorServerConnec
   return url.protocol === "http:" && canAutoStartLocalDaemonForHost(url.hostname);
 };
 
+export const profileNameFromConnectionKey = (key: string): string | null =>
+  key.startsWith("profile:") ? key.slice("profile:".length) : null;
+
+// A 401 from the server means the stored credential is stale, revoked, or
+// missing: a sign-in problem, not a transport problem. Rendered instead of
+// the raw HTTP client error so the user learns the recovery command, not the
+// failing endpoint.
+export const describeUnauthorizedCliServer = (input: {
+  readonly connection: ExecutorServerConnection;
+  readonly cliPrefix: string;
+}): string => {
+  const { connection, cliPrefix } = input;
+  const profileName = profileNameFromConnectionKey(connection.key);
+  const loginCommand = profileName
+    ? `${cliPrefix} login --server ${profileName}`
+    : `${cliPrefix} login --base-url ${connection.origin}`;
+  const server = profileName
+    ? `${connection.origin} (profile "${profileName}")`
+    : connection.origin;
+
+  if (!connection.auth) {
+    return [
+      `${server} requires authentication, and no credentials are stored for it.`,
+      `Run \`${loginCommand}\` to sign in.`,
+    ].join("\n");
+  }
+
+  if (connection.auth.kind === "oauth") {
+    return [
+      `You're signed out of ${server}: the stored login was rejected (401).`,
+      `Run \`${loginCommand}\` to sign in again.`,
+    ].join("\n");
+  }
+
+  const envHint =
+    connection.auth.kind === "bearer" && !profileName
+      ? " If the key came from EXECUTOR_API_KEY or EXECUTOR_AUTH_TOKEN, check that value."
+      : "";
+  return [
+    `${server} rejected the stored ${connection.auth.kind} credentials (401).${envHint}`,
+    `Run \`${loginCommand}\` to sign in again.`,
+  ].join("\n");
+};
+
 export type CliServerConnectionSource =
   | "explicit"
   | "default-profile"

--- a/apps/cli/src/server-connection.ts
+++ b/apps/cli/src/server-connection.ts
@@ -59,39 +59,44 @@ export const profileNameFromConnectionKey = (key: string): string | null =>
 // missing: a sign-in problem, not a transport problem. Rendered instead of
 // the raw HTTP client error so the user learns the recovery command, not the
 // failing endpoint.
+//
+// The hint mirrors how the user addressed the server. The common case types
+// no flags (the default profile, normally executor.sh), and login re-targets
+// that same default, so the fix is plain `executor login`: profile names are
+// plumbing and stay invisible. Only an explicit --server / --base-url comes
+// back in the hint.
 export const describeUnauthorizedCliServer = (input: {
   readonly connection: ExecutorServerConnection;
   readonly cliPrefix: string;
+  readonly target: { readonly baseUrl?: string; readonly serverName?: string };
 }): string => {
-  const { connection, cliPrefix } = input;
-  const profileName = profileNameFromConnectionKey(connection.key);
-  const loginCommand = profileName
-    ? `${cliPrefix} login --server ${profileName}`
-    : `${cliPrefix} login --base-url ${connection.origin}`;
-  const server = profileName
-    ? `${connection.origin} (profile "${profileName}")`
-    : connection.origin;
+  const { connection, cliPrefix, target } = input;
+  const loginCommand = target.serverName
+    ? `${cliPrefix} login --server ${target.serverName}`
+    : target.baseUrl
+      ? `${cliPrefix} login --base-url ${connection.origin}`
+      : `${cliPrefix} login`;
 
   if (!connection.auth) {
     return [
-      `${server} requires authentication, and no credentials are stored for it.`,
+      `${connection.origin} requires authentication, and no credentials are stored for it.`,
       `Run \`${loginCommand}\` to sign in.`,
     ].join("\n");
   }
 
   if (connection.auth.kind === "oauth") {
     return [
-      `You're signed out of ${server}: the stored login was rejected (401).`,
+      `You're signed out of ${connection.origin}.`,
       `Run \`${loginCommand}\` to sign in again.`,
     ].join("\n");
   }
 
   const envHint =
-    connection.auth.kind === "bearer" && !profileName
+    connection.auth.kind === "bearer" && !profileNameFromConnectionKey(connection.key)
       ? " If the key came from EXECUTOR_API_KEY or EXECUTOR_AUTH_TOKEN, check that value."
       : "";
   return [
-    `${server} rejected the stored ${connection.auth.kind} credentials (401).${envHint}`,
+    `${connection.origin} rejected the stored ${connection.auth.kind} credentials (401).${envHint}`,
     `Run \`${loginCommand}\` to sign in again.`,
   ].join("\n");
 };

--- a/e2e/local/cli-call-logged-out.test.ts
+++ b/e2e/local/cli-call-logged-out.test.ts
@@ -1,0 +1,154 @@
+// Local CLI: what `executor call` tells a user whose stored hosted-server
+// login no longer works. A stub standing in for the hosted server answers
+// every request 401 (the wire shape of an expired or revoked session), and
+// the default profile carries an expired OAuth token with no way to refresh.
+//
+// The CLI must treat that 401 as a sign-in problem, not a transport problem:
+// name the signed-out profile and the exact `executor login` command, and
+// never surface the raw `Decode error (401 GET .../api/tools)` it printed
+// before the 401 mapping existed.
+//
+// The session runs in an interactive shell with an `executor` shim on PATH so
+// the terminal.cast reads like the real moment: the user types the command,
+// the error is the whole answer.
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+
+import { scenario } from "../src/scenario";
+import { Cli, RunDir } from "../src/services";
+
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+
+/** Every route answers like a hosted server rejecting an expired session. */
+const listenAsUnauthorizedServer = () =>
+  Effect.promise(
+    () =>
+      new Promise<{ origin: string; close: () => void }>((resolve) => {
+        const server = createServer((_request, response) => {
+          response.writeHead(401, { "content-type": "application/json" });
+          response.end(JSON.stringify({ error: "unauthorized" }));
+        });
+        server.listen(0, "127.0.0.1", () => {
+          const { port } = server.address() as AddressInfo;
+          resolve({
+            origin: `http://127.0.0.1:${port}`,
+            close: () => server.close(),
+          });
+        });
+      }),
+  );
+
+/** A data dir whose default profile is a hosted server with an expired,
+ *  unrefreshable OAuth token: the state `executor server list` shows as
+ *  `stored-auth` after a login has gone stale. The `profile:` key matches
+ *  what `executor login` persists via upsertCliServerConnectionProfile. */
+const writeLoggedOutProfile = (dataDir: string, origin: string) => {
+  writeFileSync(
+    join(dataDir, "server-connections.json"),
+    JSON.stringify(
+      {
+        version: 1,
+        defaultProfile: "hosted",
+        profiles: [
+          {
+            name: "hosted",
+            connection: {
+              kind: "http",
+              key: "profile:hosted",
+              origin,
+              displayName: "hosted",
+              auth: { kind: "oauth", accessToken: "expired-access-token", expiresAt: 1 },
+            },
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+};
+
+/** An `executor` on PATH that runs this checkout's CLI, so the recording
+ *  shows the command a user actually types. */
+const writeExecutorShim = (binDir: string) => {
+  const shim = join(binDir, "executor");
+  writeFileSync(shim, `#!/bin/sh\nexec bun run "${join(repoRoot, "apps/cli/src/main.ts")}" "$@"\n`);
+  chmodSync(shim, 0o755);
+};
+
+scenario(
+  "CLI call · a signed-out hosted profile explains how to log back in",
+  { timeout: 120_000 },
+  Effect.gen(function* () {
+    const cli = yield* Cli;
+    const runDir = yield* RunDir;
+
+    const hosted = yield* listenAsUnauthorizedServer();
+    const dataDir = mkdtempSync(join(tmpdir(), "executor-cli-logged-out-"));
+    writeLoggedOutProfile(dataDir, hosted.origin);
+    writeExecutorShim(dataDir);
+
+    yield* cli
+      .session(
+        ["bash", "--noprofile", "--norc"],
+        async (term) => {
+          await term.screen.waitUntil((current) => current.text.includes("$"), {
+            timeoutMs: 30_000,
+          });
+
+          // The user browses the catalog the way the docs teach: call --help.
+          await term.keyboard.type("executor call github issues --help", { paceMs: 40 });
+          await term.keyboard.press("Enter");
+
+          // The command exits after printing its sign-in error.
+          const snapshot = await term.screen.waitUntil((current) => current.text.includes("401"), {
+            timeoutMs: 60_000,
+          });
+          const screen = snapshot.text;
+
+          // The moment reads as a sign-in problem, scoped to the profile...
+          expect(screen, "the error says the user is signed out").toContain("You're signed out");
+          expect(screen, "it names the stale profile").toContain('profile "hosted"');
+          // ...and hands over the exact recovery command (in dev mode the
+          // prefix is `bun run .../main.ts`, so assert the stable suffix).
+          expect(screen, "it prints the login command for that profile").toContain(
+            "login --server hosted",
+          );
+
+          // The pre-fix rendering must not resurface.
+          expect(screen, "the raw transport error stays internal").not.toContain("Decode error");
+          expect(screen, "the API endpoint does not leak into the message").not.toContain(
+            "/api/tools",
+          );
+        },
+        {
+          cwd: repoRoot,
+          env: {
+            EXECUTOR_DATA_DIR: dataDir,
+            EXECUTOR_SCOPE_DIR: dataDir,
+            PATH: `${dataDir}${delimiter}${process.env.PATH ?? ""}`,
+            PS1: "$ ",
+            // Keep macOS's "default shell is now zsh" banner out of the cast.
+            BASH_SILENCE_DEPRECATION_WARNING: "1",
+          },
+          record: join(runDir, "terminal.cast"),
+          viewport: { cols: 100, rows: 24 },
+        },
+      )
+      .pipe(
+        Effect.ensuring(
+          Effect.sync(() => {
+            hosted.close();
+            rmSync(dataDir, { recursive: true, force: true });
+          }),
+        ),
+      );
+  }),
+);

--- a/e2e/local/cli-call-logged-out.test.ts
+++ b/e2e/local/cli-call-logged-out.test.ts
@@ -4,9 +4,11 @@
 // the default profile carries an expired OAuth token with no way to refresh.
 //
 // The CLI must treat that 401 as a sign-in problem, not a transport problem:
-// name the signed-out profile and the exact `executor login` command, and
-// never surface the raw `Decode error (401 GET .../api/tools)` it printed
-// before the 401 mapping existed.
+// say which server the user is signed out of and that `executor login` fixes
+// it. The user typed no flags, so the hint is plain `executor login`; profile
+// names are internal plumbing and must not leak. And the raw
+// `Decode error (401 GET .../api/tools)` from before the 401 mapping must
+// never resurface.
 //
 // The session runs in an interactive shell with an `executor` shim on PATH so
 // the terminal.cast reads like the real moment: the user types the command,
@@ -108,19 +110,23 @@ scenario(
           await term.keyboard.press("Enter");
 
           // The command exits after printing its sign-in error.
-          const snapshot = await term.screen.waitUntil((current) => current.text.includes("401"), {
-            timeoutMs: 60_000,
-          });
+          const snapshot = await term.screen.waitUntil(
+            (current) => current.text.includes("sign in"),
+            { timeoutMs: 60_000 },
+          );
           const screen = snapshot.text;
 
-          // The moment reads as a sign-in problem, scoped to the profile...
+          // The moment reads as a sign-in problem naming the server...
           expect(screen, "the error says the user is signed out").toContain("You're signed out");
-          expect(screen, "it names the stale profile").toContain('profile "hosted"');
-          // ...and hands over the exact recovery command (in dev mode the
-          // prefix is `bun run .../main.ts`, so assert the stable suffix).
-          expect(screen, "it prints the login command for that profile").toContain(
-            "login --server hosted",
+          // ...fixed by plain `executor login` (dev mode prefixes the entry
+          // script, so assert the stable tail of the sentence).
+          expect(screen, "it hands over the bare login command").toContain(
+            "login` to sign in again.",
           );
+
+          // No flags were typed, so no plumbing comes back.
+          expect(screen, "profile names stay internal").not.toContain("--server");
+          expect(screen, "profiles are not mentioned at all").not.toContain("profile");
 
           // The pre-fix rendering must not resurface.
           expect(screen, "the raw transport error stays internal").not.toContain("Decode error");


### PR DESCRIPTION
Calling the API with a stale or rejected stored login used to surface the transport error, `Decode error (401 GET .../api/tools)`, with no recovery path. The CLI now treats a 401 as a sign-in problem and answers with the fix. The hint mirrors how the user addressed the server: plain `executor login` in the common no-flags case, echoing `--server` / `--base-url` only when the user typed them. Profile names stay internal; login and logout output mention them only when the user works with named profiles.

`executor login` with no flags and no stored profiles now signs in to https://executor.sh instead of failing with "No server to log in to", and prints `Signing in to <origin>` before the device flow so an implicit target is always visible.

Covered by a new local e2e scenario (recording below) plus unit tests for the message variants.

![CLI call · a signed-out hosted profile explains how to log back in (local)](https://raw.githubusercontent.com/UsefulSoftwareCo/executor/e2e-media/cli-call-a-signed-out-hosted-profile-explains-how-to-log-back-in-72b73231.gif)
