### PR TITLE
Show a loading shell in the add-connection modal while auth methods resolve

### DIFF
--- a/e2e/scenarios/add-connection-modal-loading.test.ts
+++ b/e2e/scenarios/add-connection-modal-loading.test.ts
@@ -1,0 +1,118 @@
+// Cross-target (browser): a cold deep link into the add-connection modal must
+// show a loading shell while the integration catalog is still resolving, not a
+// half-initialized credential form. The cloud harness follows the same public
+// UI path as selfhost for this open-MCP setup.
+import { randomBytes } from "node:crypto";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import { makeGreetingMcpServer, serveMcpServer } from "@executor-js/plugin-mcp/testing";
+
+import { scenario } from "../src/scenario";
+import { Browser, Target } from "../src/services";
+
+scenario(
+  "Connections · the add modal holds a loading shell until auth methods resolve",
+  {},
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const browser = yield* Browser;
+      const server = yield* serveMcpServer(() =>
+        makeGreetingMcpServer({
+          name: `loading-shell-mcp-${randomBytes(3).toString("hex")}`,
+        }),
+      );
+      const identity = yield* target.newIdentity();
+      let integrationPath = "";
+
+      yield* browser.session(identity, async ({ page, step }) => {
+        await step("Create an MCP integration with a declared API key method", async () => {
+          await page.goto(`/integrations/add/mcp?url=${encodeURIComponent(server.endpoint)}`, {
+            waitUntil: "networkidle",
+          });
+          await page.getByText("How does this server authenticate?").waitFor({ timeout: 90_000 });
+          await page.getByRole("button", { name: "Add method" }).click();
+          await page.getByText("Method 2").waitFor();
+          await page.getByRole("button", { name: "Add integration" }).click();
+          await page.waitForURL(/\/integrations\/(?!add\b)[^/?]+$/, { timeout: 30_000 });
+          integrationPath = new URL(page.url()).pathname;
+          await page.getByText("Connections").first().waitFor();
+        });
+      });
+
+      yield* browser.session(identity, async ({ page, step }) => {
+        let releaseIntegrations!: () => void;
+        const integrationsHeld = new Promise<void>((resolve) => {
+          releaseIntegrations = resolve;
+        });
+        let holdNextCatalogRequest = true;
+        let holdNextMcpServerRequest = true;
+        await page.route("**/api/integrations**", async (route) => {
+          if (!holdNextCatalogRequest) {
+            await route.continue();
+            return;
+          }
+          holdNextCatalogRequest = false;
+          const response = await route.fetch();
+          await integrationsHeld;
+          await route.fulfill({ response });
+        });
+        await page.route("**/api/mcp/servers/**", async (route) => {
+          if (!holdNextMcpServerRequest) {
+            await route.continue();
+            return;
+          }
+          holdNextMcpServerRequest = false;
+          const response = await route.fetch();
+          await integrationsHeld;
+          await route.fulfill({ response });
+        });
+
+        await step(
+          "Open the deep link while the integration catalog response is held",
+          async () => {
+            await page.goto(`${integrationPath}?addAccount=1`, { waitUntil: "commit" });
+            await page.getByRole("dialog", { name: /Add connection/ }).waitFor();
+            await page.getByTestId("add-account-loading-shell").waitFor();
+          },
+        );
+
+        await step("The held modal has no half-initialized credential form", async () => {
+          const dialog = page.getByRole("dialog", { name: /Add connection/ });
+          expect(
+            await dialog.getByRole("tab").count(),
+            "auth method tabs are not rendered until methods resolve",
+          ).toBe(0);
+          const enabledContinueButtons = await dialog
+            .getByRole("button", { name: "Continue" })
+            .evaluateAll(
+              (buttons) =>
+                buttons.filter(
+                  (button) =>
+                    button instanceof HTMLButtonElement &&
+                    !button.disabled &&
+                    button.offsetParent !== null,
+                ).length,
+            );
+          expect(
+            enabledContinueButtons,
+            "the loading shell must not expose an enabled Continue button",
+          ).toBe(0);
+          expect(
+            await page.getByTestId("add-account-loading-shell").isVisible(),
+            "the loading shell is visible while the catalog is held",
+          ).toBe(true);
+        });
+
+        await step("The resolved modal mounts with the declared method tabs", async () => {
+          const dialog = page.getByRole("dialog", { name: /Add connection/ });
+          releaseIntegrations();
+          await page.getByTestId("add-account-loading-shell").waitFor({ state: "detached" });
+          await dialog.getByRole("tab", { name: "No authentication" }).waitFor();
+          await dialog.getByRole("tab", { name: "API key (Authorization)" }).waitFor();
+        });
+      });
+    }),
+  ),
+);

--- a/packages/plugins/graphql/src/react/GraphqlAccountsPanel.tsx
+++ b/packages/plugins/graphql/src/react/GraphqlAccountsPanel.tsx
@@ -8,6 +8,7 @@ import type { IntegrationAccountHandoff } from "@executor-js/sdk/client";
 import { AccountsSection } from "@executor-js/react/components/accounts-section";
 import { integrationWriteKeys } from "@executor-js/react/api/reactivity-keys";
 import type { AuthMethod, Placement } from "@executor-js/react/lib/auth-placements";
+import { isAsyncResultLoading } from "@executor-js/react/lib/async-result";
 import {
   useCustomMethodActions,
   type AuthMethodsCodec,
@@ -96,6 +97,7 @@ export default function GraphqlAccountsPanel(props: {
         integration={slug}
         integrationName={integrationName}
         methods={methods}
+        methodsLoading={isAsyncResultLoading(configResult)}
         accountHandoff={accountHandoff}
         createCustomMethod={createCustomMethod}
         removeCustomMethod={removeCustomMethod}

--- a/packages/plugins/mcp/src/react/McpAccountsPanel.tsx
+++ b/packages/plugins/mcp/src/react/McpAccountsPanel.tsx
@@ -7,6 +7,7 @@ import { IntegrationSlug } from "@executor-js/sdk/shared";
 import type { IntegrationAccountHandoff } from "@executor-js/sdk/client";
 import { AccountsSection } from "@executor-js/react/components/accounts-section";
 import type { AuthMethod, Placement } from "@executor-js/react/lib/auth-placements";
+import { isAsyncResultLoading } from "@executor-js/react/lib/async-result";
 import {
   useCustomMethodActions,
   type AuthMethodsCodec,
@@ -104,6 +105,7 @@ export default function McpAccountsPanel(props: {
         integration={slug}
         integrationName={integrationName}
         methods={methods}
+        methodsLoading={isAsyncResultLoading(serverResult)}
         accountHandoff={accountHandoff}
         createCustomMethod={canConfigureAuth ? createCustomMethod : undefined}
         removeCustomMethod={canConfigureAuth ? removeCustomMethod : undefined}

--- a/packages/plugins/openapi/src/react/OpenApiAccountsPanel.tsx
+++ b/packages/plugins/openapi/src/react/OpenApiAccountsPanel.tsx
@@ -14,6 +14,7 @@ import { integrationWriteKeys } from "@executor-js/react/api/reactivity-keys";
 import { useOrganizationId } from "@executor-js/react/api/organization-context";
 import { defaultConnectionOwnerForHost } from "@executor-js/react/plugins/connection-owner";
 import type { AuthMethod, Placement } from "@executor-js/react/lib/auth-placements";
+import { isAsyncResultLoading } from "@executor-js/react/lib/async-result";
 import {
   useCustomMethodActions,
   type AuthMethodsCodec,
@@ -129,6 +130,7 @@ export default function OpenApiAccountsPanel(props: {
         integration={slug}
         integrationName={integrationName}
         methods={methods}
+        methodsLoading={isAsyncResultLoading(configResult)}
         accountHandoff={accountHandoff}
         createCustomMethod={createCustomMethod}
         removeCustomMethod={removeCustomMethod}

--- a/packages/react/src/components/accounts-section.tsx
+++ b/packages/react/src/components/accounts-section.tsx
@@ -366,6 +366,10 @@ export function AccountsSection(props: {
   readonly integration: IntegrationSlug;
   readonly integrationName: string;
   readonly methods: readonly AuthMethod[];
+  /** True while the caller's methods source is still resolving, so the modal can
+   *  show a loading shell instead of treating "not loaded yet" as "no
+   *  authentication". */
+  readonly methodsLoading?: boolean;
   readonly accountHandoff?: IntegrationAccountHandoff | null;
   /** When provided, Add connection shows a "+ Custom method" row. The plugin binds
    *  this to its own configure mutation. Omitted for plugins with fixed auth. */
@@ -376,6 +380,7 @@ export function AccountsSection(props: {
     integration,
     integrationName,
     methods,
+    methodsLoading,
     accountHandoff,
     createCustomMethod,
     removeCustomMethod,
@@ -445,6 +450,7 @@ export function AccountsSection(props: {
       integration={integration}
       integrationName={integrationName}
       methods={methods}
+      methodsLoading={methodsLoading}
       open={adding || reconnectHandoff !== null}
       onOpenChange={(open: boolean) => {
         setAdding(open);

--- a/packages/react/src/components/add-account-modal.tsx
+++ b/packages/react/src/components/add-account-modal.tsx
@@ -85,6 +85,7 @@ import { PlacementLine, type AuthMethod } from "../lib/auth-placements";
 import { connectionIdentifier } from "../lib/connection-name";
 import { Badge } from "./badge";
 import { Button } from "./button";
+import { Skeleton } from "./skeleton";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "./collapsible";
 import {
   DropdownMenu,
@@ -890,6 +891,10 @@ interface AddAccountModalProps {
   readonly integration: IntegrationSlug;
   readonly integrationName: string;
   readonly methods: readonly AuthMethod[];
+  /** True while the caller's methods source is still resolving, so the modal can
+   *  show a loading shell instead of treating "not loaded yet" as "no
+   *  authentication". */
+  readonly methodsLoading?: boolean;
   readonly open: boolean;
   readonly onOpenChange: (open: boolean) => void;
   readonly initialState?: IntegrationAccountHandoff | null;
@@ -909,7 +914,59 @@ interface AddAccountModalProps {
  *  OAuth popup can't wedge a later open: the stuck flow died with its instance.
  *  The parent owns only open/route intent (deep links, the reconnect handoff). */
 export function AddAccountModal(props: AddAccountModalProps) {
-  return props.open ? <AddAccountModalView {...props} /> : null;
+  if (!props.open) return null;
+  if (props.methodsLoading) {
+    return (
+      <AddAccountModalLoadingShell
+        integrationName={props.integrationName}
+        onOpenChange={props.onOpenChange}
+      />
+    );
+  }
+  return <AddAccountModalView {...props} />;
+}
+
+function AddAccountModalLoadingShell(props: {
+  readonly integrationName: string;
+  readonly onOpenChange: (open: boolean) => void;
+}) {
+  const ownerDisplay = useOwnerDisplay();
+
+  return (
+    // Non-modal for the same reason as the full add-account dialog below: a
+    // modal dialog's react-remove-scroll locks the wheel to the dialog subtree,
+    // so portaled popups opened from the dialog cannot scroll.
+    <Dialog open onOpenChange={props.onOpenChange} modal={false}>
+      <DialogContent
+        forceOverlay
+        data-testid="add-account-loading-shell"
+        className="max-h-[85vh] overflow-x-hidden overflow-y-auto sm:max-w-xl"
+      >
+        <DialogHeader>
+          <DialogTitle>Add connection · {props.integrationName}</DialogTitle>
+          <DialogDescription>
+            {ownerDisplay.showOwnerLabels
+              ? "A connection is a saved way to use this integration, owned by you or the workspace."
+              : "A connection is a saved way to use this integration."}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex w-full min-w-0 flex-col gap-5" aria-busy="true">
+          <Skeleton className="h-10 w-full rounded-md" />
+          <div className="rounded-md border border-border/60 bg-background">
+            <div className="space-y-4 border-b border-border/60 p-4">
+              <Skeleton className="h-3.5 w-28" />
+              <Skeleton className="h-9 w-full" />
+            </div>
+            <div className="space-y-3 p-4">
+              <Skeleton className="h-3.5 w-24" />
+              <Skeleton className="h-9 w-full" />
+              <Skeleton className="h-3.5 w-40" />
+            </div>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/react/src/pages/integration-detail.tsx
+++ b/packages/react/src/pages/integration-detail.tsx
@@ -297,6 +297,9 @@ export function IntegrationDetailPage(props: { namespace: string }) {
   // Prefer the integration's DECLARED methods; only fall through to inference
   // when the plugin declares none (no projector → empty `authMethods`).
   const accountsMethods = declaredMethods.length > 0 ? declaredMethods : inferredFallbackMethods;
+  const accountsMethodsLoading =
+    isAsyncResultLoading(integration) ||
+    (declaredMethods.length === 0 && isAsyncResultLoading(connectionsResult));
 
   const handleDelete = async () => {
     if (!integrationData) return;
@@ -444,6 +447,7 @@ export function IntegrationDetailPage(props: { namespace: string }) {
                   integration={slug}
                   integrationName={integrationData?.name || namespace}
                   methods={accountsMethods}
+                  methodsLoading={accountsMethodsLoading}
                   accountHandoff={accountHandoff}
                 />
               </div>


### PR DESCRIPTION
Opening the add-connection modal before the integration catalog resolved rendered a half-initialized form: an empty auth-method strip, a bare credential step, and a live Continue button, which then flipped to the real methods once the response landed. The modal now takes a `methodsLoading` signal from its callers and shows a skeleton shell until methods are resolved, so the form only ever mounts with real data.

![Connections · the add modal holds a loading shell until auth methods resolve (cloud)](https://raw.githubusercontent.com/UsefulSoftwareCo/executor/e2e-media/connections-the-add-modal-holds-a-loading-shell-until-auth-methods-resolve-ce5468ad.gif)