### PR TITLE
Pin release workflows to npm 11

### DIFF
--- a/.github/workflows/publish-executor-package.yml
+++ b/.github/workflows/publish-executor-package.yml
@@ -62,7 +62,9 @@ jobs:
 
       - name: Update npm for trusted publishing
         run: |
-          npm install -g npm@latest
+          # npm 12.0.0 fails `publish --provenance` with "Cannot find module
+          # 'sigstore'" (npm/cli#9722); 11.x supports trusted publishing and works.
+          npm install -g npm@11
           npm --version
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,9 @@ jobs:
 
       - name: Update npm for trusted publishing
         run: |
-          npm install -g npm@latest
+          # npm 12.0.0 fails `publish --provenance` with "Cannot find module
+          # 'sigstore'" (npm/cli#9722); 11.x supports trusted publishing and works.
+          npm install -g npm@11
           npm --version
 
       - name: Install dependencies


### PR DESCRIPTION
npm 12.0.0 (published 2026-07-08, picked up via `npm install -g npm@latest`) fails `npm publish --provenance` with "Cannot find module 'sigstore'" (npm/cli#9722). This broke the release run for v1.5.30 mid-publish. Pin both publishing workflows to npm 11 until the upstream bug is fixed.