### PR TITLE
E2E: selfhost-docker coverage fixes for shared-workspace scenarios

### DIFF
--- a/e2e/scenarios/api-tools.test.ts
+++ b/e2e/scenarios/api-tools.test.ts
@@ -37,7 +37,7 @@ scenario(
     // bootstrap admin, so other scenarios' connections legitimately appear here;
     // asserting a global count there is exactly what e2e/AGENTS.md forbids.
     const connections = yield* api.connections.list({ query: {} });
-    if (target.name === "selfhost") return;
+    if (target.name.startsWith("selfhost")) return;
     expect(connections.length, "a fresh org starts with no connections").toBe(0);
   }),
 );

--- a/e2e/scenarios/org-slug-routing.test.ts
+++ b/e2e/scenarios/org-slug-routing.test.ts
@@ -50,7 +50,7 @@ scenario(
       // the URL segment, so the slug is cosmetic and an unknown one canonicalizes
       // onto the shell rather than 404ing. Cloud enforces the not-found; selfhost
       // legitimately does not.
-      if (target.name !== "selfhost") {
+      if (!target.name.startsWith("selfhost")) {
         await step("An unknown org slug is a wrong address, not a redirect", async () => {
           await page.goto("/zz-no-such-org/policies", { waitUntil: "networkidle" });
           await page.getByText("Page not found").waitFor({ timeout: 30_000 });

--- a/e2e/selfhost/toolkits-ui.test.ts
+++ b/e2e/selfhost/toolkits-ui.test.ts
@@ -201,9 +201,14 @@ scenario(
           await page.getByRole("button", { name: "Manage toolkit connections" }).click();
           const dialog = page.getByRole("dialog", { name: "Manage connections" });
           await dialog.waitFor();
+          // The contract is the explanation, not the count: this suite's own
+          // hidden connection guarantees at least one, but the workspace is
+          // shared, so another scenario's personal connection may legitimately
+          // raise the number (asserting a global count is what e2e/AGENTS.md
+          // forbids).
           await dialog
             .getByText(
-              "You have 1 personal connection that is not shown because this is a shared toolkit.",
+              /You have \d+ personal connections? that (?:is|are) not shown because this is a shared toolkit\./,
             )
             .waitFor();
         });


### PR DESCRIPTION
Follow-ups to the release gate (#1392) that were committed to its branch after it merged: api-tools and org-slug-routing special-cased target.name === "selfhost" but selfhost-docker is the same single-tenant app, and toolkits-ui asserted a global personal-connection count that another scenario legitimately changes. All three fail the new docker e2e release gate without this.