### PR TITLE
Clear app executor timeout timers

### DIFF
--- a/.changeset/clear-app-executor-timers.md
+++ b/.changeset/clear-app-executor-timers.md
@@ -1,0 +1,5 @@
+---
+"executor": patch
+---
+
+Release completed app tool invocation timeout timers instead of retaining them until their deadlines.

--- a/packages/plugins/apps/src/executor/app-tool-executor-process.fixture.ts
+++ b/packages/plugins/apps/src/executor/app-tool-executor-process.fixture.ts
@@ -1,0 +1,24 @@
+import { Effect } from "effect";
+
+import { makeInProcessAppToolExecutor } from "./app-tool-executor";
+
+const bundle = `
+  export default {
+    "~executorAppTool": true,
+    description: "Fast",
+    input: undefined,
+    handler() { return { ok: true }; },
+  };
+`;
+
+await Effect.runPromise(
+  makeInProcessAppToolExecutor().invoke(
+    bundle,
+    { toolName: "fast" },
+    {},
+    { call: async () => null },
+    { timeoutMs: 30_000 },
+  ),
+);
+
+process.stdout.write("invocation complete\n");

--- a/packages/plugins/apps/src/executor/app-tool-executor.test.ts
+++ b/packages/plugins/apps/src/executor/app-tool-executor.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from "@effect/vitest";
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+import { buildSync } from "esbuild";
 import { Effect } from "effect";
 
 import { bundleEntry } from "../pipeline/bundle";
@@ -13,6 +16,28 @@ const bundle = (source: string) =>
   });
 
 describe("in-process app tool executor", () => {
+  it("releases the invocation timeout after a successful call", () => {
+    const fixture = join(import.meta.dirname, "app-tool-executor-process.fixture.ts");
+    const script = buildSync({
+      entryPoints: [fixture],
+      bundle: true,
+      platform: "node",
+      format: "esm",
+      target: "node24",
+      write: false,
+    })
+      .outputFiles.map((output) => output.text)
+      .join("\n");
+    const result = spawnSync(process.execPath, ["--input-type=module"], {
+      encoding: "utf8",
+      input: script,
+      timeout: 5_000,
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("invocation complete");
+  });
+
   it.effect("detects integration declarations and merges projected input fields", () =>
     Effect.gen(function* () {
       const bundled = yield* bundle(`

--- a/packages/plugins/apps/src/executor/app-tool-executor.ts
+++ b/packages/plugins/apps/src/executor/app-tool-executor.ts
@@ -363,22 +363,30 @@ const selectTool = (exported: unknown, entry: string): unknown => {
   return exported[entry.slice(index + marker.length)];
 };
 
-const timeout = <A>(promise: Promise<A>, timeoutMs: number): Promise<A> =>
-  Promise.race([
-    promise,
-    new Promise<A>((_, reject) => {
-      setTimeout(
-        () =>
-          reject(
-            new AppExecutorError({
-              kind: "timeout",
-              message: `app tool timed out after ${timeoutMs}ms`,
-            }),
-          ),
-        timeoutMs,
-      );
-    }),
-  ]);
+const timeout = async <A>(promise: Promise<A>, timeoutMs: number): Promise<A> => {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<A>((_, reject) => {
+        timer = setTimeout(
+          () =>
+            reject(
+              new AppExecutorError({
+                kind: "timeout",
+                message: `app tool timed out after ${timeoutMs}ms`,
+              }),
+            ),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) {
+      clearTimeout(timer);
+    }
+  }
+};
 
 const makeClient = (root: string, prefix: readonly string[], bridge: AppToolBridge): unknown =>
   new Proxy(() => undefined, {

--- a/packages/plugins/apps/src/executor/dynamic-worker-app-tool-executor.ts
+++ b/packages/plugins/apps/src/executor/dynamic-worker-app-tool-executor.ts
@@ -79,7 +79,7 @@ const mapCause = (cause: unknown, kind: AppExecutorError["kind"], message: strin
 
 // Bump this when appWorkerModule() changes so stable Worker Loader IDs do not
 // reuse an isolate running an older driver around byte-identical app bundles.
-export const DRIVER_VERSION = "1";
+export const DRIVER_VERSION = "2";
 
 const appWorkerModule = (): string => `
 import { WorkerEntrypoint } from "cloudflare:workers";
@@ -247,11 +247,18 @@ export default class AppExecutor extends WorkerEntrypoint {
         const output = await tool.handler(decoded, split.integrations);
         return { output: await validateStandard(tool.output, output, "output") };
       };
-      const value = await Promise.race([
-        invoke(),
-        new Promise((_, reject) => setTimeout(() => reject(fail("timeout", "app tool timed out after " + input.timeoutMs + "ms")), input.timeoutMs)),
-      ]);
-      return { ok: true, value };
+      let timer;
+      try {
+        const value = await Promise.race([
+          invoke(),
+          new Promise((_, reject) => {
+            timer = setTimeout(() => reject(fail("timeout", "app tool timed out after " + input.timeoutMs + "ms")), input.timeoutMs);
+          }),
+        ]);
+        return { ok: true, value };
+      } finally {
+        if (timer !== undefined) clearTimeout(timer);
+      }
     } catch (error) {
       return serializeFailure(error, "invoke");
     }

--- a/packages/plugins/apps/src/executor/dynamic-worker-app-tool-executor.worker.test.ts
+++ b/packages/plugins/apps/src/executor/dynamic-worker-app-tool-executor.worker.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "@effect/vitest";
+import { env } from "cloudflare:workers";
+import { Effect } from "effect";
+
+import { makeDynamicWorkerAppToolExecutor } from "./dynamic-worker-app-tool-executor";
+
+type WorkerLoader = Parameters<typeof makeDynamicWorkerAppToolExecutor>[0]["loader"];
+
+describe("dynamic Worker app tool executor", () => {
+  it.effect("invokes a completed tool through the generated driver", () =>
+    Effect.gen(function* () {
+      const loader = (env as { readonly LOADER: WorkerLoader }).LOADER;
+      const executor = makeDynamicWorkerAppToolExecutor({ loader });
+      const bundle = `
+        export default {
+          "~executorAppTool": true,
+          description: "Fast",
+          input: undefined,
+          handler() { return { ok: true }; },
+        };
+      `;
+
+      const result = yield* executor.invoke(
+        bundle,
+        { toolName: "fast" },
+        {},
+        { call: async () => null },
+        { timeoutMs: 30_000, isolateKey: "timer-cleanup" },
+      );
+
+      expect(result.output).toEqual({ ok: true });
+    }),
+  );
+});

--- a/packages/plugins/apps/src/executor/workerd-app-tool-executor.ts
+++ b/packages/plugins/apps/src/executor/workerd-app-tool-executor.ts
@@ -230,11 +230,18 @@ export default {
           const output = await tool.handler(decoded, split.integrations);
           return { output: await validateStandard(tool.output, output, "output") };
         };
-        const value = await Promise.race([
-          invoke(),
-          new Promise((_, reject) => setTimeout(() => reject(fail("timeout", "app tool timed out after " + input.timeoutMs + "ms")), input.timeoutMs)),
-        ]);
-        return Response.json({ ok: true, value });
+        let timer;
+        try {
+          const value = await Promise.race([
+            invoke(),
+            new Promise((_, reject) => {
+              timer = setTimeout(() => reject(fail("timeout", "app tool timed out after " + input.timeoutMs + "ms")), input.timeoutMs);
+            }),
+          ]);
+          return Response.json({ ok: true, value });
+        } finally {
+          if (timer !== undefined) clearTimeout(timer);
+        }
       }
       return Response.json({ ok: false, kind: "invoke", message: "unknown operation" });
     } catch (error) {


### PR DESCRIPTION
Fixes #1413

## Summary

Completed app tool invocations now clear their losing timeout timers instead of retaining them until the configured deadline.

The change applies to the in-process executor and the emitted workerd and dynamic Worker drivers.

## What changed

- Wrap each timeout race in `try`/`finally` and clear the timer after the race settles.
- Apply the same cleanup to the emitted workerd and dynamic Worker driver modules.
- Bump `DRIVER_VERSION` from `1` to `2` so Worker Loader does not reuse an isolate containing the previous generated driver.
- Add a process-liveness regression for the in-process executor.
- Add worker-pool coverage that invokes a completed tool through the generated dynamic Worker driver.
- Add an `executor` patch changeset.

The configured timeout, timeout error message, and app tool result contract are unchanged.

## Regression proof

The regression starts a child process that completes an app tool invocation immediately with a 30-second timeout.

Before the fix, the child printed `invocation complete` but remained alive past the test's five-second process deadline because the losing timer was still active.

After the fix, the child exits successfully within that deadline.

## Validation

From `packages/plugins/apps`:

- `bun run test -- src/executor/app-tool-executor.test.ts src/executor/app-tool-executor.conformance.test.ts`: 2 files and 19 tests passed.
- `bunx vitest run --config vitest.worker.config.ts src/executor/dynamic-worker-app-tool-executor.worker.test.ts`: 1 file and 1 test passed.
- `bun run typecheck`: passed with unrelated existing Effect suggestions.

Additional validation:

- `bun run bootstrap` passed.
- Targeted lint and formatting checks passed.
- `git diff --check` passed.
- Branch autoreview against `origin/main` returned no actionable findings.

## Limitations

The process-liveness regression directly proves timer release in the in-process Node executor. The workerd conformance tests and dynamic Worker pool test prove that the changed emitted drivers still invoke tools successfully, but those runtimes do not expose pending timer handles for the same direct assertion.

This change does not cancel the underlying tool invocation after a timeout. It only releases the losing timeout when the invocation settles first.

## Review order

1. The process fixture and process-liveness regression.
2. The canonical in-process timer cleanup.
3. Generated workerd and dynamic Worker driver parity, including cache invalidation.
4. Dynamic Worker pool coverage.
