### PR TITLE
fix: use exec-form selfhost healthcheck

### DIFF
--- a/apps/host-selfhost/Dockerfile
+++ b/apps/host-selfhost/Dockerfile
@@ -37,5 +37,5 @@ WORKDIR /app/apps/host-selfhost
 VOLUME ["/data"]
 EXPOSE 4788
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=5 \
-  CMD bun -e "fetch('http://127.0.0.1:4788/api/health').then(r=>process.exit(r.ok?0:1),()=>process.exit(1))"
+  CMD ["bun", "-e", "fetch('http://127.0.0.1:4788/api/health').then(r=>process.exit(r.ok?0:1),()=>process.exit(1))"]
 CMD ["bun", "run", "dist-server/serve.js"]


### PR DESCRIPTION
## Summary
- change the self-host Docker healthcheck to exec form so Docker does not invoke /bin/sh
- keeps the existing Bun-based /api/health probe unchanged

## Test Plan
- docker build -f apps/host-selfhost/Dockerfile -t executor-selfhost:healthcheck-fix .
- docker run -d --name selfhost-healthcheck-test -p 4789:4788 -e BETTER_AUTH_SECRET=... -e EXECUTOR_BOOTSTRAP_ADMIN_EMAIL=smoke@example.com -e EXECUTOR_BOOTSTRAP_ADMIN_PASSWORD=... -e EXECUTOR_WEB_BASE_URL=http://localhost:4789 executor-selfhost:healthcheck-fix
- observed Docker health status become healthy
- curl -fsS http://127.0.0.1:4789/api/health returned {"status":"ok"}