### PR TITLE
Support OAuth client_secret_basic

### DIFF
--- a/.changeset/oauth-client-basic-auth.md
+++ b/.changeset/oauth-client-basic-auth.md
@@ -2,4 +2,4 @@
 "@executor-js/sdk": patch
 ---
 
-Allow registered OAuth clients to use `client_secret_basic` at the token endpoint. The selected client-auth method is persisted and reused for authorization-code exchanges, client-credentials mints, token refreshes, and client-credentials re-mints; existing clients continue to default to `client_secret_post`.
+Allow registered OAuth clients to use interoperable `client_secret_basic` at the token endpoint. Basic credentials preserve the literal client ID and secret expected by common providers. The selected client-auth method is persisted and reused for authorization-code exchanges, client-credentials mints, token refreshes, and client-credentials re-mints; existing clients continue to default to `client_secret_post`.

--- a/.changeset/oauth-client-basic-auth.md
+++ b/.changeset/oauth-client-basic-auth.md
@@ -1,0 +1,5 @@
+---
+"@executor-js/sdk": patch
+---
+
+Allow registered OAuth clients to use `client_secret_basic` at the token endpoint. The selected client-auth method is persisted and reused for authorization-code exchanges, client-credentials mints, token refreshes, and client-credentials re-mints; existing clients continue to default to `client_secret_post`.

--- a/apps/cloud/drizzle/0016_slimy_amphibian.sql
+++ b/apps/cloud/drizzle/0016_slimy_amphibian.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "oauth_client" ADD COLUMN "token_endpoint_auth_method" text;

--- a/apps/cloud/drizzle/meta/0016_snapshot.json
+++ b/apps/cloud/drizzle/meta/0016_snapshot.json
@@ -1,0 +1,1492 @@
+{
+  "id": "aec7993e-87f4-40e6-87df-12fe915bf8ad",
+  "prevId": "d666b31a-c3d1-4bd7-9bd6-85f2abc4fb55",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memberships": {
+      "name": "memberships",
+      "schema": "",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "memberships_account_id_accounts_id_fk": {
+          "name": "memberships_account_id_accounts_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memberships_organization_id_organizations_id_fk": {
+          "name": "memberships_organization_id_organizations_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "organizations",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "memberships_account_id_organization_id_pk": {
+          "name": "memberships_account_id_organization_id_pk",
+          "columns": ["account_id", "organization_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artifact": {
+      "name": "artifact",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bindings": {
+          "name": "bindings",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview": {
+          "name": "preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "artifact_uidx": {
+          "name": "artifact_uidx",
+          "columns": [
+            {
+              "expression": "tenant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blob": {
+      "name": "blob",
+      "schema": "",
+      "columns": {
+        "namespace": {
+          "name": "namespace",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "blob_id_uidx": {
+          "name": "blob_id_uidx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connection": {
+      "name": "connection",
+      "schema": "",
+      "columns": {
+        "integration": {
+          "name": "integration",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template": {
+          "name": "template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_ids": {
+          "name": "item_ids",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity_label": {
+          "name": "identity_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_health": {
+          "name": "last_health",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tools_synced_at": {
+          "name": "tools_synced_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_client": {
+          "name": "oauth_client",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_client_owner": {
+          "name": "oauth_client_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_item_id": {
+          "name": "refresh_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_scope": {
+          "name": "oauth_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_token_url": {
+          "name": "oauth_token_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_state": {
+          "name": "provider_state",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "connection_uidx": {
+          "name": "connection_uidx",
+          "columns": [
+            {
+              "expression": "tenant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integration",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.definition": {
+      "name": "definition",
+      "schema": "",
+      "columns": {
+        "integration": {
+          "name": "integration",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection": {
+          "name": "connection",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema": {
+          "name": "schema",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "definition_uidx": {
+          "name": "definition_uidx",
+          "columns": [
+            {
+              "expression": "tenant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integration",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration": {
+      "name": "integration",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "health_check": {
+          "name": "health_check",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_revised_at": {
+          "name": "config_revised_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "can_remove": {
+          "name": "can_remove",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "can_refresh": {
+          "name": "can_refresh",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "integration_uidx": {
+          "name": "integration_uidx",
+          "columns": [
+            {
+              "expression": "tenant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_client": {
+      "name": "oauth_client",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorization_url": {
+          "name": "authorization_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_url": {
+          "name": "token_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grant": {
+          "name": "grant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret_item_id": {
+          "name": "client_secret_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_kind": {
+          "name": "origin_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_integration": {
+          "name": "origin_integration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_issuer": {
+          "name": "origin_issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_redirect_uri": {
+          "name": "origin_redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_client_uidx": {
+          "name": "oauth_client_uidx",
+          "columns": [
+            {
+              "expression": "tenant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_session": {
+      "name": "oauth_session",
+      "schema": "",
+      "columns": {
+        "state": {
+          "name": "state",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_slug": {
+          "name": "client_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration": {
+          "name": "integration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template": {
+          "name": "template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_url": {
+          "name": "redirect_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pkce_verifier": {
+          "name": "pkce_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_label": {
+          "name": "identity_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_session_uidx": {
+          "name": "oauth_session_uidx",
+          "columns": [
+            {
+              "expression": "tenant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plugin_storage": {
+      "name": "plugin_storage",
+      "schema": "",
+      "columns": {
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection": {
+          "name": "collection",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "plugin_storage_uidx": {
+          "name": "plugin_storage_uidx",
+          "columns": [
+            {
+              "expression": "tenant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "plugin_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "collection",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.private_executor_cloud_settings": {
+      "name": "private_executor_cloud_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.0.0'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subject": {
+      "name": "subject",
+      "schema": "",
+      "columns": {
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "subject_uidx": {
+          "name": "subject_uidx",
+          "columns": [
+            {
+              "expression": "tenant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tool": {
+      "name": "tool",
+      "schema": "",
+      "columns": {
+        "integration": {
+          "name": "integration",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection": {
+          "name": "connection",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_schema": {
+          "name": "input_schema",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_schema": {
+          "name": "output_schema",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annotations": {
+          "name": "annotations",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tool_uidx": {
+          "name": "tool_uidx",
+          "columns": [
+            {
+              "expression": "tenant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integration",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tool_policy": {
+      "name": "tool_policy",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tool_policy_uidx": {
+          "name": "tool_policy_uidx",
+          "columns": [
+            {
+              "expression": "tenant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/cloud/drizzle/meta/_journal.json
+++ b/apps/cloud/drizzle/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1785355354955,
       "tag": "0015_equal_the_leader",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1785438360346,
+      "tag": "0016_slimy_amphibian",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/cloud/src/db/executor-schema.ts
+++ b/apps/cloud/src/db/executor-schema.ts
@@ -99,6 +99,7 @@ export const oauth_client = pgTable(
     client_id: text("client_id").notNull(),
     client_secret_item_id: text("client_secret_item_id"),
     resource: text("resource"),
+    token_endpoint_auth_method: text("token_endpoint_auth_method"),
     origin_kind: text("origin_kind"),
     origin_integration: text("origin_integration"),
     origin_issuer: text("origin_issuer"),

--- a/apps/host-cloudflare/src/db/data-migrations.test.ts
+++ b/apps/host-cloudflare/src/db/data-migrations.test.ts
@@ -123,6 +123,25 @@ const insertOperationStorage = (
   });
 
 describe("runCloudflareDataMigrations", () => {
+  it.effect("adds the OAuth client token endpoint authentication method column", () =>
+    Effect.gen(function* () {
+      const db = yield* Effect.promise(() => createSqliteTestFumaDb({ tables: collectTables() }));
+      const { bucket } = makeFakeR2();
+
+      yield* Effect.promise(() =>
+        db.client.execute("ALTER TABLE oauth_client DROP COLUMN token_endpoint_auth_method"),
+      );
+
+      const d1 = makeFakeD1(db.client);
+      yield* Effect.promise(() => runCloudflareDataMigrations(d1, bucket));
+
+      const columns = yield* Effect.promise(() =>
+        db.client.execute("PRAGMA table_info('oauth_client')"),
+      );
+      expect(columns.rows.map((row) => row.name)).toContain("token_endpoint_auth_method");
+    }),
+  );
+
   it.effect("rebuilds legacy connection tables from item_id to item_ids", () =>
     Effect.gen(function* () {
       const db = yield* Effect.promise(() => createSqliteTestFumaDb({ tables: collectTables() }));

--- a/apps/host-cloudflare/src/db/data-migrations.ts
+++ b/apps/host-cloudflare/src/db/data-migrations.ts
@@ -122,6 +122,11 @@ export const ensureCloudflareD1SchemaCompatibility = async (db: D1Database): Pro
       .run();
   }
 
+  const oauthClientColumns = await tableColumns(db, "oauth_client");
+  if (oauthClientColumns.size > 0 && !oauthClientColumns.has("token_endpoint_auth_method")) {
+    await db.prepare(`ALTER TABLE oauth_client ADD COLUMN token_endpoint_auth_method text`).run();
+  }
+
   const connectionColumns = await tableColumns(db, "connection");
   if (connectionColumns.size === 0) return;
   if (!connectionColumns.has("item_ids")) {

--- a/apps/local/drizzle/0005_chemical_black_widow.sql
+++ b/apps/local/drizzle/0005_chemical_black_widow.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `oauth_client` ADD `token_endpoint_auth_method` text;

--- a/apps/local/drizzle/meta/0005_snapshot.json
+++ b/apps/local/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,934 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "3f8bf067-80ea-4545-be0c-e0fc20919d45",
+  "prevId": "85f30981-cda9-45df-b757-b2836fb70e07",
+  "tables": {
+    "blob": {
+      "name": "blob",
+      "columns": {
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "blob_id_uidx": {
+          "name": "blob_id_uidx",
+          "columns": ["id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "connection": {
+      "name": "connection",
+      "columns": {
+        "integration": {
+          "name": "integration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template": {
+          "name": "template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_ids": {
+          "name": "item_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identity_label": {
+          "name": "identity_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_client": {
+          "name": "oauth_client",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_client_owner": {
+          "name": "oauth_client_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_item_id": {
+          "name": "refresh_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_scope": {
+          "name": "oauth_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_token_url": {
+          "name": "oauth_token_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_state": {
+          "name": "provider_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connection_uidx": {
+          "name": "connection_uidx",
+          "columns": ["tenant", "owner", "subject", "integration", "name"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "definition": {
+      "name": "definition",
+      "columns": {
+        "integration": {
+          "name": "integration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connection": {
+          "name": "connection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schema": {
+          "name": "schema",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "definition_uidx": {
+          "name": "definition_uidx",
+          "columns": ["tenant", "owner", "subject", "integration", "connection", "name"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "integration": {
+      "name": "integration",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "can_remove": {
+          "name": "can_remove",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "can_refresh": {
+          "name": "can_refresh",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "integration_uidx": {
+          "name": "integration_uidx",
+          "columns": ["tenant", "slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_client": {
+      "name": "oauth_client",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "authorization_url": {
+          "name": "authorization_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_url": {
+          "name": "token_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "grant": {
+          "name": "grant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_secret_item_id": {
+          "name": "client_secret_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "origin_kind": {
+          "name": "origin_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "origin_integration": {
+          "name": "origin_integration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "origin_issuer": {
+          "name": "origin_issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "origin_redirect_uri": {
+          "name": "origin_redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_client_uidx": {
+          "name": "oauth_client_uidx",
+          "columns": ["tenant", "owner", "subject", "slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_session": {
+      "name": "oauth_session",
+      "columns": {
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_slug": {
+          "name": "client_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "integration": {
+          "name": "integration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template": {
+          "name": "template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "redirect_url": {
+          "name": "redirect_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pkce_verifier": {
+          "name": "pkce_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "identity_label": {
+          "name": "identity_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_session_uidx": {
+          "name": "oauth_session_uidx",
+          "columns": ["tenant", "state"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plugin_storage": {
+      "name": "plugin_storage",
+      "columns": {
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection": {
+          "name": "collection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "plugin_storage_uidx": {
+          "name": "plugin_storage_uidx",
+          "columns": ["tenant", "owner", "subject", "plugin_id", "collection", "key"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tool": {
+      "name": "tool",
+      "columns": {
+        "integration": {
+          "name": "integration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connection": {
+          "name": "connection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_schema": {
+          "name": "input_schema",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_schema": {
+          "name": "output_schema",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "annotations": {
+          "name": "annotations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tool_uidx": {
+          "name": "tool_uidx",
+          "columns": ["tenant", "owner", "subject", "integration", "connection", "name"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tool_policy": {
+      "name": "tool_policy",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tool_policy_uidx": {
+          "name": "tool_policy_uidx",
+          "columns": ["tenant", "owner", "subject", "id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/local/drizzle/meta/_journal.json
+++ b/apps/local/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1784581228503,
       "tag": "0004_cultured_shadowcat",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1784661475760,
+      "tag": "0005_chemical_black_widow",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/local/src/db/executor-schema.ts
+++ b/apps/local/src/db/executor-schema.ts
@@ -73,6 +73,7 @@ export const oauth_client = sqliteTable(
     client_id: text("client_id").notNull(),
     client_secret_item_id: text("client_secret_item_id"),
     resource: text("resource"),
+    token_endpoint_auth_method: text("token_endpoint_auth_method"),
     origin_kind: text("origin_kind"),
     origin_integration: text("origin_integration"),
     origin_issuer: text("origin_issuer"),

--- a/apps/local/src/db/sqlite-fumadb.ts
+++ b/apps/local/src/db/sqlite-fumadb.ts
@@ -105,6 +105,12 @@ export const createSqliteFumaDb = async <const TTables extends FumaTables>(
   ) {
     await client.execute("ALTER TABLE oauth_client ADD COLUMN origin_redirect_uri TEXT");
   }
+  if (
+    oauthClientColumns.rows.length > 0 &&
+    !oauthClientColumns.rows.some((column) => column["name"] === "token_endpoint_auth_method")
+  ) {
+    await client.execute("ALTER TABLE oauth_client ADD COLUMN token_endpoint_auth_method TEXT");
+  }
 
   const { db, fuma } = createExecutorFumaDb(drizzleDb, {
     tables: options.tables,

--- a/packages/core/api/src/handlers/oauth.ts
+++ b/packages/core/api/src/handlers/oauth.ts
@@ -105,6 +105,7 @@ export const OAuthHandlers = HttpApiBuilder.group(ExecutorApi, "oauth", (handler
             clientSecret: payload.clientSecret,
             resource: payload.resource ?? null,
             origin: { kind: "manual", integration: payload.originIntegration ?? null },
+            tokenEndpointAuthMethod: payload.tokenEndpointAuthMethod,
           });
           return { client };
         }),

--- a/packages/core/api/src/oauth/api.ts
+++ b/packages/core/api/src/oauth/api.ts
@@ -69,6 +69,9 @@ const CreateClientPayload = Schema.Struct({
   /** Integration whose connect dialog registered this manual app. Recorded so
    *  the picker matches it to this integration by intent, not root domain. */
   originIntegration: Schema.optional(Schema.NullOr(IntegrationSlug)),
+  /** Token-endpoint client auth: "body" (client_secret_post, default) or
+   *  "basic" (client_secret_basic). Omitted means "body". */
+  tokenEndpointAuthMethod: Schema.optional(Schema.Literals(["body", "basic"])),
 });
 
 const CreateClientResponse = Schema.Struct({
@@ -115,6 +118,8 @@ const OAuthClientSummaryResponse = Schema.Struct({
   tokenUrl: Schema.String,
   resource: Schema.optional(Schema.NullOr(Schema.String)),
   clientId: Schema.String,
+  /** Token-endpoint client auth ("body" | "basic"); omitted means "body". */
+  tokenEndpointAuthMethod: Schema.optional(Schema.Literals(["body", "basic"])),
   origin: Schema.Union([
     Schema.Struct({ kind: Schema.Literal("manual") }),
     Schema.Struct({

--- a/packages/core/sdk/src/core-schema.ts
+++ b/packages/core/sdk/src/core-schema.ts
@@ -265,6 +265,9 @@ export const coreTables = defineTables({
       // re-minted access token stays bound to the same resource. Null when the
       // provider doesn't use resource indicators.
       resource: nullableTextColumn("resource"),
+      // Token-endpoint client authentication. Null preserves the historical
+      // client_secret_post default; "basic" selects client_secret_basic.
+      token_endpoint_auth_method: nullableTextColumn("token_endpoint_auth_method"),
       // Where this oauth_client came from. Null in old databases is treated as
       // "manual" by the service layer.
       origin_kind: nullableTextColumn("origin_kind"),

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -166,6 +166,7 @@ import {
   exchangeClientCredentials,
   parseClientAuthMethod,
   shouldRefreshToken,
+  type ClientAuthMethod,
   type OAuthEndpointUrlPolicy,
 } from "./oauth-helpers";
 import { connectionIdentifier } from "./connection-name-identifier";
@@ -1778,6 +1779,7 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
       readonly tokenUrl: string;
       readonly grant: string;
       readonly resource: string | null;
+      readonly tokenEndpointAuthMethod: ClientAuthMethod;
     }
 
     /** What drove a refresh: the pre-call expiry check (`proactive`), or an
@@ -1882,6 +1884,7 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
               tokenUrl: firstParty.tokenUrl,
               grant: "authorization_code",
               resource: null,
+              tokenEndpointAuthMethod: "body",
             } satisfies RefreshClient;
           }
           const clientOwner = (row.oauth_client_owner ?? row.owner) as Owner;
@@ -1896,6 +1899,7 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
             tokenUrl: String(stored.token_url),
             grant: String(stored.grant),
             resource: stored.resource ? String(stored.resource) : null,
+            tokenEndpointAuthMethod: parseClientAuthMethod(stored.token_endpoint_auth_method),
           } satisfies RefreshClient;
         });
         if (!clientRow) {
@@ -1918,7 +1922,7 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
         // Null on old rows resolves to "body" (client_secret_post). Threaded
         // into both the client_credentials re-mint and the refresh_token call so
         // Basic-only providers keep working across refreshes.
-        const clientAuth = parseClientAuthMethod(clientRow.token_endpoint_auth_method);
+        const clientAuth = clientRow.tokenEndpointAuthMethod;
 
         // client_credentials (machine-to-machine) has NO refresh token — the
         // token is RE-MINTED from the client id/secret. The authorization_code

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -164,6 +164,7 @@ import { collectReferencedDefinitions } from "./schema-refs";
 import {
   refreshAccessToken,
   exchangeClientCredentials,
+  parseClientAuthMethod,
   shouldRefreshToken,
   type OAuthEndpointUrlPolicy,
 } from "./oauth-helpers";
@@ -1913,6 +1914,12 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
         // the oauth_client's configured token endpoint.
         const tokenUrl = row.oauth_token_url ? String(row.oauth_token_url) : clientRow.tokenUrl;
 
+        // How this app authenticates to the token endpoint ("body" | "basic").
+        // Null on old rows resolves to "body" (client_secret_post). Threaded
+        // into both the client_credentials re-mint and the refresh_token call so
+        // Basic-only providers keep working across refreshes.
+        const clientAuth = parseClientAuthMethod(clientRow.token_endpoint_auth_method);
+
         // client_credentials (machine-to-machine) has NO refresh token — the
         // token is RE-MINTED from the client id/secret. The authorization_code
         // path below needs a stored refresh token. Branching on grant here is
@@ -1926,6 +1933,7 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
                 clientSecret,
                 scopes: grantedScopes,
                 resource: clientRow.resource ?? undefined,
+                clientAuth,
                 endpointUrlPolicy: config.oauthEndpointUrlPolicy,
                 fetch: config.fetch,
               }).pipe(
@@ -1959,6 +1967,7 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
                   // RFC 8707: keep the re-minted token bound to the same resource
                   // (MCP servers require this on refresh).
                   resource: clientRow.resource ?? undefined,
+                  clientAuth,
                   endpointUrlPolicy: config.oauthEndpointUrlPolicy,
                   fetch: config.fetch,
                 }).pipe(

--- a/packages/core/sdk/src/oauth-client.ts
+++ b/packages/core/sdk/src/oauth-client.ts
@@ -70,8 +70,8 @@ export interface OAuthClient {
   readonly resource?: string | null;
   /** How the client authenticates to the token endpoint: `"body"`
    *  (`client_secret_post`, the default) or `"basic"` (`client_secret_basic`,
-   *  base64 `client_id:client_secret` in the Authorization header). Some
-   *  providers only accept Basic for confidential clients.
+   *  base64 of the literal UTF-8 `client_id:client_secret` pair in the
+   *  Authorization header). Some providers only accept Basic for confidential clients.
    *  Omitted/undefined is treated as `"body"` throughout. */
   readonly tokenEndpointAuthMethod?: ClientAuthMethod;
 }

--- a/packages/core/sdk/src/oauth-client.ts
+++ b/packages/core/sdk/src/oauth-client.ts
@@ -4,6 +4,12 @@ import { Schema } from "effect";
 import type { Connection } from "./connection";
 import type { UserActionableError } from "./errors";
 import type { StorageFailure } from "./fuma-runtime";
+import type { ClientAuthMethod } from "./oauth-helpers";
+
+/** Re-exported so the public OAuth contract surface (`@executor-js/sdk/shared`)
+ *  carries the token-endpoint client-auth method alongside the client shapes
+ *  that use it, without consumers importing the server-only flow helpers. */
+export type { ClientAuthMethod } from "./oauth-helpers";
 import {
   type AuthTemplateSlug,
   type ConnectionName,
@@ -62,6 +68,12 @@ export interface OAuthClient {
   /** RFC 8707 Resource Indicator (MCP). Carried so the refresh request can keep
    *  the re-minted token bound to the same resource. Null/omitted otherwise. */
   readonly resource?: string | null;
+  /** How the client authenticates to the token endpoint: `"body"`
+   *  (`client_secret_post`, the default) or `"basic"` (`client_secret_basic`,
+   *  base64 `client_id:client_secret` in the Authorization header). Some
+   *  providers only accept Basic for confidential clients.
+   *  Omitted/undefined is treated as `"body"` throughout. */
+  readonly tokenEndpointAuthMethod?: ClientAuthMethod;
 }
 
 export type OAuthClientOrigin =
@@ -179,6 +191,10 @@ export interface OAuthClientSummary {
   readonly tokenUrl: string;
   readonly resource?: string | null;
   readonly clientId: string;
+  /** Token-endpoint client authentication method ("body" | "basic"); see
+   *  {@link OAuthClient.tokenEndpointAuthMethod}. Surfaced so the UI can show
+   *  and re-edit how a registered app authenticates. */
+  readonly tokenEndpointAuthMethod?: ClientAuthMethod;
   readonly origin: OAuthClientOrigin;
 }
 

--- a/packages/core/sdk/src/oauth-flow.test.ts
+++ b/packages/core/sdk/src/oauth-flow.test.ts
@@ -693,6 +693,137 @@ describe("oauth.start / oauth.complete", () => {
     ),
   );
 
+  it.effect(
+    "client_credentials with tokenEndpointAuthMethod=basic sends HTTP Basic to the token endpoint",
+    () =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          // The AS is configured to REJECT body (client_secret_post) auth, so a
+          // successful inline mint proves the executor actually sent HTTP Basic.
+          const server = yield* serveOAuthTestServer({
+            scopes: ["read"],
+            requireClientAuthMethod: "basic",
+          });
+          const { executor } = yield* makeTestWorkspaceHarness({ plugins, redirectUri: null });
+          yield* executor.acme.seed();
+
+          yield* executor.oauth.createClient({
+            owner: "org",
+            slug: CLIENT,
+            authorizationUrl: server.authorizationEndpoint,
+            tokenUrl: server.tokenEndpoint,
+            grant: "client_credentials",
+            clientId: "test-client",
+            clientSecret: "test-secret",
+            tokenEndpointAuthMethod: "basic",
+          });
+
+          const started = yield* executor.oauth.start({
+            owner: "org",
+            client: CLIENT,
+            clientOwner: "org",
+            name: ConnectionName.make("cc"),
+            integration: INTEG,
+            template: TEMPLATE,
+          });
+          expect(started.status).toBe("connected");
+          // The single token request used HTTP Basic, not body params.
+          expect(yield* server.tokenRequestAuthMethods).toEqual(["basic"]);
+        }),
+      ),
+  );
+
+  it.effect("client_credentials without Basic is rejected by a Basic-only token endpoint", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const server = yield* serveOAuthTestServer({
+          scopes: ["read"],
+          requireClientAuthMethod: "basic",
+        });
+        const { executor } = yield* makeTestWorkspaceHarness({ plugins, redirectUri: null });
+        yield* executor.acme.seed();
+
+        // No tokenEndpointAuthMethod => the "body" (client_secret_post) default,
+        // which the Basic-only AS rejects. Proves the field actually changes the
+        // wire behavior rather than being inert.
+        yield* executor.oauth.createClient({
+          owner: "org",
+          slug: CLIENT,
+          authorizationUrl: server.authorizationEndpoint,
+          tokenUrl: server.tokenEndpoint,
+          grant: "client_credentials",
+          clientId: "test-client",
+          clientSecret: "test-secret",
+        });
+
+        const error = yield* Effect.flip(
+          executor.oauth.start({
+            owner: "org",
+            client: CLIENT,
+            clientOwner: "org",
+            name: ConnectionName.make("cc"),
+            integration: INTEG,
+            template: TEMPLATE,
+          }),
+        );
+        expect(Predicate.isTagged("OAuthStartError")(error)).toBe(true);
+        expect(yield* server.tokenRequestAuthMethods).toEqual(["body"]);
+      }),
+    ),
+  );
+
+  it.effect(
+    "authorization_code with tokenEndpointAuthMethod=basic sends HTTP Basic on the code exchange",
+    () =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          // The Basic-only AS rejects body, so a successful code exchange proves
+          // clientAuth is threaded into the authorization_code complete path too.
+          const server = yield* serveOAuthTestServer({
+            scopes: ["read"],
+            requireClientAuthMethod: "basic",
+          });
+          const { executor } = yield* makeTestWorkspaceHarness({
+            plugins,
+            redirectUri: "https://app.test/oauth/callback",
+          });
+          yield* executor.acme.seed();
+
+          yield* executor.oauth.createClient({
+            owner: "org",
+            slug: CLIENT,
+            authorizationUrl: server.authorizationEndpoint,
+            tokenUrl: server.tokenEndpoint,
+            grant: "authorization_code",
+            clientId: "test-client",
+            clientSecret: "test-secret",
+            tokenEndpointAuthMethod: "basic",
+          });
+
+          const started = yield* executor.oauth.start({
+            owner: "org",
+            client: CLIENT,
+            clientOwner: "org",
+            name: ConnectionName.make("main"),
+            integration: INTEG,
+            template: TEMPLATE,
+          });
+          expect(started.status).toBe("redirect");
+          if (started.status !== "redirect") return;
+          const callback = yield* server.completeAuthorizationCodeFlow({
+            authorizationUrl: started.authorizationUrl,
+          });
+          const connection = yield* executor.oauth.complete({
+            state: started.state,
+            code: callback.code,
+          });
+          expect(connection.name).toBe("main");
+          // Only the code exchange hit /token, and it used HTTP Basic.
+          expect(yield* server.tokenRequestAuthMethods).toEqual(["basic"]);
+        }),
+      ),
+  );
+
   it.effect("complete with an unknown state fails OAuthSessionNotFoundError", () =>
     Effect.scoped(
       Effect.gen(function* () {
@@ -812,6 +943,67 @@ describe("oauth.start / oauth.complete", () => {
 });
 
 describe("oauth token refresh in resolveConnectionValue", () => {
+  it.effect("an expired client_credentials connection re-mints via HTTP Basic", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        // Basic-only AS: every token request (initial mint AND the expiry
+        // re-mint) must carry HTTP Basic or it 401s.
+        const server = yield* serveOAuthTestServer({
+          scopes: ["read"],
+          requireClientAuthMethod: "basic",
+        });
+        const harness = yield* makeTestWorkspaceHarness({ plugins, redirectUri: null });
+        const { executor, config } = harness;
+        yield* executor.acme.seed();
+
+        yield* executor.oauth.createClient({
+          owner: "org",
+          slug: CLIENT,
+          authorizationUrl: server.authorizationEndpoint,
+          tokenUrl: server.tokenEndpoint,
+          grant: "client_credentials",
+          clientId: "test-client",
+          clientSecret: "test-secret",
+          tokenEndpointAuthMethod: "basic",
+        });
+
+        const started = yield* executor.oauth.start({
+          owner: "org",
+          client: CLIENT,
+          clientOwner: "org",
+          name: ConnectionName.make("cc"),
+          integration: INTEG,
+          template: TEMPLATE,
+        });
+        expect(started.status).toBe("connected");
+
+        const firstToken = (yield* executor.execute(
+          ToolAddress.make("tools.acme.org.cc.whoami"),
+          {},
+        )) as { token: string };
+        expect(firstToken.token).toMatch(/^at_/);
+
+        // client_credentials has no refresh token; expiring forces a fresh mint.
+        yield* Effect.promise(() =>
+          config.db.updateMany("connection", {
+            where: (b) => b("name", "=", "cc"),
+            set: { expires_at: Date.now() - 60_000 },
+          }),
+        );
+
+        const refreshedToken = (yield* executor.execute(
+          ToolAddress.make("tools.acme.org.cc.whoami"),
+          {},
+        )) as { token: string };
+        expect(refreshedToken.token).toMatch(/^at_/);
+        expect(refreshedToken.token).not.toBe(firstToken.token);
+        expect(yield* server.acceptsAccessToken(refreshedToken.token)).toBe(true);
+        // Both the initial mint and the re-mint authenticated via HTTP Basic.
+        expect(yield* server.tokenRequestAuthMethods).toEqual(["basic", "basic"]);
+      }),
+    ),
+  );
+
   it.effect("an expired access token is refreshed before resolving", () =>
     Effect.scoped(
       Effect.gen(function* () {

--- a/packages/core/sdk/src/oauth-helpers.test.ts
+++ b/packages/core/sdk/src/oauth-helpers.test.ts
@@ -705,27 +705,6 @@ describe("exchangeAuthorizationCode", () => {
     ),
   );
 
-  it.effect("uses HTTP Basic auth when clientAuth=basic (Stripe-style)", () =>
-    withTokenEndpoint(tokenResponse(validCodeBody), ({ tokenUrl, calls }) =>
-      Effect.gen(function* () {
-        yield* exchangeAuthorizationCode({
-          tokenUrl,
-          clientId: "cid",
-          clientSecret: "csecret",
-          redirectUrl: "https://app.example.com/cb",
-          codeVerifier: "verifier",
-          code: "abc",
-          clientAuth: "basic",
-        });
-        const call = (yield* calls)[0]!;
-        const expected = `Basic ${Buffer.from("cid:csecret").toString("base64")}`;
-        expect(call.headers["authorization"]).toBe(expected);
-        expect(call.body.has("client_id")).toBe(false);
-        expect(call.body.has("client_secret")).toBe(false);
-      }),
-    ),
-  );
-
   it.effect("uses the documented 20-second timeout default", () =>
     withTokenEndpoint(tokenResponse(validCodeBody), ({ tokenUrl }) =>
       Effect.gen(function* () {
@@ -844,6 +823,26 @@ describe("exchangeAuthorizationCode", () => {
 });
 
 describe("exchangeClientCredentials", () => {
+  it.effect("uses literal HTTP Basic credentials when clientAuth=basic", () =>
+    withTokenEndpoint(tokenResponse(validRefreshBody), ({ tokenUrl, calls }) =>
+      Effect.gen(function* () {
+        yield* exchangeClientCredentials({
+          tokenUrl,
+          clientId: "client_id-with-punctuation",
+          clientSecret: "client_secret-with-punctuation",
+          clientAuth: "basic",
+        });
+        const call = (yield* calls)[0]!;
+        const expected = `Basic ${Buffer.from(
+          "client_id-with-punctuation:client_secret-with-punctuation",
+        ).toString("base64")}`;
+        expect(call.headers["authorization"]).toBe(expected);
+        expect(call.body.has("client_id")).toBe(false);
+        expect(call.body.has("client_secret")).toBe(false);
+      }),
+    ),
+  );
+
   it.effect("routes token grant requests through the injected fetch", () =>
     withTokenEndpoint(tokenResponse(validRefreshBody), ({ tokenUrl }) =>
       Effect.gen(function* () {

--- a/packages/core/sdk/src/oauth-helpers.ts
+++ b/packages/core/sdk/src/oauth-helpers.ts
@@ -482,6 +482,14 @@ export type ClientAuthMethod = "body" | "basic";
  */
 export const DEFAULT_CLIENT_AUTH_METHOD: ClientAuthMethod = "body";
 
+/** Resolve a stored/raw token-endpoint client-auth value to a {@link
+ *  ClientAuthMethod}. Only `"basic"` is distinguished; everything else,
+ *  including null (old `oauth_client` rows) and unknown strings, falls through
+ *  to {@link DEFAULT_CLIENT_AUTH_METHOD} (`"body"`). Unlike the OAuth grant,
+ *  an unrecognised value here is a benign default, not a corrupt-row error. */
+export const parseClientAuthMethod = (value: unknown): ClientAuthMethod =>
+  value === "basic" ? "basic" : DEFAULT_CLIENT_AUTH_METHOD;
+
 const asFromTokenUrl = (
   tokenUrl: string,
   endpointUrlPolicy: OAuthEndpointUrlPolicy = {},

--- a/packages/core/sdk/src/oauth-helpers.ts
+++ b/packages/core/sdk/src/oauth-helpers.ts
@@ -556,9 +556,25 @@ const pickClientAuth = (
 ): oauth.ClientAuth => {
   if (!clientSecret) return oauth.None();
   return method === "basic"
-    ? oauth.ClientSecretBasic(clientSecret)
+    ? clientSecretBasicInterop(clientSecret)
     : oauth.ClientSecretPost(clientSecret);
 };
+
+// oauth4webapi's ClientSecretBasic follows RFC 6749 strictly by form-encoding
+// both credentials before base64 encoding them. A number of token endpoints
+// instead implement HTTP Basic per RFC 7617 and compare the decoded username
+// and password literally. Characters such as `_` therefore become `%5F` and
+// otherwise-valid credentials are rejected. Use the broadly interoperable
+// wire representation expected by those endpoints: base64 of the literal
+// UTF-8 `client_id:client_secret` pair.
+const clientSecretBasicInterop =
+  (clientSecret: string): oauth.ClientAuth =>
+  (_as, client, _body, headers) => {
+    const bytes = new TextEncoder().encode(`${client.client_id}:${clientSecret}`);
+    let binary = "";
+    for (const byte of bytes) binary += String.fromCharCode(byte);
+    headers.set("authorization", `Basic ${globalThis.btoa(binary)}`);
+  };
 
 const normalizedTokenScope = (
   as: oauth.AuthorizationServer,

--- a/packages/core/sdk/src/oauth-list-clients.test.ts
+++ b/packages/core/sdk/src/oauth-list-clients.test.ts
@@ -108,6 +108,43 @@ describe("oauth.listClients", () => {
     ),
   );
 
+  it.effect("round-trips tokenEndpointAuthMethod: only 'basic' is materialized", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const { executor } = yield* makeTestWorkspaceHarness({ plugins });
+
+        yield* executor.oauth.createClient({
+          owner: "org",
+          slug: ORG_CLIENT,
+          authorizationUrl: "",
+          tokenUrl: "https://acme.test/token",
+          grant: "client_credentials",
+          clientId: "basic-client",
+          clientSecret: "s3cret",
+          tokenEndpointAuthMethod: "basic",
+        });
+        // A second client with the default (body) method, sent explicitly.
+        yield* executor.oauth.createClient({
+          owner: "user",
+          slug: USER_CLIENT,
+          authorizationUrl: "",
+          tokenUrl: "https://byo.test/token",
+          grant: "client_credentials",
+          clientId: "body-client",
+          clientSecret: "s3cret",
+          tokenEndpointAuthMethod: "body",
+        });
+
+        const bySlug = new Map(
+          (yield* executor.oauth.listClients()).map((c) => [String(c.slug), c]),
+        );
+        // "basic" surfaces on the summary; "body" stays implicit (omitted).
+        expect(bySlug.get(String(ORG_CLIENT))?.tokenEndpointAuthMethod).toBe("basic");
+        expect(bySlug.get(String(USER_CLIENT))?.tokenEndpointAuthMethod).toBeUndefined();
+      }),
+    ),
+  );
+
   it.effect("hides another user's clients from the caller", () =>
     Effect.scoped(
       Effect.gen(function* () {

--- a/packages/core/sdk/src/oauth-service.ts
+++ b/packages/core/sdk/src/oauth-service.ts
@@ -518,6 +518,7 @@ export const loadedFirstPartyClient = (
   readonly clientId: string;
   readonly clientSecret: string;
   readonly resource: string | null;
+  readonly tokenEndpointAuthMethod: ClientAuthMethod;
 } => ({
   slug: String(firstPartyOAuthClientSlug(config.name)),
   authorizationUrl: config.authorizationUrl,
@@ -526,6 +527,7 @@ export const loadedFirstPartyClient = (
   clientId: config.clientId,
   clientSecret: config.clientSecret,
   resource: config.resource ?? null,
+  tokenEndpointAuthMethod: "body",
 });
 
 export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {

--- a/packages/core/sdk/src/oauth-service.ts
+++ b/packages/core/sdk/src/oauth-service.ts
@@ -71,7 +71,9 @@ import {
   exchangeAuthorizationCode,
   exchangeClientCredentials,
   isLoopbackHttpUrl,
+  parseClientAuthMethod,
   rebindTokenEndpointHostToCallbackDomain,
+  type ClientAuthMethod,
   type OAuth2TokenResponse,
   type OAuthEndpointUrlPolicy,
 } from "./oauth-helpers";
@@ -412,6 +414,8 @@ interface LoadedOAuthClient {
   /** Resolved literal secret (read from the provider via the stored item id). */
   readonly clientSecret: string;
   readonly resource: string | null;
+  /** Resolved token-endpoint client auth method ("body" | "basic"). */
+  readonly tokenEndpointAuthMethod: ClientAuthMethod;
 }
 
 /** Where an OAuth app's client secret is stored in the default writable
@@ -697,6 +701,9 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
           client_id: input.clientId,
           client_secret_item_id: clientSecretItemIdValue,
           resource: input.resource ?? null,
+          // Persist only a non-default ("basic") method; "body"/undefined stays
+          // null, which parseClientAuthMethod resolves back to the "body" default.
+          token_endpoint_auth_method: input.tokenEndpointAuthMethod === "basic" ? "basic" : null,
           origin_kind: input.origin?.kind ?? "manual",
           // Recorded intent, kept for BOTH origins: a manual app registered from
           // an integration's dialog stamps its integration so the picker can
@@ -1059,6 +1066,11 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
               tokenUrl: String(row.token_url),
               resource: row.resource == null ? null : String(row.resource),
               clientId: String(row.client_id),
+              // Only surface a non-default ("basic") method; "body" is implicit
+              // (undefined), matching how it is persisted and sent on create.
+              ...(parseClientAuthMethod(row.token_endpoint_auth_method) === "basic"
+                ? { tokenEndpointAuthMethod: "basic" as const }
+                : {}),
               origin: parseOAuthClientOrigin(row),
             } satisfies OAuthClientSummary);
           }),
@@ -1124,6 +1136,7 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
               clientId: String(row.client_id),
               clientSecret,
               resource: row.resource == null ? null : String(row.resource),
+              tokenEndpointAuthMethod: parseClientAuthMethod(row.token_endpoint_auth_method),
             } satisfies LoadedOAuthClient;
           });
         }),
@@ -1257,6 +1270,7 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
           clientSecret: client.clientSecret,
           scopes: requestedScopes,
           resource: client.resource ?? undefined,
+          clientAuth: client.tokenEndpointAuthMethod,
           endpointUrlPolicy: deps.endpointUrlPolicy,
           fetch,
         }).pipe(
@@ -1479,6 +1493,7 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
         codeVerifier: session.pkceVerifier,
         code: input.code,
         resource: client.resource ?? undefined,
+        clientAuth: client.tokenEndpointAuthMethod,
         endpointUrlPolicy: deps.endpointUrlPolicy,
         fetch,
       }).pipe(

--- a/packages/core/sdk/src/shared.ts
+++ b/packages/core/sdk/src/shared.ts
@@ -149,6 +149,7 @@ export {
   isFirstPartyOAuthClientSlug,
   type FirstPartyOAuthClientConfig,
   type OAuthGrant,
+  type ClientAuthMethod,
   type OAuthAuthentication,
   type OAuthClient,
   type OAuthClientOrigin,

--- a/packages/core/sdk/src/testing/oauth-test-server.ts
+++ b/packages/core/sdk/src/testing/oauth-test-server.ts
@@ -71,6 +71,14 @@ export interface OAuthTestServerOptions {
    *  name is approved. Mirrors authorization servers (e.g. Mercury) that
    *  reject third-party client names containing their own brand. */
   readonly approveClientName?: (name: string) => boolean;
+
+  /** When set, the `/token` endpoint ENFORCES a client-auth transport on every
+   *  request. `"basic"` rejects (401 invalid_client) any request that does not
+   *  carry HTTP Basic credentials (proves the client used `client_secret_basic`);
+   *  `"body"` rejects any
+   *  request that carries HTTP Basic (forces `client_secret_post`). Omitting it
+   *  keeps the permissive default that accepts either. */
+  readonly requireClientAuthMethod?: "basic" | "body";
 }
 
 export interface OAuthTestServerShape {
@@ -98,6 +106,11 @@ export interface OAuthTestServerShape {
   readonly requests: Effect.Effect<readonly OAuthTestServerRequest[]>;
   readonly clearRequests: Effect.Effect<void>;
   readonly issuedAccessTokens: Effect.Effect<readonly string[]>;
+  /** Ordered log of which client-auth transport (`"basic"` | `"body"`) each
+   *  `/token` request used, by arrival order; reset by `clearRequests`. Use it
+   *  to assert that `exchangeClientCredentials` / `refreshAccessToken` actually
+   *  sent credentials via HTTP Basic rather than in the form body. */
+  readonly tokenRequestAuthMethods: Effect.Effect<readonly ("basic" | "body")[]>;
   readonly acceptsAccessToken: (token: string) => Effect.Effect<boolean>;
   readonly acceptsAuthorizationHeader: (
     authorization: string | null | undefined,
@@ -173,6 +186,21 @@ const parseJsonObject = (body: string): Readonly<Record<string, unknown>> | null
 const arrayOfStrings = (value: unknown): readonly string[] =>
   Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
 
+// RFC 6749 §2.3.1: the client id and secret in an HTTP Basic header are each
+// `application/x-www-form-urlencoded` BEFORE base64, so a spec-compliant server
+// must form-decode them after splitting. oauth4webapi's ClientSecretBasic
+// percent-encodes (e.g. `test-client` -> `test%2Dclient`); without decoding,
+// the id would never match (the body/`client_secret_post` path gets this for
+// free via URLSearchParams). Falls back to the raw slice on malformed input.
+const formDecode = (value: string): string => {
+  // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: decodeURIComponent throws on malformed percent-escapes; fall back to raw
+  try {
+    return decodeURIComponent(value.replace(/\+/g, " "));
+  } catch {
+    return value;
+  }
+};
+
 const decodeBasicAuthorization = (
   value: string | undefined,
 ): { readonly username: string; readonly password: string } | null => {
@@ -183,8 +211,8 @@ const decodeBasicAuthorization = (
   const separator = decoded.indexOf(":");
   if (separator < 0) return null;
   return {
-    username: decoded.slice(0, separator),
-    password: decoded.slice(separator + 1),
+    username: formDecode(decoded.slice(0, separator)),
+    password: formDecode(decoded.slice(separator + 1)),
   };
 };
 
@@ -427,6 +455,8 @@ export const serveOAuthTestServer = (
   Effect.gen(function* () {
     const requests = yield* Ref.make<readonly OAuthTestServerRequest[]>([]);
     const issuedAccessTokens = yield* Ref.make<ReadonlySet<string>>(new Set());
+    const tokenRequestAuthMethods = yield* Ref.make<readonly ("basic" | "body")[]>([]);
+    const requireClientAuthMethod = options.requireClientAuthMethod;
     const users = {
       [options.defaultUsername ?? "alice"]: options.defaultPassword ?? "password",
       ...(options.users ?? {}),
@@ -634,6 +664,25 @@ export const serveOAuthTestServer = (
         if (requestUrl.pathname === "/token" && request.method === "POST") {
           const params = new URLSearchParams(body);
           const basic = decodeBasicAuthorization(headers.authorization);
+          // Record which client-auth transport this /token call used, then (when
+          // configured) enforce a required one. Recording happens for ALL grant
+          // types so tests can assert the transport on any flow.
+          const usedAuthMethod: "basic" | "body" = basic ? "basic" : "body";
+          yield* Ref.update(tokenRequestAuthMethods, (all) => [...all, usedAuthMethod]);
+          if (requireClientAuthMethod === "basic" && !basic) {
+            return oauthError(
+              401,
+              "invalid_client",
+              "This authorization server requires HTTP Basic client authentication",
+            );
+          }
+          if (requireClientAuthMethod === "body" && basic) {
+            return oauthError(
+              401,
+              "invalid_client",
+              "This authorization server requires client_secret_post (body) client authentication",
+            );
+          }
           const clientId = basic?.username ?? params.get("client_id");
           const clientSecret = basic?.password ?? params.get("client_secret");
           const client = clientId ? clients.get(clientId) : undefined;
@@ -784,8 +833,11 @@ export const serveOAuthTestServer = (
         tokenEndpoint: `${issuerUrl}/token`,
       }),
       requests: Ref.get(requests),
-      clearRequests: Ref.set(requests, []),
+      clearRequests: Effect.all([Ref.set(requests, []), Ref.set(tokenRequestAuthMethods, [])]).pipe(
+        Effect.asVoid,
+      ),
       issuedAccessTokens: accessTokenSet.pipe(Effect.map((tokens) => [...tokens])),
+      tokenRequestAuthMethods: Ref.get(tokenRequestAuthMethods),
       acceptsAccessToken: (token) => accessTokenSet.pipe(Effect.map((tokens) => tokens.has(token))),
       acceptsAuthorizationHeader: (authorization) => {
         const token = authorization?.replace(/^Bearer\s+/i, "");

--- a/packages/react/src/api/atoms.tsx
+++ b/packages/react/src/api/atoms.tsx
@@ -570,6 +570,7 @@ export const createOAuthClientOptimistic = oauthClientsOptimisticAtom.pipe(
           readonly clientId: string;
           readonly resource?: string | null;
           readonly originIntegration?: IntegrationSlug | null;
+          readonly tokenEndpointAuthMethod?: "body" | "basic";
         };
       },
     ) =>
@@ -582,6 +583,9 @@ export const createOAuthClientOptimistic = oauthClientsOptimisticAtom.pipe(
           tokenUrl: arg.payload.tokenUrl,
           resource: arg.payload.resource ?? null,
           clientId: arg.payload.clientId,
+          ...(arg.payload.tokenEndpointAuthMethod === "basic"
+            ? { tokenEndpointAuthMethod: "basic" as const }
+            : {}),
           // Mirror the server's stamp so the just-registered app matches its
           // integration in the picker immediately (before the refetch lands).
           origin: { kind: "manual", integration: arg.payload.originIntegration ?? null },

--- a/packages/react/src/components/add-account-modal.tsx
+++ b/packages/react/src/components/add-account-modal.tsx
@@ -2366,6 +2366,9 @@ function AddAccountModalView(props: AddAccountModalProps) {
                   tokenUrl: editingClient.tokenUrl,
                   resource: editingClient.resource ?? null,
                   grant: editingClient.grant,
+                  // Carry the stored auth method so editing a Basic client and
+                  // saving does not silently rewrite the row to body.
+                  tokenEndpointAuthMethod: editingClient.tokenEndpointAuthMethod,
                   clientId: editingClient.clientId,
                 }}
                 onCreated={() => setEditingClient(null)}

--- a/packages/react/src/components/oauth-client-form.tsx
+++ b/packages/react/src/components/oauth-client-form.tsx
@@ -4,6 +4,7 @@ import * as Exit from "effect/Exit";
 import { ExternalLink } from "lucide-react";
 import {
   OAuthClientSlug,
+  type ClientAuthMethod,
   type IntegrationSlug,
   type OAuthGrant,
   type Owner,
@@ -56,6 +57,9 @@ export interface OAuthClientFormPrefill {
    *  and they are only sent when no declared scopes exist. */
   readonly discoveredScopes?: readonly string[];
   readonly grant?: OAuthGrant;
+  /** Token-endpoint client-auth method to preselect ("body" | "basic").
+   *  Defaults to "body" (client_secret_post). */
+  readonly tokenEndpointAuthMethod?: ClientAuthMethod;
   /** Client id to seed (e.g. when editing an existing app). NOT a secret — the
    *  secret is never returned, so it is always re-entered. */
   readonly clientId?: string;
@@ -180,6 +184,9 @@ export function OAuthClientForm(props: {
   );
   const [name, setName] = useState(integrationName);
   const [grant, setGrant] = useState<OAuthGrant>(prefill?.grant ?? "authorization_code");
+  const [tokenEndpointAuthMethod, setTokenEndpointAuthMethod] = useState<ClientAuthMethod>(
+    prefill?.tokenEndpointAuthMethod ?? "body",
+  );
   const [clientId, setClientId] = useState(prefill?.clientId ?? "");
   const [clientSecret, setClientSecret] = useState("");
   const [issuerUrl, setIssuerUrl] = useState("");
@@ -338,6 +345,9 @@ export function OAuthClientForm(props: {
         clientId: clientId.trim(),
         clientSecret: clientSecret.trim(),
         resource,
+        ...(tokenEndpointAuthMethod === "basic"
+          ? { tokenEndpointAuthMethod: "basic" as const }
+          : {}),
         // Editing preserves the app's already-recorded origin (via
         // `intentIntegration`, passed verbatim by the caller); a fresh
         // registration from an integration's dialog stamps recorded intent.
@@ -544,6 +554,53 @@ export function OAuthClientForm(props: {
           />
         </div>
       </div>
+
+      {/* token-endpoint client auth, only relevant when a secret is sent.
+          Most providers accept client_secret_post; some require
+          client_secret_basic. Hidden for public clients with no secret. */}
+      {clientSecret.trim().length > 0 || grant === "client_credentials" ? (
+        <div className="space-y-2">
+          <Label className="text-xs text-muted-foreground">Client authentication</Label>
+          <RadioGroup
+            value={tokenEndpointAuthMethod}
+            onValueChange={(next: string) => setTokenEndpointAuthMethod(next as ClientAuthMethod)}
+            className="gap-2"
+          >
+            {(
+              [
+                {
+                  value: "body",
+                  label: "Request body",
+                  hint: "client_secret_post (default)",
+                },
+                {
+                  value: "basic",
+                  label: "HTTP Basic",
+                  hint: "client_secret_basic",
+                },
+              ] as const
+            ).map((option) => (
+              <Label
+                key={option.value}
+                htmlFor={`token-auth-${option.value}`}
+                className="flex cursor-pointer items-start gap-3 rounded-lg border border-border/60 bg-background/40 px-3 py-2 font-normal has-[:checked]:border-ring has-[:checked]:bg-accent/40"
+              >
+                <RadioGroupItem
+                  id={`token-auth-${option.value}`}
+                  value={option.value}
+                  className="mt-0.5"
+                />
+                <span className="min-w-0 flex-1">
+                  <span className="block text-sm font-medium">{option.label}</span>
+                  <span className="block font-mono text-xs text-muted-foreground">
+                    {option.hint}
+                  </span>
+                </span>
+              </Label>
+            ))}
+          </RadioGroup>
+        </div>
+      ) : null}
 
       {/* endpoints */}
       {endpointsKnown && !showEndpoints ? (


### PR DESCRIPTION
## Summary

Add configurable OAuth token-endpoint client authentication so registered clients can use either `client_secret_post` or `client_secret_basic`. The selected method is persisted and reused across authorization-code exchange, client-credentials minting, refresh, and re-minting.

`client_secret_basic` uses the interoperable HTTP Basic representation expected by common providers: Base64 of the literal UTF-8 `client_id:client_secret` pair.

Closes #1447

## Changes

- Persist the token-endpoint authentication method on OAuth clients in PostgreSQL, SQLite, and Cloudflare D1.
- Expose `client_secret_post` and `client_secret_basic` through the OAuth client API and registration form.
- Thread the selected method through authorization-code exchange, client-credentials minting, refresh, and client-credentials re-minting.
- Preserve `client_secret_post` as the default for existing and first-party clients.
- Encode `client_secret_basic` as the literal credential pair instead of form-encoding each component before Base64 encoding.
- Add regression coverage for Basic credentials containing underscores and punctuation.

## Interoperability example: Aikido

[Aikido's OAuth documentation](https://apidocs.aikido.dev/reference/authorization) requires client credentials in an HTTP Basic authorization header for its [token endpoint](https://apidocs.aikido.dev/reference/getaccesstoken).

The strict RFC 6749 representation form-encodes each credential component before Base64 encoding. For example, an Aikido client ID beginning with `AIK_CLIENT_` is transmitted as `AIK%5FCLIENT%5F...`. Aikido compares the decoded Basic username and password literally, so it rejects that representation as invalid credentials even though the same pair succeeds with conventional Basic clients such as `curl --user`.

Using Base64 of the literal credential pair makes this real provider work while retaining the expected `client_secret_basic` request shape. See [RFC 6749 §2.3.1](https://www.rfc-editor.org/rfc/rfc6749#section-2.3.1) for the strict encoding rule and the note that HTTP Basic is not otherwise recommended outside this client-authentication profile.

## Testing

Validated after rebasing onto Executor v1.5.42 plus current `main`:

- [x] `bun run format:check`
- [x] `bun run lint`
- [x] `bun run typecheck` (44/44 packages)
- [x] OAuth helper, flow, and client-list tests (102 tests)
- [x] Cloudflare data-migration tests (5 tests)
- [x] All five tests that timed out under full-suite parallel load rerun successfully at low load (71 tests)
- [x] Production Cloudflare build
- [x] Manual client-credentials connection against Aikido
- [x] Production deployment using the existing D1 database and encrypted credential store

The repository-wide test run reached five unrelated 5-second timeouts under parallel load; all five affected files passed immediately when rerun together at lower load. There were no assertion failures.

## Notes for reviewers

The Basic encoding is intentionally interoperable rather than RFC-strict. Exposing separate “strict” and “raw” Basic choices would require users to understand a wire-level distinction that OAuth provider documentation generally does not surface. If a provider requiring strict component encoding is identified, that can be added later as an advanced compatibility mode with a concrete test case.
