### PR TITLE
docs(agents): document worktree location convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,11 @@ Stable contracts live here. Current setup and server mechanics are in
 [RUNNING.md](RUNNING.md); e2e invariants are in
 [e2e/AGENTS.md](e2e/AGENTS.md). Run `bun run bootstrap` in every fresh rift.
 
+## Worktree location
+
+- Put new worktrees under `<main>/.worktrees/<slug>` (or the tool's native
+  root); never `git worktree add ../…` siblings next to the main checkout.
+
 ## Verification and evidence
 
 - Tests use Effect Vitest. Run scoped tests with `vitest run ...` or the


### PR DESCRIPTION
## Summary
- Add a short **Worktree location** section to `AGENTS.md` so agents create worktrees under `<main>/.worktrees/<slug>` instead of sibling directories next to the main checkout.

## Test plan
- [x] Docs-only change; no code or CI run required.

Made with [Cursor](https://cursor.com)