### PR TITLE
Add tenant-reach platform view with internal admin reads

### DIFF
--- a/apps/cloud/src/api/protected-api-key-auth.node.test.ts
+++ b/apps/cloud/src/api/protected-api-key-auth.node.test.ts
@@ -13,6 +13,7 @@ const stubApiKeys = Layer.succeed(ApiKeyService)({
     Effect.succeed(
       value === "valid_user_key"
         ? {
+            scope: "user" as const,
             accountId: "user_123",
             organizationId: "org_123",
             keyId: "api_key_123",

--- a/apps/cloud/src/auth/api-keys.node.test.ts
+++ b/apps/cloud/src/auth/api-keys.node.test.ts
@@ -42,6 +42,7 @@ describe("ApiKeyService.WorkOS", () => {
       });
 
       expect(principal).toEqual({
+        scope: "user",
         accountId: "user_123",
         organizationId: "org_123",
         keyId: "api_key_123",
@@ -66,15 +67,9 @@ describe("ApiKeyService.WorkOS", () => {
     }),
   );
 
-  it.effect("rejects missing, organization-owned, and org-less keys", () =>
+  it.effect("rejects missing and org-less keys", () =>
     Effect.gen(function* () {
       const missing = yield* validate({ apiKey: null });
-      const orgOwned = yield* validate({
-        apiKey: {
-          id: "api_key_org",
-          owner: { type: "organization", id: "org_123" },
-        },
-      });
       const orgLess = yield* validate({
         apiKey: {
           id: "api_key_no_org",
@@ -83,8 +78,28 @@ describe("ApiKeyService.WorkOS", () => {
       });
 
       expect(missing).toBeNull();
-      expect(orgOwned).toBeNull();
       expect(orgLess).toBeNull();
+    }),
+  );
+
+  it.effect("resolves organization-owned keys to the org scope with no account", () =>
+    Effect.gen(function* () {
+      // An org key USED to fail the decode and come back null — indistinguishable
+      // from an invalid key. It now resolves explicitly: `owner.id` IS the
+      // organization, and there is no member behind it.
+      const principal = yield* validate({
+        apiKey: {
+          id: "api_key_org",
+          owner: { type: "organization", id: "org_123" },
+        },
+      });
+
+      expect(principal).toEqual({
+        scope: "org",
+        accountId: null,
+        organizationId: "org_123",
+        keyId: "api_key_org",
+      });
     }),
   );
 

--- a/apps/cloud/src/auth/api-keys.ts
+++ b/apps/cloud/src/auth/api-keys.ts
@@ -3,10 +3,24 @@ import { Context, Data, Effect, Layer, Option, Schema } from "effect";
 import { ApiKeyManagementError } from "./errors";
 import { WorkOSClient } from "./workos";
 
+/**
+ * Which view a validated key resolves to.
+ *   - `"user"` — the product view. The key belongs to a member; the request
+ *     binds to that member as the acting subject. Every key today is this.
+ *   - `"org"` — the PLATFORM view. The key belongs to the organization itself,
+ *     so there is no acting member: the request gets tenant-wide READ-ONLY
+ *     reach and no bound subject. Privileged; minted separately (PR 1.5).
+ */
+export type ApiKeyScope = "user" | "org";
+
 /** The owner an api key resolves to — NOT a full {@link Principal} (no email /
  * name / roles), so it carries an honest, distinct name. */
 export type ApiKeyOwner = {
-  readonly accountId: string;
+  readonly scope: ApiKeyScope;
+  /** The acting member for a `"user"` key; `null` for an `"org"` key, which
+   *  has no member behind it. Nullable rather than a sentinel so nothing can
+   *  accidentally bind an org key to a subject. */
+  readonly accountId: string | null;
   readonly organizationId: string;
   readonly keyId: string;
 };
@@ -28,12 +42,24 @@ export class ApiKeyValidationError extends Data.TaggedError("ApiKeyValidationErr
   readonly cause: unknown;
 }> {}
 
+// WorkOS keys are owned by either a user or an organization. The user shape
+// carries the member id in `id` and the org in `organization_id`; the org shape
+// carries the ORG in `id` and no member at all. Both decode here — the
+// distinction is a branch (`ownerFromApiKey`), not a decode failure, so an
+// org-owned key is no longer indistinguishable from an invalid one.
 const UserApiKeyOwner = Schema.Struct({
   type: Schema.Literal("user"),
   id: Schema.String,
   organizationId: Schema.optional(Schema.String),
   organization_id: Schema.optional(Schema.String),
 });
+
+const OrgApiKeyOwner = Schema.Struct({
+  type: Schema.Literal("organization"),
+  id: Schema.String,
+});
+
+const WorkOSApiKeyOwner = Schema.Union([UserApiKeyOwner, OrgApiKeyOwner]);
 
 const ApiKey = Schema.Struct({
   id: Schema.String,
@@ -49,8 +75,16 @@ const ApiKey = Schema.Struct({
   last_used_at: Schema.optional(Schema.NullOr(Schema.String)),
 });
 
+// Validation accepts BOTH owner shapes. The list/create paths below stay
+// user-only on purpose: they are the console's personal-key CRUD, and minting
+// org keys is a separate, privileged surface (PR 1.5).
+const ValidatedApiKey = Schema.Struct({
+  id: Schema.String,
+  owner: WorkOSApiKeyOwner,
+});
+
 const ValidateApiKeyResponse = Schema.Struct({
-  apiKey: Schema.NullOr(ApiKey),
+  apiKey: Schema.NullOr(ValidatedApiKey),
 });
 
 const RawCreatedApiKey = Schema.Struct({
@@ -82,19 +116,31 @@ const decodeValidateApiKeyResponse = Schema.decodeUnknownOption(ValidateApiKeyRe
 const decodeListApiKeysResponse = Schema.decodeUnknownOption(ListApiKeysResponse);
 const decodeCreateApiKeyResponse = Schema.decodeUnknownOption(CreateApiKeyResponse);
 
+const ownerFromApiKey = (apiKey: typeof ValidatedApiKey.Type): ApiKeyOwner | null => {
+  if (apiKey.owner.type === "organization") {
+    // An org-owned key IS the org: `owner.id` is the organization, and there
+    // is no member to act as. This resolves to the platform view.
+    return {
+      scope: "org",
+      accountId: null,
+      organizationId: apiKey.owner.id,
+      keyId: apiKey.id,
+    };
+  }
+  const organizationId = apiKey.owner.organizationId ?? apiKey.owner.organization_id;
+  if (!organizationId) return null;
+  return {
+    scope: "user",
+    accountId: apiKey.owner.id,
+    organizationId,
+    keyId: apiKey.id,
+  };
+};
+
 const ownerFromResponse = (value: unknown): ApiKeyOwner | null =>
   Option.match(decodeValidateApiKeyResponse(value), {
     onNone: () => null,
-    onSome: ({ apiKey }) => {
-      if (!apiKey) return null;
-      const organizationId = apiKey.owner.organizationId ?? apiKey.owner.organization_id;
-      if (!organizationId) return null;
-      return {
-        accountId: apiKey.owner.id,
-        organizationId,
-        keyId: apiKey.id,
-      };
-    },
+    onSome: ({ apiKey }) => (apiKey ? ownerFromApiKey(apiKey) : null),
   });
 
 const summaryFromApiKey = (apiKey: typeof ApiKey.Type): ApiKeySummary | null => {

--- a/apps/cloud/src/auth/org-api-key-auth.node.test.ts
+++ b/apps/cloud/src/auth/org-api-key-auth.node.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Layer } from "effect";
+
+import { ApiKeyService } from "./api-keys";
+import { UserStoreService } from "./context";
+import { WorkOSClient, type WorkOSClientService } from "./workos";
+import { isPlatformAuth, resolveApiKeyPrincipal, resolveBearerAuth } from "./workos-auth-provider";
+
+// Groundwork for the PRIVILEGED, org-level API key: it resolves to the platform
+// view (tenant-wide, read-only, NO acting member) rather than to a member
+// `Principal`. The product surfaces must reject it outright rather than
+// inventing a subject for it — that is the property these tests pin.
+
+const createdAt = new Date("2026-01-01T00:00:00.000Z");
+
+const stubApiKeys = Layer.succeed(ApiKeyService)({
+  validate: (value: string) => {
+    if (value === "valid_org_key") {
+      return Effect.succeed({
+        scope: "org" as const,
+        accountId: null,
+        organizationId: "org_123",
+        keyId: "api_key_org",
+      });
+    }
+    if (value === "valid_user_key") {
+      return Effect.succeed({
+        scope: "user" as const,
+        accountId: "user_123",
+        organizationId: "org_123",
+        keyId: "api_key_123",
+      });
+    }
+    return Effect.succeed(null);
+  },
+  listUserKeys: () => Effect.succeed([]),
+  createUserKey: () => Effect.die("org api key test does not create API keys"),
+  revokeUserKey: () => Effect.void,
+});
+
+const stubWorkOS = Layer.succeed(
+  WorkOSClient,
+  new Proxy({} as WorkOSClientService, {
+    get: (_target, prop) => {
+      if (prop === "listUserMemberships") {
+        return (userId: string) =>
+          Effect.succeed({
+            data:
+              userId === "user_123"
+                ? [{ userId, organizationId: "org_123", status: "active" }]
+                : [],
+          });
+      }
+      // An org key must NOT trigger a membership check — there is no user to
+      // check. Any such call dies here, which is the assertion.
+      return () => Effect.die(`unexpected WorkOSClient.${String(prop)} call`);
+    },
+  }),
+);
+
+const stubUsers = Layer.succeed(UserStoreService)({
+  use: (fn) =>
+    Effect.promise(() =>
+      fn({
+        ensureAccount: async (id: string) => ({ id, createdAt }),
+        getAccount: async (id: string) => ({ id, createdAt }),
+        upsertOrganization: async (org: { id: string; name: string }) => ({
+          ...org,
+          slug: `org-slug-${org.id}`,
+          createdAt,
+        }),
+        getOrganization: async (id: string) => ({
+          id,
+          name: `Org ${id}`,
+          slug: `org-slug-${id}`,
+          createdAt,
+        }),
+        getOrganizationBySlug: async (slug: string) => ({
+          id: "org_by_slug",
+          name: `Org ${slug}`,
+          slug,
+          createdAt,
+        }),
+        deleteOrganizationCascade: async () => {},
+      }),
+    ),
+});
+
+const layers = Layer.mergeAll(stubApiKeys, stubWorkOS, stubUsers);
+
+const bearer = (token: string) =>
+  new Request("https://executor.test/api/tools", {
+    headers: { authorization: `Bearer ${token}` },
+  });
+
+describe("org-level API keys", () => {
+  it.effect("resolve to the platform view with no acting member", () =>
+    Effect.gen(function* () {
+      const auth = yield* resolveBearerAuth(bearer("valid_org_key")).pipe(Effect.provide(layers));
+
+      expect(isPlatformAuth(auth)).toBe(true);
+      expect(auth).toEqual({
+        kind: "platform",
+        organizationId: "org_123",
+        organizationName: "Org org_123",
+        organizationSlug: "org-slug-org_123",
+        keyId: "api_key_org",
+      });
+      // No `accountId` anywhere in the shape: nothing downstream can bind a
+      // subject from it by accident.
+      expect(auth).not.toHaveProperty("accountId");
+    }),
+  );
+
+  it.effect("user keys still resolve to a bound member principal", () =>
+    Effect.gen(function* () {
+      const auth = yield* resolveBearerAuth(bearer("valid_user_key")).pipe(Effect.provide(layers));
+
+      expect(isPlatformAuth(auth)).toBe(false);
+      expect(auth).toMatchObject({ accountId: "user_123", organizationId: "org_123" });
+    }),
+  );
+
+  it.effect("are REJECTED on the product surface rather than bound to a subject", () =>
+    Effect.gen(function* () {
+      // THE security property of the api-key half: a product request carrying
+      // an org key must fail, not silently act as some user.
+      const error = yield* Effect.flip(
+        resolveApiKeyPrincipal(bearer("valid_org_key")).pipe(Effect.provide(layers)),
+      );
+
+      expect(error).toMatchObject({
+        _tag: "Unauthorized",
+        code: "invalid_api_key",
+        message: "Organization API keys cannot be used on this endpoint",
+      });
+    }),
+  );
+
+  it.effect("do not trigger a user membership check", () =>
+    Effect.gen(function* () {
+      // `authorizeOrganization` checks a USER's live membership; there is no
+      // user here. The WorkOS stub dies on any call other than the user path,
+      // so a clean resolution proves the org branch never took it.
+      const auth = yield* resolveBearerAuth(bearer("valid_org_key")).pipe(Effect.provide(layers));
+
+      expect(isPlatformAuth(auth)).toBe(true);
+    }),
+  );
+});

--- a/apps/cloud/src/auth/workos-auth-provider.ts
+++ b/apps/cloud/src/auth/workos-auth-provider.ts
@@ -47,6 +47,7 @@ import {
   authorizeOrganization,
   authorizeOrganizationSelector,
   orgSelectorFromRequest,
+  resolveOrganization,
 } from "./organization";
 import { UserStoreService } from "./context";
 import { sealedSessionDisplayName } from "./middleware";
@@ -103,6 +104,13 @@ const NO_ORGANIZATION_IN_ACCESS_TOKEN = {
   code: "no_organization",
   message: "No organization in access token",
 };
+// An org-level key resolves to the PLATFORM view, which has no acting member.
+// The product endpoints are bound to one subject, so they reject it outright
+// rather than inventing a subject for it to act as.
+const ORG_KEY_ON_PRODUCT_SURFACE = {
+  code: "invalid_api_key",
+  message: "Organization API keys cannot be used on this endpoint",
+};
 
 // A bearer value with three dot-separated segments is a JWT (a WorkOS access
 // token from the CLI device-login); anything else is treated as an API key.
@@ -151,13 +159,50 @@ const resolveJwtPrincipal = (token: string, jwt: JwtBearerConfig) =>
   });
 
 /**
- * Resolve a `Bearer` credential into a `Principal`: a WorkOS access-token JWT
- * (when `jwt` config is supplied and the value looks like a JWT) or a WorkOS
- * API key. Returns `null` when there is no `Authorization` header, so the
- * caller falls through to the sealed-session path. (Kept the historical name,
- * the re-export and resolver tests reference it.)
+ * What an ORG-level API key resolves to: the platform view. Deliberately NOT a
+ * `Principal` — a `Principal` names an acting member (`accountId: string`), and
+ * an org key has none. Keeping it a separate shape means no product code path
+ * can accidentally treat it as a member, and the executor built from it binds
+ * `subject: null` + the read-only tenant reach rather than inventing a subject.
+ *
+ * PR 1.5 turns this into an executor at the `/admin/*` mount:
+ * `makeScopedExecutor`-equivalent with `{ tenant: organizationId, subject:
+ * undefined, platformView: true }`.
  */
-export const resolveApiKeyPrincipal = (request: Request, jwt: JwtBearerConfig | null = null) =>
+export interface PlatformAuth {
+  readonly kind: "platform";
+  readonly organizationId: string;
+  readonly organizationName: string;
+  readonly organizationSlug?: string;
+  readonly keyId: string;
+}
+
+/** A resolved bearer credential: an acting member, or the org-level platform
+ *  view. `null` means no `Authorization` header at all. */
+export type BearerAuth = Principal | PlatformAuth | null;
+
+export const isPlatformAuth = (value: BearerAuth): value is PlatformAuth =>
+  value !== null && "kind" in value && value.kind === "platform";
+
+/**
+ * Resolve a `Bearer` credential into either a member `Principal` or the
+ * org-level {@link PlatformAuth}. Returns `null` when there is no
+ * `Authorization` header, so the caller falls through to the sealed-session
+ * path.
+ *
+ * The org branch does NOT call `authorizeOrganization`: that checks a USER's
+ * live membership, and there is no user here. The key itself is the authority —
+ * WorkOS validated it and reported which org owns it — so the org row is merely
+ * resolved (mirrored on first read) for its name and slug.
+ */
+export const resolveBearerAuth = (
+  request: Request,
+  jwt: JwtBearerConfig | null = null,
+): Effect.Effect<
+  BearerAuth,
+  Unauthorized | NoOrganization | Unavailable | UserStoreError | WorkOSError,
+  WorkOSClient | ApiKeyService | UserStoreService
+> =>
   Effect.gen(function* () {
     const authHeader = request.headers.get("authorization");
     if (!authHeader) return null;
@@ -172,7 +217,7 @@ export const resolveApiKeyPrincipal = (request: Request, jwt: JwtBearerConfig | 
     if (jwt && looksLikeJwt(value)) return yield* resolveJwtPrincipal(value, jwt);
 
     const apiKeys = yield* ApiKeyService;
-    const principal = yield* apiKeys
+    const owner = yield* apiKeys
       .validate(value)
       .pipe(
         Effect.catchTag("ApiKeyValidationError", () =>
@@ -180,13 +225,28 @@ export const resolveApiKeyPrincipal = (request: Request, jwt: JwtBearerConfig | 
         ),
       );
 
-    if (!principal) return yield* new Unauthorized(INVALID_API_KEY);
+    if (!owner) return yield* new Unauthorized(INVALID_API_KEY);
 
-    const org = yield* authorizeOrganization(principal.accountId, principal.organizationId);
+    if (owner.scope === "org") {
+      const org = yield* resolveOrganization(owner.organizationId);
+      return {
+        kind: "platform",
+        organizationId: org.id,
+        organizationName: org.name,
+        ...(org.slug === undefined || org.slug === null ? {} : { organizationSlug: org.slug }),
+        keyId: owner.keyId,
+      } satisfies PlatformAuth;
+    }
+
+    // A `"user"` key always carries an accountId (see `ownerFromApiKey`); the
+    // guard keeps the narrowing honest rather than asserting.
+    if (owner.accountId == null) return yield* new Unauthorized(INVALID_API_KEY);
+
+    const org = yield* authorizeOrganization(owner.accountId, owner.organizationId);
     if (!org) return yield* new NoOrganization(NO_ORGANIZATION_IN_API_KEY);
 
     return {
-      accountId: principal.accountId,
+      accountId: owner.accountId,
       organizationId: org.id,
       organizationName: org.name,
       organizationSlug: org.slug,
@@ -195,6 +255,27 @@ export const resolveApiKeyPrincipal = (request: Request, jwt: JwtBearerConfig | 
       avatarUrl: null,
       roles: [],
     } satisfies Principal;
+  });
+
+/**
+ * The PRODUCT-view bearer resolver: as {@link resolveBearerAuth}, but an
+ * org-level key is REJECTED rather than downgraded. The product endpoints are
+ * bound to one acting subject, so there is no honest way to serve them an
+ * org key — PR 1.5 routes those to the `/admin/*` mount instead. (Kept the
+ * historical name; the re-export and resolver tests reference it.)
+ */
+export const resolveApiKeyPrincipal = (
+  request: Request,
+  jwt: JwtBearerConfig | null = null,
+): Effect.Effect<
+  Principal | null,
+  Unauthorized | NoOrganization | Unavailable | UserStoreError | WorkOSError,
+  WorkOSClient | ApiKeyService | UserStoreService
+> =>
+  Effect.gen(function* () {
+    const auth = yield* resolveBearerAuth(request, jwt);
+    if (isPlatformAuth(auth)) return yield* new Unauthorized(ORG_KEY_ON_PRODUCT_SURFACE);
+    return auth;
   });
 
 export const resolveSessionPrincipal = (request: Request) =>

--- a/apps/cloud/src/mcp/auth.ts
+++ b/apps/cloud/src/mcp/auth.ts
@@ -248,6 +248,17 @@ export const McpAuthLive = Layer.effect(
         return mcpUnauthorized("invalid_token", "The API key is invalid");
       }
 
+      // An ORG-level key resolves to the read-only platform view and has no
+      // acting member. Every MCP session binds to one subject, so there is
+      // nothing honest to bind here — reject rather than invent a subject.
+      if (principal.scope === "org" || principal.accountId == null) {
+        yield* Effect.annotateCurrentSpan({
+          "mcp.auth.outcome": "invalid",
+          "mcp.auth.invalid_reason": "org_api_key",
+        });
+        return mcpUnauthorized("invalid_token", "Organization API keys cannot open an MCP session");
+      }
+
       yield* Effect.annotateCurrentSpan({
         "mcp.auth.outcome": "verified",
         "mcp.auth.credential_type": "api_key",

--- a/packages/core/sdk/src/core-schema.ts
+++ b/packages/core/sdk/src/core-schema.ts
@@ -5,6 +5,7 @@ import { StorageError, type FumaRow } from "./fuma-runtime";
 import {
   assertOwnerPatch,
   assertOwnerWritable,
+  assertReachReadOnly,
   executorOwnerPolicyName,
   executorTenantPolicyName,
   executorUnscopedPolicyName,
@@ -67,6 +68,10 @@ const tenantExecutorTable = <const TColumns extends UserColumns>(
     name: executorTenantPolicyName,
     onRead: ({ builder, context }) => builder("tenant", "=", context.tenant),
     onCreate: ({ values, context }) => {
+      // Tenant-scoped reads are already tenant-wide, so reach doesn't widen
+      // them — but the platform view must stay read-only on EVERY table it can
+      // reach, and `subject` is one of these.
+      assertReachReadOnly(name, "write", context);
       if (values.tenant !== context.tenant) {
         // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: FumaDB table policy callbacks are promise callbacks, not Effect effects
         throw new StorageError({
@@ -75,8 +80,14 @@ const tenantExecutorTable = <const TColumns extends UserColumns>(
         });
       }
     },
-    onUpdate: ({ builder, context }) => builder("tenant", "=", context.tenant),
-    onDelete: ({ builder, context }) => builder("tenant", "=", context.tenant),
+    onUpdate: ({ builder, context }) => {
+      assertReachReadOnly(name, "write", context);
+      return builder("tenant", "=", context.tenant);
+    },
+    onDelete: ({ builder, context }) => {
+      assertReachReadOnly(name, "delete", context);
+      return builder("tenant", "=", context.tenant);
+    },
   });
 };
 
@@ -104,7 +115,13 @@ const ownedExecutorTable = <const TColumns extends UserColumns>(
       assertOwnerPatch(name, create, context);
       return ownerVisibility(builder, context);
     },
-    onDelete: ({ builder, context }) => ownerVisibility(builder, context),
+    // A delete carries no values to assert against, so the reach guard is the
+    // ONLY thing standing between a widened (platform-view) context and a
+    // tenant-wide delete — `ownerVisibility` would happily match every row.
+    onDelete: ({ builder, context }) => {
+      assertReachReadOnly(name, "delete", context);
+      return ownerVisibility(builder, context);
+    },
   });
 };
 

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -369,6 +369,15 @@ export type Executor<TPlugins extends readonly AnyPlugin[] = readonly []> = {
     readonly resolve: (address: ToolAddress) => Effect.Effect<EffectivePolicy, StorageFailure>;
   };
 
+  /**
+   * The PLATFORM VIEW: read-only, tenant-wide reads across every subject.
+   * Present only when the executor was built with `platformView: true`
+   * (default off) — every other surface on this executor stays bound to the
+   * single `{ tenant, subject }` product view and is unaffected by this one.
+   * Internal admin surface; the public HTTP shape is a separate concern.
+   */
+  readonly admin?: ExecutorAdmin;
+
   readonly execute: (
     address: ToolAddress,
     args: unknown,
@@ -377,6 +386,80 @@ export type Executor<TPlugins extends readonly AnyPlugin[] = readonly []> = {
 
   readonly close: () => Effect.Effect<void, StorageFailure>;
 } & PluginExtensions<TPlugins>;
+
+// ---------------------------------------------------------------------------
+// The platform view — internal admin reads.
+//
+// Everything else on the executor is the PRODUCT view: bound to one
+// { tenant, subject }. This is the read-only escape hatch beside it, reading
+// the same store through a `reach: "tenant"` context so it can answer
+// "who exists under this tenant, and what have they connected".
+//
+// Vocabulary note: internal code says subject/tenant/reach. Anything
+// public-facing says users/owners — the translation happens at the HTTP edge,
+// not here.
+//
+// FIELD DISCIPLINE: these shapes are a hand-picked allowlist, not a projection
+// of the row. Nothing secret-bearing may appear — no `item_ids`, no
+// `refresh_item_id`, no oauth client secrets, no credential material of any
+// kind. Adding a field here is a deliberate act.
+// ---------------------------------------------------------------------------
+
+/** One principal seen under the tenant (a row of the `subject` table). */
+export interface AdminSubject {
+  /** The host-auth principal id. Opaque — it also carries host sentinels
+   *  like "local", so nothing may parse it. */
+  readonly externalId: string;
+  readonly createdAt: Date;
+  /** Epoch ms of the last sighting on the request path; null when never seen
+   *  (a subject can be created at connection-create before any sighting). */
+  readonly lastSeenAt: number | null;
+  readonly status: string | null;
+}
+
+/** A connection as the platform view sees it: enough to answer "what has this
+ *  user connected and is it healthy", and nothing that could resolve a
+ *  credential. */
+export interface AdminConnection {
+  readonly owner: Owner;
+  /** The owning principal — `null` for org-owned connections, which belong to
+   *  the tenant rather than to any one user. */
+  readonly subject: string | null;
+  readonly integration: IntegrationSlug;
+  readonly name: ConnectionName;
+  /** The scope set the provider actually granted, space-delimited as recorded
+   *  at connect/refresh. Null for static credentials. A summary of ACCESS —
+   *  never a token. */
+  readonly oauthScope: string | null;
+  readonly lastHealth: HealthCheckResult | null;
+}
+
+/** A subject together with every connection it owns in the tenant. */
+export interface AdminSubjectWithConnections extends AdminSubject {
+  readonly connections: readonly AdminConnection[];
+}
+
+export interface AdminListSubjectsOptions {
+  readonly limit?: number;
+  readonly offset?: number;
+}
+
+export interface ExecutorAdmin {
+  /** Every subject under the tenant, oldest first (stable: ties break on
+   *  `external_id`). */
+  readonly listSubjects: (
+    options?: AdminListSubjectsOptions,
+  ) => Effect.Effect<readonly AdminSubject[], StorageFailure>;
+  /** Every connection in the tenant owned by `externalId`. Org-owned
+   *  connections are NOT attributed to a user and are excluded. */
+  readonly listSubjectConnections: (
+    externalId: string,
+  ) => Effect.Effect<readonly AdminConnection[], StorageFailure>;
+  /** `listSubjects` joined with each subject's connections. */
+  readonly listSubjectsWithConnections: (
+    options?: AdminListSubjectsOptions,
+  ) => Effect.Effect<readonly AdminSubjectWithConnections[], StorageFailure>;
+}
 
 export interface ExecutorDb {
   readonly db: FumaDb<any>;
@@ -448,6 +531,16 @@ export interface ExecutorConfig<TPlugins extends readonly AnyPlugin[] = readonly
    * config-revision re-sync still apply).
    */
   readonly toolsSyncTtlMs?: number | null;
+  /**
+   * Opt into the PLATFORM VIEW: a read-only, tenant-wide `executor.admin`
+   * surface that reads across every subject in the tenant (see
+   * {@link ExecutorAdmin}). Default OFF — `admin` is simply absent, so the
+   * escape hatch has to be asked for by a host that has authorized an
+   * org-level caller. Enabling it never changes the product view: every other
+   * surface stays bound to `{ tenant, subject }`, and the platform handle
+   * cannot write (the owner policy rejects writes at `reach: "tenant"`).
+   */
+  readonly platformView?: boolean;
 }
 
 /** Default freshness window for remote-catalog connections (see
@@ -4172,6 +4265,100 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
     }
 
     // ------------------------------------------------------------------
+    // Platform view — read-only, tenant-wide admin reads (opt-in).
+    //
+    // A SECOND handle over the same root db, bound to the same tenant but at
+    // `reach: "tenant"`. Deriving it here rather than re-scoping `rootDb`
+    // keeps the product view untouched: the bound handle above never learns
+    // about reach, so it cannot drift into the platform view. Writes through
+    // this handle are rejected by the owner policy, so "read-only" is enforced
+    // at the storage boundary, not by this module's discipline.
+    // ------------------------------------------------------------------
+
+    const makeAdmin = (): ExecutorAdmin => {
+      const platformCore = makeCoreDb(
+        makeFumaClient(
+          withQueryContext(rootDbUntyped, {
+            ...ownerContext,
+            reach: "tenant",
+          } satisfies ExecutorOwnerPolicyContext),
+        ),
+      );
+
+      const rowToAdminSubject = (row: CoreRow<"subject">): AdminSubject => ({
+        externalId: row.external_id,
+        createdAt: row.created_at instanceof Date ? row.created_at : new Date(row.created_at),
+        // bigint on drivers that return one, and a blob on SQLite — hence the
+        // ORM read rather than raw SQL (see `subject-registry.ts`).
+        lastSeenAt: row.last_seen_at == null ? null : Number(row.last_seen_at),
+        status: row.status ?? null,
+      });
+
+      const rowToAdminConnection = (row: ConnectionRow): AdminConnection => {
+        const owner = row.owner as Owner;
+        return {
+          owner,
+          // Org rows carry the empty-string sentinel, not a principal.
+          subject: owner === "org" ? null : row.subject,
+          integration: IntegrationSlug.make(row.integration),
+          name: ConnectionName.make(row.name),
+          oauthScope: row.oauth_scope == null ? null : String(row.oauth_scope),
+          lastHealth: Option.getOrNull(decodeLastHealth(row.last_health)),
+        };
+      };
+
+      const listSubjects = (
+        options?: AdminListSubjectsOptions,
+      ): Effect.Effect<readonly AdminSubject[], StorageFailure> =>
+        platformCore
+          .findMany("subject", {
+            // Oldest first, ties broken on the unique key so the order is
+            // total and paging can't repeat or skip a row.
+            orderBy: [
+              ["created_at", "asc"],
+              ["external_id", "asc"],
+            ],
+            ...(options?.limit === undefined ? {} : { limit: options.limit }),
+            ...(options?.offset === undefined ? {} : { offset: options.offset }),
+          })
+          .pipe(Effect.map((rows) => rows.map(rowToAdminSubject)));
+
+      const listSubjectConnections = (
+        externalId: string,
+      ): Effect.Effect<readonly AdminConnection[], StorageFailure> =>
+        platformCore
+          .findMany("connection", {
+            // `owner: "user"` explicitly: an org connection's `subject` is the
+            // empty-string sentinel, and attributing those to a user would be
+            // a lie in every host that has one.
+            where: (b: AnyCb) => b.and(b("owner", "=", "user"), b("subject", "=", externalId)),
+            orderBy: [
+              ["integration", "asc"],
+              ["name", "asc"],
+            ],
+          })
+          .pipe(Effect.map((rows) => rows.map(rowToAdminConnection)));
+
+      const listSubjectsWithConnections = (
+        options?: AdminListSubjectsOptions,
+      ): Effect.Effect<readonly AdminSubjectWithConnections[], StorageFailure> =>
+        Effect.gen(function* () {
+          const subjects = yield* listSubjects(options);
+          return yield* Effect.forEach(subjects, (entry) =>
+            listSubjectConnections(entry.externalId).pipe(
+              Effect.map((connections) => ({ ...entry, connections })),
+            ),
+          );
+        });
+
+      return { listSubjects, listSubjectConnections, listSubjectsWithConnections };
+    };
+
+    // Default OFF: without the opt-in there is no `admin` key at all, so the
+    // tenant-wide handle is never even constructed.
+    const admin = config.platformView === true ? makeAdmin() : undefined;
+
+    // ------------------------------------------------------------------
     // close
     // ------------------------------------------------------------------
 
@@ -4242,6 +4429,7 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
         remove: policiesRemove,
         resolve: policiesResolve,
       },
+      ...(admin ? { admin } : {}),
       execute,
       close,
     };

--- a/packages/core/sdk/src/index.ts
+++ b/packages/core/sdk/src/index.ts
@@ -161,6 +161,7 @@ export {
   executorOwnerPolicyName,
   executorUnscopedPolicyName,
   type ExecutorOwnerPolicyContext,
+  type ExecutorReach,
 } from "./owner-policy";
 
 // Provider item-id owner grammar — the partition credential providers file
@@ -343,7 +344,12 @@ export {
 // local/cloud DB bring-up). Its definition stays here because `createExecutor`
 // uses it; the host surface (`@executor-js/api/server`) re-exports it.
 export {
+  type AdminConnection,
+  type AdminListSubjectsOptions,
+  type AdminSubject,
+  type AdminSubjectWithConnections,
   type Executor,
+  type ExecutorAdmin,
   type ExecutorConfig,
   type ExecutorDb,
   type ExecutorDbFactory,

--- a/packages/core/sdk/src/owner-policy-reach.test.ts
+++ b/packages/core/sdk/src/owner-policy-reach.test.ts
@@ -1,0 +1,318 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+import { withQueryContext } from "@executor-js/fumadb/query";
+
+import { collectTables } from "./executor";
+import { createSqliteTestFumaDb, type SqliteTestFumaDb } from "./sqlite-test-db";
+
+// The platform view is `reach: "tenant"` on the owner-policy context: reads
+// widen from {this subject + org rows} to {the whole tenant}, and writes do not
+// widen at all. These tests pin BOTH halves against the real SQLite bring-up —
+// the widening is only useful if the not-widening is airtight.
+
+const TENANT = "t1";
+const OTHER_TENANT = "t2";
+const SUBJECT_A = "user_a";
+const SUBJECT_B = "user_b";
+
+const withDb = <A>(body: (db: SqliteTestFumaDb) => Promise<A>): Promise<A> =>
+  Effect.runPromise(
+    Effect.acquireUseRelease(
+      Effect.promise(() => createSqliteTestFumaDb({ tables: collectTables() })),
+      (db) => Effect.promise(() => body(db)),
+      (db) => Effect.promise(() => db.close()),
+    ),
+  );
+
+/** Insert a connection row directly, bypassing the policy — these tests are
+ *  about what a context may SEE, so the seeding must be able to write rows the
+ *  reader is not bound to. */
+const insertConnection = (
+  db: SqliteTestFumaDb,
+  row: {
+    readonly rowId: string;
+    readonly tenant: string;
+    readonly owner: string;
+    readonly subject: string;
+    readonly name: string;
+  },
+): Promise<unknown> =>
+  db.client.execute({
+    sql: `INSERT INTO connection (
+        row_id, tenant, owner, subject, integration, name, template, provider,
+        item_ids, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    args: [
+      row.rowId,
+      row.tenant,
+      row.owner,
+      row.subject,
+      "github",
+      row.name,
+      "apiKey",
+      "memory",
+      JSON.stringify({ token: `item-${row.rowId}` }),
+      Date.now(),
+      Date.now(),
+    ],
+  });
+
+const seedTwoSubjects = async (db: SqliteTestFumaDb): Promise<void> => {
+  await insertConnection(db, {
+    rowId: "c-a",
+    tenant: TENANT,
+    owner: "user",
+    subject: SUBJECT_A,
+    name: "a-personal",
+  });
+  await insertConnection(db, {
+    rowId: "c-b",
+    tenant: TENANT,
+    owner: "user",
+    subject: SUBJECT_B,
+    name: "b-personal",
+  });
+  await insertConnection(db, {
+    rowId: "c-org",
+    tenant: TENANT,
+    owner: "org",
+    subject: "",
+    name: "shared",
+  });
+  // Another tenant entirely — never visible at any reach.
+  await insertConnection(db, {
+    rowId: "c-other",
+    tenant: OTHER_TENANT,
+    owner: "user",
+    subject: SUBJECT_A,
+    name: "other-tenant",
+  });
+};
+
+describe("owner policy reach", () => {
+  it.effect("bound reach still sees only the subject's own rows plus org rows", () =>
+    Effect.promise(() =>
+      withDb(async (db) => {
+        await seedTwoSubjects(db);
+
+        const bound = withQueryContext(db.db, { tenant: TENANT, subject: SUBJECT_A });
+        const rows = await bound.findMany("connection", {});
+
+        expect(rows.map((row) => row.name).sort()).toEqual(["a-personal", "shared"]);
+      }),
+    ),
+  );
+
+  it.effect("tenant reach reads across every subject in the tenant", () =>
+    Effect.promise(() =>
+      withDb(async (db) => {
+        await seedTwoSubjects(db);
+
+        const platform = withQueryContext(db.db, {
+          tenant: TENANT,
+          subject: SUBJECT_A,
+          reach: "tenant",
+        });
+        const rows = await platform.findMany("connection", {});
+
+        // The other subject's rows are now visible — that is the whole point.
+        expect(rows.map((row) => row.name).sort()).toEqual(["a-personal", "b-personal", "shared"]);
+      }),
+    ),
+  );
+
+  it.effect("tenant reach NEVER reads across tenants", () =>
+    Effect.promise(() =>
+      withDb(async (db) => {
+        await seedTwoSubjects(db);
+
+        const platform = withQueryContext(db.db, {
+          tenant: TENANT,
+          subject: SUBJECT_A,
+          reach: "tenant",
+        });
+        const rows = await platform.findMany("connection", {});
+
+        // `tenant` is the one clause reach never relaxes.
+        expect(rows.every((row) => row.tenant === TENANT)).toBe(true);
+        expect(rows.map((row) => row.name)).not.toContain("other-tenant");
+      }),
+    ),
+  );
+
+  it.effect("tenant reach with a null subject reads the whole tenant, not just org rows", () =>
+    Effect.promise(() =>
+      withDb(async (db) => {
+        await seedTwoSubjects(db);
+
+        // The shape an org-level API key produces: no bound subject at all.
+        const platform = withQueryContext(db.db, {
+          tenant: TENANT,
+          subject: null,
+          reach: "tenant",
+        });
+        const rows = await platform.findMany("connection", {});
+
+        expect(rows.map((row) => row.name).sort()).toEqual(["a-personal", "b-personal", "shared"]);
+      }),
+    ),
+  );
+
+  // -------------------------------------------------------------------------
+  // The security property: reach widens READS ONLY.
+  // -------------------------------------------------------------------------
+
+  it.effect("tenant reach cannot create rows", () =>
+    Effect.promise(() =>
+      withDb(async (db) => {
+        const platform = withQueryContext(db.db, {
+          tenant: TENANT,
+          subject: SUBJECT_A,
+          reach: "tenant",
+        });
+
+        await expect(
+          platform.create("connection", {
+            tenant: TENANT,
+            owner: "user",
+            subject: SUBJECT_A,
+            integration: "github",
+            name: "written-by-platform-view",
+            template: "apiKey",
+            provider: "memory",
+            item_ids: { token: "item-x" },
+            created_at: new Date(),
+            updated_at: new Date(),
+          }),
+        ).rejects.toThrow(/platform view is read-only/);
+      }),
+    ),
+  );
+
+  it.effect("tenant reach cannot update another subject's rows", () =>
+    Effect.promise(() =>
+      withDb(async (db) => {
+        await seedTwoSubjects(db);
+
+        const platform = withQueryContext(db.db, {
+          tenant: TENANT,
+          subject: SUBJECT_A,
+          reach: "tenant",
+        });
+
+        // Without the reach guard the widened read condition would MATCH
+        // subject B's row and this update would land on it.
+        await expect(
+          platform.updateMany("connection", {
+            where: (b) => b("name", "=", "b-personal"),
+            set: { identity_label: "hijacked" },
+          }),
+        ).rejects.toThrow(/platform view is read-only/);
+
+        const rows = await db.client.execute(
+          "SELECT identity_label FROM connection WHERE row_id = 'c-b'",
+        );
+        expect(rows.rows[0]?.["identity_label"]).toBeNull();
+      }),
+    ),
+  );
+
+  it.effect("tenant reach cannot delete another subject's rows", () =>
+    Effect.promise(() =>
+      withDb(async (db) => {
+        await seedTwoSubjects(db);
+
+        const platform = withQueryContext(db.db, {
+          tenant: TENANT,
+          subject: SUBJECT_A,
+          reach: "tenant",
+        });
+
+        await expect(
+          platform.deleteMany("connection", { where: (b) => b("name", "=", "b-personal") }),
+        ).rejects.toThrow(/platform view is read-only/);
+
+        const rows = await db.client.execute("SELECT row_id FROM connection ORDER BY row_id");
+        expect(rows.rows.map((row) => String(row["row_id"]))).toEqual([
+          "c-a",
+          "c-b",
+          "c-org",
+          "c-other",
+        ]);
+      }),
+    ),
+  );
+
+  it.effect("tenant reach cannot write the tenant-scoped subject table", () =>
+    Effect.promise(() =>
+      withDb(async (db) => {
+        const platform = withQueryContext(db.db, {
+          tenant: TENANT,
+          subject: SUBJECT_A,
+          reach: "tenant",
+        });
+
+        // `subject` is tenant-scoped, so its reads were already tenant-wide —
+        // the read-only property still has to hold there.
+        await expect(
+          platform.create("subject", {
+            tenant: TENANT,
+            external_id: SUBJECT_B,
+            created_at: new Date(),
+            last_seen_at: Date.now(),
+            status: null,
+          }),
+        ).rejects.toThrow(/platform view is read-only/);
+      }),
+    ),
+  );
+
+  it.effect("bound reach writes are unaffected by the reach guard", () =>
+    Effect.promise(() =>
+      withDb(async (db) => {
+        // The guard must not disturb the product view: an ordinary bound
+        // context writes exactly as before.
+        const bound = withQueryContext(db.db, { tenant: TENANT, subject: SUBJECT_A });
+
+        await bound.create("connection", {
+          tenant: TENANT,
+          owner: "user",
+          subject: SUBJECT_A,
+          integration: "github",
+          name: "written-by-bound-view",
+          template: "apiKey",
+          provider: "memory",
+          item_ids: { token: "item-y" },
+          created_at: new Date(),
+          updated_at: new Date(),
+        });
+
+        const rows = await bound.findMany("connection", {});
+        expect(rows.map((row) => row.name)).toEqual(["written-by-bound-view"]);
+      }),
+    ),
+  );
+
+  it.effect("a bound context still cannot write outside its own subject", () =>
+    Effect.promise(() =>
+      withDb(async (db) => {
+        const bound = withQueryContext(db.db, { tenant: TENANT, subject: SUBJECT_A });
+
+        await expect(
+          bound.create("connection", {
+            tenant: TENANT,
+            owner: "user",
+            subject: SUBJECT_B,
+            integration: "github",
+            name: "cross-subject",
+            template: "apiKey",
+            provider: "memory",
+            item_ids: { token: "item-z" },
+            created_at: new Date(),
+            updated_at: new Date(),
+          }),
+        ).rejects.toThrow(/outside the bound subject/);
+      }),
+    ),
+  );
+});

--- a/packages/core/sdk/src/owner-policy.ts
+++ b/packages/core/sdk/src/owner-policy.ts
@@ -25,11 +25,25 @@ export const ORG_SUBJECT = "";
 
 const unscopedExecutorTables = new Set(["blob"]);
 
+/** How far a context's READS reach. Writes ignore this entirely — see
+ *  `assertOwnerWritable`. */
+export type ExecutorReach =
+  /** The product view: this subject's rows plus the tenant's org rows. */
+  | "bound"
+  /** The platform view: every row in the tenant, whatever subject owns it.
+   *  READ-ONLY by construction — it widens `ownerVisibilityCondition` and
+   *  nothing else. */
+  | "tenant";
+
 export interface ExecutorOwnerPolicyContext {
   readonly tenant: string;
   /** The acting member, or null for a pure-org executor (no `owner:"user"`
    *  reads/writes are allowed when null). */
   readonly subject: string | null;
+  /** Read reach; defaults to `"bound"`. A `"tenant"`-reach context is the
+   *  platform view: it sees the whole tenant but writes exactly as a bound
+   *  context does, so it can never mutate another subject's rows. */
+  readonly reach?: ExecutorReach;
 }
 
 type AnyConditionBuilder = ConditionBuilder<Record<string, AnyColumn>>;
@@ -51,11 +65,20 @@ const requireContext = (
 };
 
 /** The rows the bound `{ tenant, subject }` may see/mutate: org rows in the
- *  tenant, plus this subject's own user rows. */
+ *  tenant, plus this subject's own user rows.
+ *
+ *  Under `reach: "tenant"` (the platform view) this widens to the whole tenant:
+ *  every subject's rows, not just the bound one. That is a READ widening only —
+ *  the policy uses this condition for `onRead`/`onUpdate`/`onDelete` filtering,
+ *  but the write assertions below reject a tenant-reach context outright, so a
+ *  widened context can never be the one doing the mutating. */
 export const ownerVisibilityCondition = (
   builder: AnyConditionBuilder,
   context: ExecutorOwnerPolicyContext,
 ): Condition | boolean => {
+  // The platform view: partition by tenant alone. Still never cross-tenant —
+  // `tenant` is the one clause that is NEVER relaxed, at any reach.
+  if (context.reach === "tenant") return builder("tenant", "=", context.tenant);
   const orgClause = builder.and(
     builder("tenant", "=", context.tenant),
     builder("owner", "=", "org"),
@@ -69,6 +92,26 @@ export const ownerVisibilityCondition = (
   return builder.or(orgClause, userClause);
 };
 
+/**
+ * THE security property of the platform view: reach widens reads and NOTHING
+ * else. `ownerVisibilityCondition` is also what filters `onUpdate`/`onDelete`,
+ * so a widened context reaching any mutation would silently mutate every
+ * subject in the tenant. Every write path calls this first and fails loudly
+ * instead — a tenant-reach context is rejected outright rather than quietly
+ * demoted to bound behavior, because a write arriving on the read-only platform
+ * handle is a programmer error and should not be papered over.
+ */
+export const assertReachReadOnly = (
+  tableName: string,
+  access: string,
+  context: ExecutorOwnerPolicyContext | undefined,
+): void => {
+  if (context?.reach !== "tenant") return;
+  policyViolation(
+    `Storage ${access} on table "${tableName}" is not allowed: the platform view is read-only.`,
+  );
+};
+
 /** Assert a create/upsert writes a row inside the bound partition. */
 export const assertOwnerWritable = (
   tableName: string,
@@ -76,6 +119,7 @@ export const assertOwnerWritable = (
   context: ExecutorOwnerPolicyContext | undefined,
 ): void => {
   const ctx = requireContext(tableName, "write", context);
+  assertReachReadOnly(tableName, "write", ctx);
   if (values.tenant !== ctx.tenant) {
     policyViolation(`Storage write on table "${tableName}" is outside the executor tenant.`);
   }
@@ -106,6 +150,7 @@ export const assertOwnerPatch = (
   context: ExecutorOwnerPolicyContext | undefined,
 ): void => {
   const ctx = requireContext(tableName, "write", context);
+  assertReachReadOnly(tableName, "write", ctx);
   if (!patch) return;
   if (patch.tenant !== undefined && patch.tenant !== ctx.tenant) {
     policyViolation(`Storage write on table "${tableName}" cannot move a row across tenants.`);

--- a/packages/core/sdk/src/platform-view.test.ts
+++ b/packages/core/sdk/src/platform-view.test.ts
@@ -1,0 +1,365 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+
+import { collectTables, createExecutor, type Executor } from "./executor";
+import { createSqliteTestFumaDb, type SqliteTestFumaDb } from "./sqlite-test-db";
+import { Subject, Tenant } from "./ids";
+import { touchSubject } from "./subject-registry";
+
+// The platform view: `executor.admin`, an OPT-IN read-only surface that reads
+// across every subject in the tenant. Written against the real SQLite bring-up
+// so the tenant-reach policy, the bigint `last_seen_at` round-trip, and the
+// field allowlist are all live.
+
+const TENANT = "t1";
+const OTHER_TENANT = "t2";
+const SUBJECT_A = "user_a";
+const SUBJECT_B = "user_b";
+
+/** Every column on `connection` that could resolve, or help resolve, a
+ *  credential. NONE of these may appear on an admin shape — enumerated so a
+ *  future column addition has to be argued with this list. */
+const FORBIDDEN_CONNECTION_FIELDS = [
+  "item_ids",
+  "itemIds",
+  "refresh_item_id",
+  "refreshItemId",
+  "provider",
+  "provider_state",
+  "providerState",
+  "oauth_token_url",
+  "oauthTokenUrl",
+  "template",
+  "client_secret",
+  "clientSecret",
+  "secret",
+  "token",
+] as const;
+
+const withDb = <A, E>(body: (db: SqliteTestFumaDb) => Effect.Effect<A, E>): Effect.Effect<A, E> =>
+  Effect.acquireUseRelease(
+    Effect.promise(() => createSqliteTestFumaDb({ tables: collectTables() })),
+    body,
+    (db) => Effect.promise(() => db.close()),
+  );
+
+const insertConnection = (
+  db: SqliteTestFumaDb,
+  row: {
+    readonly rowId: string;
+    readonly tenant: string;
+    readonly owner: string;
+    readonly subject: string;
+    readonly integration: string;
+    readonly name: string;
+    readonly oauthScope?: string | null;
+  },
+): Effect.Effect<void> =>
+  Effect.promise(async () => {
+    await db.client.execute({
+      sql: `INSERT INTO connection (
+          row_id, tenant, owner, subject, integration, name, template, provider,
+          item_ids, refresh_item_id, oauth_scope, last_health, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      args: [
+        row.rowId,
+        row.tenant,
+        row.owner,
+        row.subject,
+        row.integration,
+        row.name,
+        "oauth2",
+        "memory",
+        // Deliberately secret-bearing: the assertions below prove these never
+        // leave the storage layer.
+        JSON.stringify({ token: `SECRET-item-${row.rowId}` }),
+        `SECRET-refresh-${row.rowId}`,
+        row.oauthScope ?? null,
+        JSON.stringify({ status: "healthy", checkedAt: 1_700_000_000_000 }),
+        Date.now(),
+        Date.now(),
+      ],
+    });
+  });
+
+/** Seed two users and an org connection under `t1`, plus an untouchable other
+ *  tenant. Subjects go in through `touchSubject` (the only legitimate writer);
+ *  connections go in raw, because no single bound executor could have written
+ *  another subject's rows. */
+const seed = (db: SqliteTestFumaDb): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    yield* touchSubject(db.db, { tenant: TENANT, externalId: SUBJECT_A });
+    yield* touchSubject(db.db, { tenant: TENANT, externalId: SUBJECT_B });
+    yield* touchSubject(db.db, { tenant: OTHER_TENANT, externalId: "user_elsewhere" });
+
+    yield* insertConnection(db, {
+      rowId: "c-a1",
+      tenant: TENANT,
+      owner: "user",
+      subject: SUBJECT_A,
+      integration: "github",
+      name: "personal",
+      oauthScope: "repo read:user",
+    });
+    yield* insertConnection(db, {
+      rowId: "c-a2",
+      tenant: TENANT,
+      owner: "user",
+      subject: SUBJECT_A,
+      integration: "linear",
+      name: "work",
+    });
+    yield* insertConnection(db, {
+      rowId: "c-b1",
+      tenant: TENANT,
+      owner: "user",
+      subject: SUBJECT_B,
+      integration: "github",
+      name: "b-personal",
+      oauthScope: "repo",
+    });
+    yield* insertConnection(db, {
+      rowId: "c-org",
+      tenant: TENANT,
+      owner: "org",
+      subject: "",
+      integration: "stripe",
+      name: "shared",
+    });
+    yield* insertConnection(db, {
+      rowId: "c-other",
+      tenant: OTHER_TENANT,
+      owner: "user",
+      subject: SUBJECT_A,
+      integration: "github",
+      name: "other-tenant",
+    });
+  });
+
+const makePlatformExecutor = (
+  db: SqliteTestFumaDb,
+  options?: { readonly platformView?: boolean; readonly subject?: string | null },
+): Effect.Effect<Executor, never> =>
+  createExecutor({
+    tenant: Tenant.make(TENANT),
+    ...(options?.subject === null ? {} : { subject: Subject.make(options?.subject ?? SUBJECT_A) }),
+    db: db.db,
+    onElicitation: "accept-all",
+    ...(options?.platformView === false ? {} : { platformView: true }),
+  }).pipe(Effect.orDie);
+
+const requireAdmin = (executor: Executor) => {
+  const admin = executor.admin;
+  if (!admin) return Effect.die("expected the platform view to be enabled");
+  return Effect.succeed(admin);
+};
+
+describe("platform view — admin.listSubjects", () => {
+  it.effect("lists every subject in the tenant and no other tenant's", () =>
+    withDb((db) =>
+      Effect.gen(function* () {
+        yield* seed(db);
+        const executor = yield* makePlatformExecutor(db);
+        const admin = yield* requireAdmin(executor);
+
+        const subjects = yield* admin.listSubjects();
+
+        // `user_elsewhere` lives under t2 — invisible at any reach.
+        expect(subjects.map((entry) => entry.externalId).sort()).toEqual([SUBJECT_A, SUBJECT_B]);
+      }),
+    ),
+  );
+
+  it.effect("returns created_at and the bigint last_seen_at through the ORM", () =>
+    withDb((db) =>
+      Effect.gen(function* () {
+        const before = Date.now();
+        yield* seed(db);
+        const executor = yield* makePlatformExecutor(db);
+        const admin = yield* requireAdmin(executor);
+
+        const subjects = yield* admin.listSubjects();
+        const entry = subjects.find((row) => row.externalId === SUBJECT_A);
+
+        expect(entry?.createdAt).toBeInstanceOf(Date);
+        // A raw SQL read would hand back an unusable blob here.
+        expect(typeof entry?.lastSeenAt).toBe("number");
+        expect(entry?.lastSeenAt ?? 0).toBeGreaterThanOrEqual(before);
+        expect(entry?.status).toBeNull();
+      }),
+    ),
+  );
+
+  it.effect("pages with a stable order", () =>
+    withDb((db) =>
+      Effect.gen(function* () {
+        yield* seed(db);
+        const executor = yield* makePlatformExecutor(db);
+        const admin = yield* requireAdmin(executor);
+
+        const all = yield* admin.listSubjects();
+        const first = yield* admin.listSubjects({ limit: 1 });
+        const second = yield* admin.listSubjects({ limit: 1, offset: 1 });
+
+        expect(all).toHaveLength(2);
+        expect(first.map((entry) => entry.externalId)).toEqual([all[0]?.externalId]);
+        expect(second.map((entry) => entry.externalId)).toEqual([all[1]?.externalId]);
+      }),
+    ),
+  );
+});
+
+describe("platform view — admin.listSubjectConnections", () => {
+  it.effect("lists another subject's connections across the tenant", () =>
+    withDb((db) =>
+      Effect.gen(function* () {
+        yield* seed(db);
+        // Bound to A; reading B is exactly what the product view cannot do.
+        const executor = yield* makePlatformExecutor(db, { subject: SUBJECT_A });
+        const admin = yield* requireAdmin(executor);
+
+        const connections = yield* admin.listSubjectConnections(SUBJECT_B);
+
+        expect(connections.map((entry) => entry.name)).toEqual(["b-personal"]);
+        expect(connections[0]?.integration).toBe("github");
+        expect(connections[0]?.owner).toBe("user");
+        expect(connections[0]?.subject).toBe(SUBJECT_B);
+        expect(connections[0]?.oauthScope).toBe("repo");
+        expect(connections[0]?.lastHealth?.status).toBe("healthy");
+      }),
+    ),
+  );
+
+  it.effect("does not attribute org-owned connections to a user", () =>
+    withDb((db) =>
+      Effect.gen(function* () {
+        yield* seed(db);
+        const executor = yield* makePlatformExecutor(db);
+        const admin = yield* requireAdmin(executor);
+
+        const forA = yield* admin.listSubjectConnections(SUBJECT_A);
+
+        // The org's `stripe/shared` belongs to the tenant, not to A.
+        expect(forA.map((entry) => entry.integration).sort()).toEqual(["github", "linear"]);
+        expect(forA.every((entry) => entry.owner === "user")).toBe(true);
+      }),
+    ),
+  );
+
+  it.effect("never returns credential-bearing fields", () =>
+    withDb((db) =>
+      Effect.gen(function* () {
+        yield* seed(db);
+        const executor = yield* makePlatformExecutor(db);
+        const admin = yield* requireAdmin(executor);
+
+        const connections = yield* admin.listSubjectConnections(SUBJECT_A);
+        expect(connections.length).toBeGreaterThan(0);
+
+        for (const connection of connections) {
+          const keys = Object.keys(connection);
+          for (const forbidden of FORBIDDEN_CONNECTION_FIELDS) {
+            expect(keys).not.toContain(forbidden);
+          }
+          // Belt and braces: no seeded secret value appears anywhere in the
+          // serialized shape, whatever it is keyed under.
+          expect(JSON.stringify(connection)).not.toContain("SECRET-");
+        }
+      }),
+    ),
+  );
+});
+
+describe("platform view — admin.listSubjectsWithConnections", () => {
+  it.effect("joins each subject to its own connections", () =>
+    withDb((db) =>
+      Effect.gen(function* () {
+        yield* seed(db);
+        const executor = yield* makePlatformExecutor(db);
+        const admin = yield* requireAdmin(executor);
+
+        const rows = yield* admin.listSubjectsWithConnections();
+        const byId = new Map(rows.map((row) => [row.externalId, row]));
+
+        expect(rows.map((row) => row.externalId).sort()).toEqual([SUBJECT_A, SUBJECT_B]);
+        expect(
+          byId
+            .get(SUBJECT_A)
+            ?.connections.map((c) => c.name)
+            .sort(),
+        ).toEqual(["personal", "work"]);
+        expect(byId.get(SUBJECT_B)?.connections.map((c) => c.name)).toEqual(["b-personal"]);
+      }),
+    ),
+  );
+
+  it.effect("never returns credential-bearing fields", () =>
+    withDb((db) =>
+      Effect.gen(function* () {
+        yield* seed(db);
+        const executor = yield* makePlatformExecutor(db);
+        const admin = yield* requireAdmin(executor);
+
+        const rows = yield* admin.listSubjectsWithConnections();
+
+        for (const row of rows) {
+          for (const connection of row.connections) {
+            const keys = Object.keys(connection);
+            for (const forbidden of FORBIDDEN_CONNECTION_FIELDS) {
+              expect(keys).not.toContain(forbidden);
+            }
+          }
+        }
+        expect(JSON.stringify(rows)).not.toContain("SECRET-");
+      }),
+    ),
+  );
+
+  it.effect("works for a pure-org executor with no bound subject", () =>
+    withDb((db) =>
+      Effect.gen(function* () {
+        yield* seed(db);
+        // The shape an org-level API key produces: platform view on, no
+        // subject bound at all.
+        const executor = yield* makePlatformExecutor(db, { subject: null });
+        const admin = yield* requireAdmin(executor);
+
+        const rows = yield* admin.listSubjectsWithConnections();
+
+        expect(rows.map((row) => row.externalId).sort()).toEqual([SUBJECT_A, SUBJECT_B]);
+        expect(rows.flatMap((row) => row.connections)).toHaveLength(3);
+      }),
+    ),
+  );
+});
+
+describe("platform view — default off", () => {
+  it.effect("an executor without the opt-in has no admin surface", () =>
+    withDb((db) =>
+      Effect.gen(function* () {
+        yield* seed(db);
+        const executor = yield* makePlatformExecutor(db, { platformView: false });
+
+        expect(executor.admin).toBeUndefined();
+      }),
+    ),
+  );
+
+  it.effect("the product view still reads only the bound subject when the opt-in is on", () =>
+    withDb((db) =>
+      Effect.gen(function* () {
+        yield* seed(db);
+        // Enabling the platform view must not widen ANY existing surface.
+        const executor = yield* makePlatformExecutor(db, { subject: SUBJECT_A });
+
+        const connections = yield* executor.connections.list().pipe(Effect.orDie);
+
+        expect(connections.map((entry) => entry.name).sort()).toEqual([
+          "personal",
+          "shared",
+          "work",
+        ]);
+      }),
+    ),
+  );
+});

--- a/packages/core/sdk/src/platform-view.test.ts
+++ b/packages/core/sdk/src/platform-view.test.ts
@@ -4,7 +4,7 @@ import { Effect } from "effect";
 import { collectTables, createExecutor, type Executor } from "./executor";
 import { createSqliteTestFumaDb, type SqliteTestFumaDb } from "./sqlite-test-db";
 import { Subject, Tenant } from "./ids";
-import { touchSubject } from "./subject-registry";
+import { resetSubjectTouchCache, touchSubject } from "./subject-registry";
 
 // The platform view: `executor.admin`, an OPT-IN read-only surface that reads
 // across every subject in the tenant. Written against the real SQLite bring-up
@@ -88,6 +88,11 @@ const insertConnection = (
  *  another subject's rows. */
 const seed = (db: SqliteTestFumaDb): Effect.Effect<void> =>
   Effect.gen(function* () {
+    // `touchSubject` keeps a process-local memory of principals it already
+    // filed, so a second seed against a FRESH database would be skipped as a
+    // repeat sighting and leave the table empty. Each seed is a new world.
+    resetSubjectTouchCache();
+
     yield* touchSubject(db.db, { tenant: TENANT, externalId: SUBJECT_A });
     yield* touchSubject(db.db, { tenant: TENANT, externalId: SUBJECT_B });
     yield* touchSubject(db.db, { tenant: OTHER_TENANT, externalId: "user_elsewhere" });


### PR DESCRIPTION
Third step, stacked on #1464. Adds the platform view: a read-only `reach: "tenant"` mode on the owner policy (writes reject under tenant reach — including tenant-wide update/delete row filters, which would otherwise widen), an opt-in `executor.admin` surface (listSubjects / listSubjectConnections / listSubjectsWithConnections, credential-bearing fields excluded), and cloud groundwork for org-scoped API keys resolving to a `PlatformAuth` distinct from `Principal`. Org keys are rejected on product and MCP surfaces. Public /admin/users endpoints land next.

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #1463
2. #1464
3. **#1465** 👈 current
4. #1466
5. #1467
6. #1469
<!-- stack:links:end -->