### PR TITLE
Add /connect/:integrationSlug deep links

### DIFF
--- a/apps/cloud/src/routeTree.gen.ts
+++ b/apps/cloud/src/routeTree.gen.ts
@@ -23,6 +23,7 @@ import { Route as ApiKeysRouteImport } from './routes/app/api-keys'
 import { Route as DotDotDotDotDotDotDotDotPackagesReactSrcRoutesToolkitsDottoolkitSlugRouteImport } from './../../../packages/react/src/routes/toolkits.$toolkitSlug'
 import { Route as ResumeDotexecutionIdRouteImport } from './routes/app/resume.$executionId'
 import { Route as DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIntegrationsDotnamespaceRouteImport } from './../../../packages/react/src/routes/integrations.$namespace'
+import { Route as DotDotDotDotDotDotDotDotPackagesReactSrcRoutesConnectDotintegrationSlugRouteImport } from './../../../packages/react/src/routes/connect.$integrationSlug'
 import { Route as Billing_DotplansRouteImport } from './routes/app/billing_.plans'
 import { Route as DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIntegrationsDotaddDotpluginKeyRouteImport } from './../../../packages/react/src/routes/integrations.add.$pluginKey'
 
@@ -107,6 +108,14 @@ const DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIntegrationsDotnamespaceRout
       getParentRoute: () => rootRouteImport,
     } as any,
   )
+const DotDotDotDotDotDotDotDotPackagesReactSrcRoutesConnectDotintegrationSlugRoute =
+  DotDotDotDotDotDotDotDotPackagesReactSrcRoutesConnectDotintegrationSlugRouteImport.update(
+    {
+      id: '/{-$orgSlug}/connect/$integrationSlug',
+      path: '/{-$orgSlug}/connect/$integrationSlug',
+      getParentRoute: () => rootRouteImport,
+    } as any,
+  )
 const Billing_DotplansRoute = Billing_DotplansRouteImport.update({
   id: '/{-$orgSlug}/billing_/plans',
   path: '/{-$orgSlug}/billing/plans',
@@ -134,6 +143,7 @@ export interface FileRoutesByFullPath {
   '/{-$orgSlug}/tools': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesToolsRoute
   '/{-$orgSlug}/': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIndexRoute
   '/{-$orgSlug}/billing/plans': typeof Billing_DotplansRoute
+  '/{-$orgSlug}/connect/$integrationSlug': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesConnectDotintegrationSlugRoute
   '/{-$orgSlug}/integrations/$namespace': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIntegrationsDotnamespaceRoute
   '/{-$orgSlug}/resume/$executionId': typeof ResumeDotexecutionIdRoute
   '/{-$orgSlug}/toolkits/$toolkitSlug': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesToolkitsDottoolkitSlugRoute
@@ -152,6 +162,7 @@ export interface FileRoutesByTo {
   '/{-$orgSlug}/tools': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesToolsRoute
   '/{-$orgSlug}': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIndexRoute
   '/{-$orgSlug}/billing/plans': typeof Billing_DotplansRoute
+  '/{-$orgSlug}/connect/$integrationSlug': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesConnectDotintegrationSlugRoute
   '/{-$orgSlug}/integrations/$namespace': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIntegrationsDotnamespaceRoute
   '/{-$orgSlug}/resume/$executionId': typeof ResumeDotexecutionIdRoute
   '/{-$orgSlug}/toolkits/$toolkitSlug': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesToolkitsDottoolkitSlugRoute
@@ -171,6 +182,7 @@ export interface FileRoutesById {
   '/{-$orgSlug}/tools': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesToolsRoute
   '/{-$orgSlug}/': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIndexRoute
   '/{-$orgSlug}/billing_/plans': typeof Billing_DotplansRoute
+  '/{-$orgSlug}/connect/$integrationSlug': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesConnectDotintegrationSlugRoute
   '/{-$orgSlug}/integrations/$namespace': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIntegrationsDotnamespaceRoute
   '/{-$orgSlug}/resume/$executionId': typeof ResumeDotexecutionIdRoute
   '/{-$orgSlug}/toolkits/$toolkitSlug': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesToolkitsDottoolkitSlugRoute
@@ -191,6 +203,7 @@ export interface FileRouteTypes {
     | '/{-$orgSlug}/tools'
     | '/{-$orgSlug}/'
     | '/{-$orgSlug}/billing/plans'
+    | '/{-$orgSlug}/connect/$integrationSlug'
     | '/{-$orgSlug}/integrations/$namespace'
     | '/{-$orgSlug}/resume/$executionId'
     | '/{-$orgSlug}/toolkits/$toolkitSlug'
@@ -209,6 +222,7 @@ export interface FileRouteTypes {
     | '/{-$orgSlug}/tools'
     | '/{-$orgSlug}'
     | '/{-$orgSlug}/billing/plans'
+    | '/{-$orgSlug}/connect/$integrationSlug'
     | '/{-$orgSlug}/integrations/$namespace'
     | '/{-$orgSlug}/resume/$executionId'
     | '/{-$orgSlug}/toolkits/$toolkitSlug'
@@ -227,6 +241,7 @@ export interface FileRouteTypes {
     | '/{-$orgSlug}/tools'
     | '/{-$orgSlug}/'
     | '/{-$orgSlug}/billing_/plans'
+    | '/{-$orgSlug}/connect/$integrationSlug'
     | '/{-$orgSlug}/integrations/$namespace'
     | '/{-$orgSlug}/resume/$executionId'
     | '/{-$orgSlug}/toolkits/$toolkitSlug'
@@ -246,6 +261,7 @@ export interface RootRouteChildren {
   DotDotDotDotDotDotDotDotPackagesReactSrcRoutesToolsRoute: typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesToolsRoute
   DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIndexRoute: typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIndexRoute
   Billing_DotplansRoute: typeof Billing_DotplansRoute
+  DotDotDotDotDotDotDotDotPackagesReactSrcRoutesConnectDotintegrationSlugRoute: typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesConnectDotintegrationSlugRoute
   DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIntegrationsDotnamespaceRoute: typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIntegrationsDotnamespaceRoute
   ResumeDotexecutionIdRoute: typeof ResumeDotexecutionIdRoute
   DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIntegrationsDotaddDotpluginKeyRoute: typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIntegrationsDotaddDotpluginKeyRoute
@@ -351,6 +367,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIntegrationsDotnamespaceRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/{-$orgSlug}/connect/$integrationSlug': {
+      id: '/{-$orgSlug}/connect/$integrationSlug'
+      path: '/{-$orgSlug}/connect/$integrationSlug'
+      fullPath: '/{-$orgSlug}/connect/$integrationSlug'
+      preLoaderRoute: typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesConnectDotintegrationSlugRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/{-$orgSlug}/billing_/plans': {
       id: '/{-$orgSlug}/billing_/plans'
       path: '/{-$orgSlug}/billing/plans'
@@ -400,6 +423,8 @@ const rootRouteChildren: RootRouteChildren = {
   DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIndexRoute:
     DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIndexRoute,
   Billing_DotplansRoute: Billing_DotplansRoute,
+  DotDotDotDotDotDotDotDotPackagesReactSrcRoutesConnectDotintegrationSlugRoute:
+    DotDotDotDotDotDotDotDotPackagesReactSrcRoutesConnectDotintegrationSlugRoute,
   DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIntegrationsDotnamespaceRoute:
     DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIntegrationsDotnamespaceRoute,
   ResumeDotexecutionIdRoute: ResumeDotexecutionIdRoute,

--- a/apps/host-cloudflare/web/routeTree.gen.ts
+++ b/apps/host-cloudflare/web/routeTree.gen.ts
@@ -17,6 +17,7 @@ import { Route as DotDotDotDotDotDotDotDotPackagesReactSrcRoutesPoliciesRouteImp
 import { Route as DotDotDotDotDotDotDotDotPackagesReactSrcRoutesToolkitsDottoolkitSlugRouteImport } from './../../../packages/react/src/routes/toolkits.$toolkitSlug'
 import { Route as DotDotDotDotDotDotDotDotPackagesReactSrcRoutesResumeDotexecutionIdRouteImport } from './../../../packages/react/src/routes/resume.$executionId'
 import { Route as DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIntegrationsDotnamespaceRouteImport } from './../../../packages/react/src/routes/integrations.$namespace'
+import { Route as DotDotDotDotDotDotDotDotPackagesReactSrcRoutesConnectDotintegrationSlugRouteImport } from './../../../packages/react/src/routes/connect.$integrationSlug'
 import { Route as DotDotDotDotDotDotDotDotPackagesReactSrcRoutesPluginsDotpluginIdDotsplatRouteImport } from './../../../packages/react/src/routes/plugins.$pluginId.$'
 import { Route as DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIntegrationsDotaddDotpluginKeyRouteImport } from './../../../packages/react/src/routes/integrations.add.$pluginKey'
 
@@ -75,6 +76,14 @@ const DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIntegrationsDotnamespaceRout
       getParentRoute: () => rootRouteImport,
     } as any,
   )
+const DotDotDotDotDotDotDotDotPackagesReactSrcRoutesConnectDotintegrationSlugRoute =
+  DotDotDotDotDotDotDotDotPackagesReactSrcRoutesConnectDotintegrationSlugRouteImport.update(
+    {
+      id: '/{-$orgSlug}/connect/$integrationSlug',
+      path: '/{-$orgSlug}/connect/$integrationSlug',
+      getParentRoute: () => rootRouteImport,
+    } as any,
+  )
 const DotDotDotDotDotDotDotDotPackagesReactSrcRoutesPluginsDotpluginIdDotsplatRoute =
   DotDotDotDotDotDotDotDotPackagesReactSrcRoutesPluginsDotpluginIdDotsplatRouteImport.update(
     {
@@ -98,6 +107,7 @@ export interface FileRoutesByFullPath {
   '/{-$orgSlug}/toolkits': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesToolkitsRouteWithChildren
   '/{-$orgSlug}/tools': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesToolsRoute
   '/{-$orgSlug}/': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIndexRoute
+  '/{-$orgSlug}/connect/$integrationSlug': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesConnectDotintegrationSlugRoute
   '/{-$orgSlug}/integrations/$namespace': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIntegrationsDotnamespaceRoute
   '/{-$orgSlug}/resume/$executionId': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesResumeDotexecutionIdRoute
   '/{-$orgSlug}/toolkits/$toolkitSlug': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesToolkitsDottoolkitSlugRoute
@@ -110,6 +120,7 @@ export interface FileRoutesByTo {
   '/{-$orgSlug}/toolkits': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesToolkitsRouteWithChildren
   '/{-$orgSlug}/tools': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesToolsRoute
   '/{-$orgSlug}': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIndexRoute
+  '/{-$orgSlug}/connect/$integrationSlug': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesConnectDotintegrationSlugRoute
   '/{-$orgSlug}/integrations/$namespace': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIntegrationsDotnamespaceRoute
   '/{-$orgSlug}/resume/$executionId': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesResumeDotexecutionIdRoute
   '/{-$orgSlug}/toolkits/$toolkitSlug': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesToolkitsDottoolkitSlugRoute
@@ -123,6 +134,7 @@ export interface FileRoutesById {
   '/{-$orgSlug}/toolkits': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesToolkitsRouteWithChildren
   '/{-$orgSlug}/tools': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesToolsRoute
   '/{-$orgSlug}/': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIndexRoute
+  '/{-$orgSlug}/connect/$integrationSlug': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesConnectDotintegrationSlugRoute
   '/{-$orgSlug}/integrations/$namespace': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIntegrationsDotnamespaceRoute
   '/{-$orgSlug}/resume/$executionId': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesResumeDotexecutionIdRoute
   '/{-$orgSlug}/toolkits/$toolkitSlug': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesToolkitsDottoolkitSlugRoute
@@ -137,6 +149,7 @@ export interface FileRouteTypes {
     | '/{-$orgSlug}/toolkits'
     | '/{-$orgSlug}/tools'
     | '/{-$orgSlug}/'
+    | '/{-$orgSlug}/connect/$integrationSlug'
     | '/{-$orgSlug}/integrations/$namespace'
     | '/{-$orgSlug}/resume/$executionId'
     | '/{-$orgSlug}/toolkits/$toolkitSlug'
@@ -149,6 +162,7 @@ export interface FileRouteTypes {
     | '/{-$orgSlug}/toolkits'
     | '/{-$orgSlug}/tools'
     | '/{-$orgSlug}'
+    | '/{-$orgSlug}/connect/$integrationSlug'
     | '/{-$orgSlug}/integrations/$namespace'
     | '/{-$orgSlug}/resume/$executionId'
     | '/{-$orgSlug}/toolkits/$toolkitSlug'
@@ -161,6 +175,7 @@ export interface FileRouteTypes {
     | '/{-$orgSlug}/toolkits'
     | '/{-$orgSlug}/tools'
     | '/{-$orgSlug}/'
+    | '/{-$orgSlug}/connect/$integrationSlug'
     | '/{-$orgSlug}/integrations/$namespace'
     | '/{-$orgSlug}/resume/$executionId'
     | '/{-$orgSlug}/toolkits/$toolkitSlug'
@@ -174,6 +189,7 @@ export interface RootRouteChildren {
   DotDotDotDotDotDotDotDotPackagesReactSrcRoutesToolkitsRoute: typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesToolkitsRouteWithChildren
   DotDotDotDotDotDotDotDotPackagesReactSrcRoutesToolsRoute: typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesToolsRoute
   DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIndexRoute: typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIndexRoute
+  DotDotDotDotDotDotDotDotPackagesReactSrcRoutesConnectDotintegrationSlugRoute: typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesConnectDotintegrationSlugRoute
   DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIntegrationsDotnamespaceRoute: typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIntegrationsDotnamespaceRoute
   DotDotDotDotDotDotDotDotPackagesReactSrcRoutesResumeDotexecutionIdRoute: typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesResumeDotexecutionIdRoute
   DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIntegrationsDotaddDotpluginKeyRoute: typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIntegrationsDotaddDotpluginKeyRoute
@@ -238,6 +254,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIntegrationsDotnamespaceRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/{-$orgSlug}/connect/$integrationSlug': {
+      id: '/{-$orgSlug}/connect/$integrationSlug'
+      path: '/{-$orgSlug}/connect/$integrationSlug'
+      fullPath: '/{-$orgSlug}/connect/$integrationSlug'
+      preLoaderRoute: typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesConnectDotintegrationSlugRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/{-$orgSlug}/plugins/$pluginId/$': {
       id: '/{-$orgSlug}/plugins/$pluginId/$'
       path: '/{-$orgSlug}/plugins/$pluginId/$'
@@ -281,6 +304,8 @@ const rootRouteChildren: RootRouteChildren = {
     DotDotDotDotDotDotDotDotPackagesReactSrcRoutesToolsRoute,
   DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIndexRoute:
     DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIndexRoute,
+  DotDotDotDotDotDotDotDotPackagesReactSrcRoutesConnectDotintegrationSlugRoute:
+    DotDotDotDotDotDotDotDotPackagesReactSrcRoutesConnectDotintegrationSlugRoute,
   DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIntegrationsDotnamespaceRoute:
     DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIntegrationsDotnamespaceRoute,
   DotDotDotDotDotDotDotDotPackagesReactSrcRoutesResumeDotexecutionIdRoute:

--- a/apps/host-selfhost/src/auth/return-to.test.ts
+++ b/apps/host-selfhost/src/auth/return-to.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "@effect/vitest";
 
-import { isSafeReturnTo, loginPath, mcpAuthorizeResumeTarget, safeReturnTo } from "./return-to";
+import {
+  isSafeReturnTo,
+  loginPath,
+  mcpAuthorizeResumeTarget,
+  postLoginTarget,
+  safeReturnTo,
+} from "./return-to";
 
 describe("isSafeReturnTo", () => {
   const safe = [
@@ -70,6 +76,44 @@ describe("mcpAuthorizeResumeTarget", () => {
     expect(
       mcpAuthorizeResumeTarget("?response_type=token&client_id=abc&redirect_uri=x"),
     ).toBeNull();
+  });
+});
+
+describe("postLoginTarget", () => {
+  // Self-host renders the login page IN PLACE of the requested route without
+  // navigating, so the live location is the only record of where the person was
+  // headed. A connect deep link must survive sign-in on that basis alone.
+  it("returns to the deep link the person actually opened", () => {
+    expect(postLoginTarget({ pathname: "/connect/linear", search: "" })).toBe("/connect/linear");
+    expect(postLoginTarget({ pathname: "/integrations/sentry", search: "?addAccount=1" })).toBe(
+      "/integrations/sentry?addAccount=1",
+    );
+  });
+
+  it("lands on the dashboard when signing in from the bare login page", () => {
+    // No deep link to resume, and echoing /login back would re-render the form.
+    expect(postLoginTarget({ pathname: "/login", search: "" })).toBe("/");
+  });
+
+  it("prefers an explicit returnTo over the current location", () => {
+    expect(postLoginTarget({ pathname: "/login", search: "?returnTo=%2Fconnect%2Flinear" })).toBe(
+      "/connect/linear",
+    );
+  });
+
+  it("prefers an MCP authorize resume over everything else", () => {
+    const target = postLoginTarget({
+      pathname: "/login",
+      search:
+        "?response_type=code&client_id=abc&redirect_uri=http%3A%2F%2Flocalhost%3A3118%2Fcallback",
+    });
+    expect(target.startsWith("/api/auth/mcp/authorize?")).toBe(true);
+  });
+
+  it("never honors an unsafe location", () => {
+    // `safeReturnTo` vets the echoed path too — an app-plane path is not a
+    // place to land a freshly signed-in browser.
+    expect(postLoginTarget({ pathname: "/api/auth/logout", search: "" })).toBe("/");
   });
 });
 

--- a/apps/host-selfhost/src/auth/return-to.ts
+++ b/apps/host-selfhost/src/auth/return-to.ts
@@ -32,3 +32,32 @@ export const mcpAuthorizeResumeTarget = (search: string): string | null => {
   if (!params.get("client_id") || !params.get("redirect_uri")) return null;
   return `${MCP_AUTHORIZE_PATH}?${params.toString()}`;
 };
+
+const LOGIN_PATH = "/login";
+
+/**
+ * Where the self-host login page sends someone after a successful sign-in, in
+ * priority order:
+ *
+ *  1. an interrupted MCP OAuth authorize (the params ARE the request),
+ *  2. an explicit safe `returnTo` (e.g. the integration OAuth callback),
+ *  3. the URL they actually opened, and
+ *  4. the dashboard.
+ *
+ * Step 3 is what makes a deep link like `/connect/linear` survive sign-in here.
+ * Unlike cloud — which redirects to `/login?returnTo=…` — self-host's gate
+ * swaps the login page in WITHOUT navigating, so the address bar still holds
+ * the requested URL and no `returnTo` was ever written. `/login` itself is
+ * excluded so signing in from the bare login page lands on the dashboard rather
+ * than looping back to the form.
+ */
+export const postLoginTarget = (location: {
+  readonly pathname: string;
+  readonly search: string;
+}): string =>
+  mcpAuthorizeResumeTarget(location.search) ??
+  safeReturnTo(new URLSearchParams(location.search).get("returnTo")) ??
+  (location.pathname === LOGIN_PATH
+    ? null
+    : safeReturnTo(`${location.pathname}${location.search}`)) ??
+  "/";

--- a/apps/host-selfhost/web/login.tsx
+++ b/apps/host-selfhost/web/login.tsx
@@ -6,7 +6,7 @@ import { Label } from "@executor-js/react/components/label";
 
 import { authClient } from "./auth-client";
 import { AuthLayout } from "./auth-layout";
-import { mcpAuthorizeResumeTarget, safeReturnTo } from "../src/auth/return-to";
+import { postLoginTarget } from "../src/auth/return-to";
 
 // Self-host login: email + password sign-in via Better Auth. On success we
 // reload so the shared AuthProvider re-reads /account/me and the AuthGate swaps
@@ -17,15 +17,10 @@ import { mcpAuthorizeResumeTarget, safeReturnTo } from "../src/auth/return-to";
 // redeeming an invite — either the full /join/<code> link, or by entering the
 // code here ("Have an invite code?"), which forwards to the same join page.
 export const LoginPage = () => {
-  const search = window.location.search;
-  // Where to go after sign-in: resume an interrupted MCP OAuth authorize if we
-  // arrived from one (Better Auth redirects it here with the OAuth params),
-  // otherwise honor a safe returnTo (e.g. an integration OAuth callback), else
-  // land on the dashboard.
-  const postLogin =
-    mcpAuthorizeResumeTarget(search) ??
-    safeReturnTo(new URLSearchParams(search).get("returnTo")) ??
-    "/";
+  // Where to go after sign-in. The gate renders this page IN PLACE of the
+  // requested route without navigating, so the live location is what carries a
+  // deep link (`/connect/linear`) across sign-in — see `postLoginTarget`.
+  const postLogin = postLoginTarget(window.location);
   const [mode, setMode] = useState<"signin" | "code">("signin");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");

--- a/apps/host-selfhost/web/routeTree.gen.ts
+++ b/apps/host-selfhost/web/routeTree.gen.ts
@@ -20,6 +20,7 @@ import { Route as JoinDotcodeRouteImport } from './routes/public/join.$code'
 import { Route as DotDotDotDotDotDotDotDotPackagesReactSrcRoutesToolkitsDottoolkitSlugRouteImport } from './../../../packages/react/src/routes/toolkits.$toolkitSlug'
 import { Route as DotDotDotDotDotDotDotDotPackagesReactSrcRoutesResumeDotexecutionIdRouteImport } from './../../../packages/react/src/routes/resume.$executionId'
 import { Route as DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIntegrationsDotnamespaceRouteImport } from './../../../packages/react/src/routes/integrations.$namespace'
+import { Route as DotDotDotDotDotDotDotDotPackagesReactSrcRoutesConnectDotintegrationSlugRouteImport } from './../../../packages/react/src/routes/connect.$integrationSlug'
 import { Route as DotDotDotDotDotDotDotDotPackagesReactSrcRoutesPluginsDotpluginIdDotsplatRouteImport } from './../../../packages/react/src/routes/plugins.$pluginId.$'
 import { Route as DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIntegrationsDotaddDotpluginKeyRouteImport } from './../../../packages/react/src/routes/integrations.add.$pluginKey'
 
@@ -93,6 +94,14 @@ const DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIntegrationsDotnamespaceRout
       getParentRoute: () => rootRouteImport,
     } as any,
   )
+const DotDotDotDotDotDotDotDotPackagesReactSrcRoutesConnectDotintegrationSlugRoute =
+  DotDotDotDotDotDotDotDotPackagesReactSrcRoutesConnectDotintegrationSlugRouteImport.update(
+    {
+      id: '/{-$orgSlug}/connect/$integrationSlug',
+      path: '/{-$orgSlug}/connect/$integrationSlug',
+      getParentRoute: () => rootRouteImport,
+    } as any,
+  )
 const DotDotDotDotDotDotDotDotPackagesReactSrcRoutesPluginsDotpluginIdDotsplatRoute =
   DotDotDotDotDotDotDotDotPackagesReactSrcRoutesPluginsDotpluginIdDotsplatRouteImport.update(
     {
@@ -119,6 +128,7 @@ export interface FileRoutesByFullPath {
   '/{-$orgSlug}/toolkits': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesToolkitsRouteWithChildren
   '/{-$orgSlug}/tools': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesToolsRoute
   '/{-$orgSlug}/': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIndexRoute
+  '/{-$orgSlug}/connect/$integrationSlug': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesConnectDotintegrationSlugRoute
   '/{-$orgSlug}/integrations/$namespace': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIntegrationsDotnamespaceRoute
   '/{-$orgSlug}/resume/$executionId': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesResumeDotexecutionIdRoute
   '/{-$orgSlug}/toolkits/$toolkitSlug': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesToolkitsDottoolkitSlugRoute
@@ -134,6 +144,7 @@ export interface FileRoutesByTo {
   '/{-$orgSlug}/toolkits': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesToolkitsRouteWithChildren
   '/{-$orgSlug}/tools': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesToolsRoute
   '/{-$orgSlug}': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIndexRoute
+  '/{-$orgSlug}/connect/$integrationSlug': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesConnectDotintegrationSlugRoute
   '/{-$orgSlug}/integrations/$namespace': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIntegrationsDotnamespaceRoute
   '/{-$orgSlug}/resume/$executionId': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesResumeDotexecutionIdRoute
   '/{-$orgSlug}/toolkits/$toolkitSlug': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesToolkitsDottoolkitSlugRoute
@@ -150,6 +161,7 @@ export interface FileRoutesById {
   '/{-$orgSlug}/toolkits': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesToolkitsRouteWithChildren
   '/{-$orgSlug}/tools': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesToolsRoute
   '/{-$orgSlug}/': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIndexRoute
+  '/{-$orgSlug}/connect/$integrationSlug': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesConnectDotintegrationSlugRoute
   '/{-$orgSlug}/integrations/$namespace': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIntegrationsDotnamespaceRoute
   '/{-$orgSlug}/resume/$executionId': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesResumeDotexecutionIdRoute
   '/{-$orgSlug}/toolkits/$toolkitSlug': typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesToolkitsDottoolkitSlugRoute
@@ -167,6 +179,7 @@ export interface FileRouteTypes {
     | '/{-$orgSlug}/toolkits'
     | '/{-$orgSlug}/tools'
     | '/{-$orgSlug}/'
+    | '/{-$orgSlug}/connect/$integrationSlug'
     | '/{-$orgSlug}/integrations/$namespace'
     | '/{-$orgSlug}/resume/$executionId'
     | '/{-$orgSlug}/toolkits/$toolkitSlug'
@@ -182,6 +195,7 @@ export interface FileRouteTypes {
     | '/{-$orgSlug}/toolkits'
     | '/{-$orgSlug}/tools'
     | '/{-$orgSlug}'
+    | '/{-$orgSlug}/connect/$integrationSlug'
     | '/{-$orgSlug}/integrations/$namespace'
     | '/{-$orgSlug}/resume/$executionId'
     | '/{-$orgSlug}/toolkits/$toolkitSlug'
@@ -197,6 +211,7 @@ export interface FileRouteTypes {
     | '/{-$orgSlug}/toolkits'
     | '/{-$orgSlug}/tools'
     | '/{-$orgSlug}/'
+    | '/{-$orgSlug}/connect/$integrationSlug'
     | '/{-$orgSlug}/integrations/$namespace'
     | '/{-$orgSlug}/resume/$executionId'
     | '/{-$orgSlug}/toolkits/$toolkitSlug'
@@ -213,6 +228,7 @@ export interface RootRouteChildren {
   DotDotDotDotDotDotDotDotPackagesReactSrcRoutesToolkitsRoute: typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesToolkitsRouteWithChildren
   DotDotDotDotDotDotDotDotPackagesReactSrcRoutesToolsRoute: typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesToolsRoute
   DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIndexRoute: typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIndexRoute
+  DotDotDotDotDotDotDotDotPackagesReactSrcRoutesConnectDotintegrationSlugRoute: typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesConnectDotintegrationSlugRoute
   DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIntegrationsDotnamespaceRoute: typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIntegrationsDotnamespaceRoute
   DotDotDotDotDotDotDotDotPackagesReactSrcRoutesResumeDotexecutionIdRoute: typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesResumeDotexecutionIdRoute
   DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIntegrationsDotaddDotpluginKeyRoute: typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIntegrationsDotaddDotpluginKeyRoute
@@ -298,6 +314,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIntegrationsDotnamespaceRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/{-$orgSlug}/connect/$integrationSlug': {
+      id: '/{-$orgSlug}/connect/$integrationSlug'
+      path: '/{-$orgSlug}/connect/$integrationSlug'
+      fullPath: '/{-$orgSlug}/connect/$integrationSlug'
+      preLoaderRoute: typeof DotDotDotDotDotDotDotDotPackagesReactSrcRoutesConnectDotintegrationSlugRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/{-$orgSlug}/plugins/$pluginId/$': {
       id: '/{-$orgSlug}/plugins/$pluginId/$'
       path: '/{-$orgSlug}/plugins/$pluginId/$'
@@ -344,6 +367,8 @@ const rootRouteChildren: RootRouteChildren = {
     DotDotDotDotDotDotDotDotPackagesReactSrcRoutesToolsRoute,
   DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIndexRoute:
     DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIndexRoute,
+  DotDotDotDotDotDotDotDotPackagesReactSrcRoutesConnectDotintegrationSlugRoute:
+    DotDotDotDotDotDotDotDotPackagesReactSrcRoutesConnectDotintegrationSlugRoute,
   DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIntegrationsDotnamespaceRoute:
     DotDotDotDotDotDotDotDotPackagesReactSrcRoutesIntegrationsDotnamespaceRoute,
   DotDotDotDotDotDotDotDotPackagesReactSrcRoutesResumeDotexecutionIdRoute:

--- a/e2e/scenarios/connect-deep-link.test.ts
+++ b/e2e/scenarios/connect-deep-link.test.ts
@@ -1,0 +1,168 @@
+// The connect deep link: a customer sends an end user a direct link for ONE
+// integration ("connect your Linear") instead of pointing them at the dashboard
+// to hunt for it. `/connect/<integration slug>` resolves the slug against the
+// tenant's catalog and lands the person in the SAME connect flow the
+// integration detail page's own button opens.
+//
+// The slug — not a plugin id — is the stable identity here: it is what a
+// customer can write down and template into an email.
+//
+// Covered:
+//   1. Signed in, known slug  → the Add connection flow is open on the right
+//      integration, with the auth methods the spec declares
+//   2. Unknown slug           → a clear not-found state, not a blank page or a
+//      crash (an end user WILL mistype these, and links outlive integrations)
+//   3. Already connected      → the deep link shows the existing connection and
+//      still offers to add another account
+import { randomBytes, randomUUID } from "node:crypto";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import { AccountHttpApi } from "@executor-js/api";
+import { composePluginApi } from "@executor-js/api/server";
+import { openApiHttpPlugin } from "@executor-js/plugin-openapi/api";
+import {
+  AuthTemplateSlug,
+  ConnectionName,
+  IntegrationSlug,
+  ProviderItemId,
+} from "@executor-js/sdk/shared";
+
+import { scenario } from "../src/scenario";
+import { Api, Browser, Target } from "../src/services";
+
+const api = composePluginApi([openApiHttpPlugin()] as const);
+
+/** OpenAPI 3 spec with a single operation — enough to be a real catalog entry. */
+const greetSpec = (baseUrl: string): string =>
+  JSON.stringify({
+    openapi: "3.0.3",
+    info: { title: "Deep Link API", version: "1.0.0" },
+    servers: [{ url: baseUrl }],
+    paths: {
+      "/greet": {
+        get: {
+          operationId: "getGreeting",
+          summary: "Return a greeting message",
+          responses: { "200": { description: "A greeting" } },
+        },
+      },
+    },
+  });
+
+scenario(
+  "Connect · /connect/<slug> lands an end user in that integration's connect flow",
+  { timeout: 180_000 },
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const browser = yield* Browser;
+    const { client } = yield* Api;
+
+    const identity = yield* target.newIdentity();
+    const apiClient = yield* client(api, identity);
+
+    // Selfhost shares one bootstrap-admin identity, so a unique slug keeps
+    // repeated and parallel runs out of each other's catalogs.
+    const slug = `connect-dl-${randomBytes(4).toString("hex")}`;
+    const specBaseUrl = "http://127.0.0.1:59999"; // never contacted here
+
+    // Org-scoped hosts canonicalize console URLs onto the active org's slug, so
+    // the deep link may legitimately arrive at either `/connect/x` or
+    // `/<org>/connect/x`. Read the slug the shell will canonicalize onto.
+    const accountClient = yield* client(AccountHttpApi, identity);
+    const me = yield* accountClient.account.me();
+    const orgSlug = me.organization?.slug ?? null;
+    const detailPath = orgSlug ? `/${orgSlug}/integrations/${slug}` : `/integrations/${slug}`;
+
+    yield* Effect.ensuring(
+      Effect.gen(function* () {
+        const added = yield* apiClient.openapi.addSpec({
+          payload: {
+            spec: { kind: "blob", value: greetSpec(specBaseUrl) },
+            slug,
+            name: "Deep Link API",
+            baseUrl: specBaseUrl,
+            authenticationTemplate: [
+              {
+                slug: "apiKey",
+                type: "apiKey",
+                headers: { "x-api-key": [{ type: "variable", name: "token" }] },
+              },
+            ],
+          },
+        });
+        expect(added.slug, "the integration keeps the requested slug").toBe(slug);
+
+        yield* browser.session(identity, async ({ page, step }) => {
+          await step("Open the connect deep link for the seeded integration", async () => {
+            await page.goto(`/connect/${slug}`, { waitUntil: "networkidle" });
+            // It forwards into the integration's OWN detail route rather than
+            // rendering a parallel connect UI, carrying the add-account handoff.
+            await page.waitForURL((url) => url.pathname === detailPath, { timeout: 30_000 });
+            expect(new URL(page.url()).searchParams.get("addAccount")).toBe("1");
+          });
+
+          await step("The Add connection flow is open for that integration", async () => {
+            await page
+              .getByRole("heading", { name: /Add connection/ })
+              .waitFor({ timeout: 20_000 });
+            // The right integration, and the declared auth method is offered —
+            // proof it resolved the slug rather than opening a generic dialog.
+            await page
+              .getByRole("dialog")
+              .getByRole("textbox", { name: "x-api-key" })
+              .waitFor({ timeout: 20_000 });
+          });
+
+          await step("An unknown slug is a clear not-found, not a blank page", async () => {
+            await page.goto("/connect/zz-no-such-integration", { waitUntil: "networkidle" });
+            await page
+              .getByText("Unknown integration: zz-no-such-integration")
+              .waitFor({ timeout: 30_000 });
+            await page.getByRole("link", { name: "Back to integrations" }).waitFor();
+          });
+        });
+
+        // Already connected: the deep link must show the existing connection
+        // and still let the person add another account.
+        const providers = yield* apiClient.providers.list();
+        expect(providers.length, "a credential provider is available").toBeGreaterThan(0);
+        yield* apiClient.connections.create({
+          payload: {
+            owner: "org",
+            name: ConnectionName.make("existing"),
+            integration: IntegrationSlug.make(slug),
+            template: AuthTemplateSlug.make("apiKey"),
+            from: { provider: providers[0]!, id: ProviderItemId.make(randomUUID()) },
+          },
+        });
+
+        yield* browser.session(identity, async ({ page, step }) => {
+          await step("The deep link surfaces the existing connection", async () => {
+            await page.goto(`/connect/${slug}`, { waitUntil: "networkidle" });
+            await page.waitForURL((url) => url.pathname === detailPath, { timeout: 30_000 });
+            // The connect flow still opens (this link means "connect me"), and
+            // the already-saved account is visible behind it.
+            await page
+              .getByRole("heading", { name: /Add connection/ })
+              .waitFor({ timeout: 20_000 });
+            await page.keyboard.press("Escape");
+            await page.getByText("existing").first().waitFor({ timeout: 20_000 });
+          });
+        });
+      }),
+      Effect.gen(function* () {
+        yield* apiClient.connections
+          .remove({
+            params: {
+              owner: "org",
+              integration: IntegrationSlug.make(slug),
+              name: ConnectionName.make("existing"),
+            },
+          })
+          .pipe(Effect.ignore);
+        yield* apiClient.openapi.removeSpec({ params: { slug } }).pipe(Effect.ignore);
+      }).pipe(Effect.ignore),
+    );
+  }),
+);

--- a/packages/app/src/routeTree.gen.ts
+++ b/packages/app/src/routeTree.gen.ts
@@ -17,6 +17,7 @@ import { Route as DotDotDotDotDotDotReactSrcRoutesPoliciesRouteImport } from './
 import { Route as DotDotDotDotDotDotReactSrcRoutesToolkitsDottoolkitSlugRouteImport } from './../../react/src/routes/toolkits.$toolkitSlug'
 import { Route as DotDotDotDotDotDotReactSrcRoutesResumeDotexecutionIdRouteImport } from './../../react/src/routes/resume.$executionId'
 import { Route as DotDotDotDotDotDotReactSrcRoutesIntegrationsDotnamespaceRouteImport } from './../../react/src/routes/integrations.$namespace'
+import { Route as DotDotDotDotDotDotReactSrcRoutesConnectDotintegrationSlugRouteImport } from './../../react/src/routes/connect.$integrationSlug'
 import { Route as DotDotDotDotDotDotReactSrcRoutesPluginsDotpluginIdDotsplatRouteImport } from './../../react/src/routes/plugins.$pluginId.$'
 import { Route as DotDotDotDotDotDotReactSrcRoutesIntegrationsDotaddDotpluginKeyRouteImport } from './../../react/src/routes/integrations.add.$pluginKey'
 
@@ -67,6 +68,12 @@ const DotDotDotDotDotDotReactSrcRoutesIntegrationsDotnamespaceRoute =
     path: '/{-$orgSlug}/integrations/$namespace',
     getParentRoute: () => rootRouteImport,
   } as any)
+const DotDotDotDotDotDotReactSrcRoutesConnectDotintegrationSlugRoute =
+  DotDotDotDotDotDotReactSrcRoutesConnectDotintegrationSlugRouteImport.update({
+    id: '/{-$orgSlug}/connect/$integrationSlug',
+    path: '/{-$orgSlug}/connect/$integrationSlug',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const DotDotDotDotDotDotReactSrcRoutesPluginsDotpluginIdDotsplatRoute =
   DotDotDotDotDotDotReactSrcRoutesPluginsDotpluginIdDotsplatRouteImport.update({
     id: '/{-$orgSlug}/plugins/$pluginId/$',
@@ -88,6 +95,7 @@ export interface FileRoutesByFullPath {
   '/{-$orgSlug}/toolkits': typeof DotDotDotDotDotDotReactSrcRoutesToolkitsRouteWithChildren
   '/{-$orgSlug}/tools': typeof DotDotDotDotDotDotReactSrcRoutesToolsRoute
   '/{-$orgSlug}/': typeof DotDotDotDotDotDotReactSrcRoutesIndexRoute
+  '/{-$orgSlug}/connect/$integrationSlug': typeof DotDotDotDotDotDotReactSrcRoutesConnectDotintegrationSlugRoute
   '/{-$orgSlug}/integrations/$namespace': typeof DotDotDotDotDotDotReactSrcRoutesIntegrationsDotnamespaceRoute
   '/{-$orgSlug}/resume/$executionId': typeof DotDotDotDotDotDotReactSrcRoutesResumeDotexecutionIdRoute
   '/{-$orgSlug}/toolkits/$toolkitSlug': typeof DotDotDotDotDotDotReactSrcRoutesToolkitsDottoolkitSlugRoute
@@ -100,6 +108,7 @@ export interface FileRoutesByTo {
   '/{-$orgSlug}/toolkits': typeof DotDotDotDotDotDotReactSrcRoutesToolkitsRouteWithChildren
   '/{-$orgSlug}/tools': typeof DotDotDotDotDotDotReactSrcRoutesToolsRoute
   '/{-$orgSlug}': typeof DotDotDotDotDotDotReactSrcRoutesIndexRoute
+  '/{-$orgSlug}/connect/$integrationSlug': typeof DotDotDotDotDotDotReactSrcRoutesConnectDotintegrationSlugRoute
   '/{-$orgSlug}/integrations/$namespace': typeof DotDotDotDotDotDotReactSrcRoutesIntegrationsDotnamespaceRoute
   '/{-$orgSlug}/resume/$executionId': typeof DotDotDotDotDotDotReactSrcRoutesResumeDotexecutionIdRoute
   '/{-$orgSlug}/toolkits/$toolkitSlug': typeof DotDotDotDotDotDotReactSrcRoutesToolkitsDottoolkitSlugRoute
@@ -113,6 +122,7 @@ export interface FileRoutesById {
   '/{-$orgSlug}/toolkits': typeof DotDotDotDotDotDotReactSrcRoutesToolkitsRouteWithChildren
   '/{-$orgSlug}/tools': typeof DotDotDotDotDotDotReactSrcRoutesToolsRoute
   '/{-$orgSlug}/': typeof DotDotDotDotDotDotReactSrcRoutesIndexRoute
+  '/{-$orgSlug}/connect/$integrationSlug': typeof DotDotDotDotDotDotReactSrcRoutesConnectDotintegrationSlugRoute
   '/{-$orgSlug}/integrations/$namespace': typeof DotDotDotDotDotDotReactSrcRoutesIntegrationsDotnamespaceRoute
   '/{-$orgSlug}/resume/$executionId': typeof DotDotDotDotDotDotReactSrcRoutesResumeDotexecutionIdRoute
   '/{-$orgSlug}/toolkits/$toolkitSlug': typeof DotDotDotDotDotDotReactSrcRoutesToolkitsDottoolkitSlugRoute
@@ -127,6 +137,7 @@ export interface FileRouteTypes {
     | '/{-$orgSlug}/toolkits'
     | '/{-$orgSlug}/tools'
     | '/{-$orgSlug}/'
+    | '/{-$orgSlug}/connect/$integrationSlug'
     | '/{-$orgSlug}/integrations/$namespace'
     | '/{-$orgSlug}/resume/$executionId'
     | '/{-$orgSlug}/toolkits/$toolkitSlug'
@@ -139,6 +150,7 @@ export interface FileRouteTypes {
     | '/{-$orgSlug}/toolkits'
     | '/{-$orgSlug}/tools'
     | '/{-$orgSlug}'
+    | '/{-$orgSlug}/connect/$integrationSlug'
     | '/{-$orgSlug}/integrations/$namespace'
     | '/{-$orgSlug}/resume/$executionId'
     | '/{-$orgSlug}/toolkits/$toolkitSlug'
@@ -151,6 +163,7 @@ export interface FileRouteTypes {
     | '/{-$orgSlug}/toolkits'
     | '/{-$orgSlug}/tools'
     | '/{-$orgSlug}/'
+    | '/{-$orgSlug}/connect/$integrationSlug'
     | '/{-$orgSlug}/integrations/$namespace'
     | '/{-$orgSlug}/resume/$executionId'
     | '/{-$orgSlug}/toolkits/$toolkitSlug'
@@ -164,6 +177,7 @@ export interface RootRouteChildren {
   DotDotDotDotDotDotReactSrcRoutesToolkitsRoute: typeof DotDotDotDotDotDotReactSrcRoutesToolkitsRouteWithChildren
   DotDotDotDotDotDotReactSrcRoutesToolsRoute: typeof DotDotDotDotDotDotReactSrcRoutesToolsRoute
   DotDotDotDotDotDotReactSrcRoutesIndexRoute: typeof DotDotDotDotDotDotReactSrcRoutesIndexRoute
+  DotDotDotDotDotDotReactSrcRoutesConnectDotintegrationSlugRoute: typeof DotDotDotDotDotDotReactSrcRoutesConnectDotintegrationSlugRoute
   DotDotDotDotDotDotReactSrcRoutesIntegrationsDotnamespaceRoute: typeof DotDotDotDotDotDotReactSrcRoutesIntegrationsDotnamespaceRoute
   DotDotDotDotDotDotReactSrcRoutesResumeDotexecutionIdRoute: typeof DotDotDotDotDotDotReactSrcRoutesResumeDotexecutionIdRoute
   DotDotDotDotDotDotReactSrcRoutesIntegrationsDotaddDotpluginKeyRoute: typeof DotDotDotDotDotDotReactSrcRoutesIntegrationsDotaddDotpluginKeyRoute
@@ -228,6 +242,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DotDotDotDotDotDotReactSrcRoutesIntegrationsDotnamespaceRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/{-$orgSlug}/connect/$integrationSlug': {
+      id: '/{-$orgSlug}/connect/$integrationSlug'
+      path: '/{-$orgSlug}/connect/$integrationSlug'
+      fullPath: '/{-$orgSlug}/connect/$integrationSlug'
+      preLoaderRoute: typeof DotDotDotDotDotDotReactSrcRoutesConnectDotintegrationSlugRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/{-$orgSlug}/plugins/$pluginId/$': {
       id: '/{-$orgSlug}/plugins/$pluginId/$'
       path: '/{-$orgSlug}/plugins/$pluginId/$'
@@ -270,6 +291,8 @@ const rootRouteChildren: RootRouteChildren = {
     DotDotDotDotDotDotReactSrcRoutesToolsRoute,
   DotDotDotDotDotDotReactSrcRoutesIndexRoute:
     DotDotDotDotDotDotReactSrcRoutesIndexRoute,
+  DotDotDotDotDotDotReactSrcRoutesConnectDotintegrationSlugRoute:
+    DotDotDotDotDotDotReactSrcRoutesConnectDotintegrationSlugRoute,
   DotDotDotDotDotDotReactSrcRoutesIntegrationsDotnamespaceRoute:
     DotDotDotDotDotDotReactSrcRoutesIntegrationsDotnamespaceRoute,
   DotDotDotDotDotDotReactSrcRoutesResumeDotexecutionIdRoute:

--- a/packages/core/api/src/account/org-slug.test.ts
+++ b/packages/core/api/src/account/org-slug.test.ts
@@ -57,7 +57,20 @@ describe("isValidOrgSlug", () => {
   });
 
   it("reserves the segments routing depends on", () => {
-    for (const critical of ["api", "mcp", "integrations", "policies", "login", "cdn-cgi"]) {
+    for (const critical of [
+      "api",
+      "mcp",
+      "integrations",
+      "policies",
+      "login",
+      "cdn-cgi",
+      // The connect deep link's root. Cloud's post-auth callback reads the
+      // first path segment as an org selector, so leaving `connect` claimable
+      // made `/connect/<slug>` look like a request for an org named "connect"
+      // — which suppressed the active-membership fallback and could drop the
+      // deep link into org onboarding after sign-in.
+      "connect",
+    ]) {
       expect(RESERVED_ORG_SLUGS.has(critical), critical).toBe(true);
     }
   });

--- a/packages/core/api/src/account/org-slug.ts
+++ b/packages/core/api/src/account/org-slug.ts
@@ -17,8 +17,8 @@ const ORG_SLUG_PATTERN = /^[a-z0-9](?:[a-z0-9]|-(?=[a-z0-9])){1,47}$/;
  * predictably will):
  *  - App planes:        api, mcp, .well-known (cloud `app-paths.ts`, selfhost
  *                       envelope, cloudflare `run_worker_first`)
- *  - Console routes:    integrations, policies, secrets, tools, resume,
- *                       plugins (the shared contract), plus host extras:
+ *  - Console routes:    connect, integrations, policies, secrets, tools,
+ *                       resume, plugins (the shared contract), plus host extras:
  *                       api-keys, org, billing, create-org, setup-mcp (cloud),
  *                       admin, join, docs (selfhost), login (Better Auth
  *                       `mcp({ loginPage })` + cloud/selfhost login UX)
@@ -41,6 +41,7 @@ export const RESERVED_ORG_SLUGS: ReadonlySet<string> = new Set([
   "mcp",
   ".well-known",
   // console + host routes
+  "connect",
   "integrations",
   "policies",
   "secrets",

--- a/packages/react/src/console-routes.ts
+++ b/packages/react/src/console-routes.ts
@@ -34,6 +34,7 @@ export const ORG_SLUG_SEGMENT = "{-$orgSlug}";
  *  are these paths prefixed with `/{-$orgSlug}`. */
 export const CONSOLE_ROUTE_PATHS = [
   "/",
+  "/connect/$integrationSlug",
   "/integrations/$namespace",
   "/integrations/add/$pluginKey",
   "/policies",
@@ -62,6 +63,10 @@ export const consoleRoutes = (options: ConsoleRoutesOptions): Array<VirtualRoute
   const file = (name: string): string => `${options.dir}/${name}`;
   const entries: ReadonlyArray<readonly [ConsoleRoutePath, VirtualRouteNode]> = [
     ["/", index(file("index.tsx"))],
+    [
+      "/connect/$integrationSlug",
+      route("/connect/$integrationSlug", file("connect.$integrationSlug.tsx")),
+    ],
     [
       "/integrations/$namespace",
       route("/integrations/$namespace", file("integrations.$namespace.tsx")),

--- a/packages/react/src/pages/connect-integration.tsx
+++ b/packages/react/src/pages/connect-integration.tsx
@@ -1,0 +1,109 @@
+import { useEffect } from "react";
+import { Link, useNavigate } from "@tanstack/react-router";
+import { useAtomValue, useAtomRefresh } from "@effect/atom-react";
+import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
+import { IntegrationSlug } from "@executor-js/sdk/shared";
+
+import { integrationAtom, integrationsOptimisticAtom } from "../api/atoms";
+import { ErrorState } from "../components/error-state";
+import { Skeleton } from "../components/skeleton";
+import { isAsyncResultLoading } from "../lib/async-result";
+import { useExecutorDocumentTitle } from "../lib/document-title";
+
+// ---------------------------------------------------------------------------
+// `/connect/<integration slug>` — the stable, shareable deep link that drops a
+// person straight into the connect flow for ONE integration ("connect your
+// Linear") instead of the dashboard.
+//
+// This page owns no connect UI of its own. It resolves the slug against the
+// tenant's catalog and forwards into the integration detail page's existing
+// account handoff (`?addAccount=1`), which is the same surface the detail
+// page's own "Add connection" button opens — multi-method tab strips, OAuth
+// popups, existing-connection lists and "add another account" all come for
+// free, and stay correct as that flow evolves.
+//
+// Deliberately keyed on the INTEGRATION SLUG, not a plugin id: the slug is the
+// catalog identity a customer can write down, whereas plugin routes are on
+// their way out. The redirect is `replace: true` so the deep link does not
+// linger in history and Back leaves the connect flow rather than bouncing.
+// ---------------------------------------------------------------------------
+
+export function ConnectIntegrationPage(props: { readonly integrationSlug: string }) {
+  const { integrationSlug } = props;
+  const slug = IntegrationSlug.make(integrationSlug);
+  const integration = useAtomValue(integrationAtom(slug));
+  const refreshIntegrations = useAtomRefresh(integrationsOptimisticAtom);
+  const navigate = useNavigate();
+
+  useExecutorDocumentTitle("Connect");
+
+  // The catalog read is a client-side find over the integrations list, so an
+  // unknown slug resolves to Success(null) rather than a failure — the missing
+  // case is a not-found state, and only a genuine fetch failure is an error.
+  const resolved = AsyncResult.isSuccess(integration) ? integration.value : null;
+  const loading = isAsyncResultLoading(integration);
+  const failed = AsyncResult.isFailure(integration);
+  const missing = !loading && !failed && resolved === null;
+
+  useEffect(() => {
+    if (resolved === null) return;
+    void navigate({
+      to: "/{-$orgSlug}/integrations/$namespace",
+      params: { namespace: String(resolved.slug) },
+      // The NUMBER 1, so the router serializes the canonical `?addAccount=1`
+      // that agent-generated handoff links already use (a string would be
+      // quoted as `%221%22`).
+      search: { tab: "accounts", addAccount: 1 },
+      replace: true,
+    });
+  }, [resolved, navigate]);
+
+  if (failed) {
+    return (
+      <ConnectStateFrame>
+        <ErrorState message="Failed to load integrations" onRetry={refreshIntegrations} />
+      </ConnectStateFrame>
+    );
+  }
+
+  if (missing) {
+    return (
+      <ConnectStateFrame>
+        <div className="flex flex-col items-center justify-center rounded-2xl border border-dashed border-border py-20">
+          <p className="mb-1 text-sm font-medium text-foreground/70">
+            Unknown integration: {integrationSlug}
+          </p>
+          <p className="mb-5 text-xs text-muted-foreground">
+            This integration is not in your workspace.
+          </p>
+          <Link
+            to="/{-$orgSlug}"
+            className="inline-flex items-center gap-1.5 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+          >
+            Back to integrations
+          </Link>
+        </div>
+      </ConnectStateFrame>
+    );
+  }
+
+  // Loading, or resolved and mid-redirect: the same quiet placeholder, so the
+  // hand-off never flashes an empty frame between catalog load and navigation.
+  return (
+    <ConnectStateFrame>
+      <div className="space-y-3">
+        <Skeleton className="h-8 w-56" />
+        <Skeleton className="h-4 w-80" />
+        <Skeleton className="h-32 w-full" />
+      </div>
+    </ConnectStateFrame>
+  );
+}
+
+function ConnectStateFrame(props: { readonly children: React.ReactNode }) {
+  return (
+    <div className="relative min-h-0 flex-1 overflow-y-auto">
+      <div className="mx-auto max-w-4xl px-6 py-10 lg:px-10 lg:py-14">{props.children}</div>
+    </div>
+  );
+}

--- a/packages/react/src/pages/integration-detail.tsx
+++ b/packages/react/src/pages/integration-detail.tsx
@@ -60,6 +60,10 @@ type ToolRow = {
 export function IntegrationDetailPage(props: {
   namespace: string;
   tab?: IntegrationDetailSearchTab;
+  /** Route-validated `addAccount=1`: open the add-connection flow on arrival.
+   *  Set by the `/connect/<slug>` deep link, which navigates client-side and so
+   *  cannot rely on the raw location search below. */
+  addAccount?: boolean;
 }) {
   const { namespace } = props;
   const slug = IntegrationSlug.make(namespace);
@@ -122,9 +126,11 @@ export function IntegrationDetailPage(props: {
   const canRefresh = integrationData?.canRefresh ?? false;
   const canRemove = integrationData?.canRemove ?? false;
   const urlAccountHandoff = useMemo<IntegrationAccountHandoff | null>(() => {
-    if (locationSearch.length === 0) return null;
     const search = new URLSearchParams(locationSearch);
-    if (search.get("addAccount") !== "1") return null;
+    // The route-validated flag and the raw `addAccount=1` are the same request;
+    // either one opens the flow. The extra prefill fields below are read from
+    // the raw search, which is populated on the full page loads that carry them.
+    if (!props.addAccount && search.get("addAccount") !== "1") return null;
     const owner = search.get("owner");
     const template = search.get("template");
     const label = search.get("label");
@@ -149,13 +155,13 @@ export function IntegrationDetailPage(props: {
       };
     })();
     return {
-      key: locationSearch,
+      key: `${String(props.addAccount)}:${locationSearch}`,
       ...(owner === "org" || owner === "user" ? { owner } : {}),
       ...(template != null && template.length > 0 ? { template } : {}),
       ...(label != null && label.length > 0 ? { label } : {}),
       ...(oauthClient !== undefined ? { oauthClient } : {}),
     };
-  }, [locationSearch]);
+  }, [locationSearch, props.addAccount]);
   const accountHandoff = manualAccountHandoff ?? urlAccountHandoff;
 
   useEffect(() => {

--- a/packages/react/src/routes/connect-deep-link.test.ts
+++ b/packages/react/src/routes/connect-deep-link.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "@effect/vitest";
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from "@tanstack/react-router";
+
+import { CONSOLE_ROUTE_PATHS } from "../console-routes";
+import { isAddAccountRequested } from "./integrations.$namespace";
+
+// Routing semantics of the `/connect/<integration slug>` deep link — the URL a
+// customer hands to an end user ("connect your Linear"). The page component is
+// exercised end-to-end in e2e/scenarios/connect-deep-link.test.ts; this locks
+// the URL contract itself: which shapes match, what the params resolve to, and
+// that the org-slug prefix round-trips.
+
+type RouteMatch = { readonly routeId: string; readonly params: Record<string, string> };
+type SpikeRouter = {
+  matchRoutes(pathname: string): ReadonlyArray<RouteMatch>;
+  buildLocation(options: unknown): { readonly href: string };
+};
+
+const CONNECT_ROUTE_ID = "/{-$orgSlug}/connect/$integrationSlug";
+
+const make = (): SpikeRouter => {
+  const rootRoute = createRootRoute();
+  const orgScope = createRoute({ getParentRoute: () => rootRoute, path: "/{-$orgSlug}" });
+  const indexRoute = createRoute({ getParentRoute: () => orgScope, path: "/" });
+  const connectRoute = createRoute({
+    getParentRoute: () => orgScope,
+    path: "/connect/$integrationSlug",
+  });
+  const nsRoute = createRoute({
+    getParentRoute: () => orgScope,
+    path: "/integrations/$namespace",
+  });
+  const routeTree = rootRoute.addChildren([
+    orgScope.addChildren([indexRoute, connectRoute, nsRoute]),
+  ]);
+  // A test-local tree is not the package's registered console tree, so widen
+  // away the global Register types — this asserts runtime semantics.
+  // oxlint-disable-next-line executor/no-double-cast -- boundary: a test-local route tree must escape the package-global router Register types
+  return createRouter({
+    routeTree,
+    history: createMemoryHistory({ initialEntries: ["/"] }),
+  }) as unknown as SpikeRouter;
+};
+
+describe("connect deep link", () => {
+  it("is part of the shared console route contract", () => {
+    // Every host mounts the contract, so the deep link exists on cloud,
+    // self-host, cloudflare and local alike.
+    expect(CONSOLE_ROUTE_PATHS).toContain("/connect/$integrationSlug");
+  });
+
+  it("matches the bare link owner.com would generate", () => {
+    const matches = make().matchRoutes("/connect/linear");
+    const match = matches.find((m) => m.routeId === CONNECT_ROUTE_ID);
+    expect(match?.params).toEqual({ integrationSlug: "linear" });
+  });
+
+  it("matches the org-prefixed form without eating the slug", () => {
+    const matches = make().matchRoutes("/acme/connect/linear");
+    const match = matches.find((m) => m.routeId === CONNECT_ROUTE_ID);
+    expect(match?.params).toEqual({ orgSlug: "acme", integrationSlug: "linear" });
+  });
+
+  it("keeps slugs that look like other console words intact", () => {
+    // The integration slug is a free-form catalog id; "tools" or "integrations"
+    // as a slug must still land on connect, not on those pages.
+    for (const slug of ["tools", "integrations", "connect"]) {
+      const match = make()
+        .matchRoutes(`/connect/${slug}`)
+        .find((m) => m.routeId === CONNECT_ROUTE_ID);
+      expect(match?.params).toEqual({ integrationSlug: slug });
+    }
+  });
+
+  it("builds the link with and without an org slug", () => {
+    const router = make();
+    expect(
+      router.buildLocation({ to: CONNECT_ROUTE_ID, params: { integrationSlug: "linear" } }).href,
+    ).toBe("/connect/linear");
+    expect(
+      router.buildLocation({
+        to: CONNECT_ROUTE_ID,
+        params: { orgSlug: "acme", integrationSlug: "linear" },
+      }).href,
+    ).toBe("/acme/connect/linear");
+  });
+
+  it("forwards into the integration's existing connect flow", () => {
+    // The page redirects here rather than rendering its own connect UI; the
+    // handoff is carried as validated search so it survives client navigation.
+    // The number 1 keeps the canonical `?addAccount=1` that agent-generated
+    // handoff links already use — a string would serialize as `%221%22`.
+    const href = make().buildLocation({
+      to: "/{-$orgSlug}/integrations/$namespace",
+      params: { namespace: "linear" },
+      search: { tab: "accounts", addAccount: 1 },
+    }).href;
+    expect(href).toBe("/integrations/linear?tab=accounts&addAccount=1");
+  });
+});
+
+describe("addAccount flag", () => {
+  it("accepts every spelling the two link sources produce", () => {
+    // A full page load parses `?addAccount=1` to the number; a client-side
+    // navigation may carry the string. Both mean "open the connect flow".
+    expect(isAddAccountRequested(1)).toBe(true);
+    expect(isAddAccountRequested("1")).toBe(true);
+    expect(isAddAccountRequested(true)).toBe(true);
+  });
+
+  it("ignores anything else instead of failing the page", () => {
+    for (const value of [undefined, null, 0, "0", "", "banana", {}]) {
+      expect(isAddAccountRequested(value)).toBe(false);
+    }
+  });
+});

--- a/packages/react/src/routes/connect-deep-link.test.ts
+++ b/packages/react/src/routes/connect-deep-link.test.ts
@@ -54,7 +54,7 @@ describe("connect deep link", () => {
     expect(CONSOLE_ROUTE_PATHS).toContain("/connect/$integrationSlug");
   });
 
-  it("matches the bare link owner.com would generate", () => {
+  it("matches the bare link a customer would generate", () => {
     const matches = make().matchRoutes("/connect/linear");
     const match = matches.find((m) => m.routeId === CONNECT_ROUTE_ID);
     expect(match?.params).toEqual({ integrationSlug: "linear" });

--- a/packages/react/src/routes/connect.$integrationSlug.tsx
+++ b/packages/react/src/routes/connect.$integrationSlug.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { ConnectIntegrationPage } from "../pages/connect-integration";
+
+export const Route = createFileRoute("/{-$orgSlug}/connect/$integrationSlug")({
+  component: () => {
+    const { integrationSlug } = Route.useParams();
+    return <ConnectIntegrationPage integrationSlug={integrationSlug} />;
+  },
+});

--- a/packages/react/src/routes/integrations.$namespace.tsx
+++ b/packages/react/src/routes/integrations.$namespace.tsx
@@ -4,21 +4,40 @@ import { createFileRoute } from "@tanstack/react-router";
 import { IntegrationDetailPage } from "../pages/integration-detail";
 import type { IntegrationDetailSearchTab } from "../lib/integration-detail-tabs";
 
+// `addAccount=1` opens the add-connection flow on arrival. It is declared here
+// (rather than only read off `window.location`) because unlisted keys do not
+// survive validation: a CLIENT-SIDE navigation carrying the handoff — the
+// `/connect/<slug>` deep link — would otherwise have it stripped before the
+// page could see it. The richer handoff fields stay URL-only; they arrive on
+// full page loads from agent-generated links.
+//
+// Typed as unknown and coerced, not as a literal, for two reasons. A URL flag
+// must never hard-fail a page: a hand-edited `?addAccount=banana` should be
+// ignored, not rendered as a validation error. And the router's search
+// serializer quotes a string "1" (`addAccount=%221%22`) while leaving the
+// number 1 bare, so accepting both is what keeps ONE canonical URL —
+// `?addAccount=1` — shared by deep links and agent-generated handoff links.
 const SearchParams = Schema.toStandardSchemaV1(
   Schema.Struct({
     tab: Schema.optional(Schema.Literals(["accounts", "source", "tools"])),
+    addAccount: Schema.optional(Schema.Unknown),
   }),
 );
+
+/** The truthy spellings of the `addAccount` URL flag. */
+export const isAddAccountRequested = (value: unknown): boolean =>
+  value === 1 || value === "1" || value === true;
 
 export const Route = createFileRoute("/{-$orgSlug}/integrations/$namespace")({
   validateSearch: SearchParams,
   component: () => {
     const { namespace } = Route.useParams();
-    const { tab } = Route.useSearch();
+    const { tab, addAccount } = Route.useSearch();
     return (
       <IntegrationDetailPage
         namespace={namespace}
         tab={tab as IntegrationDetailSearchTab | undefined}
+        addAccount={isAddAccountRequested(addAccount)}
       />
     );
   },

--- a/packages/react/src/routes/routeTree.gen.ts
+++ b/packages/react/src/routes/routeTree.gen.ts
@@ -17,6 +17,7 @@ import { Route as DotPoliciesRouteImport } from './policies'
 import { Route as DotToolkitsDottoolkitSlugRouteImport } from './toolkits.$toolkitSlug'
 import { Route as DotResumeDotexecutionIdRouteImport } from './resume.$executionId'
 import { Route as DotIntegrationsDotnamespaceRouteImport } from './integrations.$namespace'
+import { Route as DotConnectDotintegrationSlugRouteImport } from './connect.$integrationSlug'
 import { Route as DotPluginsDotpluginIdDotsplatRouteImport } from './plugins.$pluginId.$'
 import { Route as DotIntegrationsDotaddDotpluginKeyRouteImport } from './integrations.add.$pluginKey'
 
@@ -62,6 +63,12 @@ const DotIntegrationsDotnamespaceRoute =
     path: '/{-$orgSlug}/integrations/$namespace',
     getParentRoute: () => rootRouteImport,
   } as any)
+const DotConnectDotintegrationSlugRoute =
+  DotConnectDotintegrationSlugRouteImport.update({
+    id: '/{-$orgSlug}/connect/$integrationSlug',
+    path: '/{-$orgSlug}/connect/$integrationSlug',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const DotPluginsDotpluginIdDotsplatRoute =
   DotPluginsDotpluginIdDotsplatRouteImport.update({
     id: '/{-$orgSlug}/plugins/$pluginId/$',
@@ -81,6 +88,7 @@ export interface FileRoutesByFullPath {
   '/{-$orgSlug}/toolkits': typeof DotToolkitsRouteWithChildren
   '/{-$orgSlug}/tools': typeof DotToolsRoute
   '/{-$orgSlug}/': typeof DotIndexRoute
+  '/{-$orgSlug}/connect/$integrationSlug': typeof DotConnectDotintegrationSlugRoute
   '/{-$orgSlug}/integrations/$namespace': typeof DotIntegrationsDotnamespaceRoute
   '/{-$orgSlug}/resume/$executionId': typeof DotResumeDotexecutionIdRoute
   '/{-$orgSlug}/toolkits/$toolkitSlug': typeof DotToolkitsDottoolkitSlugRoute
@@ -93,6 +101,7 @@ export interface FileRoutesByTo {
   '/{-$orgSlug}/toolkits': typeof DotToolkitsRouteWithChildren
   '/{-$orgSlug}/tools': typeof DotToolsRoute
   '/{-$orgSlug}': typeof DotIndexRoute
+  '/{-$orgSlug}/connect/$integrationSlug': typeof DotConnectDotintegrationSlugRoute
   '/{-$orgSlug}/integrations/$namespace': typeof DotIntegrationsDotnamespaceRoute
   '/{-$orgSlug}/resume/$executionId': typeof DotResumeDotexecutionIdRoute
   '/{-$orgSlug}/toolkits/$toolkitSlug': typeof DotToolkitsDottoolkitSlugRoute
@@ -106,6 +115,7 @@ export interface FileRoutesById {
   '/{-$orgSlug}/toolkits': typeof DotToolkitsRouteWithChildren
   '/{-$orgSlug}/tools': typeof DotToolsRoute
   '/{-$orgSlug}/': typeof DotIndexRoute
+  '/{-$orgSlug}/connect/$integrationSlug': typeof DotConnectDotintegrationSlugRoute
   '/{-$orgSlug}/integrations/$namespace': typeof DotIntegrationsDotnamespaceRoute
   '/{-$orgSlug}/resume/$executionId': typeof DotResumeDotexecutionIdRoute
   '/{-$orgSlug}/toolkits/$toolkitSlug': typeof DotToolkitsDottoolkitSlugRoute
@@ -120,6 +130,7 @@ export interface FileRouteTypes {
     | '/{-$orgSlug}/toolkits'
     | '/{-$orgSlug}/tools'
     | '/{-$orgSlug}/'
+    | '/{-$orgSlug}/connect/$integrationSlug'
     | '/{-$orgSlug}/integrations/$namespace'
     | '/{-$orgSlug}/resume/$executionId'
     | '/{-$orgSlug}/toolkits/$toolkitSlug'
@@ -132,6 +143,7 @@ export interface FileRouteTypes {
     | '/{-$orgSlug}/toolkits'
     | '/{-$orgSlug}/tools'
     | '/{-$orgSlug}'
+    | '/{-$orgSlug}/connect/$integrationSlug'
     | '/{-$orgSlug}/integrations/$namespace'
     | '/{-$orgSlug}/resume/$executionId'
     | '/{-$orgSlug}/toolkits/$toolkitSlug'
@@ -144,6 +156,7 @@ export interface FileRouteTypes {
     | '/{-$orgSlug}/toolkits'
     | '/{-$orgSlug}/tools'
     | '/{-$orgSlug}/'
+    | '/{-$orgSlug}/connect/$integrationSlug'
     | '/{-$orgSlug}/integrations/$namespace'
     | '/{-$orgSlug}/resume/$executionId'
     | '/{-$orgSlug}/toolkits/$toolkitSlug'
@@ -157,6 +170,7 @@ export interface RootRouteChildren {
   DotToolkitsRoute: typeof DotToolkitsRouteWithChildren
   DotToolsRoute: typeof DotToolsRoute
   DotIndexRoute: typeof DotIndexRoute
+  DotConnectDotintegrationSlugRoute: typeof DotConnectDotintegrationSlugRoute
   DotIntegrationsDotnamespaceRoute: typeof DotIntegrationsDotnamespaceRoute
   DotResumeDotexecutionIdRoute: typeof DotResumeDotexecutionIdRoute
   DotIntegrationsDotaddDotpluginKeyRoute: typeof DotIntegrationsDotaddDotpluginKeyRoute
@@ -221,6 +235,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DotIntegrationsDotnamespaceRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/{-$orgSlug}/connect/$integrationSlug': {
+      id: '/{-$orgSlug}/connect/$integrationSlug'
+      path: '/{-$orgSlug}/connect/$integrationSlug'
+      fullPath: '/{-$orgSlug}/connect/$integrationSlug'
+      preLoaderRoute: typeof DotConnectDotintegrationSlugRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/{-$orgSlug}/plugins/$pluginId/$': {
       id: '/{-$orgSlug}/plugins/$pluginId/$'
       path: '/{-$orgSlug}/plugins/$pluginId/$'
@@ -256,6 +277,7 @@ const rootRouteChildren: RootRouteChildren = {
   DotToolkitsRoute: DotToolkitsRouteWithChildren,
   DotToolsRoute: DotToolsRoute,
   DotIndexRoute: DotIndexRoute,
+  DotConnectDotintegrationSlugRoute: DotConnectDotintegrationSlugRoute,
   DotIntegrationsDotnamespaceRoute: DotIntegrationsDotnamespaceRoute,
   DotResumeDotexecutionIdRoute: DotResumeDotexecutionIdRoute,
   DotIntegrationsDotaddDotpluginKeyRoute:


### PR DESCRIPTION
Stacked on #1465 (shares the branch point; no dependency on its code). Adds a slug-based connect deep link to the shared console routes: resolves against the tenant catalog and redirects into the existing add-account flow (`?tab=accounts&addAccount=1`). Survives sign-in on cloud (reserves `connect` from org-slug parsing) and self-host (login now returns to the live location instead of hardcoded `/`). e2e scenario green on cloud and selfhost targets.

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #1463
2. #1464
3. #1465
4. **#1466** 👈 current
5. #1467
6. #1469
<!-- stack:links:end -->