### PR TITLE
Add public admin users API and org API keys

### DIFF
--- a/apps/cloud/src/account/workos-account-service.ts
+++ b/apps/cloud/src/account/workos-account-service.ts
@@ -246,6 +246,32 @@ export const workosAccountProvider: Layer.Layer<
           return { success: true };
         }),
 
+      // Org keys read every user in the tenant through the `/admin/*` plane, so
+      // both paths are admin-gated — unlike personal keys, which any member may
+      // mint for themselves.
+      listOrgApiKeys: (headers) =>
+        Effect.gen(function* () {
+          const { session, org } = yield* requireOrganization(headers);
+          yield* requireAdmin(session.accountId, org.id);
+          const keys = yield* apiKeys
+            .listOrgKeys({ organizationId: org.id })
+            .pipe(Effect.catchTag("ApiKeyManagementError", toAccountError));
+          return { apiKeys: keys };
+        }),
+
+      createOrgApiKey: (headers, name) =>
+        Effect.gen(function* () {
+          const { session, org } = yield* requireOrganization(headers);
+          yield* requireAdmin(session.accountId, org.id);
+          const trimmed = name.trim().slice(0, MAX_API_KEY_NAME_LENGTH);
+          if (!trimmed) {
+            return yield* new AccountError({ message: "API key name is required" });
+          }
+          return yield* apiKeys
+            .createOrgKey({ organizationId: org.id, name: trimmed })
+            .pipe(Effect.catchTag("ApiKeyManagementError", toAccountError));
+        }),
+
       listMembers: (headers) =>
         Effect.gen(function* () {
           const { session, org } = yield* requireOrganization(headers);

--- a/apps/cloud/src/admin/admin-users-api.ts
+++ b/apps/cloud/src/admin/admin-users-api.ts
@@ -1,0 +1,203 @@
+// ---------------------------------------------------------------------------
+// Cloud admin users API — the shared, provider-neutral `AdminUsersHandlers`
+// backed by a WorkOS-authorized platform view, mounted at `/api/admin/users*`.
+//
+// TWO credentials reach this plane, and they are the two an operator actually
+// has:
+//   1. an ORG-SCOPED api key -> `PlatformAuth`. The key IS the authority: WorkOS
+//      validated it and reported which org owns it, and there is no member
+//      behind it to check membership for. This is the machine credential
+//      (owner.com's server calling us).
+//   2. an admin SESSION member -> the console. Requires a live `getUserOrgMembership`
+//      whose role slug is `admin` AND whose status is `active`, matching the
+//      strictest existing cloud guard (`auth/handlers.ts`'s org-delete check) —
+//      a pending admin invite is not an admin.
+// A plain member session, or a USER-scoped api key, is refused: both name one
+// acting member, and this plane deliberately serves the whole tenant.
+//
+// The executor is built by `makePlatformExecutor` — `{ tenant, subject:
+// undefined, platformView: true }` — so the reads are tenant-wide and read-only
+// by storage policy, and no `subject` row is minted for the caller.
+//
+// Cross-tenant isolation is structural, not a check in this file: the tenant is
+// taken from the resolved credential (the key's own org, or the session's
+// authorized org), never from client input, and `reach: "tenant"` still filters
+// every query by that tenant.
+// ---------------------------------------------------------------------------
+
+import { HttpRouter } from "effect/unstable/http";
+import { Effect, Layer } from "effect";
+
+import {
+  AdminUsersProvider,
+  DbProvider,
+  HostConfig,
+  PluginsProvider,
+  listAdminUserConnections,
+  listAdminUsers,
+  listAdminUsersWithConnections,
+  makeAdminUsersApiLayer,
+  makePlatformExecutor,
+  platformViewOf,
+  requestScopedMiddleware,
+  type AdminUsersHeaders,
+} from "@executor-js/api/server";
+import { AdminUsersError, AdminUsersForbidden, AdminUsersUnauthorized } from "@executor-js/api";
+import type { Executor } from "@executor-js/sdk";
+
+import { ApiKeyService } from "../auth/api-keys";
+import { UserStoreService } from "../auth/context";
+import { isPlatformAuth, resolveBearerAuth } from "../auth/workos-auth-provider";
+import { orgSelectorFromRequest, authorizeOrganizationSelector } from "../auth/organization";
+import { WorkOSClient } from "../auth/workos";
+import { DbService } from "../db/db";
+import { CloudExecutionSeamsLayer } from "../engine/execution-stack";
+
+/**
+ * Resolve the tenant this request may read, or fail with the neutral 401/403.
+ *
+ * Returns only the organization id: nothing downstream needs to know WHICH of
+ * the two credentials got the caller here, and keeping the acting member out of
+ * the return value means no admin read can accidentally become subject-scoped.
+ */
+const authorizeTenant = (
+  request: Request,
+): Effect.Effect<
+  string,
+  AdminUsersUnauthorized | AdminUsersForbidden,
+  WorkOSClient | ApiKeyService | UserStoreService
+> =>
+  Effect.gen(function* () {
+    // (1) The bearer path. `resolveBearerAuth` (not `resolveApiKeyPrincipal`,
+    // which rejects org keys for the product plane) is what distinguishes an
+    // org key from a user key.
+    const bearer = yield* resolveBearerAuth(request).pipe(
+      // Every rejected-credential and infra failure collapses to one refusal:
+      // this plane must not report whether a key exists, belongs to another
+      // org, or merely lacks privilege.
+      Effect.catchCause(() => Effect.succeed(null)),
+    );
+    if (bearer !== null) {
+      if (isPlatformAuth(bearer)) return bearer.organizationId;
+      // A user-scoped key authenticated fine but names one member; the platform
+      // plane has no honest way to serve it.
+      return yield* new AdminUsersForbidden();
+    }
+
+    // (2) The session path: a live admin membership in the selected org.
+    const workos = yield* WorkOSClient;
+    const session = yield* workos
+      .authenticateRequest(request)
+      .pipe(Effect.catchCause(() => Effect.succeed(null)));
+    if (!session) return yield* new AdminUsersUnauthorized();
+
+    const selector = orgSelectorFromRequest(request) ?? session.organizationId;
+    if (!selector) return yield* new AdminUsersForbidden();
+    // Re-checks live membership, so the org selector header can only ever name
+    // an org the caller already belongs to.
+    const org = yield* authorizeOrganizationSelector(session.userId, selector).pipe(
+      Effect.catchCause(() => Effect.succeed(null)),
+    );
+    if (!org) return yield* new AdminUsersForbidden();
+
+    const membership = yield* workos
+      .getUserOrgMembership(org.id, session.userId)
+      .pipe(Effect.catchCause(() => Effect.succeed(null)));
+    // A pending admin invite is not an active admin — require both.
+    if (!membership || membership.status !== "active" || membership.role?.slug !== "admin") {
+      return yield* new AdminUsersForbidden();
+    }
+    return org.id;
+  });
+
+/**
+ * Authorize, then run `body` against the tenant's platform view.
+ *
+ * The executor is built per request and closed after, like every other cloud
+ * execution stack: it holds the per-request postgres socket, which Cloudflare's
+ * I/O isolation forbids sharing across requests.
+ */
+const withPlatformView = <A>(
+  headers: AdminUsersHeaders,
+  body: (executor: Executor) => Effect.Effect<A, AdminUsersError>,
+): Effect.Effect<
+  A,
+  AdminUsersError | AdminUsersUnauthorized | AdminUsersForbidden,
+  WorkOSClient | ApiKeyService | UserStoreService | DbProvider | PluginsProvider | HostConfig
+> =>
+  Effect.gen(function* () {
+    const organizationId = yield* authorizeTenant(
+      new Request("https://admin.invalid", { headers }),
+    );
+    const executor = yield* makePlatformExecutor(organizationId).pipe(
+      Effect.mapError(() => new AdminUsersError({ message: "Failed to open the platform view" })),
+    );
+    return yield* Effect.ensuring(body(executor), executor.close().pipe(Effect.ignore));
+  });
+
+/**
+ * Cloud's `AdminUsersProvider`, built per request so the platform executor
+ * closes over the per-request postgres socket.
+ */
+export const workosAdminUsersProvider: Layer.Layer<
+  AdminUsersProvider,
+  never,
+  WorkOSClient | ApiKeyService | UserStoreService | DbProvider | PluginsProvider | HostConfig
+> = Layer.effect(AdminUsersProvider)(
+  Effect.gen(function* () {
+    const context = yield* Effect.context<
+      WorkOSClient | ApiKeyService | UserStoreService | DbProvider | PluginsProvider | HostConfig
+    >();
+    return AdminUsersProvider.of({
+      listUsers: (headers, options) =>
+        withPlatformView(headers, (executor) =>
+          platformViewOf(executor).pipe(Effect.flatMap((admin) => listAdminUsers(admin, options))),
+        ).pipe(Effect.provideContext(context)),
+      listUsersWithConnections: (headers, options) =>
+        withPlatformView(headers, (executor) =>
+          platformViewOf(executor).pipe(
+            Effect.flatMap((admin) => listAdminUsersWithConnections(admin, options)),
+          ),
+        ).pipe(Effect.provideContext(context)),
+      listUserConnections: (headers, externalId) =>
+        withPlatformView(headers, (executor) =>
+          platformViewOf(executor).pipe(
+            Effect.flatMap((admin) => listAdminUserConnections(admin, externalId)),
+          ),
+        ).pipe(Effect.provideContext(context)),
+    });
+  }),
+);
+
+// Builds the provider per request, providing it to the handlers. Long-lived
+// `WorkOSClient | ApiKeyService` come from the surrounding boot context; the
+// per-request `DbService`/`UserStoreService` (and the execution seams built
+// over them) are supplied by the combined `requestScopedMiddleware`.
+const AdminUsersProviderMiddleware = HttpRouter.middleware<{ provides: AdminUsersProvider }>()(
+  Effect.gen(function* () {
+    const longLived = yield* Effect.context<WorkOSClient | ApiKeyService>();
+    return (httpEffect) =>
+      Effect.gen(function* () {
+        // Built inside the request body so the execution seams close over the
+        // per-request postgres socket.
+        const provider = yield* Effect.provide(
+          AdminUsersProvider.asEffect(),
+          workosAdminUsersProvider.pipe(Layer.provide(CloudExecutionSeamsLayer)),
+        );
+        return yield* Effect.provideService(httpEffect, AdminUsersProvider, provider);
+      }).pipe(Effect.provideContext(longLived));
+  }),
+);
+
+/**
+ * The cloud admin-users route layer, mounted as an app extension under the same
+ * `/api` prefix as the rest of the cloud router.
+ */
+export const makeCloudAdminUsersRoutes = (
+  rsLive: Layer.Layer<DbService | UserStoreService>,
+  options: Parameters<typeof makeAdminUsersApiLayer>[1] = {},
+) =>
+  makeAdminUsersApiLayer(
+    AdminUsersProviderMiddleware.combine(requestScopedMiddleware(rsLive)).layer,
+    options,
+  );

--- a/apps/cloud/src/admin/admin-users-api.ts
+++ b/apps/cloud/src/admin/admin-users-api.ts
@@ -7,7 +7,7 @@
 //   1. an ORG-SCOPED api key -> `PlatformAuth`. The key IS the authority: WorkOS
 //      validated it and reported which org owns it, and there is no member
 //      behind it to check membership for. This is the machine credential
-//      (owner.com's server calling us).
+//      (a customer's backend calling us).
 //   2. an admin SESSION member -> the console. Requires a live `getUserOrgMembership`
 //      whose role slug is `admin` AND whose status is `active`, matching the
 //      strictest existing cloud guard (`auth/handlers.ts`'s org-delete check) —

--- a/apps/cloud/src/api/protected-api-key-auth.node.test.ts
+++ b/apps/cloud/src/api/protected-api-key-auth.node.test.ts
@@ -23,6 +23,8 @@ const stubApiKeys = Layer.succeed(ApiKeyService)({
   listUserKeys: () => Effect.succeed([]),
   createUserKey: () => Effect.die("protected API auth test does not create API keys"),
   revokeUserKey: () => Effect.void,
+  listOrgKeys: () => Effect.die("auth resolution test does not list org API keys"),
+  createOrgKey: () => Effect.die("auth resolution test does not create org API keys"),
 });
 
 const stubWorkOS = Layer.succeed(

--- a/apps/cloud/src/api/protected-jwt-auth.node.test.ts
+++ b/apps/cloud/src/api/protected-jwt-auth.node.test.ts
@@ -40,6 +40,8 @@ const stubApiKeys = Layer.succeed(ApiKeyService)({
   listUserKeys: () => Effect.succeed([]),
   createUserKey: () => Effect.die("JWT auth test does not create API keys"),
   revokeUserKey: () => Effect.void,
+  listOrgKeys: () => Effect.die("auth resolution test does not list org API keys"),
+  createOrgKey: () => Effect.die("auth resolution test does not create org API keys"),
 });
 
 const stubWorkOS = Layer.succeed(

--- a/apps/cloud/src/auth/api-keys.ts
+++ b/apps/cloud/src/auth/api-keys.ts
@@ -75,9 +75,10 @@ const ApiKey = Schema.Struct({
   last_used_at: Schema.optional(Schema.NullOr(Schema.String)),
 });
 
-// Validation accepts BOTH owner shapes. The list/create paths below stay
-// user-only on purpose: they are the console's personal-key CRUD, and minting
-// org keys is a separate, privileged surface (PR 1.5).
+// Validation accepts BOTH owner shapes. The user list/create paths below stay
+// user-only on purpose (they are the console's personal-key CRUD); the ORG
+// list/create paths are the separate, privileged surface beside them, gated to
+// admins at the account-provider boundary.
 const ValidatedApiKey = Schema.Struct({
   id: Schema.String,
   owner: WorkOSApiKeyOwner,
@@ -106,6 +107,45 @@ const ListApiKeysResponse = Schema.Struct({
   data: Schema.Array(ApiKey),
 });
 
+// The ORG-owned mirror of `ApiKey` / `RawCreatedApiKey`. A separate shape
+// rather than a widened one: `summaryFromApiKey` reads the user shape's
+// `organization_id` to prove the key belongs to the caller's org, and an
+// org-owned row carries the org in `owner.id` instead. Merging them would mean
+// one nullable field standing for two different things.
+const OrgApiKey = Schema.Struct({
+  id: Schema.String,
+  owner: OrgApiKeyOwner,
+  name: Schema.optional(Schema.String),
+  obfuscatedValue: Schema.optional(Schema.String),
+  obfuscated_value: Schema.optional(Schema.String),
+  createdAt: Schema.optional(Schema.String),
+  created_at: Schema.optional(Schema.String),
+  updatedAt: Schema.optional(Schema.String),
+  updated_at: Schema.optional(Schema.String),
+  lastUsedAt: Schema.optional(Schema.NullOr(Schema.String)),
+  last_used_at: Schema.optional(Schema.NullOr(Schema.String)),
+});
+
+const RawCreatedOrgApiKey = Schema.Struct({
+  ...OrgApiKey.fields,
+  value: Schema.String,
+});
+
+// `data` is decoded element-by-element, NOT as `Schema.Array(OrgApiKey)`: WorkOS
+// may return user-owned keys alongside org-owned ones, and a whole-array decode
+// fails on the first non-org element — blanking the entire list rather than
+// dropping the one row that doesn't belong. Same per-row tolerance the user-key
+// path gets from `summaryFromApiKey` returning null.
+const ListOrgApiKeysResponse = Schema.Struct({
+  data: Schema.Array(Schema.Unknown),
+});
+
+const CreateOrgApiKeyResponse = Schema.Union([
+  RawCreatedOrgApiKey,
+  Schema.Struct({ apiKey: RawCreatedOrgApiKey }),
+  Schema.Struct({ api_key: RawCreatedOrgApiKey }),
+]);
+
 const CreateApiKeyResponse = Schema.Union([
   RawCreatedApiKey,
   Schema.Struct({ apiKey: RawCreatedApiKey }),
@@ -115,6 +155,9 @@ const CreateApiKeyResponse = Schema.Union([
 const decodeValidateApiKeyResponse = Schema.decodeUnknownOption(ValidateApiKeyResponse);
 const decodeListApiKeysResponse = Schema.decodeUnknownOption(ListApiKeysResponse);
 const decodeCreateApiKeyResponse = Schema.decodeUnknownOption(CreateApiKeyResponse);
+const decodeListOrgApiKeysResponse = Schema.decodeUnknownOption(ListOrgApiKeysResponse);
+const decodeOrgApiKey = Schema.decodeUnknownOption(OrgApiKey);
+const decodeCreateOrgApiKeyResponse = Schema.decodeUnknownOption(CreateOrgApiKeyResponse);
 
 const ownerFromApiKey = (apiKey: typeof ValidatedApiKey.Type): ApiKeyOwner | null => {
   if (apiKey.owner.type === "organization") {
@@ -166,6 +209,53 @@ const listFromResponse = (value: unknown): readonly ApiKeySummary[] =>
       }),
   });
 
+// The org-owned mirror of `summaryFromApiKey`. `organizationId` is checked by
+// the CALLER against the org it asked for: WorkOS's workspace api key is
+// workspace-wide, so a response naming a different org than the one requested
+// must not be surfaced as that org's key.
+const summaryFromOrgApiKey = (
+  apiKey: typeof OrgApiKey.Type,
+  organizationId: string,
+): ApiKeySummary | null => {
+  if (apiKey.owner.id !== organizationId) return null;
+  return {
+    id: apiKey.id,
+    name: apiKey.name ?? "API key",
+    obfuscatedValue: apiKey.obfuscatedValue ?? apiKey.obfuscated_value ?? "",
+    createdAt: apiKey.createdAt ?? apiKey.created_at ?? "",
+    updatedAt: apiKey.updatedAt ?? apiKey.updated_at ?? "",
+    lastUsedAt: apiKey.lastUsedAt ?? apiKey.last_used_at ?? null,
+  };
+};
+
+const orgListFromResponse = (value: unknown, organizationId: string): readonly ApiKeySummary[] =>
+  Option.match(decodeListOrgApiKeysResponse(value), {
+    onNone: () => [],
+    onSome: ({ data }) =>
+      data.flatMap((entry) =>
+        Option.match(decodeOrgApiKey(entry), {
+          // Not an org-owned key (a user key sharing the listing, or a shape we
+          // don't recognize) — skip the row, keep the rest.
+          onNone: () => [],
+          onSome: (apiKey) => {
+            const summary = summaryFromOrgApiKey(apiKey, organizationId);
+            return summary ? [summary] : [];
+          },
+        }),
+      ),
+  });
+
+const orgCreatedFromResponse = (value: unknown, organizationId: string): CreatedApiKey | null =>
+  Option.match(decodeCreateOrgApiKeyResponse(value), {
+    onNone: () => null,
+    onSome: (response) => {
+      const apiKey =
+        "value" in response ? response : "apiKey" in response ? response.apiKey : response.api_key;
+      const summary = summaryFromOrgApiKey(apiKey, organizationId);
+      return summary ? { ...summary, value: apiKey.value } : null;
+    },
+  });
+
 const createdFromResponse = (value: unknown): CreatedApiKey | null =>
   Option.match(decodeCreateApiKeyResponse(value), {
     onNone: () => null,
@@ -193,6 +283,18 @@ export class ApiKeyService extends Context.Service<
     readonly revokeUserKey: (input: {
       readonly keyId: string;
     }) => Effect.Effect<void, ApiKeyManagementError>;
+    /**
+     * The org-owned keys of an organization — the credentials that resolve to
+     * the read-only platform view. Privileged: callers gate on admin membership
+     * before reaching this.
+     */
+    readonly listOrgKeys: (input: {
+      readonly organizationId: string;
+    }) => Effect.Effect<readonly ApiKeySummary[], ApiKeyManagementError>;
+    readonly createOrgKey: (input: {
+      readonly organizationId: string;
+      readonly name: string;
+    }) => Effect.Effect<CreatedApiKey, ApiKeyManagementError>;
   }
 >()("@executor-js/cloud/ApiKeyService") {
   static WorkOS = Layer.effect(this)(
@@ -223,6 +325,21 @@ export class ApiKeyService extends Context.Service<
           workos
             .deleteApiKey(keyId)
             .pipe(Effect.mapError((cause) => new ApiKeyManagementError({ cause }))),
+        listOrgKeys: ({ organizationId }) =>
+          workos.listOrgApiKeys(organizationId).pipe(
+            Effect.map((response) => orgListFromResponse(response, organizationId)),
+            Effect.mapError((cause) => new ApiKeyManagementError({ cause })),
+          ),
+        createOrgKey: ({ organizationId, name }) =>
+          workos.createOrgApiKey({ organizationId, name }).pipe(
+            Effect.mapError((cause) => new ApiKeyManagementError({ cause })),
+            Effect.flatMap((response) => {
+              const created = orgCreatedFromResponse(response, organizationId);
+              return created
+                ? Effect.succeed(created)
+                : Effect.fail(new ApiKeyManagementError({ cause: "invalid_create_response" }));
+            }),
+          ),
       };
     }),
   );

--- a/apps/cloud/src/auth/org-api-key-auth.node.test.ts
+++ b/apps/cloud/src/auth/org-api-key-auth.node.test.ts
@@ -36,6 +36,8 @@ const stubApiKeys = Layer.succeed(ApiKeyService)({
   listUserKeys: () => Effect.succeed([]),
   createUserKey: () => Effect.die("org api key test does not create API keys"),
   revokeUserKey: () => Effect.void,
+  listOrgKeys: () => Effect.die("auth resolution test does not list org API keys"),
+  createOrgKey: () => Effect.die("auth resolution test does not create org API keys"),
 });
 
 const stubWorkOS = Layer.succeed(

--- a/apps/cloud/src/auth/org-api-key-mint.node.test.ts
+++ b/apps/cloud/src/auth/org-api-key-mint.node.test.ts
@@ -64,10 +64,10 @@ describe("organization API keys", () => {
           }),
       });
 
-      const created = yield* apiKeys.createOrgKey({ organizationId: ORG, name: "owner.com" });
+      const created = yield* apiKeys.createOrgKey({ organizationId: ORG, name: "acme-backend" });
 
       expect(created.id).toBe("key_org_1");
-      expect(created.name).toBe("owner.com");
+      expect(created.name).toBe("acme-backend");
       expect(created.value, "create returns the one-time plaintext secret").toBe(
         "sk_org_plaintext",
       );
@@ -84,7 +84,7 @@ describe("organization API keys", () => {
           Effect.succeed({
             object: "list",
             data: [
-              orgKeyResponse(organizationId, "key_org_1", "owner.com"),
+              orgKeyResponse(organizationId, "key_org_1", "acme-backend"),
               orgKeyResponse(organizationId, "key_org_2", "ci"),
             ],
             listMetadata: { before: null, after: null },
@@ -93,7 +93,7 @@ describe("organization API keys", () => {
 
       const keys = yield* apiKeys.listOrgKeys({ organizationId: ORG });
 
-      expect(keys.map((key) => key.name)).toEqual(["owner.com", "ci"]);
+      expect(keys.map((key) => key.name)).toEqual(["acme-backend", "ci"]);
       expect(JSON.stringify(keys), "the list never carries a plaintext secret").not.toContain(
         "sk_org_plaintext",
       );
@@ -136,7 +136,7 @@ describe("organization API keys", () => {
       });
 
       const error = yield* Effect.flip(
-        apiKeys.createOrgKey({ organizationId: ORG, name: "owner.com" }),
+        apiKeys.createOrgKey({ organizationId: ORG, name: "acme-backend" }),
       );
 
       expect(error).toBeInstanceOf(ApiKeyManagementError);

--- a/apps/cloud/src/auth/org-api-key-mint.node.test.ts
+++ b/apps/cloud/src/auth/org-api-key-mint.node.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Layer } from "effect";
+
+import { ApiKeyService } from "./api-keys";
+import { ApiKeyManagementError } from "./errors";
+import { WorkOSClient, type WorkOSClientService } from "./workos";
+
+// ---------------------------------------------------------------------------
+// Minting and listing ORGANIZATION-owned api keys — the privileged credential
+// that resolves to the read-only platform view (`/admin/*`).
+//
+// The decode boundary is what these pin. WorkOS returns an org-owned key with
+// the ORG in `owner.id` and no member at all, which is a different shape from
+// the user-owned keys the console's personal-key CRUD handles. The workspace
+// api key is also workspace-WIDE, so a response naming a different org than the
+// one asked for must not be surfaced as that org's key.
+//
+// NOTE (emulator gap): the WorkOS emulator's `serializeApiKey` hardcodes
+// `owner.type: "user"` and exposes no org-key mint route, so this path cannot
+// be exercised over the wire in e2e today. These stubs encode the REAL WorkOS
+// API shape (`organizations.createOrganizationApiKey` /
+// `listOrganizationApiKeys`, per the installed SDK's types).
+// ---------------------------------------------------------------------------
+
+const ORG = "org_123";
+
+const orgKeyResponse = (organizationId: string, id: string, name: string) => ({
+  object: "api_key",
+  id,
+  owner: { type: "organization", id: organizationId },
+  name,
+  obfuscatedValue: "sk_org…a1b2",
+  lastUsedAt: null,
+  permissions: [],
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+});
+
+const stubWorkOS = (overrides: Record<string, unknown> = {}) =>
+  Layer.succeed(
+    WorkOSClient,
+    new Proxy({} as WorkOSClientService, {
+      get: (_target, prop) => {
+        const override = overrides[String(prop)];
+        if (override) return override;
+        return () => Effect.die(`unexpected WorkOSClient.${String(prop)} call`);
+      },
+    }),
+  );
+
+const serviceWith = (overrides: Record<string, unknown>) =>
+  ApiKeyService.asEffect().pipe(
+    Effect.provide(ApiKeyService.WorkOS.pipe(Layer.provide(stubWorkOS(overrides)))),
+  );
+
+describe("organization API keys", () => {
+  it.effect("mints an org-owned key and returns the one-time secret", () =>
+    Effect.gen(function* () {
+      const apiKeys = yield* serviceWith({
+        createOrgApiKey: (params: { organizationId: string; name: string }) =>
+          Effect.succeed({
+            ...orgKeyResponse(params.organizationId, "key_org_1", params.name),
+            value: "sk_org_plaintext",
+          }),
+      });
+
+      const created = yield* apiKeys.createOrgKey({ organizationId: ORG, name: "owner.com" });
+
+      expect(created.id).toBe("key_org_1");
+      expect(created.name).toBe("owner.com");
+      expect(created.value, "create returns the one-time plaintext secret").toBe(
+        "sk_org_plaintext",
+      );
+      expect(created.obfuscatedValue, "the display value is masked, not the secret").not.toBe(
+        created.value,
+      );
+    }),
+  );
+
+  it.effect("lists the organization's own keys, masked", () =>
+    Effect.gen(function* () {
+      const apiKeys = yield* serviceWith({
+        listOrgApiKeys: (organizationId: string) =>
+          Effect.succeed({
+            object: "list",
+            data: [
+              orgKeyResponse(organizationId, "key_org_1", "owner.com"),
+              orgKeyResponse(organizationId, "key_org_2", "ci"),
+            ],
+            listMetadata: { before: null, after: null },
+          }),
+      });
+
+      const keys = yield* apiKeys.listOrgKeys({ organizationId: ORG });
+
+      expect(keys.map((key) => key.name)).toEqual(["owner.com", "ci"]);
+      expect(JSON.stringify(keys), "the list never carries a plaintext secret").not.toContain(
+        "sk_org_plaintext",
+      );
+    }),
+  );
+
+  it.effect("drops a key owned by a DIFFERENT organization", () =>
+    Effect.gen(function* () {
+      // The WorkOS workspace api key is workspace-wide, so a response naming
+      // another org must never be surfaced as this org's key.
+      const apiKeys = yield* serviceWith({
+        listOrgApiKeys: () =>
+          Effect.succeed({
+            object: "list",
+            data: [
+              orgKeyResponse(ORG, "key_mine", "mine"),
+              orgKeyResponse("org_other", "key_theirs", "theirs"),
+            ],
+            listMetadata: { before: null, after: null },
+          }),
+      });
+
+      const keys = yield* apiKeys.listOrgKeys({ organizationId: ORG });
+
+      expect(
+        keys.map((key) => key.id),
+        "only this org's key survives",
+      ).toEqual(["key_mine"]);
+    }),
+  );
+
+  it.effect("refuses a create response that names another organization", () =>
+    Effect.gen(function* () {
+      const apiKeys = yield* serviceWith({
+        createOrgApiKey: () =>
+          Effect.succeed({
+            ...orgKeyResponse("org_other", "key_theirs", "theirs"),
+            value: "sk_org_plaintext",
+          }),
+      });
+
+      const error = yield* Effect.flip(
+        apiKeys.createOrgKey({ organizationId: ORG, name: "owner.com" }),
+      );
+
+      expect(error).toBeInstanceOf(ApiKeyManagementError);
+    }),
+  );
+
+  it.effect("ignores a user-owned key in an org-key listing", () =>
+    Effect.gen(function* () {
+      // The org and user shapes are decoded separately on purpose; a user key
+      // appearing here would mean the caller could mistake a member's personal
+      // credential for a workspace one.
+      const apiKeys = yield* serviceWith({
+        listOrgApiKeys: () =>
+          Effect.succeed({
+            object: "list",
+            data: [
+              orgKeyResponse(ORG, "key_mine", "mine"),
+              {
+                object: "api_key",
+                id: "key_user",
+                owner: { type: "user", id: "user_1", organization_id: ORG },
+                name: "personal",
+                obfuscatedValue: "sk_user…c3d4",
+                lastUsedAt: null,
+                createdAt: "2026-01-01T00:00:00.000Z",
+                updatedAt: "2026-01-01T00:00:00.000Z",
+              },
+            ],
+            listMetadata: { before: null, after: null },
+          }),
+      });
+
+      const keys = yield* apiKeys.listOrgKeys({ organizationId: ORG });
+
+      expect(
+        keys.map((key) => key.id),
+        "a user-owned key is not an org key",
+      ).toEqual(["key_mine"]);
+    }),
+  );
+});

--- a/apps/cloud/src/auth/org-selector-auth.node.test.ts
+++ b/apps/cloud/src/auth/org-selector-auth.node.test.ts
@@ -29,6 +29,8 @@ const stubApiKeys = Layer.succeed(ApiKeyService)({
   listUserKeys: () => Effect.succeed([]),
   createUserKey: () => Effect.die("not used"),
   revokeUserKey: () => Effect.void,
+  listOrgKeys: () => Effect.die("auth resolution test does not list org API keys"),
+  createOrgKey: () => Effect.die("auth resolution test does not create org API keys"),
 });
 
 const stubWorkOS = Layer.succeed(

--- a/apps/cloud/src/auth/workos.ts
+++ b/apps/cloud/src/auth/workos.ts
@@ -544,6 +544,33 @@ const make = Effect.gen(function* () {
         return response.data;
       }),
 
+    /**
+     * List the ORGANIZATION-owned api keys of an org. Unlike the user-key
+     * paths above, org keys are first-class in the installed SDK
+     * (`organizations.listOrganizationApiKeys`), so no raw escape hatch is
+     * needed. Returned unknown and decoded in `auth/api-keys.ts` like every
+     * other key response.
+     */
+    listOrgApiKeys: (organizationId: string) =>
+      use(async (wos) =>
+        collectWorkOSList(await wos.organizations.listOrganizationApiKeys({ organizationId })),
+      ),
+
+    /**
+     * Mint an ORGANIZATION-owned api key: the credential that resolves to the
+     * read-only platform view (`PlatformAuth`) instead of an acting member.
+     * Privileged — the caller must be an admin of the org, which is enforced at
+     * the account-provider boundary, not here.
+     */
+    createOrgApiKey: (params: { organizationId: string; name: string }) =>
+      use(
+        (wos) =>
+          wos.organizations.createOrganizationApiKey({
+            organizationId: params.organizationId,
+            name: params.name,
+          }) as Promise<unknown>,
+      ),
+
     deleteApiKey: (id: string) => use((wos) => wos.apiKeys.deleteApiKey(id)),
 
     /** List organization memberships with user details. */

--- a/apps/cloud/src/extensions/docs.ts
+++ b/apps/cloud/src/extensions/docs.ts
@@ -2,12 +2,18 @@ import { Effect, Layer } from "effect";
 import { HttpRouter, HttpServerResponse } from "effect/unstable/http";
 import { HttpApiSwagger, OpenApi } from "effect/unstable/httpapi";
 
+import { AccountApi, AdminUsersApi } from "@executor-js/api";
+
 import { CloudAuthApi, CloudAuthPublicApi } from "../auth/api";
 import { OrgApi } from "../org/api";
 
 import { ProtectedCloudApi } from "../api/layers";
 
-export const CloudOpenApi = ProtectedCloudApi.add(CloudAuthPublicApi).add(CloudAuthApi).add(OrgApi);
+export const CloudOpenApi = ProtectedCloudApi.add(CloudAuthPublicApi)
+  .add(CloudAuthApi)
+  .add(OrgApi)
+  .add(AccountApi)
+  .add(AdminUsersApi);
 
 const spec = OpenApi.fromApi(CloudOpenApi);
 

--- a/apps/cloud/src/extensions/routes.ts
+++ b/apps/cloud/src/extensions/routes.ts
@@ -34,6 +34,7 @@ import {
 } from "../auth/handlers";
 import { CloudAuthApi, CloudAuthPublicApi } from "../auth/api";
 import { SessionAuthLive } from "../auth/middleware-live";
+import { makeCloudAdminUsersRoutes } from "../admin/admin-users-api";
 import { OrgApi, OrgHttpApi } from "../org/api";
 import { orgAuthMiddleware } from "../org/auth-middleware";
 import { OrgHandlers } from "../org/handlers";
@@ -100,5 +101,18 @@ export const makeCloudExtensionRoutes = (rsLive: Layer.Layer<DbService | UserSto
 
   const BillingRoutes = AutumnRoutesLive.pipe(Layer.provide(requestScopedMiddleware(rsLive).layer));
 
-  return [SessionRoutes, OrgRoutes, DocsRoutes, BillingRoutes, ApiErrorLoggingLive] as const;
+  // The tenant-wide admin plane (`/api/admin/users*`). Mounted as an extension
+  // rather than on the protected API because the protected plane's middleware
+  // binds a product-view executor to one acting member — this one authorizes an
+  // org key (or an admin session) and builds a subject-less platform view.
+  const AdminUsersRoutes = makeCloudAdminUsersRoutes(rsLive, { router: apiPrefixedRouter });
+
+  return [
+    SessionRoutes,
+    OrgRoutes,
+    AdminUsersRoutes,
+    DocsRoutes,
+    BillingRoutes,
+    ApiErrorLoggingLive,
+  ] as const;
 };

--- a/apps/cloud/src/extensions/routes.ts
+++ b/apps/cloud/src/extensions/routes.ts
@@ -24,6 +24,7 @@ import { HttpRouter, HttpServerResponse } from "effect/unstable/http";
 import { HttpApiBuilder } from "effect/unstable/httpapi";
 import { HttpApiSwagger, OpenApi } from "effect/unstable/httpapi";
 
+import { AccountApi, AdminUsersApi } from "@executor-js/api";
 import { requestScopedMiddleware } from "@executor-js/api/server";
 
 import { UserStoreService } from "../auth/context";
@@ -56,6 +57,8 @@ const apiPrefixedRouter = Layer.effect(HttpRouter.HttpRouter)(
 const CloudOpenApi = ProtectedCloudApi.add(CloudAuthPublicApi)
   .add(CloudAuthApi)
   .add(OrgApi)
+  .add(AccountApi)
+  .add(AdminUsersApi)
   .prefix("/api");
 
 const spec = OpenApi.fromApi(CloudOpenApi);

--- a/apps/host-cloudflare/src/account/account-provider.ts
+++ b/apps/host-cloudflare/src/account/account-provider.ts
@@ -61,6 +61,10 @@ export const cloudflareAccountProvider = (
     listApiKeys: () => Effect.succeed({ apiKeys: [] }),
     createApiKey: () => forbiddenWrite,
     revokeApiKey: () => forbiddenWrite,
+    // Org-owned keys are a WorkOS concept; Access-managed instances have no
+    // credential store of their own to mint one from.
+    listOrgApiKeys: () => Effect.succeed({ apiKeys: [] }),
+    createOrgApiKey: () => forbiddenWrite,
     listMembers: () => Effect.succeed({ members: [] }),
     listRoles: () => Effect.succeed({ roles: [] }),
     inviteMember: () => forbiddenWrite,

--- a/apps/host-selfhost/src/account/better-auth-account-provider.ts
+++ b/apps/host-selfhost/src/account/better-auth-account-provider.ts
@@ -106,6 +106,22 @@ export const betterAuthAccountProvider: Layer.Layer<AccountProvider, never, Bett
             auth.api.deleteApiKey({ body: { keyId: apiKeyId }, headers: toHeaders(headers) }),
           ).pipe(Effect.as({ success: true })),
 
+        // Better Auth has no organization-OWNED key concept: every key it
+        // issues belongs to the user who created it. Rather than inventing one
+        // (a shared key filed under whichever admin happened to click the
+        // button is not an org key — it dies with that member), self-host
+        // reports no org keys and refuses to mint. Self-host's own `/admin/*`
+        // plane is gated on an owner/admin SESSION instead, which is the
+        // credential a single-instance operator already has.
+        listOrgApiKeys: () => Effect.succeed({ apiKeys: [] }),
+
+        createOrgApiKey: () =>
+          Effect.fail(
+            new AccountError({
+              message: "Organization API keys are not available on self-hosted instances",
+            }),
+          ),
+
         listMembers: (headers) =>
           Effect.gen(function* () {
             const resolved = yield* getSession(headers);

--- a/apps/host-selfhost/src/admin/admin-users-api.ts
+++ b/apps/host-selfhost/src/admin/admin-users-api.ts
@@ -1,0 +1,136 @@
+// ---------------------------------------------------------------------------
+// Self-host admin users API — the shared, provider-neutral `AdminUsersHandlers`
+// backed by a Better-Auth-authorized platform view, mounted at
+// `/api/admin/users*` beside the existing invite-code admin routes.
+//
+// AUTH: an owner/admin member of the single org, resolved through the org
+// primitive's `getActiveMember` — the SAME gate the invite-code admin API uses
+// (`admin/handlers.ts`), not a new permission concept. Self-host has no
+// organization-OWNED api key (Better Auth keys always belong to the user who
+// created one), so there is no machine-credential path here; the operator's own
+// admin session is the credential. That asymmetry with cloud is deliberate and
+// is why `AdminUsersProvider` is a seam rather than one shared implementation.
+//
+// The READ half is identical to cloud's: a subject-less, tenant-reach executor
+// from `makePlatformExecutor`, projected by the shared `admin/reads`. Self-host
+// is single-tenant, so the tenant is always the boot-seeded org.
+// ---------------------------------------------------------------------------
+
+import { HttpRouter } from "effect/unstable/http";
+import { Effect, Layer } from "effect";
+
+import {
+  AdminUsersProvider,
+  DbProvider,
+  HostConfig,
+  PluginsProvider,
+  listAdminUserConnections,
+  listAdminUsers,
+  listAdminUsersWithConnections,
+  makeAdminUsersApiLayer,
+  makePlatformExecutor,
+  platformViewOf,
+  requestScopedMiddleware,
+  type AdminUsersHeaders,
+} from "@executor-js/api/server";
+import { AdminUsersError, AdminUsersForbidden, AdminUsersUnauthorized } from "@executor-js/api";
+import type { Executor } from "@executor-js/sdk";
+
+import { BetterAuth, type BetterAuthHandle } from "../auth/better-auth";
+import { SelfHostDb, SelfHostDbProvider, type SelfHostDbHandle } from "../db/self-host-db";
+import { SelfHostHostConfig, SelfHostPluginsProvider } from "../execution";
+
+/**
+ * The same owner/admin gate the invite-code admin API applies. A plain member
+ * session is refused: this plane reports every user in the instance.
+ */
+const requireAdmin = (headers: AdminUsersHeaders) =>
+  Effect.gen(function* () {
+    const { auth } = yield* BetterAuth;
+    const member = yield* Effect.tryPromise({
+      try: () => auth.api.getActiveMember({ headers: new Headers(headers) }),
+      catch: () => new AdminUsersError({ message: "Failed to resolve session" }),
+    }).pipe(Effect.orElseSucceed(() => null));
+    if (!member) return yield* new AdminUsersUnauthorized();
+    if (member.role !== "owner" && member.role !== "admin") return yield* new AdminUsersForbidden();
+    return member;
+  });
+
+const withPlatformView = <A>(
+  headers: AdminUsersHeaders,
+  organizationId: string,
+  body: (executor: Executor) => Effect.Effect<A, AdminUsersError>,
+): Effect.Effect<
+  A,
+  AdminUsersError | AdminUsersUnauthorized | AdminUsersForbidden,
+  BetterAuth | DbProvider | PluginsProvider | HostConfig
+> =>
+  Effect.gen(function* () {
+    yield* requireAdmin(headers);
+    const executor = yield* makePlatformExecutor(organizationId).pipe(
+      Effect.mapError(() => new AdminUsersError({ message: "Failed to open the platform view" })),
+    );
+    return yield* Effect.ensuring(body(executor), executor.close().pipe(Effect.ignore));
+  });
+
+export const betterAuthAdminUsersProvider: Layer.Layer<
+  AdminUsersProvider,
+  never,
+  BetterAuth | DbProvider | PluginsProvider | HostConfig
+> = Layer.effect(AdminUsersProvider)(
+  Effect.gen(function* () {
+    const context = yield* Effect.context<BetterAuth | DbProvider | PluginsProvider | HostConfig>();
+    const { organizationId } = yield* BetterAuth;
+    return AdminUsersProvider.of({
+      listUsers: (headers, options) =>
+        withPlatformView(headers, organizationId, (executor) =>
+          platformViewOf(executor).pipe(Effect.flatMap((admin) => listAdminUsers(admin, options))),
+        ).pipe(Effect.provideContext(context)),
+      listUsersWithConnections: (headers, options) =>
+        withPlatformView(headers, organizationId, (executor) =>
+          platformViewOf(executor).pipe(
+            Effect.flatMap((admin) => listAdminUsersWithConnections(admin, options)),
+          ),
+        ).pipe(Effect.provideContext(context)),
+      listUserConnections: (headers, externalId) =>
+        withPlatformView(headers, organizationId, (executor) =>
+          platformViewOf(executor).pipe(
+            Effect.flatMap((admin) => listAdminUserConnections(admin, externalId)),
+          ),
+        ).pipe(Effect.provideContext(context)),
+    });
+  }),
+);
+
+export interface SelfHostAdminUsersApiDeps {
+  readonly betterAuth: BetterAuthHandle;
+  readonly db: SelfHostDbHandle;
+  readonly mountPrefix: `/${string}`;
+}
+
+/**
+ * The mountable extension route layer for `/api/admin/users*`. Self-host's DB
+ * handle and Better Auth are app singletons, so the provider is self-contained
+ * (no per-request socket to close over, unlike cloud) — but it still goes
+ * through `requestScopedMiddleware`, because an HttpApi handler's service
+ * requirement is not erased by a plain `Layer.provide` on the builder layer.
+ */
+export const makeSelfHostAdminUsersApiLayer = ({
+  betterAuth,
+  db,
+  mountPrefix,
+}: SelfHostAdminUsersApiDeps) => {
+  const prefixedRouter = Layer.effect(HttpRouter.HttpRouter)(
+    Effect.map(HttpRouter.HttpRouter.asEffect(), (router) => router.prefixed(mountPrefix)),
+  );
+  const provider = betterAuthAdminUsersProvider.pipe(
+    Layer.provide(Layer.succeed(BetterAuth)(betterAuth)),
+    Layer.provide(SelfHostDbProvider),
+    Layer.provide(SelfHostPluginsProvider),
+    Layer.provide(SelfHostHostConfig),
+    Layer.provide(Layer.succeed(SelfHostDb)(db)),
+  );
+  return makeAdminUsersApiLayer(requestScopedMiddleware(provider).layer, {
+    router: prefixedRouter,
+  });
+};

--- a/apps/host-selfhost/src/admin/admin-users.node.test.ts
+++ b/apps/host-selfhost/src/admin/admin-users.node.test.ts
@@ -1,0 +1,110 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterAll, expect, test } from "@effect/vitest";
+
+import { mintInviteCode } from "../testing/mint-invite";
+
+// The self-host admin users plane (`/api/admin/users*`), over the REAL booted
+// app: Better Auth, the libSQL store, and the mounted route layer.
+//
+// Self-host has no organization-owned api key (Better Auth keys always belong
+// to the user who made one), so the credential here is the operator's own
+// owner/admin session — the same gate the invite-code admin API uses. What this
+// pins is that the mount is live, that the owner/admin gate actually refuses a
+// plain member, and that a member who has used the instance shows up in the
+// owner's view without their credential coming with them.
+
+process.env.EXECUTOR_DATA_DIR = mkdtempSync(join(tmpdir(), "eh-admin-users-"));
+process.env.BETTER_AUTH_SECRET = "admin-users-test-secret-0123456789-abcdefghij";
+process.env.EXECUTOR_BOOTSTRAP_ADMIN_EMAIL = "admin@admin-users.test";
+process.env.EXECUTOR_BOOTSTRAP_ADMIN_PASSWORD = "admin-pass-123456";
+
+const { makeSelfHostApiHandler } = await import("../app");
+const { handler, dispose } = await makeSelfHostApiHandler();
+afterAll(() => dispose());
+
+const BASE = "http://localhost:4788";
+
+const signIn = async (email: string, password: string): Promise<string> => {
+  const response = await handler(
+    new Request(`${BASE}/api/auth/sign-in/email`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ email, password }),
+    }),
+  );
+  return response.headers.get("set-auth-token") ?? "";
+};
+
+const adminUsers = (token?: string, path = "/api/admin/users") =>
+  handler(
+    new Request(`${BASE}${path}`, {
+      headers: token ? { authorization: `Bearer ${token}` } : {},
+    }),
+  );
+
+test("the owner sees who uses the instance; a plain member cannot look", async () => {
+  const adminToken = await signIn(
+    process.env.EXECUTOR_BOOTSTRAP_ADMIN_EMAIL!,
+    process.env.EXECUTOR_BOOTSTRAP_ADMIN_PASSWORD!,
+  );
+  expect(adminToken).not.toBe("");
+
+  // A second person joins through the real invite flow and uses the instance.
+  const inviteCode = await mintInviteCode(handler);
+  const signUp = await handler(
+    new Request(`${BASE}/api/auth/sign-up/email`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        email: "member@admin-users.test",
+        password: "password-12345678",
+        name: "Member",
+        inviteCode,
+      }),
+    }),
+  );
+  expect(signUp.status).toBe(200);
+  const memberToken = signUp.headers.get("set-auth-token") ?? "";
+  expect(memberToken).not.toBe("");
+
+  // A user earns their row the first time they touch the EXECUTOR plane, so
+  // have both make one product read before looking at the admin view.
+  for (const token of [adminToken, memberToken]) {
+    const integrations = await handler(
+      new Request(`${BASE}/api/integrations`, { headers: { authorization: `Bearer ${token}` } }),
+    );
+    expect(integrations.status).toBe(200);
+  }
+
+  // The owner's view reports both people.
+  const response = await adminUsers(adminToken);
+  expect(response.status).toBe(200);
+  const body = (await response.json()) as {
+    users: ReadonlyArray<{ externalId: string; lastSeenAt: number | null }>;
+  };
+  expect(body.users.length, "both the owner and the invited member are reported").toBe(2);
+  expect(typeof body.users[0]?.lastSeenAt, "last-seen crosses the wire as a number").toBe("number");
+
+  // The joined view is mounted too.
+  const joined = await adminUsers(adminToken, "/api/admin/users/with-connections");
+  expect(joined.status).toBe(200);
+  const joinedBody = (await joined.json()) as {
+    users: ReadonlyArray<{ externalId: string; connections: readonly unknown[] }>;
+  };
+  expect(joinedBody.users.length).toBe(2);
+  expect(
+    joinedBody.users.every((user) => Array.isArray(user.connections)),
+    "every user carries a connections array",
+  ).toBe(true);
+
+  // The gate: a plain member may not read the instance-wide view.
+  const asMember = await adminUsers(memberToken);
+  expect(asMember.status, "a member is refused").toBe(403);
+
+  // And an anonymous caller has no session at all.
+  const anonymous = await adminUsers();
+  expect(anonymous.status, "no session → unauthorized").toBe(401);
+});

--- a/apps/host-selfhost/src/app.ts
+++ b/apps/host-selfhost/src/app.ts
@@ -9,6 +9,7 @@ import { runSqliteDataMigrations } from "@executor-js/sdk";
 import { resolveAuthProviders } from "./auth";
 import { selfHostDataMigrations } from "./db/data-migrations";
 import { makeSelfHostAdminApiLayer } from "./admin/handlers";
+import { makeSelfHostAdminUsersApiLayer } from "./admin/admin-users-api";
 import { makeSelfHostSystemApiLayer } from "./system/handlers";
 import { selfHostAccountMiddleware } from "./account";
 import { loadConfig, SELF_HOST_NAMESPACE, SELF_HOST_SCHEMA_VERSION } from "./config";
@@ -117,6 +118,10 @@ export const makeSelfHostApp = async (options: MakeSelfHostAppOptions = {}) => {
         HttpRouter.add("*", "/api/mcp-sessions/*", HttpEffect.fromWebHandler(mcp.approvalHandler)),
         // App-local admin (invite-code) API, served under /api/admin/*.
         makeSelfHostAdminApiLayer({ betterAuth, db: dbHandle, mountPrefix: "/api" }),
+        // Tenant-wide admin users API (/api/admin/users*): the owner's view of
+        // who uses this instance and what they've connected. Owner/admin-gated,
+        // same as the invite routes above.
+        makeSelfHostAdminUsersApiLayer({ betterAuth, db: dbHandle, mountPrefix: "/api" }),
         // Public system API: /api/health + /api/setup-status (unauthenticated).
         makeSelfHostSystemApiLayer({ betterAuth, db: dbHandle, mountPrefix: "/api" }),
         // Swagger UI at /docs, over the /api-prefixed spec (matches the served paths).

--- a/e2e/cloud/admin-users.test.ts
+++ b/e2e/cloud/admin-users.test.ts
@@ -1,0 +1,309 @@
+// Cloud-only: the OWNER's view of a workspace — `/api/admin/users*`. The
+// product plane answers "what can I, this member, reach"; this plane answers
+// "who uses my workspace, and what have they connected", reading across every
+// member of the tenant instead of binding to one.
+//
+// Two members are built through the REAL flows (login → create-organization →
+// invite → accept-invitation), each connects their own credential, and the
+// admin then reads the joined view — the exact shape a customer dashboard's
+// icon grid consumes. The guarantees pinned here:
+//
+//   1. the joined view reports BOTH members and each one's own connections,
+//      even though no single product-view caller can see another member's;
+//   2. it never carries credential material;
+//   3. a plain member is refused (403) and an anonymous caller too (401);
+//   4. another tenant's admin sees none of it.
+//
+// EMULATOR GAP: the WorkOS emulator hardcodes `owner.type: "user"` in its api-key
+// serializer and exposes no organization-key mint route, so an org-scoped API
+// key — the machine credential for this plane — cannot exist end-to-end here.
+// This scenario therefore drives the ADMIN SESSION path, which is the other
+// credential the plane accepts. The org-key half is covered at unit level in
+// `apps/cloud/src/auth/org-api-key-mint.node.test.ts` (against the real WorkOS
+// response shape) and `org-api-key-auth.node.test.ts` (PlatformAuth resolution).
+import { randomBytes } from "node:crypto";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import type { HttpApiClient } from "effect/unstable/httpapi";
+import { AdminUsersHttpApi } from "@executor-js/api";
+import { composePluginApi } from "@executor-js/api/server";
+import { openApiHttpPlugin } from "@executor-js/plugin-openapi/api";
+import { AuthTemplateSlug, ConnectionName, IntegrationSlug } from "@executor-js/sdk/shared";
+
+import { scenario } from "../src/scenario";
+import { Api, Target } from "../src/services";
+import type { Identity, Target as TargetShape } from "../src/target";
+
+const api = composePluginApi([openApiHttpPlugin()] as const);
+type Client = HttpApiClient.ForApi<typeof api>;
+
+const TEMPLATE_API_KEY = AuthTemplateSlug.make("apiKey");
+
+/** Minimal OpenAPI spec with a single GET /ping — never contacted here. */
+const pingSpec = JSON.stringify({
+  openapi: "3.0.3",
+  info: { title: "Ping API", version: "1.0.0" },
+  paths: {
+    "/ping": {
+      get: { operationId: "ping", summary: "Ping", responses: { "200": { description: "pong" } } },
+    },
+  },
+});
+
+/** Registers a fresh apiKey-authenticated integration for connections to bind to. */
+const registerIntegration = (client: Client) =>
+  Effect.gen(function* () {
+    const slug = IntegrationSlug.make(`admin-scn-${randomBytes(4).toString("hex")}`);
+    yield* client.openapi.addSpec({
+      payload: {
+        spec: { kind: "blob", value: pingSpec },
+        slug,
+        baseUrl: "http://127.0.0.1:59999", // never contacted during registration
+        authenticationTemplate: [
+          {
+            slug: "apiKey",
+            type: "apiKey",
+            headers: { authorization: ["Bearer ", { type: "variable", name: "token" }] },
+          },
+        ],
+      },
+    });
+    return slug;
+  });
+
+const freshConnectionName = () => ConnectionName.make(`conn${randomBytes(4).toString("hex")}`);
+
+const cookieOf = (identity: Identity): string => identity.headers?.["cookie"] ?? "";
+
+const postJson = (target: TargetShape, path: string, identity: Identity, body: unknown) =>
+  Effect.promise(async () => {
+    const response = await fetch(new URL(path, target.baseUrl), {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        origin: new URL(target.baseUrl).origin,
+        cookie: cookieOf(identity),
+      },
+      body: JSON.stringify(body),
+    });
+    if (!response.ok) {
+      throw new Error(`${path} failed (${response.status}): ${await response.text()}`);
+    }
+    return response;
+  });
+
+/** The identity re-bound to the refreshed session cookie a response set. */
+const withRefreshedSession = (identity: Identity, response: Response): Identity => {
+  const refreshed = (response.headers.getSetCookie?.() ?? [])
+    .find((header) => header.startsWith("wos-session="))
+    ?.split(";")[0];
+  if (!refreshed) throw new Error("response did not refresh the session cookie");
+  return { ...identity, headers: { cookie: refreshed } };
+};
+
+/** Invite `member` into `admin`'s org and accept — the real invite flow. */
+const joinOrg = (target: TargetShape, admin: Identity, member: Identity) =>
+  Effect.gen(function* () {
+    const inviteResponse = yield* postJson(target, "/api/account/members/invite", admin, {
+      email: member.credentials?.email,
+    });
+    const invitation = (yield* Effect.promise(() => inviteResponse.json())) as { id: string };
+    const acceptResponse = yield* postJson(target, "/api/auth/accept-invitation", member, {
+      invitationId: invitation.id,
+    });
+    return withRefreshedSession(member, acceptResponse);
+  });
+
+/** The caller's own account id — the `externalId` the admin plane reports. */
+const accountIdOf = (target: TargetShape, identity: Identity) =>
+  Effect.promise(async () => {
+    const response = await fetch(new URL("/api/account/me", target.baseUrl), {
+      headers: { cookie: cookieOf(identity) },
+    });
+    if (!response.ok) throw new Error(`/api/account/me failed (${response.status})`);
+    const body = (await response.json()) as { user: { id: string } };
+    return body.user.id;
+  });
+
+scenario(
+  "Admin · the owner sees every member of the workspace and what each has connected",
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const { client: apiClient } = yield* Api;
+
+    const admin = yield* target.newIdentity();
+    const invitee = yield* target.newIdentity({ org: false });
+    const member = yield* joinOrg(target, admin, invitee);
+
+    const adminClient = yield* apiClient(api, admin);
+    const memberClient = yield* apiClient(api, member);
+    const adminId = yield* accountIdOf(target, admin);
+    const memberId = yield* accountIdOf(target, member);
+
+    const integration = yield* registerIntegration(adminClient);
+    const adminConnection = freshConnectionName();
+    const memberConnection = freshConnectionName();
+
+    yield* Effect.ensuring(
+      Effect.gen(function* () {
+        // Each member stores their OWN credential. Neither can see the other's
+        // through the product plane — that is the whole point of the admin one.
+        yield* adminClient.connections.create({
+          payload: {
+            owner: "user",
+            name: adminConnection,
+            integration,
+            template: TEMPLATE_API_KEY,
+            value: "admin-personal-token",
+          },
+        });
+        yield* memberClient.connections.create({
+          payload: {
+            owner: "user",
+            name: memberConnection,
+            integration,
+            template: TEMPLATE_API_KEY,
+            value: "member-personal-token",
+          },
+        });
+
+        const client = yield* apiClient(AdminUsersHttpApi, admin);
+
+        // (1) The joined view: both members, each with their own connection.
+        const joined = yield* client.adminUsers.listUsersWithConnections({ query: {} });
+        const byId = new Map(joined.users.map((user) => [user.externalId, user]));
+
+        expect([...byId.keys()].sort(), "both members of the workspace are reported").toEqual(
+          [adminId, memberId].sort(),
+        );
+        expect(
+          byId.get(adminId)?.connections.map((connection) => connection.name),
+          "the admin's own connection is attributed to them",
+        ).toContain(adminConnection);
+        expect(
+          byId.get(memberId)?.connections.map((connection) => connection.name),
+          "the member's connection is visible to the owner, though not to the admin's product view",
+        ).toContain(memberConnection);
+
+        // The flat list agrees with the joined one.
+        const flat = yield* client.adminUsers.listUsers({ query: {} });
+        expect(
+          flat.users.map((user) => user.externalId).sort(),
+          "the flat list reports the same members",
+        ).toEqual([adminId, memberId].sort());
+
+        // Per-user connections resolve the same rows.
+        const memberConnections = yield* client.adminUsers.listUserConnections({
+          params: { externalId: memberId },
+        });
+        expect(
+          memberConnections.connections.map((connection) => connection.name),
+          "the member's connections are readable by external id",
+        ).toContain(memberConnection);
+
+        // (2) No credential material anywhere in the joined view.
+        expect(
+          JSON.stringify(joined),
+          "the admin view never carries a stored credential",
+        ).not.toContain("member-personal-token");
+        expect(JSON.stringify(joined)).not.toContain("admin-personal-token");
+
+        // (3) A plain member is refused: this plane reports on everyone.
+        const asMember = yield* Effect.promise(() =>
+          fetch(new URL("/api/admin/users", target.baseUrl), {
+            headers: { cookie: cookieOf(member) },
+          }),
+        );
+        expect(asMember.status, "a non-admin member cannot read the workspace view").toBe(403);
+
+        // And an anonymous caller has no credential at all.
+        const anonymous = yield* Effect.promise(() =>
+          fetch(new URL("/api/admin/users", target.baseUrl)),
+        );
+        expect(anonymous.status, "no session → unauthorized").toBe(401);
+      }),
+      Effect.all(
+        [
+          adminClient.connections
+            .remove({ params: { owner: "user", integration, name: adminConnection } })
+            .pipe(Effect.ignore),
+          memberClient.connections
+            .remove({ params: { owner: "user", integration, name: memberConnection } })
+            .pipe(Effect.ignore),
+          adminClient.openapi.removeSpec({ params: { slug: integration } }).pipe(Effect.ignore),
+        ],
+        { discard: true },
+      ),
+    );
+  }),
+);
+
+scenario(
+  "Admin · one workspace's owner sees nothing of another workspace",
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const { client: apiClient } = yield* Api;
+
+    const mine = yield* target.newIdentity();
+    const theirs = yield* target.newIdentity();
+    const myId = yield* accountIdOf(target, mine);
+    const theirId = yield* accountIdOf(target, theirs);
+
+    const myClient = yield* apiClient(api, mine);
+    // A user earns their row in the workspace the first time they touch the
+    // EXECUTOR plane (the account plane doesn't bind an executor), so the other
+    // owner makes one product read — otherwise their own workspace is empty and
+    // the isolation assertion below would pass vacuously.
+    yield* (yield* apiClient(api, theirs)).connections.list({ query: {} });
+    const integration = yield* registerIntegration(myClient);
+    const connection = freshConnectionName();
+
+    yield* Effect.ensuring(
+      Effect.gen(function* () {
+        yield* myClient.connections.create({
+          payload: {
+            owner: "user",
+            name: connection,
+            integration,
+            template: TEMPLATE_API_KEY,
+            value: "my-private-token",
+          },
+        });
+
+        const theirAdmin = yield* apiClient(AdminUsersHttpApi, theirs);
+        const theirView = yield* theirAdmin.adminUsers.listUsersWithConnections({ query: {} });
+
+        expect(
+          theirView.users.map((user) => user.externalId),
+          "another workspace's owner never sees my members",
+        ).not.toContain(myId);
+        expect(
+          theirView.users.map((user) => user.externalId),
+          "they do see their own",
+        ).toContain(theirId);
+        expect(
+          JSON.stringify(theirView),
+          "and none of my connections leak across the tenant boundary",
+        ).not.toContain(connection);
+
+        // Naming my account id directly returns nothing rather than my rows.
+        const probe = yield* theirAdmin.adminUsers.listUserConnections({
+          params: { externalId: myId },
+        });
+        expect(probe.connections, "a cross-tenant id resolves to nothing").toEqual([]);
+      }),
+      Effect.all(
+        [
+          myClient.connections
+            .remove({ params: { owner: "user", integration, name: connection } })
+            .pipe(Effect.ignore),
+          myClient.openapi.removeSpec({ params: { slug: integration } }).pipe(Effect.ignore),
+        ],
+        { discard: true },
+      ),
+    );
+  }),
+);

--- a/packages/core/api/src/account/api.ts
+++ b/packages/core/api/src/account/api.ts
@@ -97,6 +97,18 @@ export const CreatedApiKeyResponse = Schema.Struct({
   value: Schema.String,
 });
 
+/**
+ * ORGANIZATION-owned api keys — the credentials that authenticate as the
+ * workspace itself rather than as a member, and are the credential for the
+ * `/admin/*` plane. Listed and minted beside personal keys (same surface, same
+ * shapes) but gated to admins, since an org key can read every user in the
+ * tenant. A provider without an org-key concept (self-host) reports an empty
+ * list and refuses to mint.
+ */
+export const OrgApiKeysResponse = Schema.Struct({
+  apiKeys: Schema.Array(ApiKeySummary),
+});
+
 export const OrgMember = Schema.Struct({
   id: Schema.String,
   userId: Schema.String,
@@ -192,6 +204,19 @@ export const AccountApi = HttpApiGroup.make("account")
       params: ApiKeyParams,
       success: SuccessResponse,
       error: [AccountError, AccountUnauthorized, AccountNoOrganization],
+    }),
+  )
+  .add(
+    HttpApiEndpoint.get("listOrgApiKeys", "/account/org-api-keys", {
+      success: OrgApiKeysResponse,
+      error: [AccountError, AccountUnauthorized, AccountForbidden, AccountNoOrganization],
+    }),
+  )
+  .add(
+    HttpApiEndpoint.post("createOrgApiKey", "/account/org-api-keys", {
+      payload: CreateApiKeyBody,
+      success: CreatedApiKeyResponse,
+      error: [AccountError, AccountUnauthorized, AccountForbidden, AccountNoOrganization],
     }),
   )
   .add(

--- a/packages/core/api/src/account/handlers.ts
+++ b/packages/core/api/src/account/handlers.ts
@@ -44,6 +44,18 @@ export const AccountHandlers = HttpApiBuilder.group(AccountHttpApi, "account", (
         return yield* (yield* AccountProvider).revokeApiKey(headers, params.apiKeyId);
       }),
     )
+    .handle("listOrgApiKeys", () =>
+      Effect.gen(function* () {
+        const headers = yield* requestHeaders;
+        return yield* (yield* AccountProvider).listOrgApiKeys(headers);
+      }),
+    )
+    .handle("createOrgApiKey", ({ payload }) =>
+      Effect.gen(function* () {
+        const headers = yield* requestHeaders;
+        return yield* (yield* AccountProvider).createOrgApiKey(headers, payload.name);
+      }),
+    )
     .handle("listMembers", () =>
       Effect.gen(function* () {
         const headers = yield* requestHeaders;

--- a/packages/core/api/src/account/service.ts
+++ b/packages/core/api/src/account/service.ts
@@ -7,6 +7,7 @@ import {
   type AccountUnauthorized,
   AccountMeResponse,
   ApiKeysResponse,
+  OrgApiKeysResponse,
   CreatedApiKeyResponse,
   OrgMembersResponse,
   OrgRolesResponse,
@@ -33,6 +34,7 @@ export type AccountHeaders = Record<string, string>;
 
 type Me = typeof AccountMeResponse.Type;
 type ApiKeys = typeof ApiKeysResponse.Type;
+type OrgApiKeys = typeof OrgApiKeysResponse.Type;
 type CreatedApiKey = typeof CreatedApiKeyResponse.Type;
 type Members = typeof OrgMembersResponse.Type;
 type Roles = typeof OrgRolesResponse.Type;
@@ -49,6 +51,12 @@ export interface AccountProviderShape {
   readonly listApiKeys: (headers: AccountHeaders) => OrgScoped<ApiKeys>;
   readonly createApiKey: (headers: AccountHeaders, name: string) => OrgScoped<CreatedApiKey>;
   readonly revokeApiKey: (headers: AccountHeaders, apiKeyId: string) => OrgScoped<Success>;
+  /** Org-owned keys: admin-gated, hence the `AccountForbidden` on both. */
+  readonly listOrgApiKeys: (headers: AccountHeaders) => OrgScoped<OrgApiKeys, AccountForbidden>;
+  readonly createOrgApiKey: (
+    headers: AccountHeaders,
+    name: string,
+  ) => OrgScoped<CreatedApiKey, AccountForbidden>;
   readonly listMembers: (headers: AccountHeaders) => OrgScoped<Members>;
   readonly listRoles: (headers: AccountHeaders) => OrgScoped<Roles>;
   readonly inviteMember: (

--- a/packages/core/api/src/admin/admin-users.test.ts
+++ b/packages/core/api/src/admin/admin-users.test.ts
@@ -1,0 +1,495 @@
+import { HttpApiBuilder } from "effect/unstable/httpapi";
+import { HttpRouter, HttpServer } from "effect/unstable/http";
+import { describe, expect, it } from "@effect/vitest";
+import { Context, Effect, Layer, type Scope } from "effect";
+
+import { Subject, Tenant, collectTables, createExecutor, type Executor } from "@executor-js/sdk";
+import { createSqliteTestFumaDb, type SqliteTestFumaDb } from "@executor-js/sdk/testing";
+import { touchSubject } from "@executor-js/sdk/host-internal";
+
+import { AdminUsersHttpApi, AdminUsersForbidden, AdminUsersUnauthorized } from "./api";
+import { AdminUsersHandlers } from "./handlers";
+import { AdminUsersProvider, type AdminUsersHeaders } from "./service";
+import { listUserConnections, listUsers, listUsersWithConnections, platformViewOf } from "./reads";
+
+// ---------------------------------------------------------------------------
+// The admin users HTTP surface, over a real SQLite-backed platform view.
+//
+// The reads themselves (tenant reach, the bigint `last_seen_at` round-trip, the
+// field allowlist) are proven in the SDK's `platform-view.test.ts`. What this
+// file proves is the HTTP EDGE on top of them:
+//   - the public vocabulary + wire shapes the contract promises,
+//   - the authorization outcomes (401 vs 403) a host's provider produces,
+//   - that a tenant's admin plane cannot see another tenant's rows,
+//   - that no credential-bearing field survives the projection.
+//
+// The provider seam is stubbed the way each host's real one behaves, so the
+// authz assertions are about the CONTRACT (which status a refusal renders),
+// not about WorkOS or Better Auth.
+// ---------------------------------------------------------------------------
+
+const TENANT_A = "org_a";
+const TENANT_B = "org_b";
+const USER_A1 = "user_a1";
+const USER_A2 = "user_a2";
+const USER_B1 = "user_b1";
+
+/** Every field that could resolve, or help resolve, a credential. NONE may
+ *  appear anywhere in an admin HTTP response — enumerated so a future column
+ *  addition has to be argued with this list. Mirrors the SDK's own list. */
+const FORBIDDEN_FIELDS = [
+  "item_ids",
+  "itemIds",
+  "refresh_item_id",
+  "refreshItemId",
+  "provider",
+  "provider_state",
+  "providerState",
+  "oauth_token_url",
+  "oauthTokenUrl",
+  "template",
+  "client_secret",
+  "clientSecret",
+  "secret",
+  "token",
+  // The internal partition keys: the public vocabulary is users/owners, so
+  // neither the raw column name nor the tenant may leak onto the wire.
+  "subject",
+  "tenant",
+] as const;
+
+// The bodies below acquire a scoped web handler, so `R` carries `Scope` rather
+// than being erased; `Effect.scoped` closes it when the body finishes.
+const withDb = <A, E>(
+  body: (db: SqliteTestFumaDb) => Effect.Effect<A, E, Scope.Scope>,
+): Effect.Effect<A, E> =>
+  Effect.scoped(
+    Effect.acquireUseRelease(
+      Effect.promise(() => createSqliteTestFumaDb({ tables: collectTables() })),
+      body,
+      (db) => Effect.promise(() => db.close()),
+    ),
+  );
+
+const insertConnection = (
+  db: SqliteTestFumaDb,
+  row: {
+    readonly rowId: string;
+    readonly tenant: string;
+    readonly owner: string;
+    readonly subject: string;
+    readonly integration: string;
+    readonly name: string;
+    readonly oauthScope?: string | null;
+  },
+): Effect.Effect<void> =>
+  Effect.promise(async () => {
+    await db.client.execute({
+      sql: `INSERT INTO connection (
+          row_id, tenant, owner, subject, integration, name, template, provider,
+          item_ids, refresh_item_id, oauth_scope, last_health, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      args: [
+        row.rowId,
+        row.tenant,
+        row.owner,
+        row.subject,
+        row.integration,
+        row.name,
+        "oauth2",
+        "memory",
+        // Deliberately secret-bearing: the assertions below prove these never
+        // reach an HTTP response.
+        JSON.stringify({ token: `SECRET-item-${row.rowId}` }),
+        `SECRET-refresh-${row.rowId}`,
+        row.oauthScope ?? null,
+        JSON.stringify({ status: "healthy", checkedAt: 1_700_000_000_000 }),
+        Date.now(),
+        Date.now(),
+      ],
+    });
+  });
+
+/** Two users with connections under tenant A, plus a whole separate tenant B
+ *  that A's admin plane must never see. */
+const seed = (db: SqliteTestFumaDb): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    yield* touchSubject(db.db, { tenant: TENANT_A, externalId: USER_A1 });
+    yield* touchSubject(db.db, { tenant: TENANT_A, externalId: USER_A2 });
+    yield* touchSubject(db.db, { tenant: TENANT_B, externalId: USER_B1 });
+
+    yield* insertConnection(db, {
+      rowId: "c-a1-gh",
+      tenant: TENANT_A,
+      owner: "user",
+      subject: USER_A1,
+      integration: "github",
+      name: "personal",
+      oauthScope: "repo read:user",
+    });
+    yield* insertConnection(db, {
+      rowId: "c-a2-linear",
+      tenant: TENANT_A,
+      owner: "user",
+      subject: USER_A2,
+      integration: "linear",
+      name: "work",
+    });
+    yield* insertConnection(db, {
+      rowId: "c-b1-gh",
+      tenant: TENANT_B,
+      owner: "user",
+      subject: USER_B1,
+      integration: "github",
+      name: "b-secret",
+      oauthScope: "admin:org",
+    });
+  });
+
+const platformExecutorFor = (db: SqliteTestFumaDb, tenant: string): Effect.Effect<Executor> =>
+  createExecutor({
+    tenant: Tenant.make(tenant),
+    db: db.db,
+    onElicitation: "accept-all",
+    platformView: true,
+  }).pipe(Effect.orDie);
+
+/** A product-view executor: bound to one subject, no platform view at all. */
+const productExecutorFor = (db: SqliteTestFumaDb, tenant: string): Effect.Effect<Executor> =>
+  createExecutor({
+    tenant: Tenant.make(tenant),
+    subject: Subject.make(USER_A1),
+    db: db.db,
+    onElicitation: "accept-all",
+  }).pipe(Effect.orDie);
+
+/**
+ * A stub `AdminUsersProvider` shaped like a host's real one: it authorizes off
+ * the request headers, then delegates to the shared reads. `authorize` returns
+ * the tenant an authorized caller may read, or a refusal — exactly the decision
+ * cloud makes from an org key / admin session and self-host from a Better Auth
+ * member.
+ */
+const stubProvider = (
+  executorFor: (tenant: string) => Effect.Effect<Executor>,
+  authorize: (
+    headers: AdminUsersHeaders,
+  ) => Effect.Effect<string, AdminUsersUnauthorized | AdminUsersForbidden>,
+) =>
+  Layer.succeed(AdminUsersProvider)({
+    listUsers: (headers, options) =>
+      authorize(headers).pipe(
+        Effect.flatMap(executorFor),
+        Effect.flatMap((executor) =>
+          platformViewOf(executor).pipe(Effect.flatMap((admin) => listUsers(admin, options))),
+        ),
+      ),
+    listUsersWithConnections: (headers, options) =>
+      authorize(headers).pipe(
+        Effect.flatMap(executorFor),
+        Effect.flatMap((executor) =>
+          platformViewOf(executor).pipe(
+            Effect.flatMap((admin) => listUsersWithConnections(admin, options)),
+          ),
+        ),
+      ),
+    listUserConnections: (headers, externalId) =>
+      authorize(headers).pipe(
+        Effect.flatMap(executorFor),
+        Effect.flatMap((executor) =>
+          platformViewOf(executor).pipe(
+            Effect.flatMap((admin) => listUserConnections(admin, externalId)),
+          ),
+        ),
+      ),
+  });
+
+/**
+ * The authorization the hosts implement, reduced to its decision table:
+ * an org-scoped key (or admin session) names its tenant; a plain member or a
+ * user-scoped key is forbidden; no credential at all is unauthorized.
+ */
+const headerAuthorize = (headers: AdminUsersHeaders) => {
+  const credential = headers["authorization"];
+  if (!credential) return Effect.fail(new AdminUsersUnauthorized());
+  if (credential === "Bearer org_a_key") return Effect.succeed(TENANT_A);
+  if (credential === "Bearer org_b_key") return Effect.succeed(TENANT_B);
+  // A valid user-scoped key / plain member session: authentic, but this plane
+  // serves the whole tenant and they name one member.
+  return Effect.fail(new AdminUsersForbidden());
+};
+
+// `HttpRouter.provideRequest` (not a plain `Layer.provide`) is what clears the
+// handlers' per-request `AdminUsersProvider` marker — the same reason the real
+// hosts mount the provider through a router middleware.
+const webHandlerFor = (provider: Layer.Layer<AdminUsersProvider>) =>
+  Effect.acquireRelease(
+    Effect.sync(() =>
+      HttpRouter.toWebHandler(
+        HttpApiBuilder.layer(AdminUsersHttpApi).pipe(
+          Layer.provide(AdminUsersHandlers),
+          HttpRouter.provideRequest(provider),
+          Layer.provideMerge(HttpServer.layerServices),
+          Layer.provideMerge(Layer.succeed(HttpRouter.RouterConfig)({ maxParamLength: 1000 })),
+        ),
+        { disableLogger: true },
+      ),
+    ),
+    (web) => Effect.promise(() => web.dispose()),
+  );
+
+const get = (
+  web: {
+    readonly handler: (request: Request, context: Context.Context<never>) => Promise<Response>;
+  },
+  path: string,
+  credential?: string,
+) =>
+  Effect.promise(() =>
+    web.handler(
+      new Request(`http://localhost${path}`, {
+        headers: credential ? { authorization: credential } : {},
+      }),
+      Context.empty(),
+    ),
+  );
+
+const jsonOf = <A>(response: Response) => Effect.promise(() => response.json() as Promise<A>);
+
+type UsersBody = { readonly users: ReadonlyArray<{ readonly externalId: string }> };
+type ConnectionsBody = {
+  readonly connections: ReadonlyArray<{ readonly integration: string; readonly name: string }>;
+};
+type UsersWithConnectionsBody = {
+  readonly users: ReadonlyArray<{
+    readonly externalId: string;
+    readonly lastSeenAt: number | null;
+    readonly status: string | null;
+    readonly connections: ReadonlyArray<{
+      readonly integration: string;
+      readonly oauthScope: string | null;
+      readonly lastHealth: { readonly status: string } | null;
+    }>;
+  }>;
+};
+
+const ORG_A = "Bearer org_a_key";
+
+describe("admin users API", () => {
+  it.effect("lists every user of the tenant for an authorized org caller", () =>
+    withDb((db) =>
+      Effect.gen(function* () {
+        yield* seed(db);
+        const web = yield* webHandlerFor(
+          stubProvider((tenant) => platformExecutorFor(db, tenant), headerAuthorize),
+        );
+
+        const response = yield* get(web, "/admin/users", ORG_A);
+        expect(response.status).toBe(200);
+        const body = yield* jsonOf<UsersBody>(response);
+
+        expect(
+          body.users.map((user) => user.externalId),
+          "both of the tenant's users are reported",
+        ).toEqual([USER_A1, USER_A2]);
+      }),
+    ),
+  );
+
+  it.effect("reports a user's connections with access summary but no credential", () =>
+    withDb((db) =>
+      Effect.gen(function* () {
+        yield* seed(db);
+        const web = yield* webHandlerFor(
+          stubProvider((tenant) => platformExecutorFor(db, tenant), headerAuthorize),
+        );
+
+        const response = yield* get(web, `/admin/users/${USER_A1}/connections`, ORG_A);
+        expect(response.status).toBe(200);
+        const body = yield* jsonOf<ConnectionsBody>(response);
+
+        expect(
+          body.connections.map((connection) => connection.integration),
+          "the user's own connection is reported",
+        ).toEqual(["github"]);
+        expect(body.connections[0]?.name).toBe("personal");
+      }),
+    ),
+  );
+
+  it.effect("joins users with their connections for the dashboard view", () =>
+    withDb((db) =>
+      Effect.gen(function* () {
+        yield* seed(db);
+        const web = yield* webHandlerFor(
+          stubProvider((tenant) => platformExecutorFor(db, tenant), headerAuthorize),
+        );
+
+        const response = yield* get(web, "/admin/users/with-connections", ORG_A);
+        expect(response.status).toBe(200);
+        const body = yield* jsonOf<UsersWithConnectionsBody>(response);
+
+        expect(
+          body.users.map((user) => [user.externalId, user.connections.map((c) => c.integration)]),
+          "each user carries their own connections",
+        ).toEqual([
+          [USER_A1, ["github"]],
+          [USER_A2, ["linear"]],
+        ]);
+        // The access summary and health travel; `lastSeenAt` is a number the
+        // dashboard can render (a raw SQL read would hand back a blob).
+        expect(body.users[0]?.connections[0]?.oauthScope).toBe("repo read:user");
+        expect(body.users[0]?.connections[0]?.lastHealth?.status).toBe("healthy");
+        expect(typeof body.users[0]?.lastSeenAt).toBe("number");
+        expect(body.users[0]?.status, "no lifecycle state is recorded yet").toBeNull();
+      }),
+    ),
+  );
+
+  it.effect("never serves credential material on any admin response", () =>
+    withDb((db) =>
+      Effect.gen(function* () {
+        yield* seed(db);
+        const web = yield* webHandlerFor(
+          stubProvider((tenant) => platformExecutorFor(db, tenant), headerAuthorize),
+        );
+
+        for (const path of [
+          "/admin/users",
+          "/admin/users/with-connections",
+          `/admin/users/${USER_A1}/connections`,
+        ]) {
+          const response = yield* get(web, path, ORG_A);
+          const raw = yield* Effect.promise(() => response.text());
+
+          for (const field of FORBIDDEN_FIELDS) {
+            expect(raw, `${path} must not expose "${field}"`).not.toContain(`"${field}"`);
+          }
+          // The seeded secrets are the ground truth: nothing derived from a
+          // credential may appear, whatever it is called.
+          expect(raw, `${path} must not leak a stored secret`).not.toContain("SECRET-");
+        }
+      }),
+    ),
+  );
+
+  it.effect("isolates tenants: an org caller sees nothing of another tenant", () =>
+    withDb((db) =>
+      Effect.gen(function* () {
+        yield* seed(db);
+        const web = yield* webHandlerFor(
+          stubProvider((tenant) => platformExecutorFor(db, tenant), headerAuthorize),
+        );
+
+        const users = yield* jsonOf<UsersBody>(yield* get(web, "/admin/users", ORG_A));
+        expect(
+          users.users.map((user) => user.externalId),
+          "tenant B's user is invisible to tenant A",
+        ).not.toContain(USER_B1);
+
+        // Naming another tenant's user directly returns nothing rather than
+        // that user's connections — the tenant clause is never relaxed.
+        const crossTenant = yield* jsonOf<ConnectionsBody>(
+          yield* get(web, `/admin/users/${USER_B1}/connections`, ORG_A),
+        );
+        expect(crossTenant.connections, "tenant B's connections stay in tenant B").toEqual([]);
+
+        // And tenant B's own caller does see them — proving the emptiness above
+        // is isolation, not a broken fixture.
+        const ownView = yield* jsonOf<ConnectionsBody>(
+          yield* get(web, `/admin/users/${USER_B1}/connections`, "Bearer org_b_key"),
+        );
+        expect(ownView.connections.map((c) => c.name)).toEqual(["b-secret"]);
+      }),
+    ),
+  );
+
+  it.effect("refuses a caller with no credential and a caller who is only a member", () =>
+    withDb((db) =>
+      Effect.gen(function* () {
+        yield* seed(db);
+        const web = yield* webHandlerFor(
+          stubProvider((tenant) => platformExecutorFor(db, tenant), headerAuthorize),
+        );
+
+        const anonymous = yield* get(web, "/admin/users");
+        expect(anonymous.status, "no credential → unauthorized").toBe(401);
+
+        // A user-scoped API key or plain member session: authentic, but this
+        // plane serves the whole tenant.
+        const member = yield* get(web, "/admin/users", "Bearer user_scoped_key");
+        expect(member.status, "a non-admin caller → forbidden").toBe(403);
+
+        const memberJoined = yield* get(web, "/admin/users/with-connections", "Bearer user_key");
+        expect(memberJoined.status).toBe(403);
+        const memberConnections = yield* get(
+          web,
+          `/admin/users/${USER_A1}/connections`,
+          "Bearer user_key",
+        );
+        expect(memberConnections.status).toBe(403);
+      }),
+    ),
+  );
+
+  // The response schema strips unknown fields on encode, so the HTTP assertions
+  // above would still pass if the projection leaked one. Assert the projection
+  // directly too: it is the layer that is supposed to be an allowlist, and both
+  // layers should hold on their own.
+  it.effect("projects only allowlisted fields, before the schema ever encodes", () =>
+    withDb((db) =>
+      Effect.gen(function* () {
+        yield* seed(db);
+        const executor = yield* platformExecutorFor(db, TENANT_A);
+        const admin = yield* platformViewOf(executor);
+
+        const { connections } = yield* listUserConnections(admin, USER_A1);
+        expect(
+          Object.keys(connections[0] ?? {}).sort(),
+          "the connection projection is exactly the allowlist",
+        ).toEqual(["integration", "lastHealth", "name", "oauthScope", "owner"]);
+
+        const { users } = yield* listUsers(admin, {});
+        expect(
+          Object.keys(users[0] ?? {}).sort(),
+          "the user projection is exactly the allowlist",
+        ).toEqual(["createdAt", "externalId", "lastSeenAt", "status"]);
+      }),
+    ),
+  );
+
+  it.effect("fails loudly when wired to a product-view executor", () =>
+    withDb((db) =>
+      Effect.gen(function* () {
+        yield* seed(db);
+        // A host that forgot `platformView: true` must not silently report an
+        // empty tenant — that would read as "this owner has no users".
+        const web = yield* webHandlerFor(
+          stubProvider((tenant) => productExecutorFor(db, tenant), headerAuthorize),
+        );
+
+        const response = yield* get(web, "/admin/users", ORG_A);
+        expect(response.status, "a missing platform view is a server error").toBe(500);
+      }),
+    ),
+  );
+
+  it.effect("pages the user list", () =>
+    withDb((db) =>
+      Effect.gen(function* () {
+        yield* seed(db);
+        const web = yield* webHandlerFor(
+          stubProvider((tenant) => platformExecutorFor(db, tenant), headerAuthorize),
+        );
+
+        const first = yield* jsonOf<UsersBody>(yield* get(web, "/admin/users?limit=1", ORG_A));
+        expect(first.users.map((user) => user.externalId)).toEqual([USER_A1]);
+
+        const second = yield* jsonOf<UsersBody>(
+          yield* get(web, "/admin/users?limit=1&offset=1", ORG_A),
+        );
+        expect(second.users.map((user) => user.externalId)).toEqual([USER_A2]);
+      }),
+    ),
+  );
+});

--- a/packages/core/api/src/admin/admin-users.test.ts
+++ b/packages/core/api/src/admin/admin-users.test.ts
@@ -5,7 +5,7 @@ import { Context, Effect, Layer, type Scope } from "effect";
 
 import { Subject, Tenant, collectTables, createExecutor, type Executor } from "@executor-js/sdk";
 import { createSqliteTestFumaDb, type SqliteTestFumaDb } from "@executor-js/sdk/testing";
-import { touchSubject } from "@executor-js/sdk/host-internal";
+import { resetSubjectTouchCache, touchSubject } from "@executor-js/sdk/host-internal";
 
 import { AdminUsersHttpApi, AdminUsersForbidden, AdminUsersUnauthorized } from "./api";
 import { AdminUsersHandlers } from "./handlers";
@@ -114,6 +114,11 @@ const insertConnection = (
  *  that A's admin plane must never see. */
 const seed = (db: SqliteTestFumaDb): Effect.Effect<void> =>
   Effect.gen(function* () {
+    // `touchSubject` keeps a process-local memory of principals it already
+    // filed, so a second seed against a FRESH database would be skipped as a
+    // repeat sighting and leave the table empty. Each seed is a new world.
+    resetSubjectTouchCache();
+
     yield* touchSubject(db.db, { tenant: TENANT_A, externalId: USER_A1 });
     yield* touchSubject(db.db, { tenant: TENANT_A, externalId: USER_A2 });
     yield* touchSubject(db.db, { tenant: TENANT_B, externalId: USER_B1 });

--- a/packages/core/api/src/admin/api.ts
+++ b/packages/core/api/src/admin/api.ts
@@ -1,0 +1,183 @@
+// ---------------------------------------------------------------------------
+// Admin Users HTTP API — the public, tenant-wide operator surface.
+//
+// The product plane (`/api/*`) answers "what can I, this member, reach". This
+// one answers the OWNER's question: "who are my users, and what have they
+// connected". It reads the SDK's platform view (`executor.admin`, opt-in via
+// `platformView: true`), which is read-only by construction — the owner policy
+// rejects writes at `reach: "tenant"` — so every endpoint here is a GET.
+//
+// VOCABULARY: this is the translation seam. Internal code says subject / tenant
+// / reach; everything public-facing says users / owners. `AdminSubject
+// .externalId` becomes `externalId` on a `users` collection, and nothing below
+// leaks the word "subject".
+//
+// FIELD DISCIPLINE: the response shapes are 1:1 with the SDK's hand-picked
+// admin allowlist (`AdminSubject` / `AdminConnection`), NOT a projection of the
+// underlying rows. No credential material of any kind may appear — no item ids,
+// no refresh ids, no oauth client secrets, no tokens. `oauthScope` is a summary
+// of ACCESS (which scopes were granted), never a token. Adding a field here is
+// a deliberate act that has to be argued against `platform-view.test.ts`'s
+// forbidden-field list.
+//
+// Auth is applied by each host's own admin middleware (cloud: an org-scoped API
+// key or an admin session member; self-host: a Better Auth owner/admin member),
+// so this contract carries no provider-specific auth scheme — the same shape
+// the Account API uses.
+// ---------------------------------------------------------------------------
+
+import { HttpApi, HttpApiEndpoint, HttpApiGroup } from "effect/unstable/httpapi";
+import { Schema } from "effect";
+
+import { ConnectionName, HealthCheckResult, IntegrationSlug, Owner } from "@executor-js/sdk/shared";
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+export class AdminUsersError extends Schema.TaggedErrorClass<AdminUsersError>()(
+  "AdminUsersError",
+  { message: Schema.String },
+  { httpApiStatus: 500 },
+) {}
+
+export class AdminUsersUnauthorized extends Schema.TaggedErrorClass<AdminUsersUnauthorized>()(
+  "AdminUsersUnauthorized",
+  {},
+  { httpApiStatus: 401 },
+) {}
+
+export class AdminUsersForbidden extends Schema.TaggedErrorClass<AdminUsersForbidden>()(
+  "AdminUsersForbidden",
+  {},
+  { httpApiStatus: 403 },
+) {}
+
+// ---------------------------------------------------------------------------
+// Response schemas — the public projection of the SDK's admin shapes.
+// ---------------------------------------------------------------------------
+
+/**
+ * One user of the tenant. Mirrors `AdminSubject` with the public vocabulary.
+ *
+ * `lastSeenAt` is epoch ms of the last sighting on the request path, and is
+ * deliberately COARSE: the writer (`touchSubject`) only rewrites it past a
+ * throttle interval (1 hour by default), so treat it as "active around then",
+ * never as a precise last-activity timestamp. `null` means never seen on a
+ * request — a user can earn a row at connection-create before any sighting.
+ */
+export const AdminUser = Schema.Struct({
+  /** The host-auth principal id (cloud: the WorkOS user id). Opaque — it also
+   *  carries host sentinels like "local", so nothing may parse it. */
+  externalId: Schema.String,
+  /** Epoch ms the user was first recorded under this tenant. */
+  createdAt: Schema.Number,
+  lastSeenAt: Schema.NullOr(Schema.Number),
+  /** User lifecycle. Unconstrained until the lifecycle values are defined;
+   *  `null` means no state recorded (which is every row today). */
+  status: Schema.NullOr(Schema.String),
+});
+
+/**
+ * A connection as the platform view sees it: enough to answer "what has this
+ * user connected, and is it healthy", and nothing that could resolve a
+ * credential. Mirrors `AdminConnection`.
+ */
+export const AdminUserConnection = Schema.Struct({
+  owner: Owner,
+  integration: IntegrationSlug,
+  name: ConnectionName,
+  /** The scope set the provider actually granted, space-delimited as recorded
+   *  at connect/refresh. Null for static credentials. A summary of ACCESS —
+   *  never a token. */
+  oauthScope: Schema.NullOr(Schema.String),
+  lastHealth: Schema.NullOr(HealthCheckResult),
+});
+
+/** A user joined with every connection they own in the tenant. */
+export const AdminUserWithConnections = Schema.Struct({
+  ...AdminUser.fields,
+  connections: Schema.Array(AdminUserConnection),
+});
+
+export const AdminUsersResponse = Schema.Struct({
+  users: Schema.Array(AdminUser),
+});
+
+export const AdminUserConnectionsResponse = Schema.Struct({
+  connections: Schema.Array(AdminUserConnection),
+});
+
+export const AdminUsersWithConnectionsResponse = Schema.Struct({
+  users: Schema.Array(AdminUserWithConnections),
+});
+
+// ---------------------------------------------------------------------------
+// Params / query
+// ---------------------------------------------------------------------------
+
+const AdminUserParams = { externalId: Schema.String };
+
+// Paging, mirroring `AdminListSubjectsOptions`. Query params arrive as strings,
+// so decode them here rather than making every handler interpret raw strings —
+// an out-of-range or non-numeric value is a 400 from the contract, not a
+// silently-ignored filter. The joined endpoint reads per-user connections, so
+// its page size is bounded harder than the flat list's.
+const AdminListQuery = Schema.Struct({
+  limit: Schema.optional(
+    Schema.FiniteFromString.check(Schema.isBetween({ minimum: 1, maximum: 500 })),
+  ),
+  offset: Schema.optional(
+    Schema.FiniteFromString.check(
+      Schema.isBetween({ minimum: 0, maximum: Number.MAX_SAFE_INTEGER }),
+    ),
+  ),
+});
+
+// ---------------------------------------------------------------------------
+// Group
+// ---------------------------------------------------------------------------
+
+/**
+ * The admin users group, mounted at `/admin/*` by each host.
+ *
+ * The joined view is its OWN path (`/admin/users/with-connections`) rather than
+ * an `?include=connections` flag on `/admin/users`, because the two return
+ * different row shapes. A query flag that changes the response schema can't be
+ * expressed as one typed endpoint — the repo's list endpoints use query params
+ * only to FILTER a fixed shape (`/tools`, `/connections`), never to switch it.
+ * It sorts before `/admin/users/:externalId/...` in the router either way, and
+ * "with-connections" is not a valid opaque principal id.
+ */
+export const AdminUsersApi = HttpApiGroup.make("adminUsers")
+  .add(
+    HttpApiEndpoint.get("listUsers", "/admin/users", {
+      query: AdminListQuery,
+      success: AdminUsersResponse,
+      error: [AdminUsersError, AdminUsersUnauthorized, AdminUsersForbidden],
+    }),
+  )
+  .add(
+    HttpApiEndpoint.get("listUsersWithConnections", "/admin/users/with-connections", {
+      query: AdminListQuery,
+      success: AdminUsersWithConnectionsResponse,
+      error: [AdminUsersError, AdminUsersUnauthorized, AdminUsersForbidden],
+    }),
+  )
+  .add(
+    HttpApiEndpoint.get("listUserConnections", "/admin/users/:externalId/connections", {
+      params: AdminUserParams,
+      success: AdminUserConnectionsResponse,
+      error: [AdminUsersError, AdminUsersUnauthorized, AdminUsersForbidden],
+    }),
+  );
+
+/**
+ * Standalone HttpApi wrapping just the admin users group. Hosts mount THIS as
+ * an extension route (like the account API) rather than adding the group to
+ * `CoreExecutorApi`: the core API is served behind the execution-stack
+ * middleware, which binds a product-view executor to one acting subject. The
+ * admin plane needs the opposite (no subject, tenant reach), so it gets its own
+ * mount and its own per-host auth.
+ */
+export const AdminUsersHttpApi = HttpApi.make("executor-admin-users").add(AdminUsersApi);

--- a/packages/core/api/src/admin/handlers.ts
+++ b/packages/core/api/src/admin/handlers.ts
@@ -1,0 +1,58 @@
+import { HttpApiBuilder } from "effect/unstable/httpapi";
+import { HttpServerRequest } from "effect/unstable/http";
+import { Effect } from "effect";
+
+import { AdminUsersHttpApi } from "./api";
+import { AdminUsersProvider, type AdminUsersHeaders, type AdminUsersListOptions } from "./service";
+
+// ---------------------------------------------------------------------------
+// Shared, provider-neutral handlers for the Admin Users API. They do nothing
+// but read the request headers + paging and delegate to the injected
+// `AdminUsersProvider`, so cloud and self-host serve identical routes — only
+// the authorization impl differs. The neutral errors map to their HTTP statuses
+// (401/403/500) via the contract annotations.
+// ---------------------------------------------------------------------------
+
+const requestHeaders = Effect.map(
+  HttpServerRequest.HttpServerRequest.asEffect(),
+  (request): AdminUsersHeaders => ({ ...request.headers }),
+);
+
+// The contract decodes `limit`/`offset` to numbers, but leaves them optional.
+// Spread only the keys that are present so the SDK's own defaults apply rather
+// than an explicit `undefined` overriding them.
+const listOptions = (query: {
+  readonly limit?: number | undefined;
+  readonly offset?: number | undefined;
+}): AdminUsersListOptions => ({
+  ...(query.limit === undefined ? {} : { limit: query.limit }),
+  ...(query.offset === undefined ? {} : { offset: query.offset }),
+});
+
+export const AdminUsersHandlers = HttpApiBuilder.group(
+  AdminUsersHttpApi,
+  "adminUsers",
+  (handlers) =>
+    handlers
+      .handle("listUsers", ({ query }) =>
+        Effect.gen(function* () {
+          const headers = yield* requestHeaders;
+          return yield* (yield* AdminUsersProvider).listUsers(headers, listOptions(query));
+        }),
+      )
+      .handle("listUsersWithConnections", ({ query }) =>
+        Effect.gen(function* () {
+          const headers = yield* requestHeaders;
+          return yield* (yield* AdminUsersProvider).listUsersWithConnections(
+            headers,
+            listOptions(query),
+          );
+        }),
+      )
+      .handle("listUserConnections", ({ params }) =>
+        Effect.gen(function* () {
+          const headers = yield* requestHeaders;
+          return yield* (yield* AdminUsersProvider).listUserConnections(headers, params.externalId);
+        }),
+      ),
+);

--- a/packages/core/api/src/admin/reads.ts
+++ b/packages/core/api/src/admin/reads.ts
@@ -1,0 +1,115 @@
+// ---------------------------------------------------------------------------
+// The READ half of the admin users surface, shared by every host.
+//
+// A host's `AdminUsersProvider` owns AUTHORIZATION (who may look) and delegates
+// the actual reads here, so the projection from the SDK's platform view onto
+// the wire shapes exists exactly ONCE. That matters because the projection IS
+// the field-discipline boundary: if each host mapped rows itself, a credential
+// field could leak into one host's responses and not the other's.
+//
+// Every mapping below is explicit rather than a spread. A spread would silently
+// forward any field a future SDK change adds to `AdminSubject`/`AdminConnection`
+// — the opposite of an allowlist.
+// ---------------------------------------------------------------------------
+
+import { Effect } from "effect";
+
+import type {
+  AdminConnection,
+  AdminSubject,
+  AdminSubjectWithConnections,
+  Executor,
+  ExecutorAdmin,
+} from "@executor-js/sdk";
+
+import {
+  AdminUsersError,
+  type AdminUserConnectionsResponse,
+  type AdminUsersResponse,
+  type AdminUsersWithConnectionsResponse,
+} from "./api";
+import type { AdminUsersListOptions } from "./service";
+
+/**
+ * Narrow an executor to its platform view. `admin` is present only when the
+ * executor was built with `platformView: true`; a host that reaches these reads
+ * with a product-view executor is a wiring bug, so it fails loudly as a 500
+ * rather than silently returning an empty tenant (which would read as "this
+ * owner has no users").
+ */
+export const platformViewOf = (executor: Executor): Effect.Effect<ExecutorAdmin, AdminUsersError> =>
+  executor.admin
+    ? Effect.succeed(executor.admin)
+    : Effect.fail(
+        new AdminUsersError({
+          message: "Admin reads require an executor built with the platform view enabled",
+        }),
+      );
+
+// Storage faults are the only failure these reads can raise. They surface as a
+// 500 with a flat message — the cause carries the detail into the host's error
+// capture, and is deliberately not echoed to an API consumer.
+const readFailed = (what: string) => () =>
+  new AdminUsersError({ message: `Failed to list ${what}` });
+
+/**
+ * `AdminSubject` → the public `AdminUser` shape.
+ *
+ * `createdAt` crosses the wire as epoch ms (the SDK hands back a `Date`), which
+ * matches how every other "when did this happen" field on the API is carried
+ * and keeps the whole response JSON-native.
+ */
+const toUser = (subject: AdminSubject) => ({
+  externalId: subject.externalId,
+  createdAt: subject.createdAt.getTime(),
+  lastSeenAt: subject.lastSeenAt,
+  status: subject.status,
+});
+
+/**
+ * `AdminConnection` → the public `AdminUserConnection` shape.
+ *
+ * `subject` is dropped: on `/admin/users/:externalId/connections` it is the
+ * path parameter, and on the joined view it is the enclosing user's own id, so
+ * carrying it would be redundant on both. Everything kept here is either an
+ * identifier or a health/access summary — never credential material.
+ */
+const toConnection = (connection: AdminConnection) => ({
+  owner: connection.owner,
+  integration: connection.integration,
+  name: connection.name,
+  oauthScope: connection.oauthScope,
+  lastHealth: connection.lastHealth,
+});
+
+const toUserWithConnections = (subject: AdminSubjectWithConnections) => ({
+  ...toUser(subject),
+  connections: subject.connections.map(toConnection),
+});
+
+export const listUsers = (
+  admin: ExecutorAdmin,
+  options: AdminUsersListOptions,
+): Effect.Effect<typeof AdminUsersResponse.Type, AdminUsersError> =>
+  admin.listSubjects(options).pipe(
+    Effect.map((subjects) => ({ users: subjects.map(toUser) })),
+    Effect.mapError(readFailed("users")),
+  );
+
+export const listUsersWithConnections = (
+  admin: ExecutorAdmin,
+  options: AdminUsersListOptions,
+): Effect.Effect<typeof AdminUsersWithConnectionsResponse.Type, AdminUsersError> =>
+  admin.listSubjectsWithConnections(options).pipe(
+    Effect.map((subjects) => ({ users: subjects.map(toUserWithConnections) })),
+    Effect.mapError(readFailed("users")),
+  );
+
+export const listUserConnections = (
+  admin: ExecutorAdmin,
+  externalId: string,
+): Effect.Effect<typeof AdminUserConnectionsResponse.Type, AdminUsersError> =>
+  admin.listSubjectConnections(externalId).pipe(
+    Effect.map((connections) => ({ connections: connections.map(toConnection) })),
+    Effect.mapError(readFailed("connections")),
+  );

--- a/packages/core/api/src/admin/service.ts
+++ b/packages/core/api/src/admin/service.ts
@@ -1,0 +1,66 @@
+// ---------------------------------------------------------------------------
+// AdminUsersProvider — the provider seam behind the neutral Admin Users API.
+//
+// The shared `AdminUsersHandlers` are generic: they read the request headers,
+// authorize through this service, and project the SDK's platform view onto the
+// wire shapes. Each host implements the AUTHORIZATION half differently:
+//   - cloud      → an org-scoped API key (PlatformAuth) OR an admin session member
+//   - self-host  → a Better Auth owner/admin member of the single org
+// while the READ half is identical everywhere (`executor.admin`).
+//
+// This mirrors `AccountProvider`: one set of handlers, one contract, per-host
+// implementations. Methods take the raw request headers (cookie / bearer) so
+// the implementation can resolve and authorize the caller itself — the admin
+// plane is NOT behind the execution-stack middleware, because that middleware
+// binds a product-view executor to one acting subject and the admin plane needs
+// a subject-less, tenant-reach one.
+// ---------------------------------------------------------------------------
+
+import { Context, type Effect } from "effect";
+
+import {
+  type AdminUsersError,
+  type AdminUsersForbidden,
+  type AdminUsersUnauthorized,
+  AdminUsersResponse,
+  AdminUserConnectionsResponse,
+  AdminUsersWithConnectionsResponse,
+} from "./api";
+
+export type AdminUsersHeaders = Record<string, string>;
+
+/** Paging options, mirroring the SDK's `AdminListSubjectsOptions`. */
+export interface AdminUsersListOptions {
+  readonly limit?: number;
+  readonly offset?: number;
+}
+
+type Users = typeof AdminUsersResponse.Type;
+type UserConnections = typeof AdminUserConnectionsResponse.Type;
+type UsersWithConnections = typeof AdminUsersWithConnectionsResponse.Type;
+
+/** Every admin read: authorized, and failing with the neutral triple. */
+type Authorized<A> = Effect.Effect<
+  A,
+  AdminUsersError | AdminUsersUnauthorized | AdminUsersForbidden
+>;
+
+export interface AdminUsersProviderShape {
+  readonly listUsers: (
+    headers: AdminUsersHeaders,
+    options: AdminUsersListOptions,
+  ) => Authorized<Users>;
+  readonly listUsersWithConnections: (
+    headers: AdminUsersHeaders,
+    options: AdminUsersListOptions,
+  ) => Authorized<UsersWithConnections>;
+  readonly listUserConnections: (
+    headers: AdminUsersHeaders,
+    externalId: string,
+  ) => Authorized<UserConnections>;
+}
+
+export class AdminUsersProvider extends Context.Service<
+  AdminUsersProvider,
+  AdminUsersProviderShape
+>()("@executor-js/api/AdminUsersProvider") {}

--- a/packages/core/api/src/index.ts
+++ b/packages/core/api/src/index.ts
@@ -46,6 +46,7 @@ export {
   AccountMeResponse,
   ApiKeySummary,
   ApiKeysResponse,
+  OrgApiKeysResponse,
   CreateApiKeyBody,
   CreatedApiKeyResponse,
   OrgMember,
@@ -60,6 +61,19 @@ export {
   UpdateOrgNameResponse,
   SuccessResponse,
 } from "./account/api";
+export {
+  AdminUsersApi,
+  AdminUsersHttpApi,
+  AdminUsersError,
+  AdminUsersForbidden,
+  AdminUsersUnauthorized,
+  AdminUser,
+  AdminUserConnection,
+  AdminUserWithConnections,
+  AdminUsersResponse,
+  AdminUserConnectionsResponse,
+  AdminUsersWithConnectionsResponse,
+} from "./admin/api";
 export {
   RESERVED_ORG_SLUGS,
   generateOrgSlug,

--- a/packages/core/api/src/server.ts
+++ b/packages/core/api/src/server.ts
@@ -18,6 +18,19 @@ export {
 } from "./plugin-routes";
 export { AccountProvider, type AccountProviderShape, type AccountHeaders } from "./account/service";
 export { AccountHandlers } from "./account/handlers";
+export {
+  AdminUsersProvider,
+  type AdminUsersProviderShape,
+  type AdminUsersHeaders,
+  type AdminUsersListOptions,
+} from "./admin/service";
+export { AdminUsersHandlers } from "./admin/handlers";
+export {
+  platformViewOf,
+  listUsers as listAdminUsers,
+  listUsersWithConnections as listAdminUsersWithConnections,
+  listUserConnections as listAdminUserConnections,
+} from "./admin/reads";
 export { requestScopedMiddleware } from "./server/request-scoped";
 export { RouterConfigLive } from "./server/router-config";
 export { consoleErrorCapture } from "./server/console-error-capture";
@@ -53,6 +66,7 @@ export {
 } from "./server/executor-fuma-db";
 export {
   makeScopedExecutor,
+  makePlatformExecutor,
   HostConfig,
   PluginsProvider,
   RequestWebOrigin,
@@ -89,10 +103,12 @@ export {
 export {
   makeProtectedApiLayer,
   makeAccountApiLayer,
+  makeAdminUsersApiLayer,
   accountProviderMiddlewareLayer,
   toApiHandler,
   type MakeProtectedApiLayerOptions,
   type MakeAccountApiLayerOptions,
+  type MakeAdminUsersApiLayerOptions,
   type ApiHandler,
 } from "./server/host-foundation";
 export {

--- a/packages/core/api/src/server/host-foundation.ts
+++ b/packages/core/api/src/server/host-foundation.ts
@@ -40,6 +40,8 @@ import { observabilityMiddleware, type ErrorCapture } from "../observability";
 import { AccountHttpApi } from "../account/api";
 import { AccountHandlers } from "../account/handlers";
 import type { AccountProvider } from "../account/service";
+import { AdminUsersHttpApi } from "../admin/api";
+import { AdminUsersHandlers } from "../admin/handlers";
 import { composePluginApi, composePluginHandlerLayer } from "../plugin-routes";
 import { CoreHandlers } from "../handlers";
 import { requestScopedMiddleware } from "./request-scoped";
@@ -178,6 +180,46 @@ export const makeAccountApiLayer = <MOut, ME, MR>(
 export const accountProviderMiddlewareLayer = (
   accountProviderLayer: Layer.Layer<AccountProvider>,
 ) => requestScopedMiddleware(accountProviderLayer).layer;
+
+// ---------------------------------------------------------------------------
+// Admin Users API
+// ---------------------------------------------------------------------------
+
+export interface MakeAdminUsersApiLayerOptions {
+  /**
+   * Optional prefixed `HttpRouter` view, matching the protected API's prefix so
+   * the admin routes register on the same `/api`-prefixed router.
+   */
+  readonly router?: RouterLayer;
+}
+
+/**
+ * Mount the shared, provider-neutral `AdminUsersHandlers` (the tenant-wide
+ * users + connections reads) behind a per-request `AdminUsersProvider`.
+ *
+ * Structurally identical to `makeAccountApiLayer`, and for the same reason: an
+ * HttpApi handler's service requirement is NOT erased by a plain
+ * `Layer.provide` on the builder layer (it leaks into the app layer's
+ * requirements and breaks the host build), so the provider arrives through a
+ * per-request router middleware.
+ *
+ * This is mounted as an app EXTENSION route rather than added to
+ * `CoreExecutorApi`, because the core API is served behind the execution-stack
+ * middleware — which authenticates a member `Principal` and binds a
+ * product-view executor to them. The admin plane's callers (an org API key with
+ * no member behind it) and its executor (subject-less, tenant reach) are both
+ * the opposite of that, so it gets its own mount and its own auth.
+ */
+export const makeAdminUsersApiLayer = <MOut, ME, MR>(
+  adminUsersProviderMiddleware: Layer.Layer<MOut, ME, MR>,
+  options: MakeAdminUsersApiLayerOptions = {},
+) => {
+  const base = HttpApiBuilder.layer(AdminUsersHttpApi).pipe(
+    Layer.provide(AdminUsersHandlers),
+    Layer.provide(adminUsersProviderMiddleware),
+  );
+  return options.router ? base.pipe(Layer.provide(options.router)) : base;
+};
 
 // ---------------------------------------------------------------------------
 // App-layer web-handler binding

--- a/packages/core/api/src/server/scoped-executor.ts
+++ b/packages/core/api/src/server/scoped-executor.ts
@@ -300,3 +300,58 @@ export const makeScopedExecutor = <
     // `createExecutor({ plugins })` call.
     return executor as Executor<TPlugins>;
   });
+
+// ---------------------------------------------------------------------------
+// makePlatformExecutor — the subject-less, read-only sibling of
+// `makeScopedExecutor`, for the `/admin/*` plane.
+//
+// An org-level caller (a WorkOS org-scoped API key, or an owner/admin acting on
+// the whole workspace) has NO acting member, so there is no honest subject to
+// bind. This builds the executor that shape implies: `{ tenant, subject:
+// undefined, platformView: true }` — the tenant-wide READ-ONLY view. The owner
+// policy rejects writes at `reach: "tenant"`, so the read-only property is
+// enforced by the storage layer, not by this factory remembering to be careful.
+//
+// Three deliberate differences from `makeScopedExecutor`:
+//   - no `subject`, so no `owner: "user"` rows resolve implicitly and the
+//     product view is untouched;
+//   - no `touchSubject`, because there is no principal to record a sighting
+//     for. An org key must never mint a `subject` row — that row would show up
+//     in the very list this plane serves, as a user that does not exist;
+//   - no OAuth redirect / core-tools wiring. Those exist to drive interactive
+//     connect flows on behalf of a member; an admin read has neither.
+// ---------------------------------------------------------------------------
+
+export const makePlatformExecutor = (
+  organizationId: string,
+): Effect.Effect<Executor, StorageFailure, DbProvider | PluginsProvider | HostConfig> =>
+  Effect.gen(function* () {
+    const { db, blobs } = yield* DbProvider.asEffect().pipe(
+      Effect.withSpan("executor.platform.db_provider"),
+    );
+    const { plugins: pluginsFactory } = yield* PluginsProvider.asEffect().pipe(
+      Effect.withSpan("executor.platform.plugins_provider"),
+    );
+    const config = yield* HostConfig.asEffect().pipe(
+      Effect.withSpan("executor.platform.host_config"),
+    );
+
+    // The plugin set still has to be built: the platform view reads the
+    // `connection` table, whose rows name integrations a plugin owns, and the
+    // executor's construction validates against the registered plugin set.
+    const plugins = yield* Effect.sync(() => pluginsFactory()).pipe(
+      Effect.withSpan("executor.platform.plugins.init"),
+    );
+    const hostedHttpOptions = { allowLocalNetwork: config.allowLocalNetwork };
+
+    return yield* createExecutor({
+      tenant: Tenant.make(organizationId),
+      db,
+      blobs,
+      plugins,
+      httpClientLayer: makeHostedHttpClientLayer(hostedHttpOptions),
+      fetch: makeHostedFetch(hostedHttpOptions),
+      onElicitation: "accept-all",
+      platformView: true,
+    }).pipe(Effect.withSpan("executor.platform.create_executor"));
+  });


### PR DESCRIPTION
Stacked on #1465. Public admin surface on the platform view, mounted like the Account API with per-host auth: `GET /admin/users`, `GET /admin/users/with-connections`, `GET /admin/users/:externalId/connections` — credential fields excluded by projection (direct assertion, mutation-tested). Gated by org-scoped API key (cloud, minted via `POST /api/account/org-api-keys`, admin-only) or admin membership (cloud admin role / self-host Better Auth owner-admin). Platform executors skip touchSubject so org keys never appear as users. Known gap: the WorkOS emulator lacks org-key minting, so e2e drives the admin-session path; org keys covered at unit level (upstream emulate change filed as follow-up).

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #1463
2. #1464
3. #1465
4. #1466
5. **#1467** 👈 current
6. #1469
<!-- stack:links:end -->