### PR TITLE
Refresh OAuth tokens when the upstream returns 401

### DIFF
--- a/.changeset/olive-donkeys-smile.md
+++ b/.changeset/olive-donkeys-smile.md
@@ -1,0 +1,5 @@
+---
+"executor": patch
+---
+
+Refresh OAuth tokens when the upstream rejects them with HTTP 401, not only when the stored expiry says they are due. Connections whose authorization server omits `expires_in` can now recover without a manual reconnect, and the refresh path is traced.

--- a/e2e/scenarios/oauth-refresh-on-401.test.ts
+++ b/e2e/scenarios/oauth-refresh-on-401.test.ts
@@ -1,0 +1,326 @@
+// Cross-target: when the upstream rejects a token executor still believes is
+// valid, executor re-mints it and retries — the caller never sees the 401.
+//
+// `expires_at` only ever holds the authorization server's ADVERTISED lifetime.
+// A token can stop working well before that: server-side revocation, an
+// identity provider idle-timeout policy shorter than the token lifetime, or an
+// AS that never advertised an expiry at all. Before the reactive path, the
+// proactive expiry check was the only thing that triggered a refresh, so every
+// one of those cases surfaced to the user as "re-authenticate" even though the
+// stored refresh token would have worked.
+//
+// The journey: an OpenAPI integration completes a real authorization-code flow
+// against a live test AS that issues LONG-LIVED tokens (so the proactive check
+// never fires). The upstream then revokes the bearer it was given. The next
+// tool call gets a 401, executor re-mints against the AS, retries with the new
+// token, and the call succeeds — proven from the upstream's own request ledger,
+// which records both the rejected bearer and the accepted one.
+import { randomBytes } from "node:crypto";
+import { createServer } from "node:http";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import { composePluginApi } from "@executor-js/api/server";
+import { openApiHttpPlugin } from "@executor-js/plugin-openapi/api";
+import {
+  AuthTemplateSlug,
+  ConnectionName,
+  IntegrationSlug,
+  OAuthClientSlug,
+} from "@executor-js/sdk/shared";
+import { serveOAuthTestServer } from "@executor-js/sdk/testing";
+
+import { scenario } from "../src/scenario";
+import { Api, Mcp, Target } from "../src/services";
+
+const api = composePluginApi([openApiHttpPlugin()] as const);
+
+const unique = (prefix: string) => `${prefix}_${randomBytes(4).toString("hex")}`;
+
+type UpstreamHandle = {
+  readonly url: string;
+  /** Every bearer the upstream saw, oldest first — the evidence that a retry
+   *  happened and that it carried a DIFFERENT token than the rejected call. */
+  readonly bearers: () => readonly string[];
+  /** Stop honouring the bearer(s) seen so far, exactly as a revocation or an
+   *  idle-timeout policy would. Anything minted afterwards still works. */
+  readonly revokeSeenBearers: () => void;
+  readonly close: () => void;
+};
+
+/** Upstream on 127.0.0.1 that authenticates for real: `GET /issues` is 200 for
+ *  any bearer it has not been told to reject, and 401 for one it has. */
+const serveUpstream = () =>
+  Effect.acquireRelease(
+    Effect.callback<UpstreamHandle>((resume) => {
+      const seen: string[] = [];
+      const revoked = new Set<string>();
+      const server = createServer((request, response) => {
+        const bearer = (request.headers.authorization ?? "").replace(/^Bearer\s+/i, "");
+        if (request.method === "GET" && (request.url ?? "").startsWith("/issues")) {
+          seen.push(bearer);
+          if (revoked.has(bearer)) {
+            response.writeHead(401, { "content-type": "application/json" });
+            response.end(JSON.stringify({ error: "invalid_token" }));
+            return;
+          }
+          response.writeHead(200, { "content-type": "application/json" });
+          response.end(JSON.stringify({ issues: [{ id: 1, title: "first" }] }));
+          return;
+        }
+        response.writeHead(404, { "content-type": "application/json" });
+        response.end(JSON.stringify({ error: "not_found" }));
+      });
+      server.listen(0, "127.0.0.1", () => {
+        const address = server.address();
+        const port = typeof address === "object" && address ? address.port : 0;
+        resume(
+          Effect.succeed({
+            url: `http://127.0.0.1:${port}`,
+            bearers: () => [...seen],
+            revokeSeenBearers: () => {
+              for (const bearer of seen) revoked.add(bearer);
+            },
+            close: () => {
+              server.close();
+              server.closeAllConnections();
+            },
+          }),
+        );
+      });
+    }),
+    (server) => Effect.sync(server.close),
+  );
+
+const spec = (
+  baseUrl: string,
+  oauth: { readonly authorizationEndpoint: string; readonly tokenEndpoint: string },
+): string =>
+  JSON.stringify({
+    openapi: "3.0.3",
+    info: { title: "Issues API", version: "1.0.0" },
+    servers: [{ url: baseUrl }],
+    paths: {
+      "/issues": {
+        get: {
+          operationId: "listIssues",
+          summary: "List issues",
+          security: [{ oauth: ["issues.read"] }],
+          responses: { "200": { description: "issues" } },
+        },
+      },
+    },
+    components: {
+      securitySchemes: {
+        oauth: {
+          type: "oauth2",
+          flows: {
+            authorizationCode: {
+              authorizationUrl: oauth.authorizationEndpoint,
+              tokenUrl: oauth.tokenEndpoint,
+              scopes: { "issues.read": "Read issues" },
+            },
+          },
+        },
+      },
+    },
+  });
+
+const invokeByAddressCode = (address: string, args: unknown) => `
+const segments = ${JSON.stringify(address)}.split(".").slice(1);
+let node = tools;
+for (const segment of segments) node = node[segment];
+const result = await node(${JSON.stringify(args)});
+return JSON.stringify(result);
+`;
+
+type ToolEnvelope = {
+  readonly ok: boolean;
+  readonly data?: unknown;
+  readonly error?: {
+    readonly code?: string;
+    readonly message?: string;
+    readonly status?: number;
+  };
+};
+
+scenario(
+  "Auth failures · a token the upstream rejects is re-minted and the call retried, so a revoked credential recovers without a reconnect",
+  {},
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const { client: makeClient } = yield* Api;
+      const mcp = yield* Mcp;
+      const identity = yield* target.newIdentity();
+      const client = yield* makeClient(api, identity);
+      const upstream = yield* serveUpstream();
+      // LONG-LIVED tokens are the point: the proactive expiry check must never
+      // fire, so the only thing that can trigger a refresh here is the
+      // upstream's 401. Refresh support is on, so the re-mint can succeed.
+      const oauth = yield* serveOAuthTestServer({
+        scopes: ["issues.read"],
+        tokenExpiresInSeconds: 3600,
+      });
+      const slug = unique("refresh401");
+      const clientSlug = OAuthClientSlug.make(unique("refresh401c"));
+
+      yield* Effect.ensuring(
+        Effect.gen(function* () {
+          yield* client.openapi.addSpec({
+            payload: {
+              spec: { kind: "blob", value: spec(upstream.url, oauth) },
+              slug,
+              baseUrl: upstream.url,
+              authenticationTemplate: [
+                {
+                  slug: "oauth",
+                  kind: "oauth2",
+                  authorizationUrl: oauth.authorizationEndpoint,
+                  tokenUrl: oauth.tokenEndpoint,
+                  scopes: ["issues.read"],
+                },
+              ],
+            },
+          });
+          yield* client.oauth.createClient({
+            payload: {
+              owner: "org",
+              slug: clientSlug,
+              grant: "authorization_code",
+              authorizationUrl: oauth.authorizationEndpoint,
+              tokenUrl: oauth.tokenEndpoint,
+              clientId: "test-client",
+              clientSecret: "test-secret",
+              originIntegration: IntegrationSlug.make(slug),
+            },
+          });
+
+          const started = yield* client.oauth.start({
+            payload: {
+              client: clientSlug,
+              clientOwner: "org",
+              owner: "org",
+              name: ConnectionName.make("main"),
+              integration: IntegrationSlug.make(slug),
+              template: AuthTemplateSlug.make("oauth"),
+            },
+          });
+          expect(started.status, "oauth.start redirects to the authorization server").toBe(
+            "redirect",
+          );
+          if (started.status !== "redirect") return yield* Effect.die("no redirect");
+
+          // Drive the test IdP's consent by hand (authorize → login → code).
+          const code = yield* Effect.promise(async () => {
+            const authorize = await fetch(started.authorizationUrl, { redirect: "manual" });
+            const loginUrl = authorize.headers.get("location");
+            if (!loginUrl) throw new Error(`authorize did not redirect: ${authorize.status}`);
+            const login = await fetch(loginUrl, {
+              method: "POST",
+              headers: {
+                authorization: `Basic ${Buffer.from("alice:password").toString("base64")}`,
+              },
+              redirect: "manual",
+            });
+            const callbackUrl = login.headers.get("location");
+            if (!callbackUrl) throw new Error(`login did not redirect: ${login.status}`);
+            const minted = new URL(callbackUrl).searchParams.get("code");
+            if (!minted) throw new Error("callback carried no authorization code");
+            return minted;
+          });
+          yield* client.oauth.complete({ payload: { state: started.state, code } });
+
+          const tools = yield* client.tools.list({ query: {} });
+          const address = tools
+            .filter((tool) => String(tool.integration) === slug)
+            .map((tool) => String(tool.address))
+            .find((addr) => addr.endsWith("listIssues"));
+          expect(address, "the listIssues tool is in the catalog").toBeDefined();
+
+          const session = mcp.session(identity);
+          const call = (): Effect.Effect<ToolEnvelope, unknown> =>
+            Effect.gen(function* () {
+              let called = yield* session.call("execute", {
+                code: invokeByAddressCode(address!, {}),
+              });
+              // Approval-gated tools pause the execution once per gated call.
+              let guard = 0;
+              while (called.text.includes("executionId:") && guard < 10) {
+                called = yield* session.approvePaused(called.text);
+                guard += 1;
+              }
+              expect(
+                called.ok,
+                `the MCP execute call itself completed (got: ${called.text.slice(0, 400)})`,
+              ).toBe(true);
+              return JSON.parse(called.text) as ToolEnvelope;
+            });
+
+          // Baseline: the connection works, and the upstream records the bearer.
+          const first = yield* call();
+          expect(first.ok, "the first call succeeds on the freshly minted token").toBe(true);
+          const bearersAfterFirst = upstream.bearers();
+          expect(bearersAfterFirst.length, "the upstream saw exactly one call").toBe(1);
+
+          // Revoke it upstream. Executor's stored `expires_at` still says this
+          // token is good for an hour — the divergence this whole path exists
+          // for. Nothing in executor's state changes here.
+          upstream.revokeSeenBearers();
+
+          const second = yield* call();
+
+          // THE guarantee: the caller sees a successful call, not a 401 and not
+          // a re-authenticate wall. Executor absorbed the rejection by
+          // re-minting and retrying.
+          expect(
+            second.ok,
+            `the call succeeded after the upstream rejected the stored token (got: ${JSON.stringify(second.error ?? {}).slice(0, 400)})`,
+          ).toBe(true);
+
+          // Proven from the upstream's own ledger: the retry really happened,
+          // and it carried a DIFFERENT bearer than the one that was rejected.
+          const bearers = upstream.bearers();
+          expect(bearers.length, "the upstream saw the rejected call and the retry (3 total)").toBe(
+            3,
+          );
+          const rejected = bearers[1]!;
+          const retried = bearers[2]!;
+          expect(rejected, "the second call reused the token the upstream had revoked").toBe(
+            bearersAfterFirst[0],
+          );
+          expect(retried, "the retry carried a freshly minted token").not.toBe(rejected);
+          expect(
+            yield* oauth.acceptsAccessToken(retried),
+            "the retry's token is one the authorization server actually issued",
+          ).toBe(true);
+
+          // A refresh grant really was redeemed — not a silent reuse of
+          // something already cached.
+          const refreshGrants = (yield* oauth.requests).filter(
+            (request) =>
+              request.path === "/token" &&
+              request.method === "POST" &&
+              request.body.includes("grant_type=refresh_token"),
+          );
+          expect(refreshGrants.length, "exactly one refresh grant was redeemed").toBe(1);
+        }),
+        Effect.gen(function* () {
+          yield* client.connections
+            .remove({
+              params: {
+                owner: "org",
+                integration: IntegrationSlug.make(slug),
+                name: ConnectionName.make("main"),
+              },
+            })
+            .pipe(Effect.ignore);
+          yield* client.oauth
+            .removeClient({ params: { slug: clientSlug }, payload: { owner: "org" } })
+            .pipe(Effect.ignore);
+          yield* client.openapi.removeSpec({ params: { slug } }).pipe(Effect.ignore);
+        }),
+      );
+    }),
+  ),
+);

--- a/packages/core/sdk/src/auth-tool-failure.ts
+++ b/packages/core/sdk/src/auth-tool-failure.ts
@@ -1,4 +1,4 @@
-import { ToolResult, type ToolError } from "./tool-result";
+import { isToolResult, ToolResult, type ToolError } from "./tool-result";
 
 export type AuthToolFailureCode =
   | "connection_value_missing"
@@ -84,3 +84,21 @@ export const authToolFailure = <T = never>(input: AuthToolFailureInput): ToolRes
   };
   return ToolResult.fail(error);
 };
+
+/**
+ * Whether a tool result is the upstream saying "this credential is not valid"
+ * — an HTTP 401 that every protocol plugin reports as `connection_rejected`.
+ *
+ * This is the trigger for a reactive token refresh, so it is deliberately
+ * exact. `oauth_scope_insufficient` and any 403 are excluded: those mean
+ * authenticated-but-not-permitted, and re-minting the same grant returns the
+ * identical answer (a retry loop that burns a refresh-token rotation per call
+ * and never converges). `oauth_reauth_required` and `oauth_refresh_failed` are
+ * excluded too — they are raised by the refresh path itself, so retrying on
+ * them would mean refreshing in response to a failed refresh.
+ */
+export const isUnauthorizedToolFailure = (value: unknown): boolean =>
+  isToolResult(value) &&
+  !value.ok &&
+  value.error.code === "connection_rejected" &&
+  value.error.status === 401;

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -1662,10 +1662,17 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
       }).pipe(
         // The refresh path was previously invisible to telemetry: no span, no
         // log, no metric. When a customer reported "my OAuth just died", there
-        // was no way to answer "did a refresh even fire, and what did the AS
-        // say?" without a repro. Stamp the outcome and the AS's own error code
-        // (an enumerable RFC 6749 §5.2 identifier, never user content or token
-        // material) so refresh health is greppable in traces.
+        // was no way to answer "did a refresh even fire, and did it work?"
+        // without a repro. Stamp the outcome and the failure KIND — enumerable
+        // identifiers only, never user content or token material.
+        //
+        // The AS's own RFC 6749 §5.2 code is not stamped here: it survives only
+        // inside the error's message, and that message embeds the token
+        // endpoint's response URL and a body preview, so it can't go on a span
+        // attribute. Making that code a queryable dimension needs it lifted to
+        // a typed field on CredentialResolutionError first — worth doing, since
+        // invalid_client (a rotated secret, fleet-wide) currently looks exactly
+        // like a transient server_error from a trace.
         Effect.tap(() => Effect.annotateCurrentSpan({ "executor.oauth.refresh.outcome": "ok" })),
         Effect.tapError((error: StorageFailure | CredentialResolutionError) =>
           Effect.annotateCurrentSpan({

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -151,6 +151,7 @@ import {
 } from "./oauth-helpers";
 import { connectionIdentifier } from "./connection-name-identifier";
 import { annotateToolResultOutcome } from "./tool-result";
+import { isUnauthorizedToolFailure } from "./auth-tool-failure";
 
 const PLUGIN_STORAGE_DELETE_KEY_BATCH_SIZE = 90;
 const PLUGIN_STORAGE_CREATE_ROW_BATCH_SIZE = 90;
@@ -1500,10 +1501,15 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
         where: (b: AnyCb) => b.and(byOwner(owner)(b), b("slug", "=", slug)),
       });
 
+    /** What drove a refresh: the pre-call expiry check (`proactive`), or an
+     *  upstream 401 on a token we believed was still valid (`reactive`). */
+    type RefreshTrigger = "proactive" | "reactive";
+
     // Perform the actual refresh-token grant and persist the rotated material.
     const performTokenRefresh = (
       row: ConnectionRow,
       provider: CredentialProvider,
+      trigger: RefreshTrigger,
     ): Effect.Effect<string | null, StorageFailure | CredentialResolutionError> =>
       Effect.gen(function* () {
         const owner = row.owner as Owner;
@@ -1653,11 +1659,45 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
         });
 
         return token.access_token;
-      });
+      }).pipe(
+        // The refresh path was previously invisible to telemetry: no span, no
+        // log, no metric. When a customer reported "my OAuth just died", there
+        // was no way to answer "did a refresh even fire, and what did the AS
+        // say?" without a repro. Stamp the outcome and the AS's own error code
+        // (an enumerable RFC 6749 §5.2 identifier, never user content or token
+        // material) so refresh health is greppable in traces.
+        Effect.tap(() => Effect.annotateCurrentSpan({ "executor.oauth.refresh.outcome": "ok" })),
+        Effect.tapError((error: StorageFailure | CredentialResolutionError) =>
+          Effect.annotateCurrentSpan({
+            "executor.oauth.refresh.outcome": "fail",
+            "executor.oauth.refresh.error": Predicate.isTagged(error, "CredentialResolutionError")
+              ? "CredentialResolutionError"
+              : "StorageFailure",
+            // Whether the AS's refusal was definitive (RFC 6749 invalid_grant →
+            // the refresh token itself is dead) or a transient failure the next
+            // invoke can retry. The split is the actionable half of the signal.
+            ...(Predicate.isTagged(error, "CredentialResolutionError")
+              ? { "executor.oauth.refresh.reauth_required": error.reauthRequired === true }
+              : {}),
+          }),
+        ),
+        Effect.withSpan("executor.oauth.refresh", {
+          attributes: {
+            "executor.integration": String(row.integration),
+            "executor.connection": String(row.name),
+            // Which path drove this refresh: the expiry check ahead of a call,
+            // or an upstream 401 on a token we believed was still good. The
+            // ratio is the health signal — a rising `reactive` share means
+            // tokens are dying earlier than their advertised expiry.
+            "executor.oauth.refresh.trigger": trigger,
+          },
+        }),
+      );
 
     const refreshConnectionToken = (
       row: ConnectionRow,
       provider: CredentialProvider,
+      trigger: RefreshTrigger = "proactive",
     ): Effect.Effect<string | null, StorageFailure | CredentialResolutionError> =>
       // Share a single refresh per connection so concurrent resolves of the same
       // connection all await one refresh-token grant (the AS rotates the refresh
@@ -1666,11 +1706,16 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
       // expiry can refresh again.
       Effect.gen(function* () {
         const key = connectionKey(row);
+        // Joining an in-flight grant is correct for BOTH triggers: whatever
+        // that peer mints is newer than the token this fiber just saw rejected,
+        // which is exactly what a reactive retry wants. The gate is cleared on
+        // settle, so a 401 arriving after a refresh completed starts a fresh
+        // grant rather than replaying the stale memoized one.
         const existing = refreshInFlight.get(key);
         if (existing) return yield* existing;
         // `Effect.cached` memoizes the grant onto a deferred: it runs once and
         // replays to every awaiter sharing this entry.
-        const memoized = yield* Effect.cached(performTokenRefresh(row, provider));
+        const memoized = yield* Effect.cached(performTokenRefresh(row, provider, trigger));
         const gated = memoized.pipe(
           Effect.ensuring(Effect.sync(() => refreshInFlight.delete(key))),
         );
@@ -1719,6 +1764,29 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
           ),
         ),
       );
+
+    /** Re-mint an OAuth connection's access token unconditionally, ignoring the
+     *  stored expiry. Drives the reactive path: the upstream just rejected the
+     *  token we sent, which is authoritative regardless of what `expires_at`
+     *  claims (revoked server-side, an idle-timeout policy shorter than the
+     *  advertised lifetime, or an expiry the AS never advertised at all).
+     *
+     *  Returns null when the connection can't be re-minted without a human —
+     *  not OAuth-backed, or holding no refresh token — so the caller keeps the
+     *  upstream's own auth failure instead of inventing one. */
+    const forceRefreshConnectionValues = (
+      row: ConnectionRow,
+    ): Effect.Effect<
+      Record<string, string | null> | null,
+      StorageFailure | CredentialResolutionError
+    > =>
+      Effect.gen(function* () {
+        if (row.oauth_client == null || row.refresh_item_id == null) return null;
+        const provider = credentialProviders.get(row.provider);
+        if (!provider) return null;
+        const access = yield* refreshConnectionToken(row, provider, "reactive");
+        return { [PRIMARY_INPUT_VARIABLE]: access };
+      });
 
     /** The primary (`token`) value — the public seam for OAuth + single-input
      *  callers that only ever need one value. */
@@ -3798,27 +3866,58 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
         const values = yield* resolveConnectionValues(connectionRow);
         const integrationRow = yield* findIntegrationRow(parsed.integration);
         const grantedScopes = grantedScopesFromRow(connectionRow);
-        const credential: ToolInvocationCredential = {
-          owner: parsed.owner,
-          integration: parsed.integration,
-          connection: parsed.connection,
-          template: AuthTemplateSlug.make(connectionRow.template),
-          value: values[PRIMARY_INPUT_VARIABLE] ?? null,
-          values,
-          config: integrationRow ? decodeJsonColumn(integrationRow.config) : undefined,
-          ...(grantedScopes ? { grantedScopes } : {}),
+        const invokeTool = runtime.plugin.invokeTool;
+        const invokeWith = (
+          resolved: Record<string, string | null>,
+        ): Effect.Effect<unknown, ToolInvocationError> => {
+          const credential: ToolInvocationCredential = {
+            owner: parsed.owner,
+            integration: parsed.integration,
+            connection: parsed.connection,
+            template: AuthTemplateSlug.make(connectionRow.template),
+            value: resolved[PRIMARY_INPUT_VARIABLE] ?? null,
+            values: resolved,
+            config: integrationRow ? decodeJsonColumn(integrationRow.config) : undefined,
+            ...(grantedScopes ? { grantedScopes } : {}),
+          };
+          return wrapInvocationError(
+            invokeTool({
+              ctx: runtime.ctx,
+              toolRow: row,
+              credential,
+              args,
+              elicit: buildElicit(address, args, handler),
+              invokeOptions: options,
+            }),
+          );
         };
 
-        return yield* wrapInvocationError(
-          runtime.plugin.invokeTool({
-            ctx: runtime.ctx,
-            toolRow: row,
-            credential,
-            args,
-            elicit: buildElicit(address, args, handler),
-            invokeOptions: options,
-          }),
+        const first = yield* invokeWith(values);
+        // Reactive refresh. `expires_at` is only ever the AS's ADVERTISED
+        // lifetime; the upstream rejecting the token is the authoritative word
+        // on whether it is still good. The two diverge routinely: server-side
+        // revocation, an identity provider's idle-timeout policy shorter than
+        // the token lifetime, and connections whose AS omitted `expires_in`
+        // entirely (null expiry → the proactive check never fires, so this is
+        // their ONLY route back to a working token short of a reconnect).
+        //
+        // Deliberately narrow: exactly one retry, only on the 401 that means
+        // "this credential is not valid", and only for a connection holding a
+        // refresh token. A 403 is excluded — it means authenticated-but-not-
+        // permitted, and re-minting the same grant returns the same answer.
+        // If the retry also fails its result stands, so a genuinely dead grant
+        // still surfaces the upstream's own auth failure and its reconnect
+        // guidance rather than a masked one.
+        if (!isUnauthorizedToolFailure(first)) return first;
+        const refreshed = yield* forceRefreshConnectionValues(connectionRow).pipe(
+          // A failed re-mint is not this call's failure to report: the upstream
+          // already produced an auth failure with recovery guidance, which is
+          // strictly more actionable than a refresh-plumbing error. Keep it.
+          Effect.catchTag("CredentialResolutionError", () => Effect.succeed(null)),
         );
+        if (!refreshed) return first;
+        yield* Effect.annotateCurrentSpan({ "executor.oauth.refresh.retried": true });
+        return yield* invokeWith(refreshed);
       }).pipe(
         // Expected tool failures (`ToolResult.fail`) resolve through the
         // success channel, so the tracer alone would record them as healthy

--- a/packages/core/sdk/src/index.ts
+++ b/packages/core/sdk/src/index.ts
@@ -404,6 +404,7 @@ export {
 } from "./sqlite-oauth-client-gc-migration";
 export {
   authToolFailure,
+  isUnauthorizedToolFailure,
   type AuthToolFailureCode,
   type AuthToolFailureInput,
 } from "./auth-tool-failure";

--- a/packages/core/sdk/src/oauth-flow.test.ts
+++ b/packages/core/sdk/src/oauth-flow.test.ts
@@ -10,11 +10,13 @@ import {
   ToolAddress,
   ToolName,
 } from "./ids";
+import { authToolFailure } from "./auth-tool-failure";
 import { decodeOAuthCallbackState } from "./oauth";
 import { OAuthStartError } from "./oauth-client";
 import { missingGrantedOAuthScopes } from "./oauth-service";
 import { definePlugin } from "./plugin";
 import { makeTestWorkspaceHarness, memoryCredentialsPlugin } from "./test-config";
+import { ToolResult } from "./tool-result";
 import { serveOAuthTestServer } from "./testing/oauth-test-server";
 
 // Milestone 2: prove the v2 `oauth.start` / `oauth.complete` token-minting flow
@@ -1219,4 +1221,333 @@ describe("missingGrantedOAuthScopes canonicalization", () => {
     );
     expect(missing).toEqual([]);
   });
+});
+
+// ---------------------------------------------------------------------------
+// Reactive refresh: an upstream 401 re-mints the access token and retries once.
+//
+// `expires_at` is only ever the authorization server's ADVERTISED lifetime. The
+// upstream rejecting the token is the authoritative word on whether it is still
+// good, and the two diverge routinely: server-side revocation, an identity
+// provider's idle-timeout policy shorter than the token lifetime, and the case
+// these tests pin hardest — an AS that omits `expires_in` entirely, leaving a
+// null expiry that the proactive check can never fire on.
+// ---------------------------------------------------------------------------
+
+/** A plugin whose tool authenticates for real: any token in `revoked` gets the
+ *  same `connection_rejected` / HTTP 401 shape every protocol plugin emits;
+ *  anything else succeeds. Modelling revocation (rather than "only the newest
+ *  token works") is what lets a test assert that the RETRY succeeded — the
+ *  re-minted token is simply one the upstream never revoked. */
+const makeRejectingPlugin = (state: {
+  revoked: Set<string>;
+  /** Reject every token, even a freshly minted one — a dead grant. */
+  rejectEverything?: boolean;
+  calls: string[];
+}) =>
+  definePlugin(() => ({
+    id: "acme" as const,
+    storage: () => ({}),
+    resolveTools: () =>
+      Effect.succeed({ tools: [{ name: ToolName.make("whoami"), description: "whoami" }] }),
+    describeAuthMethods: () => [
+      {
+        id: "oauth",
+        label: "OAuth2",
+        kind: "oauth" as const,
+        template: String(TEMPLATE),
+        oauth: { scopes: [] },
+      },
+    ],
+    invokeTool: ({ credential }) => {
+      const token = credential.value;
+      state.calls.push(String(token));
+      if (token !== null && !state.rejectEverything && !state.revoked.has(token)) {
+        return Effect.succeed(ToolResult.ok({ token }));
+      }
+      return Effect.succeed(
+        authToolFailure({
+          code: "connection_rejected",
+          status: 401,
+          message: "Upstream rejected credentials with HTTP 401.",
+          integration: { id: String(credential.integration) },
+          credential: { kind: "upstream", label: String(credential.connection) },
+        }),
+      );
+    },
+    extension: (ctx) => ({
+      seed: () => ctx.core.integrations.register({ slug: INTEG, description: "Acme", config: {} }),
+    }),
+  }))();
+
+/** Mint a connection against `server` and return the harness + call log. */
+const connectRejecting = (options?: { readonly tokenExpiresInSeconds?: number }) =>
+  Effect.gen(function* () {
+    const server = yield* serveOAuthTestServer({
+      scopes: ["read"],
+      ...(options?.tokenExpiresInSeconds !== undefined
+        ? { tokenExpiresInSeconds: options.tokenExpiresInSeconds }
+        : {}),
+    });
+    const state = {
+      revoked: new Set<string>(),
+      rejectEverything: false,
+      calls: [] as string[],
+    };
+    const issuedLatest = Effect.gen(function* () {
+      const issued = yield* server.issuedAccessTokens;
+      return issued.length > 0 ? issued[issued.length - 1]! : null;
+    });
+    const harness = yield* makeTestWorkspaceHarness({
+      plugins: [memoryCredentialsPlugin(), makeRejectingPlugin(state)] as const,
+    });
+    const { executor, config } = harness;
+    yield* executor.acme.seed();
+    yield* executor.oauth.createClient({
+      owner: "org",
+      slug: CLIENT,
+      authorizationUrl: server.authorizationEndpoint,
+      tokenUrl: server.tokenEndpoint,
+      grant: "authorization_code",
+      clientId: "test-client",
+      clientSecret: "test-secret",
+    });
+    const started = yield* executor.oauth.start({
+      owner: "org",
+      client: CLIENT,
+      clientOwner: "org",
+      name: ConnectionName.make("mine"),
+      integration: INTEG,
+      template: TEMPLATE,
+    });
+    if (started.status !== "redirect") {
+      return yield* Effect.die("expected a redirect-status OAuth start");
+    }
+    const callback = yield* server.completeAuthorizationCodeFlow({
+      authorizationUrl: started.authorizationUrl,
+    });
+    yield* executor.oauth.complete({ state: started.state, code: callback.code });
+    return { server, state, executor, config, issuedLatest };
+  });
+
+const ADDRESS = ToolAddress.make("tools.acme.org.mine.whoami");
+
+/** Mark every token the AS has issued so far as no longer honoured upstream —
+ *  the state a revocation or an idle-timeout policy leaves behind. */
+const revokeIssuedSoFar = (
+  server: { readonly issuedAccessTokens: Effect.Effect<readonly string[]> },
+  state: { revoked: Set<string> },
+) =>
+  Effect.gen(function* () {
+    for (const token of yield* server.issuedAccessTokens) state.revoked.add(token);
+  });
+
+const refreshGrants = (requests: readonly { readonly path: string; readonly body: string }[]) =>
+  requests.filter((r) => r.path === "/token" && r.body.includes("grant_type=refresh_token"));
+
+describe("reactive OAuth refresh on upstream 401", () => {
+  it.effect(
+    "re-mints and retries once when the upstream rejects a token it still believes valid",
+    () =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          const { server, state, executor, issuedLatest } = yield* connectRejecting();
+
+          // Simulate the divergence: the AS says the token is good for an hour,
+          // but the upstream has already stopped honouring it (revoked / idle
+          // timeout). Nothing about `expires_at` reflects this.
+          yield* revokeIssuedSoFar(server, state);
+          yield* server.clearRequests;
+
+          const result = (yield* executor.execute(ADDRESS, {})) as {
+            data: { token: string };
+          };
+
+          // The retry ran against a token the upstream would accept, so the call
+          // succeeded rather than surfacing the 401 to the user.
+          const latest = yield* issuedLatest;
+          expect(result.data.token).toBe(latest);
+          expect(state.calls).toHaveLength(2);
+          expect(state.calls[0]).not.toBe(state.calls[1]);
+
+          // Exactly one refresh grant — the retry is single-shot, not a loop.
+          expect(refreshGrants(yield* server.requests)).toHaveLength(1);
+        }),
+      ),
+  );
+
+  it.effect("recovers a null-expiry connection, which the proactive check can never fire on", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const { server, state, executor, config, issuedLatest } = yield* connectRejecting();
+
+        // An AS that omits `expires_in` leaves expires_at null. `shouldRefreshToken`
+        // returns false for null forever, so before the reactive path these
+        // connections could never refresh at all — they died silently and only a
+        // manual reconnect brought them back. 5 such rows existed in production.
+        yield* Effect.promise(() =>
+          config.db.updateMany("connection", {
+            where: (b) => b("name", "=", "mine"),
+            set: { expires_at: null },
+          }),
+        );
+        yield* revokeIssuedSoFar(server, state);
+        yield* server.clearRequests;
+
+        const result = (yield* executor.execute(ADDRESS, {})) as {
+          data: { token: string };
+        };
+
+        expect(result.data.token).toBe(yield* issuedLatest);
+        expect(refreshGrants(yield* server.requests)).toHaveLength(1);
+      }),
+    ),
+  );
+
+  it.effect("persists the re-minted token so the next call needs no second refresh", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const { server, state, executor, issuedLatest } = yield* connectRejecting();
+        yield* revokeIssuedSoFar(server, state);
+        yield* executor.execute(ADDRESS, {});
+
+        // The re-minted token is not revoked, so a second call must reuse the
+        // stored value rather than refreshing again.
+        const current = yield* issuedLatest;
+        yield* server.clearRequests;
+
+        const result = (yield* executor.execute(ADDRESS, {})) as {
+          data: { token: string };
+        };
+        expect(result.data.token).toBe(current);
+        expect(refreshGrants(yield* server.requests)).toHaveLength(0);
+      }),
+    ),
+  );
+
+  it.effect("surfaces the upstream's own 401 when the re-minted token is also rejected", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const { server, state, executor } = yield* connectRejecting();
+
+        // The upstream rejects everything, including whatever the refresh mints
+        // — a genuinely dead grant, not a stale token. The user must see the
+        // upstream's auth failure and its reconnect guidance, NOT a masked
+        // error or a retry loop.
+        state.rejectEverything = true;
+        yield* server.clearRequests;
+
+        const result = yield* executor.execute(ADDRESS, {});
+
+        expect(result).toMatchObject({
+          ok: false,
+          error: { code: "connection_rejected", status: 401 },
+        });
+        // Tried twice, refreshed once, then stopped.
+        expect(state.calls).toHaveLength(2);
+        expect(refreshGrants(yield* server.requests)).toHaveLength(1);
+      }),
+    ),
+  );
+
+  it.effect("does not retry a 403 — re-minting the same grant returns the same answer", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const server = yield* serveOAuthTestServer({ scopes: ["read"] });
+        const calls: string[] = [];
+        const forbiddenPlugin = definePlugin(() => ({
+          id: "acme" as const,
+          storage: () => ({}),
+          resolveTools: () =>
+            Effect.succeed({ tools: [{ name: ToolName.make("whoami"), description: "whoami" }] }),
+          describeAuthMethods: () => [
+            {
+              id: "oauth",
+              label: "OAuth2",
+              kind: "oauth" as const,
+              template: String(TEMPLATE),
+              oauth: { scopes: [] },
+            },
+          ],
+          invokeTool: ({ credential }) => {
+            calls.push(String(credential.value));
+            return Effect.succeed(
+              authToolFailure({
+                code: "connection_rejected",
+                status: 403,
+                message: "Upstream rejected credentials with HTTP 403.",
+                integration: { id: String(credential.integration) },
+                credential: { kind: "upstream", label: String(credential.connection) },
+              }),
+            );
+          },
+          extension: (ctx) => ({
+            seed: () =>
+              ctx.core.integrations.register({ slug: INTEG, description: "Acme", config: {} }),
+          }),
+        }))();
+
+        const { executor } = yield* makeTestWorkspaceHarness({
+          plugins: [memoryCredentialsPlugin(), forbiddenPlugin] as const,
+        });
+        yield* executor.acme.seed();
+        yield* executor.oauth.createClient({
+          owner: "org",
+          slug: CLIENT,
+          authorizationUrl: server.authorizationEndpoint,
+          tokenUrl: server.tokenEndpoint,
+          grant: "authorization_code",
+          clientId: "test-client",
+          clientSecret: "test-secret",
+        });
+        const started = yield* executor.oauth.start({
+          owner: "org",
+          client: CLIENT,
+          clientOwner: "org",
+          name: ConnectionName.make("mine"),
+          integration: INTEG,
+          template: TEMPLATE,
+        });
+        if (started.status !== "redirect") return;
+        const callback = yield* server.completeAuthorizationCodeFlow({
+          authorizationUrl: started.authorizationUrl,
+        });
+        yield* executor.oauth.complete({ state: started.state, code: callback.code });
+        yield* server.clearRequests;
+
+        const result = yield* executor.execute(ADDRESS, {});
+
+        // A 403 is authenticated-but-not-permitted. Retrying would burn a
+        // refresh-token rotation per call and never converge.
+        expect(result).toMatchObject({ ok: false, error: { status: 403 } });
+        expect(calls).toHaveLength(1);
+        expect(refreshGrants(yield* server.requests)).toHaveLength(0);
+      }),
+    ),
+  );
+
+  it.effect("does not retry when the connection holds no refresh token", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const { server, state, executor, config } = yield* connectRejecting();
+
+        // Nothing to re-mint from: the only recovery is a human reconnect, so
+        // the upstream's failure must reach the caller on the first try.
+        yield* Effect.promise(() =>
+          config.db.updateMany("connection", {
+            where: (b) => b("name", "=", "mine"),
+            set: { refresh_item_id: null },
+          }),
+        );
+        yield* revokeIssuedSoFar(server, state);
+        yield* server.clearRequests;
+
+        const result = yield* executor.execute(ADDRESS, {});
+
+        expect(result).toMatchObject({ ok: false, error: { status: 401 } });
+        expect(state.calls).toHaveLength(1);
+        expect(refreshGrants(yield* server.requests)).toHaveLength(0);
+      }),
+    ),
+  );
 });

--- a/packages/core/sdk/src/oauth-helpers.ts
+++ b/packages/core/sdk/src/oauth-helpers.ts
@@ -746,6 +746,19 @@ export const refreshAccessToken = (
 // Refresh-needed predicate
 // ---------------------------------------------------------------------------
 
+/** Whether the stored access token is close enough to its expiry to be
+ *  re-minted BEFORE the next call goes out (the proactive path).
+ *
+ *  A null `expiresAt` means the authorization server never told us when the
+ *  token dies (`expires_in` omitted from the token response). That is not the
+ *  same as "never expires": the token may well be revoked or time out
+ *  upstream. We deliberately do NOT refresh on every call for those — that
+ *  would hammer the AS on connections whose tokens are genuinely long-lived,
+ *  and there is no expiry to be "close to". Instead the reactive path owns
+ *  them: an upstream 401 is the only truthful signal that an unknown-expiry
+ *  token is dead, and `executor.execute` re-mints and retries once on that
+ *  signal. Keep the two paths in sync — narrowing the reactive retry strands
+ *  every null-expiry connection with no way to recover short of a reconnect. */
 export const shouldRefreshToken = (input: {
   readonly expiresAt: number | null;
   readonly now?: number;

--- a/packages/plugins/mcp/src/sdk/connection-pool.test.ts
+++ b/packages/plugins/mcp/src/sdk/connection-pool.test.ts
@@ -153,4 +153,45 @@ describe("MCP connection pool", () => {
       }),
     ),
   );
+
+  it.effect("drops a pooled session whose bearer the server has stopped accepting", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const server = yield* serveMcpServer(() => makeEchoMcpServer());
+        const pool = createMcpConnectionPool();
+
+        yield* invoke({
+          endpoint: server.endpoint,
+          pool,
+          toolName: "echo",
+          args: { value: "before" },
+        });
+
+        // A 401 means the bearer this session was dialled with is no longer
+        // accepted. The session is bound to that token for its lifetime, so
+        // retaining it would serve the same dead credential for the full idle
+        // window — and would defeat core's post-401 refresh, whose new token can
+        // only reach the server over a NEW session.
+        yield* server.rejectNextSessionRequest(401);
+        yield* invoke({
+          endpoint: server.endpoint,
+          pool,
+          toolName: "echo",
+          args: { value: "unauthorized" },
+        }).pipe(Effect.flip);
+
+        const after = yield* invoke({
+          endpoint: server.endpoint,
+          pool,
+          toolName: "echo",
+          args: { value: "after" },
+        });
+
+        expect(after).toMatchObject({ content: [{ type: "text", text: "after" }] });
+        // A second session was dialled rather than the dead one being reused.
+        expect(server.sessionCount()).toBe(2);
+        yield* pool.close();
+      }),
+    ),
+  );
 });

--- a/packages/plugins/mcp/src/sdk/connection-pool.ts
+++ b/packages/plugins/mcp/src/sdk/connection-pool.ts
@@ -27,6 +27,13 @@ const isDeadConnectionFailure = (error: unknown): boolean => {
   return (
     error.transportFailure === true ||
     error.status === 400 ||
+    // A 401 means the bearer this session was dialled with is no longer
+    // accepted. The session is bound to that token for its lifetime, so
+    // retaining it would hand the same dead credential to every caller for the
+    // full idle window — and would defeat core's post-401 token refresh, whose
+    // freshly minted token can only reach the server over a NEW session. Drop
+    // it so the retry dials with the new credential.
+    error.status === 401 ||
     error.status === 404 ||
     error.status === 408
   );


### PR DESCRIPTION
## Problem

Refresh is only triggered by the pre-call expiry check. `expires_at` holds the authorization server's advertised lifetime, which can be longer than the token actually lasts — server-side revocation, an identity provider idle-timeout policy, or an AS that omits `expires_in`.

With `expires_in` omitted, `expires_at` is null and `shouldRefreshToken` returns false, so those connections never refresh and need a manual reconnect. There are 5 such connections in production.

When a token dies early, the plugins turn the upstream 401 into a re-authenticate failure without attempting a refresh, so users are asked to reconnect in cases where a refresh would have worked.

## Change

Re-mint once on a 401 and retry the call. Scoped to:

- 401 only. A 403 means authenticated but not permitted, so the same grant would return the same result.
- One retry. If the re-minted token is also rejected, the upstream's failure is returned unchanged, including its reconnect guidance.
- Connections holding a refresh token. Without one the only recovery is a reconnect, so the failure should reach the caller directly.

Pooled MCP sessions are also dropped on 401. A session is bound to the bearer it was dialled with, so a retained one would keep using the old credential for the 5-minute idle window, and a refreshed token only reaches the server over a new session.

The refresh path had no span, log, or metric. It now has a span carrying the outcome, the failure kind, whether re-auth is required, and whether the trigger was proactive or reactive.

## Verification

`format:check`, `lint`, `typecheck`, and `test` pass (37/37 tasks).

**E2E** — `e2e/scenarios/oauth-refresh-on-401.test.ts`, passing on both `selfhost` and `cloud`. It drives a real authorization-code flow against the test authorization server using long-lived (1h) tokens, so the proactive expiry check never fires and the upstream's 401 is the only thing that can trigger a refresh. The upstream then revokes the bearer it was issued, and the next call must still succeed.

The assertions come from the upstream's own request ledger rather than from executor's internals: three upstream calls total, the second carrying the token that was revoked and the third carrying a different one the AS confirms it issued, plus exactly one refresh grant redeemed at the token endpoint.

Verified fail-before/pass-after by reverting the fix — the scenario fails with `connection_rejected` / HTTP 401 and the message "Re-authenticate or update the connection", which is the exact user-facing behaviour this change removes.

**Unit** — seven tests. Six in `oauth-flow.test.ts` run against the test authorization server with a plugin that checks the token it receives: the 401 re-mint and retry, recovery of a null-expiry connection, reuse of the re-minted token on the next call, a dead grant returning the upstream 401 after one refresh, no retry on 403, and no retry without a refresh token. One in `connection-pool.test.ts` covers dropping a 401'd session.