### PR TITLE
Remember the last-visited org for bare URL entries

### DIFF
--- a/apps/cloud/src/auth/handlers.ts
+++ b/apps/cloud/src/auth/handlers.ts
@@ -27,6 +27,7 @@ import {
   isOverFreeOrganizationLimit,
   shouldApplyFreeOrganizationLimit,
 } from "../extensions/billing/plans";
+import { LAST_ORG_COOKIE } from "./last-org-cookie";
 import {
   ORG_SELECTOR_HEADER,
   authorizeOrganization,
@@ -218,11 +219,25 @@ export const CloudAuthPublicHandlers = HttpApiBuilder.group(
             : null;
 
           // Prefer the org in the URL that sent the user to login. If the URL
-          // is bare, or not an org route, fall back to WorkOS's org and then to
-          // the first active membership for org-less sessions. Pending
-          // memberships are skipped because refreshing into one 400s and would
-          // bypass invite consent.
-          let targetOrganizationId = requestedOrg?.id ?? result.organizationId ?? null;
+          // is bare, or not an org route, prefer the org this browser last
+          // worked in (the last-org cookie — it outlives the session precisely
+          // so a fresh login lands where the user left off), then WorkOS's
+          // org, then the first active membership for org-less sessions.
+          // Pending memberships are skipped because refreshing into one 400s
+          // and would bypass invite consent. The cookie is membership-checked
+          // like any selector, so a stale one just falls through.
+          let targetOrganizationId = requestedOrg?.id ?? null;
+          if (!targetOrganizationId && !requestedOrgSelector) {
+            const lastOrgSlug = request.cookies[LAST_ORG_COOKIE];
+            const lastOrg =
+              lastOrgSlug && isValidOrgSlug(lastOrgSlug)
+                ? yield* authorizeOrganizationSelector(result.user.id, lastOrgSlug).pipe(
+                    Effect.orElseSucceed(() => null),
+                  )
+                : null;
+            targetOrganizationId = lastOrg?.id ?? null;
+          }
+          targetOrganizationId ??= result.organizationId ?? null;
           if (!targetOrganizationId && !requestedOrgSelector) {
             const memberships = yield* workos.listUserMemberships(result.user.id);
             const existingActive = memberships.data.find((m) => m.status === "active");

--- a/apps/cloud/src/auth/last-org-cookie.ts
+++ b/apps/cloud/src/auth/last-org-cookie.ts
@@ -1,0 +1,32 @@
+// ---------------------------------------------------------------------------
+// Last-visited-org cookie — the browser's "which org was I working in" memory.
+//
+// Org switching is stateless by design (the URL slug scopes every request; see
+// organization.ts), which leaves nothing that remembers the last org across
+// entries: the sealed session still carries the org pinned at LOGIN time, so a
+// bare URL (`executor.sh/`) would always canonicalize onto that first org. This
+// cookie fills the gap: the client records the slug of the org it's verifiably
+// viewing, and the two bare-entry deciders honor it —
+//
+//   - the SSR auth gate redirects bare document paths onto it (ssr-gate.ts)
+//   - the login callback prefers it when picking the org for a fresh session
+//     with a bare returnTo (handlers.ts)
+//
+// It is a PREFERENCE, never an authority: both readers re-check live membership
+// through the same authorize path as any org selector, so a stale or forged
+// value at worst falls back to today's behavior. Not HttpOnly — the client is
+// the writer. Deliberately NOT cleared on logout: surviving the session is what
+// lets the next login land on the last-used org.
+// ---------------------------------------------------------------------------
+
+export const LAST_ORG_COOKIE = "executor-last-org";
+
+/** Outlives the 7d session on purpose — it spans logins. */
+const LAST_ORG_MAX_AGE_SECONDS = 60 * 60 * 24 * 365;
+
+/** Browser-side write. Slugs are `[a-z0-9-]` by grammar, so no encoding. */
+export const writeLastOrgCookie = (slug: string): void => {
+  document.cookie = `${LAST_ORG_COOKIE}=${slug}; Path=/; Max-Age=${LAST_ORG_MAX_AGE_SECONDS}; SameSite=Lax${
+    window.location.protocol === "https:" ? "; Secure" : ""
+  }`;
+};

--- a/apps/cloud/src/auth/ssr-gate.ts
+++ b/apps/cloud/src/auth/ssr-gate.ts
@@ -23,6 +23,7 @@
 import { createMiddleware } from "@tanstack/react-start";
 import { Effect, Exit, Layer, ManagedRuntime } from "effect";
 
+import { isValidOrgSlug } from "@executor-js/api";
 import {
   AUTH_HINT_COOKIE,
   AUTH_HINT_MAX_AGE_SECONDS,
@@ -35,7 +36,9 @@ import { isAppOwnedPath } from "../app-paths";
 import { makeDbLayer } from "../db/db";
 import { makeUserStoreLayer, UserStoreService } from "./context";
 import { parseCookie } from "./cookies";
+import { LAST_ORG_COOKIE } from "./last-org-cookie";
 import { sealedSessionDisplayName } from "./middleware";
+import { authorizeOrganizationSelector } from "./organization";
 import { browserOriginFromRequest } from "./request-origin";
 import { loginPath, safeReturnTo } from "./return-to";
 import { ONBOARDING_PATHS, PUBLIC_PATHS } from "./route-paths";
@@ -158,6 +161,23 @@ const organizationDisplay = async (
     : { name: "", slug: "" };
 };
 
+// Live membership check for the last-org cookie's slug. Same authorize path
+// as any org selector — the cookie is a preference, so a slug the user can't
+// access (stale after removal/deletion, or forged) resolves to null and the
+// bare path falls through to today's canonicalize-onto-session-org behavior.
+// Per-request store layers for the same reason as organizationDisplay.
+const authorizeLastOrgSlug = async (
+  userId: string,
+  slug: string,
+): Promise<{ readonly id: string } | null> => {
+  const exit = await getRuntime().runPromiseExit(
+    authorizeOrganizationSelector(userId, slug).pipe(
+      Effect.provide(Layer.provide(makeUserStoreLayer(), makeDbLayer())),
+    ),
+  );
+  return Exit.isSuccess(exit) ? exit.value : null;
+};
+
 const hintSetCookie = (hint: AuthHint) =>
   `${AUTH_HINT_COOKIE}=${encodeAuthHint(hint)}; ${HINT_COOKIE_ATTRIBUTES}; Max-Age=${AUTH_HINT_MAX_AGE_SECONDS}`;
 
@@ -224,6 +244,39 @@ export const authGateMiddleware = createMiddleware({ type: "request" }).server(
     // exists so the app shell is never painted for an org-less session.
     if (!session.organizationId && !ONBOARDING_PATHS.has(pathname)) {
       return redirect("/create-org", { refreshedSession: session.refreshedSession });
+    }
+
+    // A BARE console path (no org slug in the URL) canonicalizes onto the org
+    // this browser last worked in (the last-org cookie), not the org pinned in
+    // the session at login time — a multi-org user re-entering at `/` lands
+    // where they left off. Slugged URLs never enter here (the URL names its
+    // own scope), so this costs nothing on the steady state; the not-found
+    // contract is untouched because an unknown-but-valid slug in the URL reads
+    // as slugged, not bare. When the cookie matches the session's own org (the
+    // overwhelmingly common single-org case) the client-side OrgSlugGate
+    // already canonicalizes onto it, so skip the live membership check and the
+    // redirect entirely.
+    const lastOrgSlug = parseCookie(cookieHeader, LAST_ORG_COOKIE);
+    const firstSegment = pathname.split("/")[1] ?? "";
+    if (
+      session.organizationId &&
+      lastOrgSlug &&
+      isValidOrgSlug(lastOrgSlug) &&
+      !isValidOrgSlug(firstSegment) &&
+      !ONBOARDING_PATHS.has(pathname)
+    ) {
+      const sessionOrgSlug = (await organizationDisplay(session.organizationId)).slug;
+      if (lastOrgSlug !== sessionOrgSlug) {
+        // The cookie is a preference, not an authority: only redirect onto an
+        // org the caller actively belongs to (stale/forged values fall through
+        // to today's session-org canonicalization).
+        const lastOrg = await authorizeLastOrgSlug(session.userId, lastOrgSlug);
+        if (lastOrg) {
+          return redirect(`/${lastOrgSlug}${pathname === "/" ? "" : pathname}${url.search}`, {
+            refreshedSession: session.refreshedSession,
+          });
+        }
+      }
     }
 
     // Serve the document WITH the verified identity: the hint rides to the

--- a/apps/cloud/src/web/auth.tsx
+++ b/apps/cloud/src/web/auth.tsx
@@ -9,6 +9,7 @@ import {
 } from "@executor-js/react/multiplayer/auth-context";
 import type { AuthHint } from "@executor-js/react/multiplayer/auth-hint";
 
+import { writeLastOrgCookie } from "../auth/last-org-cookie";
 import { CloudApiClient } from "./client";
 
 // ---------------------------------------------------------------------------
@@ -57,6 +58,16 @@ export const AuthProvider = ({
 
   const onIdentify = React.useCallback<IdentifyFn>(
     (state) => {
+      // Record the org this browser is verifiably viewing: onIdentify fires
+      // only on resolved `/account/me` answers (never hint optimism), and that
+      // call is URL-scoped, so `state.organization` IS the org of the current
+      // tab. The cookie makes the next bare entry (`/`) and the next login
+      // land here instead of the session's login-time org — see
+      // ../auth/last-org-cookie.ts. Deliberately not cleared on signout: the
+      // preference is the point of surviving the session.
+      if (state.status === "authenticated" && state.organization) {
+        writeLastOrgCookie(state.organization.slug);
+      }
       if (!posthog) return;
       if (state.status === "authenticated") {
         posthog.identify(state.user.id, {

--- a/e2e/cloud/org-last-visited.test.ts
+++ b/e2e/cloud/org-last-visited.test.ts
@@ -1,0 +1,95 @@
+// Cloud-only (browser): a bare entry (`/`) lands in the org this browser LAST
+// worked in, not the org pinned into the session cookie at login time.
+//
+// Org switching is stateless (the URL slug scopes every request; nothing
+// rewrites the session cookie), so without extra memory a bare entry would
+// always canonicalize onto the session's login-time org — for a multi-org user
+// that reads as "executor.sh forgot which org I was on". The last-org cookie
+// (`executor-last-org`) is that memory: the client records the slug of the org
+// it is verifiably viewing, and the SSR gate redirects bare document requests
+// onto it after re-checking live membership.
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+
+import { scenario } from "../src/scenario";
+import { Browser, Target } from "../src/services";
+
+const CLOUD_ORIGIN_HEADERS = (baseUrl: string) => ({ origin: new URL(baseUrl).origin });
+
+scenario(
+  "Org URLs · a bare entry lands in the last-visited org, not the session's login org",
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const browser = yield* Browser;
+
+    // Identity starts in org A. Create org B through the real endpoint, which
+    // returns the refreshed cookie — the SESSION is now pinned to org B, so
+    // without the last-org cookie every bare entry would land in B.
+    const identity = yield* target.newIdentity();
+    const cookie = identity.headers?.cookie ?? "";
+
+    const createB = yield* Effect.promise(() =>
+      fetch(new URL("/api/auth/create-organization", target.baseUrl), {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          cookie,
+          ...CLOUD_ORIGIN_HEADERS(target.baseUrl),
+        },
+        body: JSON.stringify({ name: "Last Visited Org B" }),
+      }),
+    );
+    expect(createB.ok, "org B was created").toBe(true);
+    const orgB = (yield* Effect.promise(() => createB.json())) as { slug: string };
+    const setCookie = createB.headers.get("set-cookie") ?? "";
+    const sessionB = /wos-session=([^;]+)/.exec(setCookie)?.[1];
+    expect(sessionB, "creating org B pinned the session into it").toBeTruthy();
+
+    const orgs = (yield* Effect.promise(() =>
+      fetch(new URL("/api/auth/organizations", target.baseUrl), {
+        headers: { cookie: `wos-session=${sessionB}` },
+      }).then((r) => r.json()),
+    )) as { organizations: ReadonlyArray<{ name: string; slug: string }> };
+    const slugA = orgs.organizations.find((o) => o.name.startsWith("Org user-"))?.slug;
+    expect(slugA, "org A has a slug").toBeTruthy();
+    expect(slugA, "the two orgs have distinct slugs").not.toBe(orgB.slug);
+
+    // Drive the browser as the session pinned to B.
+    const inB = {
+      ...identity,
+      headers: { cookie: `wos-session=${sessionB}` },
+      cookies: [{ name: "wos-session", value: sessionB! }],
+    };
+
+    yield* browser.session(inB, async ({ page, step }) => {
+      await step("Work in org A by its slug URL (the session still pins org B)", async () => {
+        await page.goto(`/${slugA}`, { waitUntil: "networkidle" });
+        await page.getByText("Integrations").first().waitFor({ timeout: 30_000 });
+        // The client records the viewed org once /account/me confirms it.
+        await page.waitForFunction(
+          (slug) => document.cookie.includes(`executor-last-org=${slug}`),
+          slugA,
+          { timeout: 30_000 },
+        );
+      });
+
+      await step("A bare entry (`/`) returns to org A, not the session's org B", async () => {
+        await page.goto("/", { waitUntil: "networkidle" });
+        await page.waitForURL(
+          (url) => url.pathname === `/${slugA}` || url.pathname === `/${slugA}/`,
+          {
+            timeout: 30_000,
+          },
+        );
+        await page.getByText("Integrations").first().waitFor({ timeout: 30_000 });
+      });
+
+      await step("A bare deep link keeps its path while landing in org A", async () => {
+        await page.goto("/policies", { waitUntil: "networkidle" });
+        await page.waitForURL((url) => url.pathname === `/${slugA}/policies`, { timeout: 30_000 });
+        await page.getByText("Policies").first().waitFor({ timeout: 30_000 });
+      });
+    });
+  }),
+);


### PR DESCRIPTION
Bare entries (`executor.sh/`) always canonicalized onto the org pinned into the session at login time — effectively the first org — because stateless org switching never updates the session cookie.

Adds an `executor-last-org` preference cookie:

- the client records the slug of the org it is verifiably viewing (on resolved `/account/me` answers)
- the SSR gate redirects bare document paths onto it after a live membership check
- the login callback prefers it when picking the org for a fresh session with a bare returnTo, so it survives logouts

The cookie is a preference, never an authority: both readers re-check live membership through the same selector authorization as any org-scoped request, so stale or forged values fall back to today's behavior.

e2e: `cloud/org-last-visited.test.ts` (bare entry + bare deep link land in the last-visited org while the session cookie pins another); neighboring org suites (switcher, multitab, foreign slug, oauth callback scope, slug routing) pass unchanged.