### PR TITLE
Fill OAuth connection labels from account identity

### DIFF
--- a/e2e/scenarios/google-health-checks.test.ts
+++ b/e2e/scenarios/google-health-checks.test.ts
@@ -116,6 +116,7 @@ const connectGoogleAccount = (input: {
   readonly target: TargetShape;
   readonly integration: IntegrationSlug;
   readonly oauthClient: OAuthClientSlug;
+  readonly newConnection?: boolean;
 }) =>
   Effect.gen(function* () {
     const redirectUri = new URL("/api/oauth/callback", input.target.baseUrl).toString();
@@ -146,6 +147,25 @@ const connectGoogleAccount = (input: {
       },
     });
 
+    return yield* runGoogleOAuthFlow(input, redirectUri);
+  });
+
+/** Run one authorize+complete round through the already-registered app. Split
+ *  from `connectGoogleAccount` so a scenario can connect a SECOND account
+ *  through the same app (`newConnection: true`) without re-registering it. */
+const runGoogleOAuthFlow = (
+  input: {
+    readonly client: Client;
+    readonly target: TargetShape;
+    readonly integration: IntegrationSlug;
+    readonly oauthClient: OAuthClientSlug;
+    readonly newConnection?: boolean;
+  },
+  redirectUriOverride?: string,
+) =>
+  Effect.gen(function* () {
+    const redirectUri =
+      redirectUriOverride ?? new URL("/api/oauth/callback", input.target.baseUrl).toString();
     const started = yield* input.client.oauth.start({
       payload: {
         client: input.oauthClient,
@@ -155,6 +175,7 @@ const connectGoogleAccount = (input: {
         integration: input.integration,
         template: GOOGLE_AUTH_TEMPLATE,
         redirectUri,
+        ...(input.newConnection === true ? { newConnection: true } : {}),
       },
     });
     expect(started.status, "OAuth starts with an emulator redirect").toBe("redirect");
@@ -167,6 +188,7 @@ const connectGoogleAccount = (input: {
     expect(completed.integration, "OAuth completion creates the connection").toBe(
       input.integration,
     );
+    return completed;
   });
 
 scenario(
@@ -334,13 +356,53 @@ scenario(
           refreshed.find((connection) => connection.name === CONNECTION)?.identityLabel,
           "Google Sheets still shows the OAuth grant identity after no-probe health",
         ).toBe(GOOGLE_EMULATOR_ACCOUNT_EMAIL);
+
+        // Reconnecting the SAME connection must not clobber a curated label
+        // with the grant identity.
+        yield* client.connections.update({
+          params: { owner: "org", integration: slug, name: CONNECTION },
+          payload: { identityLabel: "Finance account" },
+        });
+        yield* runGoogleOAuthFlow({ client, target, integration: slug, oauthClient });
+        const reconnected = yield* client.connections.list({
+          query: { owner: "org", integration: slug },
+        });
+        expect(
+          reconnected.find((connection) => connection.name === CONNECTION)?.identityLabel,
+          "reconnect keeps the curated label over the grant identity",
+        ).toBe("Finance account");
+
+        // A `newConnection` connect under a taken name mints a SECOND
+        // connection with a suffixed name instead of replacing the first.
+        const second = yield* runGoogleOAuthFlow({
+          client,
+          target,
+          integration: slug,
+          oauthClient,
+          newConnection: true,
+        });
+        expect(String(second.name), "second account mints a suffixed connection").toBe(
+          `${String(CONNECTION)}2`,
+        );
+        expect(second.identityLabel, "second account label comes from the grant identity").toBe(
+          GOOGLE_EMULATOR_ACCOUNT_EMAIL,
+        );
+        const both = yield* client.connections.list({
+          query: { owner: "org", integration: slug },
+        });
+        expect(
+          both.map((connection) => String(connection.name)).sort(),
+          "both accounts coexist",
+        ).toEqual([String(CONNECTION), `${String(CONNECTION)}2`]);
       }),
       Effect.gen(function* () {
-        yield* client.connections
-          .remove({
-            params: { owner: "org", integration: slug, name: CONNECTION },
-          })
-          .pipe(Effect.ignore);
+        for (const name of [CONNECTION, ConnectionName.make(`${String(CONNECTION)}2`)]) {
+          yield* client.connections
+            .remove({
+              params: { owner: "org", integration: slug, name },
+            })
+            .pipe(Effect.ignore);
+        }
         yield* client.oauth
           .removeClient({ params: { slug: oauthClient }, payload: { owner: "org" } })
           .pipe(Effect.ignore);

--- a/packages/core/api/src/handlers/oauth.ts
+++ b/packages/core/api/src/handlers/oauth.ts
@@ -161,6 +161,7 @@ export const OAuthHandlers = HttpApiBuilder.group(ExecutorApi, "oauth", (handler
             integration: payload.integration,
             template: payload.template,
             identityLabel: payload.identityLabel,
+            newConnection: payload.newConnection,
             redirectUri: payload.redirectUri,
           });
           return startResultToResponse(result);

--- a/packages/core/api/src/oauth/api.ts
+++ b/packages/core/api/src/oauth/api.ts
@@ -160,6 +160,9 @@ const StartPayload = Schema.Struct({
   integration: IntegrationSlug,
   template: AuthTemplateSlug,
   identityLabel: Schema.optional(Schema.NullOr(Schema.String)),
+  /** Mint a NEW connection: a taken `name` resolves to the next free suffixed
+   *  name server-side instead of re-minting the existing row. */
+  newConnection: Schema.optional(Schema.Boolean),
   redirectUri: Schema.optional(Schema.NullOr(Schema.String)),
 });
 

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -2489,14 +2489,22 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
           integration: input.integration,
           name,
         };
+        // Label precedence: an explicit (user-chosen) label always wins; a
+        // derived label (OIDC claims) only FILLS an empty slot. Like
+        // `description` below, a reconnect or token refresh must not erase a
+        // label the user curated. Resolved once, used by every write below.
+        let identityLabel: string | null = null;
         yield* transaction(
           Effect.gen(function* () {
             const existing = yield* findConnectionRow(ref);
+            const existingLabel = existing?.identity_label?.trim() ? existing.identity_label : null;
+            identityLabel =
+              input.identityLabel ?? existingLabel ?? input.derivedIdentityLabel ?? null;
             const set: Record<string, unknown> = {
               template: String(input.template),
               provider: input.provider,
               item_ids: { [PRIMARY_INPUT_VARIABLE]: input.itemId },
-              identity_label: input.identityLabel ?? null,
+              identity_label: identityLabel,
               oauth_client: String(input.oauthClient),
               oauth_client_owner: input.oauthClientOwner,
               refresh_item_id: input.refreshItemId,
@@ -2529,7 +2537,7 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
                 template: String(input.template),
                 provider: input.provider,
                 item_ids: { [PRIMARY_INPUT_VARIABLE]: input.itemId },
-                identity_label: input.identityLabel ?? null,
+                identity_label: identityLabel,
                 // Curated description: never stamped by a mint — a reconnect
                 // or token refresh must not erase what the user wrote.
                 description: null,
@@ -2568,7 +2576,7 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
               template: String(input.template),
               provider: input.provider,
               item_ids: { [PRIMARY_INPUT_VARIABLE]: input.itemId },
-              identity_label: input.identityLabel ?? null,
+              identity_label: identityLabel,
               description: null,
               oauth_client: String(input.oauthClient),
               oauth_client_owner: input.oauthClientOwner,
@@ -3848,6 +3856,7 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
       ownedKeys: (owner: Owner) => ownedKeys(owner),
       defaultWritableProvider,
       mintOAuthConnection: (input: MintOAuthConnectionInput) => mintOAuthConnection(input),
+      connectionNameTaken: (ref) => findConnectionRow(ref).pipe(Effect.map((row) => row !== null)),
       // One integration-row read + one projector run. Resolve the method this
       // template selects exactly as the runtime's `selectAuthMethod` does —
       // exact slug match, else the sole declared method (single-method

--- a/packages/core/sdk/src/oauth-client.ts
+++ b/packages/core/sdk/src/oauth-client.ts
@@ -127,7 +127,15 @@ export interface OAuthStartInput {
   readonly name: ConnectionName;
   readonly integration: IntegrationSlug;
   readonly template: AuthTemplateSlug;
+  /** Display label for the minted connection. When omitted, the server derives
+   *  one from the provider's OIDC account claims (the account email) when the
+   *  grant carries them; a re-mint of an existing connection keeps its stored
+   *  label. Send a value only for a label the user actually chose. */
   readonly identityLabel?: string | null;
+  /** Mint a NEW connection: when `name` is already taken, the mint picks the
+   *  next free suffixed name (`personalGmail2`) instead of re-minting the
+   *  existing row. Omit for reconnect flows, which target the existing row. */
+  readonly newConnection?: boolean;
   /** Browser-facing callback URL for this flow. Defaults to the executor's configured redirectUri. */
   readonly redirectUri?: string | null;
 }

--- a/packages/core/sdk/src/oauth-flow.test.ts
+++ b/packages/core/sdk/src/oauth-flow.test.ts
@@ -384,6 +384,115 @@ describe("oauth.start / oauth.complete", () => {
     ),
   );
 
+  it.effect("newConnection resolves a taken name to the next free suffix", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const server = yield* serveOAuthTestServer({
+          scopes: ["openid", "email", "profile", "read"],
+          idTokenClaims: { email: "alice@example.com", sub: "user-1" },
+        });
+        const { executor } = yield* makeTestWorkspaceHarness({ plugins });
+        yield* executor.acme.seed(["openid", "email", "profile", "read"]);
+
+        yield* executor.oauth.createClient({
+          owner: "org",
+          slug: CLIENT,
+          authorizationUrl: server.authorizationEndpoint,
+          tokenUrl: server.tokenEndpoint,
+          grant: "authorization_code",
+          clientId: "test-client",
+          clientSecret: "test-secret",
+        });
+
+        const runFlow = Effect.gen(function* () {
+          const started = yield* executor.oauth.start({
+            owner: "org",
+            client: CLIENT,
+            clientOwner: "org",
+            name: ConnectionName.make("main"),
+            integration: INTEG,
+            template: TEMPLATE,
+            newConnection: true,
+          });
+          expect(started.status).toBe("redirect");
+          if (started.status !== "redirect") return null;
+          const callback = yield* server.completeAuthorizationCodeFlow({
+            authorizationUrl: started.authorizationUrl,
+          });
+          return yield* executor.oauth.complete({
+            state: started.state,
+            code: callback.code,
+          });
+        });
+
+        const first = yield* runFlow;
+        const second = yield* runFlow;
+        expect(String(first?.name)).toBe("main");
+        expect(String(second?.name)).toBe("main2");
+
+        const connections = yield* executor.connections.list({ integration: INTEG });
+        expect(connections.map((connection) => String(connection.name)).sort()).toEqual([
+          "main",
+          "main2",
+        ]);
+      }),
+    ),
+  );
+
+  it.effect("preserves a curated label when reconnecting without an explicit label", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const server = yield* serveOAuthTestServer({
+          scopes: ["openid", "email", "profile", "read"],
+          idTokenClaims: { email: "alice@example.com", sub: "user-1" },
+        });
+        const { executor } = yield* makeTestWorkspaceHarness({ plugins });
+        yield* executor.acme.seed(["openid", "email", "profile", "read"]);
+
+        yield* executor.oauth.createClient({
+          owner: "org",
+          slug: CLIENT,
+          authorizationUrl: server.authorizationEndpoint,
+          tokenUrl: server.tokenEndpoint,
+          grant: "authorization_code",
+          clientId: "test-client",
+          clientSecret: "test-secret",
+        });
+
+        const runFlow = Effect.gen(function* () {
+          const started = yield* executor.oauth.start({
+            owner: "org",
+            client: CLIENT,
+            clientOwner: "org",
+            name: ConnectionName.make("main"),
+            integration: INTEG,
+            template: TEMPLATE,
+          });
+          expect(started.status).toBe("redirect");
+          if (started.status !== "redirect") return null;
+          const callback = yield* server.completeAuthorizationCodeFlow({
+            authorizationUrl: started.authorizationUrl,
+          });
+          return yield* executor.oauth.complete({
+            state: started.state,
+            code: callback.code,
+          });
+        });
+
+        const first = yield* runFlow;
+        expect(first?.identityLabel).toBe("alice@example.com");
+
+        // The user renames the connection, then reconnects (no typed label).
+        yield* executor.connections.update(
+          { owner: "org", integration: INTEG, name: ConnectionName.make("main") },
+          { identityLabel: "Finance account" },
+        );
+        const second = yield* runFlow;
+        expect(second?.identityLabel).toBe("Finance account");
+      }),
+    ),
+  );
+
   it.effect("does not overwrite connection identity from id_token claims on refresh", () =>
     Effect.scoped(
       Effect.gen(function* () {

--- a/packages/core/sdk/src/oauth-service.ts
+++ b/packages/core/sdk/src/oauth-service.ts
@@ -83,6 +83,10 @@ export interface MintOAuthConnectionInput {
   readonly integration: IntegrationSlug;
   readonly template: AuthTemplateSlug;
   readonly identityLabel?: string | null;
+  /** Display label derived from the provider (OIDC id_token claims), as opposed
+   *  to `identityLabel` which the user chose. Only fills an EMPTY label slot:
+   *  a re-mint must never clobber a curated label with a derived one. */
+  readonly derivedIdentityLabel?: string | null;
   /** Credential provider key + item id the access token is stored under. */
   readonly provider: string;
   readonly itemId: string;
@@ -127,6 +131,14 @@ export interface OAuthServiceDeps {
   readonly mintOAuthConnection: (
     input: MintOAuthConnectionInput,
   ) => Effect.Effect<Connection, StorageFailure>;
+  /** Whether a connection row exists under `(owner, integration, name)`: the
+   *  raw row, not the policy-filtered list, so `start` can resolve a free
+   *  name for `newConnection` flows against what is actually stored. */
+  readonly connectionNameTaken: (ref: {
+    readonly owner: Owner;
+    readonly integration: IntegrationSlug;
+    readonly name: ConnectionName;
+  }) => Effect.Effect<boolean, StorageFailure>;
   /**
    * Resolve the OAuth scope policy for a `(integration, template)`:
    *  - `{ kind: "scopes", scopes }`: the scopes the integration's auth template
@@ -1060,6 +1072,32 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
         });
       }
 
+      // newConnection: resolve the requested name to a FREE one against the
+      // stored rows (not a client-side, policy-filtered view), so a second
+      // untyped connect mints `personalGmail2` instead of silently re-minting
+      // the first account's row. Reconnects omit the flag and keep targeting
+      // their existing row. Bounded: a pathological owner with 1000 same-named
+      // connections fails loudly rather than scanning forever.
+      let name = input.name;
+      if (input.newConnection === true) {
+        let suffix = 2;
+        while (
+          yield* deps.connectionNameTaken({
+            owner: input.owner,
+            integration: input.integration,
+            name,
+          })
+        ) {
+          if (suffix > 1000) {
+            return yield* new OAuthStartError({
+              message: `No free connection name derivable from ${input.name}.`,
+            });
+          }
+          name = ConnectionName.make(`${String(input.name)}${suffix}`);
+          suffix++;
+        }
+      }
+
       // Declared scopes win (driven by the selected auth template). MCP-style
       // integrations declare none and discover them from the client's protected
       // resource / authorization server metadata at connect.
@@ -1107,7 +1145,7 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
           ),
         );
         const connection = yield* mintFromToken(
-          input,
+          { ...input, name },
           client,
           token,
           requestedScopes,
@@ -1163,7 +1201,7 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
           state: String(state),
           client_slug: String(input.client),
           integration: String(input.integration),
-          name: String(input.name),
+          name: String(name),
           template: String(input.template),
           redirect_url: flowRedirectUri,
           pkce_verifier: verifier,
@@ -1308,7 +1346,7 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
           name: session.name,
           integration: session.integration,
           template: session.template,
-          identityLabel: session.identityLabel ?? token.idTokenIdentityLabel ?? null,
+          identityLabel: session.identityLabel ?? null,
         },
         client,
         token,
@@ -1384,6 +1422,9 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
         integration: target.integration,
         template: target.template,
         identityLabel: target.identityLabel ?? null,
+        // The OIDC account claims travel separately: they may only FILL an
+        // empty label, never replace a user-curated one on reconnect.
+        derivedIdentityLabel: token.idTokenIdentityLabel ?? null,
         provider: String(provider.key),
         itemId,
         oauthClient: OAuthClientSlug.make(client.slug),

--- a/packages/react/src/components/add-account-modal.test.ts
+++ b/packages/react/src/components/add-account-modal.test.ts
@@ -19,6 +19,8 @@ import {
   oauthIdentityLabelFromHealth,
   runCimdConnect,
   runDcrConnect,
+  typedIdentityLabel,
+  uniqueConnectionName,
 } from "./add-account-modal";
 
 const apiKeyMethod = (id: string, source: "spec" | "custom", template = id): AuthMethod => ({
@@ -111,6 +113,32 @@ describe("connectionNameFrom", () => {
   });
 });
 
+describe("uniqueConnectionName", () => {
+  const base = connectionNameFrom("", "user", "Gmail", "org_123");
+
+  it("keeps the derived name when it is not taken", () => {
+    expect(String(uniqueConnectionName(base, new Set()))).toBe("personalGmail");
+  });
+
+  it("suffixes past taken names so a second untyped connect mints a NEW connection", () => {
+    expect(String(uniqueConnectionName(base, new Set(["personalGmail"])))).toBe("personalGmail2");
+    expect(String(uniqueConnectionName(base, new Set(["personalGmail", "personalGmail2"])))).toBe(
+      "personalGmail3",
+    );
+  });
+});
+
+describe("typedIdentityLabel", () => {
+  it("returns undefined for empty/whitespace labels so oauth.start omits the label", () => {
+    expect(typedIdentityLabel("")).toBeUndefined();
+    expect(typedIdentityLabel("   ")).toBeUndefined();
+  });
+
+  it("returns the trimmed label the user typed", () => {
+    expect(typedIdentityLabel("  Work Gmail ")).toBe("Work Gmail");
+  });
+});
+
 describe("oauthIdentityLabelFromHealth", () => {
   const healthyResult = {
     status: "healthy" as const,
@@ -118,13 +146,12 @@ describe("oauthIdentityLabelFromHealth", () => {
     checkedAt: 1,
   };
 
-  it("uses a healthy probed identity when the stored label is still the default", () => {
+  it("fills an unset label (untyped connect with no OIDC claims)", () => {
     expect(
       oauthIdentityLabelFromHealth({
         result: healthyResult,
         typedLabel: "",
-        storedIdentityLabel: "Personal Google",
-        defaultIdentityLabel: "Personal Google",
+        storedIdentityLabel: null,
       }),
     ).toBe("user@example.com");
   });
@@ -135,7 +162,6 @@ describe("oauthIdentityLabelFromHealth", () => {
         result: healthyResult,
         typedLabel: "My Google Account",
         storedIdentityLabel: "My Google Account",
-        defaultIdentityLabel: "Personal Google",
       }),
     ).toBeNull();
   });
@@ -146,7 +172,16 @@ describe("oauthIdentityLabelFromHealth", () => {
         result: healthyResult,
         typedLabel: "",
         storedIdentityLabel: "Finance Google",
-        defaultIdentityLabel: "Personal Google",
+      }),
+    ).toBeNull();
+  });
+
+  it("does not overwrite a label already filled from OIDC claims", () => {
+    expect(
+      oauthIdentityLabelFromHealth({
+        result: healthyResult,
+        typedLabel: "",
+        storedIdentityLabel: "alice@example.com",
       }),
     ).toBeNull();
   });
@@ -156,16 +191,14 @@ describe("oauthIdentityLabelFromHealth", () => {
       oauthIdentityLabelFromHealth({
         result: { status: "degraded", checkedAt: 1 },
         typedLabel: "",
-        storedIdentityLabel: "Personal Google",
-        defaultIdentityLabel: "Personal Google",
+        storedIdentityLabel: null,
       }),
     ).toBeNull();
     expect(
       oauthIdentityLabelFromHealth({
         result: { status: "healthy", checkedAt: 1 },
         typedLabel: "",
-        storedIdentityLabel: "Personal Google",
-        defaultIdentityLabel: "Personal Google",
+        storedIdentityLabel: null,
       }),
     ).toBeNull();
   });

--- a/packages/react/src/components/add-account-modal.tsx
+++ b/packages/react/src/components/add-account-modal.tsx
@@ -573,18 +573,41 @@ export const connectionNameFrom = (
 ): ConnectionName =>
   connectionIdentifier(connectionLabelForHost(label, owner, integrationName, organizationId));
 
+/** Uniquify a derived callable name against the owner's existing connections
+ *  for the integration: a fresh OAuth connect mints a NEW connection, and two
+ *  untyped connects both derive `personalGmail`; without a suffix the second
+ *  silently replaces the first account's token and label. */
+export const uniqueConnectionName = (
+  base: ConnectionName,
+  takenNames: ReadonlySet<string>,
+): ConnectionName => {
+  if (!takenNames.has(String(base))) return base;
+  let suffix = 2;
+  while (takenNames.has(`${String(base)}${suffix}`)) suffix++;
+  return ConnectionName.make(`${String(base)}${suffix}`);
+};
+
+/** The `oauth.start` identity label: only a label the user actually typed.
+ *  An untyped connect sends none, so the server may fill the label from the
+ *  provider's OIDC claims (the account email) instead of a generic
+ *  "Personal Gmail" that would also clobber a curated label on reconnect. */
+export const typedIdentityLabel = (label: string): string | undefined => {
+  const trimmed = label.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+};
+
 export const oauthIdentityLabelFromHealth = (input: {
   readonly result: HealthCheckResult;
   readonly typedLabel: string;
   readonly storedIdentityLabel?: string | null;
-  readonly defaultIdentityLabel: string;
 }): string | null => {
   const identity = input.result.identity?.trim();
   if (input.result.status !== "healthy" || !identity) return null;
   if (input.typedLabel.trim().length > 0) return null;
-  const defaultLabel = input.defaultIdentityLabel.trim();
-  const storedLabel = (input.storedIdentityLabel ?? defaultLabel).trim();
-  return storedLabel === defaultLabel ? identity : null;
+  // Fill only an unset label: an untyped connect stores none unless the grant
+  // carried OIDC claims, and anything already stored (typed, curated, or
+  // claims-derived) wins over a probed identity.
+  return (input.storedIdentityLabel ?? "").trim().length === 0 ? identity : null;
 };
 
 // ---------------------------------------------------------------------------
@@ -1241,6 +1264,30 @@ function AddAccountModalView(props: AddAccountModalProps) {
     () => buildUsageMap(AsyncResult.isSuccess(connectionsResult) ? connectionsResult.value : []),
     [connectionsResult],
   );
+  // PREVIEW-ONLY uniquify against the loaded connections list: the callable
+  // name shown before an OAuth connect anticipates the server's suffixing
+  // (`personalGmail2`). The AUTHORITATIVE resolution happens in `oauth.start`
+  // against stored rows (`newConnection: true`); this view may be stale or
+  // policy-filtered and must never be the thing preventing an overwrite.
+  const takenConnectionNames = useMemo<ReadonlyMap<Owner, ReadonlySet<string>>>(() => {
+    const map = new Map<Owner, Set<string>>();
+    if (!AsyncResult.isSuccess(connectionsResult)) return map;
+    for (const connection of connectionsResult.value) {
+      if (String(connection.integration) !== String(integration)) continue;
+      const names = map.get(connection.owner) ?? new Set<string>();
+      names.add(String(connection.name));
+      map.set(connection.owner, names);
+    }
+    return map;
+  }, [connectionsResult, integration]);
+  const previewConnectionName = useCallback(
+    (typed: string, connectionOwner: Owner): ConnectionName =>
+      uniqueConnectionName(
+        connectionNameFrom(typed, connectionOwner, integrationName, organizationId),
+        takenConnectionNames.get(connectionOwner) ?? new Set<string>(),
+      ),
+    [takenConnectionNames, integrationName, organizationId],
+  );
 
   const method = useMemo(
     () => allMethods.find((m: AuthMethod) => m.id === methodId) ?? allMethods[0],
@@ -1523,7 +1570,12 @@ function AddAccountModalView(props: AddAccountModalProps) {
   const savedToOptions = isOAuth && !automaticOAuthActive ? oauthConnectionOptions : ownerOptions;
   const savedToOwner = isOAuth && !automaticOAuthActive ? oauthConnectionOwner : owner;
   const showSavedToPicker = !oauthRegistering && savedToOptions.length > 1;
-  const callableName = connectionNameFrom(label, savedToOwner, integrationName, organizationId);
+  // OAuth mints a NEW connection per connect, so its preview shows the
+  // uniquified name (`personalGmail2`); credential saves keep the plain
+  // derivation (they surface an explicit overwrite through the same name).
+  const callableName = isOAuth
+    ? previewConnectionName(label, savedToOwner)
+    : connectionNameFrom(label, savedToOwner, integrationName, organizationId);
   const authStepLabel = isOAuth ? (cimdActive ? "OAuth setup" : "OAuth app") : "Credential";
 
   // Build the picker row's Edit/Remove menu for an app, but only once its full
@@ -1666,7 +1718,6 @@ function AddAccountModalView(props: AddAccountModalProps) {
   const probeAndAutoNameOAuthConnection = async (
     connection: OAuthCompletionPayload,
     typedLabel: string,
-    defaultIdentityLabel: string,
   ): Promise<void> => {
     const check = await doCheckConnectionHealth({
       params: {
@@ -1682,7 +1733,6 @@ function AddAccountModalView(props: AddAccountModalProps) {
       result: check.value,
       typedLabel,
       storedIdentityLabel: connection.identityLabel,
-      defaultIdentityLabel,
     });
     if (nextIdentityLabel === null) return;
     const updated = await doUpdateConnection({
@@ -1881,20 +1931,21 @@ function AddAccountModalView(props: AddAccountModalProps) {
     // backend resolves the app own→shared from the slug, so the payload carries
     // only the host-resolved connection owner.
     const connectionOwner = oauthConnectionOwner;
-    const identityLabel = connectionLabelForHost(
-      label,
-      connectionOwner,
-      integrationName,
-      organizationId,
-    );
+    // Untyped connects carry NO identity label: the server fills it from the
+    // provider's OIDC claims (the account email), and the fallback probe below
+    // covers providers without an id_token. Sending the "<owner> <integration>"
+    // default here would both bury the real account identity and clobber a
+    // curated label on a same-name reconnect.
+    const identityLabel = typedIdentityLabel(label);
     const payload = {
       client: chosenClient.slug,
       clientOwner: chosenClient.owner,
       owner: connectionOwner,
-      name: connectionNameFrom(label, connectionOwner, integrationName, organizationId),
+      name: previewConnectionName(label, connectionOwner),
+      newConnection: true,
       integration,
       template: method.template,
-      identityLabel,
+      ...(identityLabel !== undefined ? { identityLabel } : {}),
     };
     // client_credentials mints inline (no redirect); authorization_code runs the popup.
     if (chosenClient.grant === "client_credentials") {
@@ -1915,7 +1966,7 @@ function AddAccountModalView(props: AddAccountModalProps) {
         return;
       }
       if (exit.value.status === "connected") {
-        await probeAndAutoNameOAuthConnection(exit.value.connection, label, identityLabel);
+        await probeAndAutoNameOAuthConnection(exit.value.connection, label);
       }
       setCcBusy(false);
       toast.success("Connection added");
@@ -1948,7 +1999,7 @@ function AddAccountModalView(props: AddAccountModalProps) {
         });
       },
       onSuccess: async (connection: OAuthCompletionPayload) => {
-        await probeAndAutoNameOAuthConnection(connection, label, identityLabel);
+        await probeAndAutoNameOAuthConnection(connection, label);
         toast.success("Connection added");
         close();
       },
@@ -1963,8 +2014,8 @@ function AddAccountModalView(props: AddAccountModalProps) {
       return;
     }
     const cimdOwner = owner;
-    const connectionName = connectionNameFrom(label, cimdOwner, integrationName, organizationId);
-    const identityLabel = connectionLabelForHost(label, cimdOwner, integrationName, organizationId);
+    const connectionName = previewConnectionName(label, cimdOwner);
+    const identityLabel = typedIdentityLabel(label);
     setCimdBusy(true);
     const outcome = await runCimdConnect(
       {
@@ -1996,10 +2047,11 @@ function AddAccountModalView(props: AddAccountModalProps) {
               name: connectionName,
               integration,
               template: method.template,
-              identityLabel,
+              newConnection: true,
+              ...(identityLabel !== undefined ? { identityLabel } : {}),
             },
             onSuccess: async (connection: OAuthCompletionPayload) => {
-              await probeAndAutoNameOAuthConnection(connection, label, identityLabel);
+              await probeAndAutoNameOAuthConnection(connection, label);
               toast.success("Connection added");
               close();
             },
@@ -2039,8 +2091,8 @@ function AddAccountModalView(props: AddAccountModalProps) {
       return;
     }
     const dcrOwner = owner;
-    const connectionName = connectionNameFrom(label, dcrOwner, integrationName, organizationId);
-    const identityLabel = connectionLabelForHost(label, dcrOwner, integrationName, organizationId);
+    const connectionName = previewConnectionName(label, dcrOwner);
+    const identityLabel = typedIdentityLabel(label);
     setDcrBusy(true);
     const outcome = await runDcrConnect(
       {
@@ -2087,10 +2139,11 @@ function AddAccountModalView(props: AddAccountModalProps) {
               name: connectionName,
               integration,
               template: method.template,
-              identityLabel,
+              newConnection: true,
+              ...(identityLabel !== undefined ? { identityLabel } : {}),
             },
             onSuccess: async (connection: OAuthCompletionPayload) => {
-              await probeAndAutoNameOAuthConnection(connection, label, identityLabel);
+              await probeAndAutoNameOAuthConnection(connection, label);
               toast.success("Connection added");
               close();
             },
@@ -2699,7 +2752,9 @@ function AddAccountModalView(props: AddAccountModalProps) {
                     hint={
                       nameOptions.length > 0
                         ? "from the account your key returned, or type your own"
-                        : "how you'll tell accounts apart"
+                        : isOAuth
+                          ? "detected from the account you sign in with, or type your own"
+                          : "how you'll tell accounts apart"
                     }
                     htmlFor="connection-name"
                   />
@@ -2729,12 +2784,11 @@ function AddAccountModalView(props: AddAccountModalProps) {
                   ) : (
                     <Input
                       id="connection-name"
-                      placeholder={connectionLabelForHost(
-                        "",
-                        owner,
-                        integrationName,
-                        organizationId,
-                      )}
+                      placeholder={
+                        isOAuth
+                          ? "you@example.com"
+                          : connectionLabelForHost("", owner, integrationName, organizationId)
+                      }
                       value={label}
                       onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                         setLabel(e.target.value);

--- a/packages/react/src/plugins/oauth-sign-in.tsx
+++ b/packages/react/src/plugins/oauth-sign-in.tsx
@@ -69,6 +69,9 @@ export type OAuthStartPayload = {
   readonly integration: IntegrationSlug;
   readonly template: AuthTemplateSlug;
   readonly identityLabel?: string;
+  /** Mint a NEW connection: the server resolves a taken `name` to the next
+   *  free suffixed one. Omitted on reconnect, which targets the existing row. */
+  readonly newConnection?: boolean;
   readonly redirectUri?: string;
 };
 
@@ -381,6 +384,7 @@ export function useOAuthPopupFlow<
               integration: input.payload.integration,
               template: input.payload.template,
               identityLabel: input.payload.identityLabel,
+              newConnection: input.payload.newConnection,
               redirectUri: input.payload.redirectUri ?? oauthCallbackUrl(callbackPath),
             },
           }).then((exit) =>


### PR DESCRIPTION
Connecting through OAuth (e.g. Gmail) used to stamp the generic "Personal Gmail" display name onto the connection, and a reconnect with an empty name field overwrote any label the user had set. A second untyped connect also silently re-minted the same connection row, replacing the first account.

- An untyped connect now sends no identity label. The server fills the label from the OIDC id_token claims (the account email); the existing post-connect health probe covers providers without an id_token.
- Re-mints never clobber a stored label: explicit label wins, then the existing label, then the derived one (same rule as description).
- New connects pass `newConnection: true` and `oauth.start` resolves a taken name to the next free suffix (`personalGmail2`) server-side against stored rows, so two accounts coexist instead of the second replacing the first.
- Connect dialog: display name hint/placeholder now says the name is detected from the account; the callable-name preview anticipates the suffix.

Covered by SDK oauth-flow tests (label precedence, reconnect preservation, name suffixing), modal helper unit tests, and the Google emulator e2e scenario extended with reconnect-keeps-curated-label and second-account assertions.