### PR TITLE
Downgrade apps-plugin removal changeset to patch

### DIFF
--- a/.changeset/remove-apps-plugin.md
+++ b/.changeset/remove-apps-plugin.md
@@ -1,5 +1,5 @@
 ---
-"executor": minor
+"executor": patch
 ---
 
 Remove the custom apps plugin. Git and local-directory app sources are no


### PR DESCRIPTION
The custom apps plugin was never part of a published release, so removing it is not a user-facing minor. Downgrading to patch keeps the next release a patch (1.5.36) instead of 1.6.0.