### PR TITLE
Trace the OAuth lifecycle: token requests, connects, and health checks

### DIFF
--- a/e2e/scenarios/oauth-refresh-rejected.test.ts
+++ b/e2e/scenarios/oauth-refresh-rejected.test.ts
@@ -118,6 +118,7 @@ type ToolEnvelope = {
     readonly details?: {
       readonly category?: string;
       readonly recovery?: Record<string, string>;
+      readonly upstream?: { readonly details?: { readonly oauthErrorCode?: string } };
     };
   };
 };
@@ -249,6 +250,10 @@ scenario(
             failure.error?.message ?? "",
             "the message carries the AS's RFC 6749 error code",
           ).toContain("invalid_request");
+          expect(
+            failure.error?.details?.upstream?.details?.oauthErrorCode,
+            "the AS's code is ALSO a structured field, so agents and telemetry never parse the message for it",
+          ).toBe("invalid_request");
           expect(
             failure.error?.message ?? "",
             "the message carries the AS's error description",

--- a/packages/core/execution/src/tool-invoker.ts
+++ b/packages/core/execution/src/tool-invoker.ts
@@ -177,6 +177,7 @@ const credentialResolutionToolFailure = (input: {
   readonly label: string;
   readonly message: string;
   readonly reauthRequired?: boolean;
+  readonly oauthErrorCode?: string;
 }) =>
   authToolFailure({
     code: input.reauthRequired === true ? "oauth_reauth_required" : "oauth_refresh_failed",
@@ -188,6 +189,12 @@ const credentialResolutionToolFailure = (input: {
       kind: "oauth",
       label: input.label,
     },
+    // The AS's own RFC 6749 §5.2 verdict, when there was one — structured so
+    // the agent (and anyone reading the failure) can distinguish a dead grant
+    // from a misconfigured app without parsing the message.
+    ...(input.oauthErrorCode !== undefined
+      ? { upstream: { details: { oauthErrorCode: input.oauthErrorCode } } }
+      : {}),
   });
 
 const bindingToolFailure = (value: unknown): ToolError | null => {
@@ -310,6 +317,7 @@ export const makeExecutorToolInvoker = (
             label: `${err.integration}.${err.owner}.${err.name}`,
             message: err.message,
             reauthRequired: err.reauthRequired,
+            oauthErrorCode: err.oauthErrorCode,
           }),
         ),
       ),

--- a/packages/core/sdk/src/errors.ts
+++ b/packages/core/sdk/src/errors.ts
@@ -181,6 +181,13 @@ export class CredentialResolutionError extends Schema.TaggedErrorClass<Credentia
     /** True when the stored grant is permanently invalid and the user must
      *  sign in again (RFC 6749 §5.2 invalid_grant and friends). */
     reauthRequired: Schema.optional(Schema.Boolean),
+    /** The authorization server's RFC 6749 §5.2 error code (`invalid_grant`,
+     *  `invalid_client`, …), when the failure came from a token-endpoint
+     *  refusal. A typed field rather than message text so telemetry and
+     *  classification read it structurally — the misclassification where
+     *  `invalid_client` (rotated app secret, fleet-wide) surfaced as a vague
+     *  "degraded" was only findable by grepping persisted message strings. */
+    oauthErrorCode: Schema.optional(Schema.String),
   },
 ) {}
 

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -1804,6 +1804,7 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
                         // oxlint-disable-next-line executor/no-unknown-error-message -- boundary: OAuth2Error carries a typed `message`
                         message: `OAuth token refresh was rejected (${cause.error}): ${cause.message}`,
                         reauthRequired: cause.error === "invalid_grant",
+                        oauthErrorCode: cause.error,
                       });
                     }
                     return new StorageError({
@@ -1849,16 +1850,13 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
         // The refresh path was previously invisible to telemetry: no span, no
         // log, no metric. When a customer reported "my OAuth just died", there
         // was no way to answer "did a refresh even fire, and did it work?"
-        // without a repro. Stamp the outcome and the failure KIND — enumerable
-        // identifiers only, never user content or token material.
-        //
-        // The AS's own RFC 6749 §5.2 code is not stamped here: it survives only
-        // inside the error's message, and that message embeds the token
-        // endpoint's response URL and a body preview, so it can't go on a span
-        // attribute. Making that code a queryable dimension needs it lifted to
-        // a typed field on CredentialResolutionError first — worth doing, since
-        // invalid_client (a rotated secret, fleet-wide) currently looks exactly
-        // like a transient server_error from a trace.
+        // without a repro. Stamp the outcome, the failure KIND, and the AS's
+        // own RFC 6749 §5.2 code (from the typed `oauthErrorCode` field, NOT
+        // the message — the message embeds the token endpoint's response URL
+        // and a body preview). Enumerable identifiers only, never user content
+        // or token material. The code is the dimension that separates
+        // invalid_client (a rotated app secret — fleet-wide, page someone)
+        // from server_error (transient, the next invoke retries).
         Effect.tap(() => Effect.annotateCurrentSpan({ "executor.oauth.refresh.outcome": "ok" })),
         Effect.tapError((error: StorageFailure | CredentialResolutionError) =>
           Effect.annotateCurrentSpan({
@@ -1870,7 +1868,12 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
             // the refresh token itself is dead) or a transient failure the next
             // invoke can retry. The split is the actionable half of the signal.
             ...(Predicate.isTagged(error, "CredentialResolutionError")
-              ? { "executor.oauth.refresh.reauth_required": error.reauthRequired === true }
+              ? {
+                  "executor.oauth.refresh.reauth_required": error.reauthRequired === true,
+                  ...(error.oauthErrorCode !== undefined
+                    ? { "executor.oauth.error_code": error.oauthErrorCode }
+                    : {}),
+                }
               : {}),
           }),
         ),
@@ -3092,6 +3095,25 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
         return out;
       });
 
+    /** Stamp the verdict + which path produced it onto the enclosing health
+     *  span. Every health outcome is HTTP 200, so WITHOUT these attributes the
+     *  request envelope cannot separate healthy from expired — the "what
+     *  fraction of connections are dead right now" question was previously
+     *  only answerable by querying the database. `status` and `httpStatus`
+     *  are enumerable; `detail`/`identity` (upstream free text / an email)
+     *  never go on a span. */
+    const annotateHealthVerdict = (
+      source: "cache" | "no_capability" | "credential_only" | "probe",
+      result: HealthCheckResult,
+    ): Effect.Effect<void> =>
+      Effect.annotateCurrentSpan({
+        "executor.health.status": result.status,
+        "executor.health.source": source,
+        ...(result.httpStatus !== undefined
+          ? { "executor.health.http_status": result.httpStatus }
+          : {}),
+      });
+
     const connectionCheckHealth = (
       ref: ConnectionRef,
       options?: {
@@ -3116,7 +3138,10 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
         }
         if (options?.ifStaleMs !== undefined) {
           const cached = Option.getOrNull(decodeLastHealth(connectionRow.last_health));
-          if (cached && Date.now() - cached.checkedAt < options.ifStaleMs) return cached;
+          if (cached && Date.now() - cached.checkedAt < options.ifStaleMs) {
+            yield* annotateHealthVerdict("cache", cached);
+            return cached;
+          }
         }
         const integrationRow = yield* findIntegrationRow(ref.integration);
         if (!integrationRow) {
@@ -3124,10 +3149,19 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
         }
         const runtime = runtimes.get(integrationRow.plugin_id);
         const check = runtime?.plugin.checkHealth;
-        if (!runtime || !check) return unknownHealth();
+        if (!runtime || !check) {
+          const result = unknownHealth();
+          yield* annotateHealthVerdict("no_capability", result);
+          return result;
+        }
         const spec = describeHealthCheckForRow(integrationRow) ?? undefined;
         if (spec === undefined && connectionRow.oauth_client != null) {
+          // No probe operation is declared, so "healthy" here means only "the
+          // credential resolved (refreshing if due)" — a refresh failure is
+          // the one real signal this path can produce, and it must not hide
+          // inside a green span.
           const result = yield* oauthCredentialHealthWithoutProbe(connectionRow);
+          yield* annotateHealthVerdict("credential_only", result);
           yield* persistHealthResult(ref, result);
           return result;
         }
@@ -3156,12 +3190,20 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
             `Health check for connection "${ref.name}" failed.`,
           );
         }).pipe(Effect.catchTag("CredentialResolutionError", healthFromCredentialResolutionError));
+        yield* annotateHealthVerdict("probe", result);
         // Persist the verdict on the connection row so the accounts list shows
         // alive/expired at a glance. Best-effort: a write failure must not turn
         // a successful probe into an error.
         yield* persistHealthResult(ref, result);
         return result;
-      });
+      }).pipe(
+        Effect.withSpan("executor.connection.health.check", {
+          attributes: {
+            "executor.integration": String(ref.integration),
+            "executor.connection": String(ref.name),
+          },
+        }),
+      );
 
     const connectionValidate = (
       input: ValidateConnectionInput,
@@ -3196,11 +3238,25 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
         // from the integration row. Nothing persists here: validate is the
         // key-first flow's dry run.
         const spec = input.spec ?? describeHealthCheckForRow(integrationRow) ?? undefined;
-        return yield* foldPluginFailure(
+        const result = yield* foldPluginFailure(
           check({ ctx: runtime.ctx, integration: record, credential, spec }),
           `Validating credential for "${input.integration}" failed.`,
         );
-      });
+        // Nothing persists here BY DESIGN, which makes this span the only
+        // possible record of "what fraction of pasted credentials are rejected
+        // at the door" — a signal the DB can never carry.
+        yield* Effect.annotateCurrentSpan({
+          "executor.health.status": result.status,
+          ...(result.httpStatus !== undefined
+            ? { "executor.health.http_status": result.httpStatus }
+            : {}),
+        });
+        return result;
+      }).pipe(
+        Effect.withSpan("executor.connection.validate", {
+          attributes: { "executor.integration": String(input.integration) },
+        }),
+      );
 
     // Clear the sync stamp so the next tools read re-produces this connection's
     // catalog. The deferred variant of `connectionsRefresh` for signals that

--- a/packages/core/sdk/src/oauth-helpers.ts
+++ b/packages/core/sdk/src/oauth-helpers.ts
@@ -367,6 +367,43 @@ const toOAuth2ErrorWithHttpSummary = (cause: unknown): Effect.Effect<OAuth2Error
 const failOAuth2WithHttpSummary = (cause: unknown): Effect.Effect<never, OAuth2Error> =>
   toOAuth2ErrorWithHttpSummary(cause).pipe(Effect.flatMap((error) => Effect.fail(error)));
 
+/** Trace one token-endpoint round trip. This is the ONLY place a token request
+ *  can be observed: oauth4webapi drives the raw global `fetch`, not Effect's
+ *  HttpClient, so no `http.client` span exists underneath — without this span
+ *  the AS's latency and refusal rate are invisible.
+ *
+ *  Attribute discipline: hostname (never the full URL — some providers carry
+ *  tenant ids in the path), the grant literal, the auth method, and on failure
+ *  the AS's RFC 6749 §5.2 code. Never the OAuth2Error message (it embeds the
+ *  response URL and a body preview), never token or code material. */
+const withTokenRequestSpan =
+  (input: {
+    readonly grantType: "authorization_code" | "client_credentials" | "refresh_token";
+    readonly tokenUrl: string;
+    readonly clientAuth: ClientAuthMethod | undefined;
+    readonly hasResource: boolean;
+  }) =>
+  <A>(effect: Effect.Effect<A, OAuth2Error>): Effect.Effect<A, OAuth2Error> =>
+    effect.pipe(
+      Effect.tapError((error) =>
+        Effect.annotateCurrentSpan({
+          ...(error.error !== undefined ? { "executor.oauth.error_code": error.error } : {}),
+        }),
+      ),
+      Effect.withSpan("executor.oauth.token_request", {
+        attributes: {
+          "executor.oauth.grant_type": input.grantType,
+          "executor.oauth.token_host": hostnameForTelemetry(input.tokenUrl),
+          "executor.oauth.client_auth": input.clientAuth ?? DEFAULT_CLIENT_AUTH_METHOD,
+          "executor.oauth.has_resource": input.hasResource,
+        },
+      }),
+    );
+
+/** The hostname alone — a malformed URL yields "invalid" rather than leaking
+ *  whatever string failed to parse. */
+const hostnameForTelemetry = (url: string): string => URL.parse(url)?.hostname ?? "invalid";
+
 // ---------------------------------------------------------------------------
 // oauth4webapi adapter helpers
 // ---------------------------------------------------------------------------
@@ -614,7 +651,15 @@ export const exchangeAuthorizationCode = (
       return await processTokenEndpointResponse(as, client, response);
     },
     catch: (cause) => cause,
-  }).pipe(Effect.catch(failOAuth2WithHttpSummary));
+  }).pipe(
+    Effect.catch(failOAuth2WithHttpSummary),
+    withTokenRequestSpan({
+      grantType: "authorization_code",
+      tokenUrl: input.tokenUrl,
+      clientAuth: input.clientAuth,
+      hasResource: input.resource !== undefined,
+    }),
+  );
 
 // ---------------------------------------------------------------------------
 // Exchange client credentials → tokens (RFC 6749 §4.4)
@@ -669,7 +714,15 @@ export const exchangeClientCredentials = (
       return tokenResponseFrom(result);
     },
     catch: (cause) => cause,
-  }).pipe(Effect.catch(failOAuth2WithHttpSummary));
+  }).pipe(
+    Effect.catch(failOAuth2WithHttpSummary),
+    withTokenRequestSpan({
+      grantType: "client_credentials",
+      tokenUrl: input.tokenUrl,
+      clientAuth: input.clientAuth,
+      hasResource: input.resource !== undefined,
+    }),
+  );
 
 // ---------------------------------------------------------------------------
 // Refresh access token
@@ -740,7 +793,15 @@ export const refreshAccessToken = (
       return tokenResponseFrom(result);
     },
     catch: (cause) => cause,
-  }).pipe(Effect.catch(failOAuth2WithHttpSummary));
+  }).pipe(
+    Effect.catch(failOAuth2WithHttpSummary),
+    withTokenRequestSpan({
+      grantType: "refresh_token",
+      tokenUrl: input.tokenUrl,
+      clientAuth: input.clientAuth,
+      hasResource: input.resource !== undefined,
+    }),
+  );
 
 // ---------------------------------------------------------------------------
 // Refresh-needed predicate

--- a/packages/core/sdk/src/oauth-service.ts
+++ b/packages/core/sdk/src/oauth-service.ts
@@ -1283,6 +1283,15 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
           clientOwnerFromPayload(sessionRow.payload) ?? (String(sessionRow.owner) as Owner),
       };
 
+      // Annotate as soon as the session resolves the flow's identity, so even
+      // a completion that fails at the exchange still says WHOSE connect died.
+      yield* Effect.annotateCurrentSpan({
+        "executor.integration": String(session.integration),
+        "executor.connection": String(session.name),
+        "executor.template": String(session.template),
+        "executor.oauth.client": String(session.clientSlug),
+      });
+
       // Expired sessions are not redeemable — drop + treat as not found.
       if (Number.isFinite(session.expiresAt) && session.expiresAt <= Date.now()) {
         yield* deleteSession(input.state);
@@ -1368,9 +1377,24 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
         ),
       );
 
+      // Everything a "why did this connect fail / where did it go" question
+      // needs, none of it secret: slugs, owner scope, and whether the token
+      // host was rebound to a regional endpoint (the Datadog multi-site path —
+      // a bug there previously shipped and was only diagnosable by hand).
+      // Deliberately absent: the code, the PKCE verifier, the token, the
+      // callback domain (can embed an org's private site), and identityLabel
+      // (resolves to an email).
+      yield* Effect.annotateCurrentSpan({
+        "executor.oauth.token_host_rebound": tokenUrl !== client.tokenUrl,
+      });
+
       yield* deleteSession(input.state);
       return connection;
-    });
+    }).pipe(
+      Effect.withSpan("executor.oauth.complete", {
+        attributes: { "executor.oauth.grant": "authorization_code" },
+      }),
+    );
 
   // -----------------------------------------------------------------------
   // Mint the connection from a freshly exchanged token: store the access
@@ -1416,6 +1440,24 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
       }
 
       const oauthScope = recordedOAuthScope(token, requestedScopes);
+      const missingScopes =
+        client.grant === "authorization_code"
+          ? missingGrantedOAuthScopes(requestedScopes, oauthScope)
+          : [];
+      // The freshness facts of this connection AT BIRTH, on the enclosing
+      // span (executor.oauth.complete, or the reconnect path's request
+      // envelope). Every "why did this connection later go stale" question
+      // starts here: a partial grant fails later as oauth_scope_insufficient
+      // in an unrelated trace; no refresh token means the first expiry is
+      // terminal; no advertised expiry means only the reactive 401 path can
+      // ever refresh it. Counts and booleans only — scope VALUES can encode
+      // customer resource names on some providers.
+      yield* Effect.annotateCurrentSpan({
+        "executor.oauth.scope_requested_count": requestedScopes.length,
+        "executor.oauth.scope_missing_count": missingScopes.length,
+        "executor.oauth.has_refresh_token": token.refresh_token !== undefined,
+        "executor.oauth.has_advertised_expiry": typeof token.expires_in === "number",
+      });
       return yield* deps.mintOAuthConnection({
         owner: target.owner,
         name: target.name,
@@ -1436,10 +1478,7 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
         // non-resource scope from the token `scope` string, so preserve it when
         // the refresh token proves it was granted.
         oauthScope,
-        missingOAuthScopes:
-          client.grant === "authorization_code"
-            ? missingGrantedOAuthScopes(requestedScopes, oauthScope)
-            : [],
+        missingOAuthScopes: missingScopes,
         oauthTokenUrl,
       });
     });

--- a/packages/plugins/mcp/src/sdk/plugin.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.ts
@@ -1555,7 +1555,23 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
             detail: error.message,
           } satisfies HealthCheckResult),
         ),
-        Effect.withSpan("mcp.plugin.check_health"),
+        // Every failure above folds onto the SUCCESS channel, so without this
+        // the span ends green on an expired credential — a 401 auth wall and a
+        // healthy dial were indistinguishable in traces.
+        Effect.tap((result) =>
+          Effect.annotateCurrentSpan({
+            "mcp.health.status": result.status,
+            ...("httpStatus" in result && result.httpStatus !== undefined
+              ? { "mcp.health.http_status": result.httpStatus }
+              : {}),
+          }),
+        ),
+        Effect.withSpan("mcp.plugin.check_health", {
+          attributes: {
+            "executor.integration": String(credential.integration),
+            "mcp.connection.name": String(credential.connection),
+          },
+        }),
       ),
 
     describeAuthMethods: describeMcpAuthMethods,


### PR DESCRIPTION
Stacked on #1475.

## Problem

The OAuth domain layer had no spans, and the token POST bypasses Effect's HttpClient (oauth4webapi drives the raw fetch), so no `http.client` span existed underneath either. Questions that came up during the recent refresh investigation — did a refresh fire, what did the AS say, how many connections are expired right now — were only answerable by querying the database.

## Change

- `executor.oauth.token_request` on all three grants (authorization_code, client_credentials, refresh_token): grant type, token endpoint hostname, client auth method, and the AS's RFC 6749 error code on failure. Hostname only, never a full URL.
- `executor.oauth.complete` around code redemption: integration, connection, client slug, whether the token host was rebound to a regional endpoint (the Datadog multi-site path), plus the connection's freshness facts at birth — refresh token present, expiry advertised, scope requested/missing counts. A connection minted without a refresh token or advertised expiry is now visible the moment it's created rather than when it later dies.
- `executor.connection.health.check` and `executor.connection.validate`: the verdict, its source (cache / probe / credential-only / no-capability), and http status. `mcp.plugin.check_health` gets the same outcome stamp — its failures fold onto the success channel, so the span previously ended green on an expired credential.
- The AS's error code is now a typed `oauthErrorCode` field on `CredentialResolutionError`, stamped on the `executor.oauth.refresh` span, and carried as a structured detail on the sandbox-facing failure. Previously it survived only inside message text — `invalid_client` (rotated app secret, fleet-wide) was indistinguishable from `server_error` (transient) in every trace.

Attribute discipline throughout: hostnames, enumerable codes, statuses, slugs, counts, and booleans. No tokens, codes, full URLs, scope values, or identity labels.

## Verification

`format:check`, `lint`, `typecheck`, and `test` pass (37/37 tasks). The refresh-rejected e2e scenario now also asserts the structured `oauthErrorCode` reaches the sandbox failure.