### PR TITLE
mcp: make hung executions detectable in tracing

### DIFF
--- a/apps/cloud/src/mcp/telemetry.test.ts
+++ b/apps/cloud/src/mcp/telemetry.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+import type * as Tracer from "effect/Tracer";
+
+import { annotateMcpRequest } from "./telemetry";
+
+// A tracer that records attributes per span so the test can assert what
+// `annotateMcpRequest` stamps on the active request span.
+const makeRecordingTracer = (): {
+  tracer: Tracer.Tracer;
+  attributesOf: (name: string) => ReadonlyMap<string, unknown> | undefined;
+} => {
+  const spans = new Map<string, Map<string, unknown>>();
+  const tracer: Tracer.Tracer = {
+    span: (options) => {
+      const attributes = spans.get(options.name) ?? new Map<string, unknown>();
+      spans.set(options.name, attributes);
+      let status: Tracer.SpanStatus = { _tag: "Started", startTime: options.startTime };
+      return {
+        _tag: "Span",
+        name: options.name,
+        spanId: `span-${spans.size}`,
+        traceId: "trace-1",
+        parent: options.parent,
+        annotations: options.annotations,
+        get status() {
+          return status;
+        },
+        attributes,
+        links: options.links,
+        sampled: options.sampled,
+        kind: options.kind,
+        end: (endTime, exit) => {
+          status = { _tag: "Ended", startTime: options.startTime, endTime, exit };
+        },
+        attribute: (key, value) => {
+          attributes.set(key, value);
+        },
+        event: () => undefined,
+        addLinks: () => undefined,
+      };
+    },
+  };
+  return { tracer, attributesOf: (name) => spans.get(name) };
+};
+
+const postRequest = (body: unknown): Request =>
+  new Request("https://executor.sh/mcp", {
+    method: "POST",
+    headers: { "content-type": "application/json", "mcp-session-id": "sess-123" },
+    body: JSON.stringify(body),
+  });
+
+const annotate = (request: Request) =>
+  annotateMcpRequest(request, { token: null, parseBody: true });
+
+describe("annotateMcpRequest — cancellation join keys", () => {
+  it.effect("stamps the cancelled request id and reason from notifications/cancelled", () => {
+    const { tracer, attributesOf } = makeRecordingTracer();
+    return Effect.gen(function* () {
+      yield* annotate(
+        postRequest({
+          jsonrpc: "2.0",
+          method: "notifications/cancelled",
+          params: { requestId: 42, reason: "client timeout" },
+        }),
+      );
+      const attributes = attributesOf("mcp.request")!;
+      expect(attributes.get("mcp.rpc.method")).toBe("notifications/cancelled");
+      expect(attributes.get("mcp.rpc.cancelled_id")).toBe("42");
+      expect(attributes.get("mcp.rpc.cancelled_reason")).toBe("client timeout");
+      expect(attributes.get("mcp.request.session_id")).toBe("sess-123");
+    }).pipe(Effect.withSpan("mcp.request"), Effect.withTracer(tracer));
+  });
+
+  it.effect("still stamps mcp.rpc.id on ordinary requests", () => {
+    const { tracer, attributesOf } = makeRecordingTracer();
+    return Effect.gen(function* () {
+      yield* annotate(
+        postRequest({
+          jsonrpc: "2.0",
+          id: 7,
+          method: "tools/call",
+          params: { name: "execute" },
+        }),
+      );
+      const attributes = attributesOf("mcp.request")!;
+      expect(attributes.get("mcp.rpc.id")).toBe("7");
+      expect(attributes.get("mcp.tool.name")).toBe("execute");
+      expect(attributes.get("mcp.rpc.cancelled_id")).toBeUndefined();
+    }).pipe(Effect.withSpan("mcp.request"), Effect.withTracer(tracer));
+  });
+});

--- a/apps/cloud/src/mcp/telemetry.test.ts
+++ b/apps/cloud/src/mcp/telemetry.test.ts
@@ -5,21 +5,27 @@ import type * as Tracer from "effect/Tracer";
 import { annotateMcpRequest } from "./telemetry";
 
 // A tracer that records attributes per span so the test can assert what
-// `annotateMcpRequest` stamps on the active request span.
+// `annotateMcpRequest` stamps on the active request span. One record per span
+// creation (never keyed by name) so same-named spans stay distinct.
+type RecordedSpan = {
+  readonly name: string;
+  readonly attributes: ReadonlyMap<string, unknown>;
+};
+
 const makeRecordingTracer = (): {
   tracer: Tracer.Tracer;
   attributesOf: (name: string) => ReadonlyMap<string, unknown> | undefined;
 } => {
-  const spans = new Map<string, Map<string, unknown>>();
+  const spans: RecordedSpan[] = [];
   const tracer: Tracer.Tracer = {
     span: (options) => {
-      const attributes = spans.get(options.name) ?? new Map<string, unknown>();
-      spans.set(options.name, attributes);
+      const attributes = new Map<string, unknown>();
+      spans.push({ name: options.name, attributes });
       let status: Tracer.SpanStatus = { _tag: "Started", startTime: options.startTime };
       return {
         _tag: "Span",
         name: options.name,
-        spanId: `span-${spans.size}`,
+        spanId: `span-${spans.length}`,
         traceId: "trace-1",
         parent: options.parent,
         annotations: options.annotations,
@@ -41,7 +47,11 @@ const makeRecordingTracer = (): {
       };
     },
   };
-  return { tracer, attributesOf: (name) => spans.get(name) };
+  return { tracer, attributesOf: (name) => spans.find((span) => span.name === name)?.attributes };
+};
+
+const expectDefined: <T>(value: T) => asserts value is NonNullable<T> = (value) => {
+  expect(value).toBeDefined();
 };
 
 const postRequest = (body: unknown): Request =>
@@ -65,7 +75,8 @@ describe("annotateMcpRequest — cancellation join keys", () => {
           params: { requestId: 42, reason: "client timeout" },
         }),
       );
-      const attributes = attributesOf("mcp.request")!;
+      const attributes = attributesOf("mcp.request");
+      expectDefined(attributes);
       expect(attributes.get("mcp.rpc.method")).toBe("notifications/cancelled");
       expect(attributes.get("mcp.rpc.cancelled_id")).toBe("42");
       expect(attributes.get("mcp.rpc.cancelled_reason")).toBe("client timeout");
@@ -84,7 +95,8 @@ describe("annotateMcpRequest — cancellation join keys", () => {
           params: { name: "execute" },
         }),
       );
-      const attributes = attributesOf("mcp.request")!;
+      const attributes = attributesOf("mcp.request");
+      expectDefined(attributes);
       expect(attributes.get("mcp.rpc.id")).toBe("7");
       expect(attributes.get("mcp.tool.name")).toBe("execute");
       expect(attributes.get("mcp.rpc.cancelled_id")).toBeUndefined();

--- a/apps/cloud/src/mcp/telemetry.ts
+++ b/apps/cloud/src/mcp/telemetry.ts
@@ -105,12 +105,23 @@ const InitializeParams = Schema.Struct({
 const NamedParams = Schema.Struct({ name: Schema.optional(Schema.String) });
 const UriParams = Schema.Struct({ uri: Schema.optional(Schema.String) });
 
+// `notifications/cancelled` carries no JSON-RPC id of its own, but its params
+// name the request the client gave up on. Surfacing that id as
+// `mcp.rpc.cancelled_id` makes "a client gave up" joinable to the exact
+// `tools/call` (and the execution spans, which carry `mcp.rpc.id`) that hung —
+// the best available proxy for a killed execution.
+const CancelledParams = Schema.Struct({
+  requestId: Schema.optional(Schema.Union([Schema.String, Schema.Number])),
+  reason: Schema.optional(Schema.String),
+});
+
 const decodeJsonRpcEnvelopeString = Schema.decodeUnknownOption(
   Schema.fromJsonString(JsonRpcEnvelope),
 );
 const decodeInitializeParams = Schema.decodeUnknownOption(InitializeParams);
 const decodeNamedParams = Schema.decodeUnknownOption(NamedParams);
 const decodeUriParams = Schema.decodeUnknownOption(UriParams);
+const decodeCancelledParams = Schema.decodeUnknownOption(CancelledParams);
 const decodeElicitationReplyResult = Schema.decodeUnknownOption(ElicitationReplyResult);
 
 const readJsonRpcEnvelope = (request: Request): Effect.Effect<Option.Option<JsonRpcEnvelope>> =>
@@ -156,6 +167,15 @@ const methodAttrs = (envelope: JsonRpcEnvelope): Record<string, unknown> => {
       Option.match(decodeNamedParams(params), {
         onNone: () => ({}) as Record<string, unknown>,
         onSome: ({ name }) => (name ? { "mcp.prompt.name": name } : {}),
+      }),
+    ),
+    Match.when("notifications/cancelled", () =>
+      Option.match(decodeCancelledParams(params), {
+        onNone: () => ({}) as Record<string, unknown>,
+        onSome: ({ requestId, reason }) => ({
+          ...(requestId !== undefined && { "mcp.rpc.cancelled_id": String(requestId) }),
+          ...(reason && { "mcp.rpc.cancelled_reason": reason }),
+        }),
       }),
     ),
     Match.option,

--- a/packages/hosts/mcp/src/tool-server.test.ts
+++ b/packages/hosts/mcp/src/tool-server.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "@effect/vitest";
 import { Data, Deferred, Effect } from "effect";
+import type * as Tracer from "effect/Tracer";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { ElicitRequestSchema } from "@modelcontextprotocol/sdk/types.js";
@@ -87,6 +88,72 @@ const withNativeClient = async <E extends Cause.YieldableError>(
   capabilities: ClientCapabilities,
   fn: (client: Client) => Promise<void>,
 ) => withClient(engine, capabilities, fn, { elicitationMode: { mode: "native" } });
+
+type RecordedSpan = {
+  readonly name: string;
+  readonly attributes: ReadonlyMap<string, unknown>;
+  ended: boolean;
+};
+
+/** A tracer that records every span + its attributes and end state. */
+const makeRecordingTracer = (): { tracer: Tracer.Tracer; spans: RecordedSpan[] } => {
+  const spans: RecordedSpan[] = [];
+  const tracer: Tracer.Tracer = {
+    span: (options) => {
+      const attributes = new Map<string, unknown>();
+      const recorded: RecordedSpan = { name: options.name, attributes, ended: false };
+      spans.push(recorded);
+      let status: Tracer.SpanStatus = { _tag: "Started", startTime: options.startTime };
+      return {
+        _tag: "Span",
+        name: options.name,
+        spanId: `span-${spans.length}`,
+        traceId: "trace-1",
+        parent: options.parent,
+        annotations: options.annotations,
+        get status() {
+          return status;
+        },
+        attributes,
+        links: options.links,
+        sampled: options.sampled,
+        kind: options.kind,
+        end: (endTime, exit) => {
+          recorded.ended = true;
+          status = { _tag: "Ended", startTime: options.startTime, endTime, exit };
+        },
+        attribute: (key, value) => {
+          attributes.set(key, value);
+        },
+        event: () => undefined,
+        addLinks: () => undefined,
+      };
+    },
+  };
+  return { tracer, spans };
+};
+
+/** withClient, but with a recording tracer installed for the whole server. */
+const withTracedClient = async <E extends Cause.YieldableError>(
+  engine: ExecutionEngine<E>,
+  fn: (client: Client, spans: RecordedSpan[]) => Promise<void>,
+) => {
+  const { tracer, spans } = makeRecordingTracer();
+  const mcpServer = await Effect.runPromise(
+    createExecutorMcpServer({ engine }).pipe(Effect.withTracer(tracer)),
+  );
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: "test-client", version: "1.0.0" }, { capabilities: NO_CAPS });
+  await mcpServer.connect(serverTransport);
+  await client.connect(clientTransport);
+  // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: test helper must close MCP transports after async client assertions
+  try {
+    await fn(client, spans);
+  } finally {
+    await clientTransport.close();
+    await serverTransport.close();
+  }
+};
 
 const ELICITATION_CAPS: ClientCapabilities = {
   elicitation: { form: {}, url: {} },
@@ -1755,6 +1822,52 @@ describe("MCP host server — skills tool", () => {
       expect(textOf(result)).toContain('No skill named "nope"');
       expect(textOf(result)).toContain("`execute`");
       expect(result.structuredContent).toBeUndefined();
+    });
+  });
+});
+
+describe("MCP host server — hang-visibility tracing", () => {
+  it("execute emits a start marker and stamps the JSON-RPC id on execution spans", async () => {
+    const engine = makeStubEngine({});
+
+    await withTracedClient(engine, async (client, spans) => {
+      await client.callTool({ name: "execute", arguments: { code: "1+1" } });
+
+      // The start marker exports immediately: a start without a matching
+      // completed `mcp.host.tool.execute` is the killed-execution signal.
+      const start = spans.find((span) => span.name === "mcp.host.tool.execute.start");
+      expect(start).toBeDefined();
+      expect(start!.ended).toBe(true);
+      expect(start!.attributes.get("mcp.rpc.id")).toBeDefined();
+
+      // The completion span carries the same join key.
+      const execute = spans.find((span) => span.name === "mcp.host.tool.execute");
+      expect(execute).toBeDefined();
+      expect(execute!.attributes.get("mcp.rpc.id")).toBe(start!.attributes.get("mcp.rpc.id"));
+      expect(execute!.ended).toBe(true);
+    });
+  });
+
+  it("resume emits a start marker carrying the execution id and rpc id", async () => {
+    const engine = makeStubEngine({
+      resume: () => Effect.succeed({ status: "completed", result: { result: "resumed" } }),
+    });
+
+    await withTracedClient(engine, async (client, spans) => {
+      await client.callTool({
+        name: "resume",
+        arguments: { executionId: "exec-1", action: "accept" },
+      });
+
+      const start = spans.find((span) => span.name === "mcp.host.tool.resume.start");
+      expect(start).toBeDefined();
+      expect(start!.ended).toBe(true);
+      expect(start!.attributes.get("mcp.execute.execution_id")).toBe("exec-1");
+      expect(start!.attributes.get("mcp.rpc.id")).toBeDefined();
+
+      const resume = spans.find((span) => span.name === "mcp.host.tool.resume");
+      expect(resume).toBeDefined();
+      expect(resume!.attributes.get("mcp.rpc.id")).toBe(start!.attributes.get("mcp.rpc.id"));
     });
   });
 });

--- a/packages/hosts/mcp/src/tool-server.test.ts
+++ b/packages/hosts/mcp/src/tool-server.test.ts
@@ -35,6 +35,10 @@ const expectString: (value: unknown) => asserts value is string = (value) => {
   expect(typeof value).toBe("string");
 };
 
+const expectDefined: <T>(value: T) => asserts value is NonNullable<T> = (value) => {
+  expect(value).toBeDefined();
+};
+
 const makeStubEngine = <E extends Cause.YieldableError = never>(overrides: {
   execute?: ExecutionEngine<E>["execute"];
   executeWithPause?: ExecutionEngine<E>["executeWithPause"];
@@ -54,22 +58,26 @@ const makeStubEngine = <E extends Cause.YieldableError = never>(overrides: {
   getDescription: Effect.succeed(overrides.description ?? "test executor"),
 });
 
+type TestServerConfig<E extends Cause.YieldableError> = Pick<
+  ExecutorMcpServerConfig<E>,
+  | "debug"
+  | "elicitationMode"
+  | "browserApprovalStore"
+  | "pausedExecutionHooks"
+  | "pausedExecutionLeaseMs"
+  | "resumeFallback"
+>;
+
 /** Connect a real MCP Client to our executor MCP server over in-memory transports. */
 const withClient = async <E extends Cause.YieldableError>(
   engine: ExecutionEngine<E>,
   capabilities: ClientCapabilities,
   fn: (client: Client) => Promise<void>,
-  config?: Pick<
-    ExecutorMcpServerConfig<E>,
-    | "debug"
-    | "elicitationMode"
-    | "browserApprovalStore"
-    | "pausedExecutionHooks"
-    | "pausedExecutionLeaseMs"
-    | "resumeFallback"
-  >,
+  config?: TestServerConfig<E> & { readonly tracer?: Tracer.Tracer },
 ) => {
-  const mcpServer = await Effect.runPromise(createExecutorMcpServer({ engine, ...config }));
+  const { tracer, ...serverConfig } = config ?? {};
+  const create = createExecutorMcpServer({ engine, ...serverConfig });
+  const mcpServer = await Effect.runPromise(tracer ? Effect.withTracer(create, tracer) : create);
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
   const client = new Client({ name: "test-client", version: "1.0.0" }, { capabilities });
   await mcpServer.connect(serverTransport);
@@ -137,22 +145,10 @@ const makeRecordingTracer = (): { tracer: Tracer.Tracer; spans: RecordedSpan[] }
 const withTracedClient = async <E extends Cause.YieldableError>(
   engine: ExecutionEngine<E>,
   fn: (client: Client, spans: RecordedSpan[]) => Promise<void>,
+  config?: TestServerConfig<E>,
 ) => {
   const { tracer, spans } = makeRecordingTracer();
-  const mcpServer = await Effect.runPromise(
-    createExecutorMcpServer({ engine }).pipe(Effect.withTracer(tracer)),
-  );
-  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
-  const client = new Client({ name: "test-client", version: "1.0.0" }, { capabilities: NO_CAPS });
-  await mcpServer.connect(serverTransport);
-  await client.connect(clientTransport);
-  // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: test helper must close MCP transports after async client assertions
-  try {
-    await fn(client, spans);
-  } finally {
-    await clientTransport.close();
-    await serverTransport.close();
-  }
+  await withClient(engine, NO_CAPS, (client) => fn(client, spans), { ...config, tracer });
 };
 
 const ELICITATION_CAPS: ClientCapabilities = {
@@ -1833,18 +1829,22 @@ describe("MCP host server — hang-visibility tracing", () => {
     await withTracedClient(engine, async (client, spans) => {
       await client.callTool({ name: "execute", arguments: { code: "1+1" } });
 
-      // The start marker exports immediately: a start without a matching
-      // completed `mcp.host.tool.execute` is the killed-execution signal.
+      // The start marker ends (becomes exportable) the moment execution
+      // begins: a start without a matching completed `mcp.host.tool.execute`
+      // is the killed-execution signal.
       const start = spans.find((span) => span.name === "mcp.host.tool.execute.start");
-      expect(start).toBeDefined();
-      expect(start!.ended).toBe(true);
-      expect(start!.attributes.get("mcp.rpc.id")).toBeDefined();
+      expectDefined(start);
+      expect(start.ended).toBe(true);
+      expect(start.attributes.get("mcp.rpc.id")).toBeDefined();
+      // Session id is stamped even without a transport session so the rpc id
+      // is never ambiguous across sessions.
+      expect(start.attributes.get("mcp.request.session_id")).toBeDefined();
 
       // The completion span carries the same join key.
       const execute = spans.find((span) => span.name === "mcp.host.tool.execute");
-      expect(execute).toBeDefined();
-      expect(execute!.attributes.get("mcp.rpc.id")).toBe(start!.attributes.get("mcp.rpc.id"));
-      expect(execute!.ended).toBe(true);
+      expectDefined(execute);
+      expect(execute.attributes.get("mcp.rpc.id")).toBe(start.attributes.get("mcp.rpc.id"));
+      expect(execute.ended).toBe(true);
     });
   });
 
@@ -1860,14 +1860,48 @@ describe("MCP host server — hang-visibility tracing", () => {
       });
 
       const start = spans.find((span) => span.name === "mcp.host.tool.resume.start");
-      expect(start).toBeDefined();
-      expect(start!.ended).toBe(true);
-      expect(start!.attributes.get("mcp.execute.execution_id")).toBe("exec-1");
-      expect(start!.attributes.get("mcp.rpc.id")).toBeDefined();
+      expectDefined(start);
+      expect(start.ended).toBe(true);
+      expect(start.attributes.get("mcp.execute.execution_id")).toBe("exec-1");
+      expect(start.attributes.get("mcp.rpc.id")).toBeDefined();
 
       const resume = spans.find((span) => span.name === "mcp.host.tool.resume");
-      expect(resume).toBeDefined();
-      expect(resume!.attributes.get("mcp.rpc.id")).toBe(start!.attributes.get("mcp.rpc.id"));
+      expectDefined(resume);
+      expect(resume.attributes.get("mcp.rpc.id")).toBe(start.attributes.get("mcp.rpc.id"));
     });
+  });
+
+  it("browser-approval resume emits its own start marker paired to its completion span", async () => {
+    const engine = makeStubEngine({
+      resume: () => Effect.succeed({ status: "completed", result: { result: "resumed" } }),
+    });
+
+    await withTracedClient(
+      engine,
+      async (client, spans) => {
+        await client.callTool({ name: "resume", arguments: { executionId: "exec-2" } });
+
+        // Distinct marker name: pairing start↔completion 1:1 keeps the
+        // started-without-finishing query unambiguous across resume modes.
+        const start = spans.find(
+          (span) => span.name === "mcp.host.tool.resume.browser_approval.start",
+        );
+        expectDefined(start);
+        expect(start.ended).toBe(true);
+        expect(start.attributes.get("mcp.execute.execution_id")).toBe("exec-2");
+
+        const completion = spans.find(
+          (span) => span.name === "mcp.host.tool.resume.browser_approval",
+        );
+        expectDefined(completion);
+        expect(completion.attributes.get("mcp.rpc.id")).toBe(start.attributes.get("mcp.rpc.id"));
+      },
+      {
+        elicitationMode: { mode: "browser", approvalUrl: (id) => `/approve/${id}` },
+        browserApprovalStore: {
+          takeResponse: () => Effect.succeed({ action: "accept" as const }),
+        },
+      },
+    );
   });
 });

--- a/packages/hosts/mcp/src/tool-server.ts
+++ b/packages/hosts/mcp/src/tool-server.ts
@@ -647,6 +647,39 @@ const extractInventory = (description: string): string => {
   return index === -1 ? "" : description.slice(index).trimEnd();
 };
 
+// ---------------------------------------------------------------------------
+// Hang-visibility join keys
+// ---------------------------------------------------------------------------
+// A killed execution exports nothing: OTEL only ships a span when it ends, and
+// a Cloudflare deploy/eviction cancels the request without an error, so a hung
+// `execute` is invisible in the trace store. Two mitigations live here:
+//   1. Every execution-path span carries the JSON-RPC id + transport session id
+//      (`mcp.rpc.id`, `mcp.request.session_id`), so a client's
+//      `notifications/cancelled` — which names the cancelled request id — can
+//      be joined to the exact call it gave up on.
+//   2. A zero-duration start marker span is emitted the moment execution
+//      begins. It ends (and therefore exports) immediately, so a start marker
+//      without a matching completion span is a true positive for an execution
+//      that died mid-flight.
+
+type McpRequestJoinKeys = {
+  readonly requestId: string | number;
+  readonly sessionId?: string | undefined;
+};
+
+const joinKeyAttributes = (extra: McpRequestJoinKeys): Record<string, unknown> => ({
+  "mcp.rpc.id": String(extra.requestId),
+  ...(extra.sessionId ? { "mcp.request.session_id": extra.sessionId } : {}),
+});
+
+const withJoinKeys = <A, EffE>(
+  effect: Effect.Effect<A, EffE>,
+  extra: McpRequestJoinKeys,
+): Effect.Effect<A, EffE> => Effect.annotateSpans(effect, joinKeyAttributes(extra));
+
+const startMarker = (name: string, attributes: Record<string, unknown>): Effect.Effect<void> =>
+  Effect.void.pipe(Effect.withSpan(name, { attributes }));
+
 const JsonObjectFromString = Schema.fromJsonString(Schema.Record(Schema.String, Schema.Unknown));
 const decodeJsonObjectString = Schema.decodeUnknownOption(JsonObjectFromString);
 
@@ -764,8 +797,15 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
         ),
     ).pipe(Effect.withSpan("mcp.host.create_server"));
 
-    const executeCode = (code: string): Effect.Effect<McpToolResult, E> =>
+    const executeCode = (
+      code: string,
+      extra: McpRequestJoinKeys,
+    ): Effect.Effect<McpToolResult, E> =>
       Effect.gen(function* () {
+        yield* startMarker("mcp.host.tool.execute.start", {
+          "mcp.tool.name": "execute",
+          "mcp.execute.code_length": code.length,
+        });
         debugLog("execute.call", {
           elicitationMode: elicitationMode.mode,
           elicitationSupport: getElicitationSupport(server),
@@ -807,14 +847,20 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
             "mcp.execute.code_length": code.length,
           },
         }),
+        (effect) => withJoinKeys(effect, extra),
       );
 
     const resumeExecution = (
       executionId: string,
       action: "accept" | "decline" | "cancel",
       content: Record<string, unknown> | undefined,
+      extra: McpRequestJoinKeys,
     ): Effect.Effect<McpToolResult, E> =>
       Effect.gen(function* () {
+        yield* startMarker("mcp.host.tool.resume.start", {
+          "mcp.tool.name": "resume",
+          "mcp.execute.execution_id": executionId,
+        });
         debugLog("resume.call", {
           executionId,
           action,
@@ -855,6 +901,7 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
             "mcp.execute.execution_id": executionId,
           },
         }),
+        (effect) => withJoinKeys(effect, extra),
       );
 
     const requireUserResumeApproval = (executionId: string): Effect.Effect<McpToolResult> =>
@@ -898,8 +945,15 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
       );
     };
 
-    const resumeAfterBrowserApproval = (executionId: string): Effect.Effect<McpToolResult, E> =>
+    const resumeAfterBrowserApproval = (
+      executionId: string,
+      extra: McpRequestJoinKeys,
+    ): Effect.Effect<McpToolResult, E> =>
       Effect.gen(function* () {
+        yield* startMarker("mcp.host.tool.resume.start", {
+          "mcp.tool.name": "resume",
+          "mcp.execute.execution_id": executionId,
+        });
         const response = yield* waitForBrowserApprovalResponse(executionId);
         if (!response) return yield* requireUserResumeApproval(executionId);
 
@@ -926,6 +980,7 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
             "mcp.execute.execution_id": executionId,
           },
         }),
+        (effect) => withJoinKeys(effect, extra),
       );
 
     // --- tools ---
@@ -937,7 +992,7 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
           description,
           inputSchema: { code: z.string().trim().min(1) },
         },
-        ({ code }) => runToolEffect(executeCode(code)),
+        ({ code }, extra) => runToolEffect(executeCode(code, extra)),
       ),
     ).pipe(
       Effect.withSpan("mcp.host.register_tool", {
@@ -993,8 +1048,10 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
                 .default("{}"),
             },
           },
-          ({ executionId, action, content: rawContent }) =>
-            runToolEffect(resumeExecution(executionId, action, parseJsonContent(rawContent))),
+          ({ executionId, action, content: rawContent }, extra) =>
+            runToolEffect(
+              resumeExecution(executionId, action, parseJsonContent(rawContent), extra),
+            ),
         );
       }
 
@@ -1010,7 +1067,7 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
             executionId: z.string().describe("The execution ID from the paused result"),
           },
         },
-        ({ executionId }) => runToolEffect(resumeAfterBrowserApproval(executionId)),
+        ({ executionId }, extra) => runToolEffect(resumeAfterBrowserApproval(executionId, extra)),
       );
     }).pipe(
       Effect.withSpan("mcp.host.register_tool", {

--- a/packages/hosts/mcp/src/tool-server.ts
+++ b/packages/hosts/mcp/src/tool-server.ts
@@ -657,25 +657,29 @@ const extractInventory = (description: string): string => {
 //      (`mcp.rpc.id`, `mcp.request.session_id`), so a client's
 //      `notifications/cancelled` — which names the cancelled request id — can
 //      be joined to the exact call it gave up on.
-//   2. A zero-duration start marker span is emitted the moment execution
-//      begins. It ends (and therefore exports) immediately, so a start marker
-//      without a matching completion span is a true positive for an execution
-//      that died mid-flight.
+//   2. A zero-duration start marker span (`<completion span name>.start`, a
+//      1:1 pairing so "started without finishing" is a single unambiguous
+//      query) is emitted the moment execution begins. It ends immediately, so
+//      it becomes exportable while the execution is still running; whether it
+//      actually ships before a kill depends on the host's span processor
+//      draining first (cloud batches on a 1s timer, so markers for executions
+//      that survive >1s export, sub-second kills can still lose theirs). A
+//      start marker without a matching completion span is a true positive for
+//      an execution that died mid-flight.
 
 type McpRequestJoinKeys = {
   readonly requestId: string | number;
   readonly sessionId?: string | undefined;
 };
 
-const joinKeyAttributes = (extra: McpRequestJoinKeys): Record<string, unknown> => ({
-  "mcp.rpc.id": String(extra.requestId),
-  ...(extra.sessionId ? { "mcp.request.session_id": extra.sessionId } : {}),
+// `mcp.request.session_id` is emitted unconditionally (empty string when the
+// transport carries none) to match the worker-side `annotateMcpRequest`
+// producer: JSON-RPC ids are small per-session integers, so a row without the
+// session key would make `mcp.rpc.id` globally ambiguous.
+const joinKeyAttributes = (joinKeys: McpRequestJoinKeys): Record<string, unknown> => ({
+  "mcp.rpc.id": String(joinKeys.requestId),
+  "mcp.request.session_id": joinKeys.sessionId ?? "",
 });
-
-const withJoinKeys = <A, EffE>(
-  effect: Effect.Effect<A, EffE>,
-  extra: McpRequestJoinKeys,
-): Effect.Effect<A, EffE> => Effect.annotateSpans(effect, joinKeyAttributes(extra));
 
 const startMarker = (name: string, attributes: Record<string, unknown>): Effect.Effect<void> =>
   Effect.void.pipe(Effect.withSpan(name, { attributes }));
@@ -847,7 +851,7 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
             "mcp.execute.code_length": code.length,
           },
         }),
-        (effect) => withJoinKeys(effect, extra),
+        Effect.annotateSpans(joinKeyAttributes(extra)),
       );
 
     const resumeExecution = (
@@ -901,7 +905,7 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
             "mcp.execute.execution_id": executionId,
           },
         }),
-        (effect) => withJoinKeys(effect, extra),
+        Effect.annotateSpans(joinKeyAttributes(extra)),
       );
 
     const requireUserResumeApproval = (executionId: string): Effect.Effect<McpToolResult> =>
@@ -950,7 +954,7 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
       extra: McpRequestJoinKeys,
     ): Effect.Effect<McpToolResult, E> =>
       Effect.gen(function* () {
-        yield* startMarker("mcp.host.tool.resume.start", {
+        yield* startMarker("mcp.host.tool.resume.browser_approval.start", {
           "mcp.tool.name": "resume",
           "mcp.execute.execution_id": executionId,
         });
@@ -980,7 +984,7 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
             "mcp.execute.execution_id": executionId,
           },
         }),
-        (effect) => withJoinKeys(effect, extra),
+        Effect.annotateSpans(joinKeyAttributes(extra)),
       );
 
     // --- tools ---


### PR DESCRIPTION
A tool call killed mid-flight (deploy, DO eviction) exports no span at all — OTEL only ships spans on completion, and Cloudflare treats the cancellation as a non-error. This makes hung executions detectable:

- Execution-path spans (`mcp.host.tool.execute`, `mcp.host.tool.resume`, and all their children) now carry `mcp.rpc.id` and `mcp.request.session_id` from the MCP SDK request context, so they join to the request-plane spans.
- `notifications/cancelled` is annotated with `mcp.rpc.cancelled_id` (+ reason), so "a client gave up" points at the exact call it abandoned.
- A zero-duration start marker span (`mcp.host.tool.execute.start` / `mcp.host.tool.resume.start`) exports the moment execution begins; a start marker with no matching completion span is a true positive for a killed execution.