### PR TITLE
Fail closed on the org selector for org-scoped reads

### DIFF
--- a/apps/cloud/src/account/workos-account-service.ts
+++ b/apps/cloud/src/account/workos-account-service.ts
@@ -91,16 +91,19 @@ export const workosAccountProvider: Layer.Layer<
         ? Effect.succeed(caller.session)
         : Effect.fail<AccountUnauthorized>(new AccountUnauthorized());
 
-    // The org scope for an org-scoped request: the console URL's org (sent in
-    // the selector header) when present, else the session's own org. Membership
-    // is re-checked live, so the header is a selector, not a trust boundary —
+    // The org scope for an org-scoped request: the console URL's org, sent in
+    // the selector header. FAIL CLOSED when it's missing — the session's own
+    // org is a browser-global pinned to whichever org WorkOS last touched, so
+    // falling back to it scopes a multi-org user's request to the WRONG org
+    // (see workos-auth-provider.resolveSessionPrincipal). Membership is
+    // re-checked live, so the header is a selector, not a trust boundary —
     // and two browser tabs on different orgs each send their own header, so
     // they stay independent (see organization.ts). Yields the session +
     // resolved org, or AccountNoOrganization.
     const requireOrganization = (headers: AccountHeaders) =>
       Effect.gen(function* () {
         const session = yield* requireSession();
-        const selector = headers[ORG_SELECTOR_HEADER] ?? session.organizationId;
+        const selector = headers[ORG_SELECTOR_HEADER];
         if (!selector) {
           return yield* new AccountNoOrganization();
         }
@@ -180,9 +183,15 @@ export const workosAccountProvider: Layer.Layer<
       me: (headers) =>
         Effect.gen(function* () {
           const session = yield* requireSession();
-          // Same selector precedence as requireOrganization: the URL's org
-          // (header) drives /account/me so the shell reflects the org the tab
-          // is viewing, not a session-global active org.
+          // The ONE sanctioned fallback to the session org. /account/me is
+          // identity, not tenant data: on a bare URL (no org slug yet, so no
+          // header) it answers "which org should this browser land in", and
+          // the session's pinned org is the only candidate. Every org-scoped
+          // DATA read fails closed instead (requireOrganization above,
+          // resolveSessionPrincipal) — serving tenant data from this fallback
+          // is exactly the wrong-org connection-list bug (2026-07). With a
+          // header (any slugged URL), the URL's org drives the answer so the
+          // shell reflects the org the tab is viewing.
           const selector = headers[ORG_SELECTOR_HEADER] ?? session.organizationId;
           const org = selector
             ? yield* authorizeOrganizationSelector(session.accountId, selector).pipe(

--- a/apps/cloud/src/auth/org-selector-auth.node.test.ts
+++ b/apps/cloud/src/auth/org-selector-auth.node.test.ts
@@ -7,9 +7,11 @@ import { resolveSessionPrincipal } from "./workos-auth-provider";
 import { WorkOSClient, type WorkOSClientService } from "./workos";
 
 // The org a console request resolves to is the URL's org (sent in the
-// `x-executor-organization` selector header), not the session's stored org —
-// with the session org as the fallback for non-console callers, and live
-// membership re-checked either way. This is what makes two browser tabs on
+// `x-executor-organization` selector header) — NEVER the session's stored org.
+// The sealed cookie's org is a browser-global pinned to whichever org WorkOS
+// last touched, so a fallback to it silently scopes a multi-org user's request
+// to the wrong org; a header-less request fails closed instead. Live
+// membership is re-checked either way. This is what makes two browser tabs on
 // different orgs independent.
 
 const createdAt = new Date("2026-01-01T00:00:00.000Z");
@@ -95,10 +97,15 @@ const run = (headers: Record<string, string>) =>
   );
 
 describe("resolveSessionPrincipal · URL org selector", () => {
-  it.effect("falls back to the session org when no selector header is sent", () =>
+  it.effect("fails closed when no selector header is sent", () =>
     Effect.gen(function* () {
-      const principal = yield* run({ cookie: "wos-session=x" });
-      expect(principal.organizationId, "scopes to the session org").toBe(SESSION_ORG);
+      // No fallback to the session org: the cookie's org is browser-global
+      // and can name a different org than the tab's URL for a multi-org user.
+      const error = yield* Effect.flip(run({ cookie: "wos-session=x" }));
+      expect(error, "rejects instead of scoping to the session org").toMatchObject({
+        _tag: "NoOrganization",
+        code: "no_organization",
+      });
     }),
   );
 

--- a/apps/cloud/src/auth/workos-auth-provider.ts
+++ b/apps/cloud/src/auth/workos-auth-provider.ts
@@ -16,6 +16,7 @@
 //   - invalid api key            -> Unauthorized  401 invalid_api_key
 //   - api-key org not authorized -> NoOrganization 403 no_organization
 //   - no/invalid session         -> NoOrganization 403 no_organization
+//   - session without org header -> NoOrganization 403 no_organization (fail closed)
 //   - session org not authorized -> NoOrganization 403 no_organization
 //   - no auth header             -> falls through to the sealed-session path
 // The org-resolution infra errors (`UserStoreError` / `WorkOSError`) are
@@ -85,6 +86,10 @@ const NO_ORGANIZATION_IN_API_KEY = {
 const NO_ORGANIZATION_IN_SESSION = {
   code: "no_organization",
   message: "No organization in session",
+};
+const NO_ORGANIZATION_SELECTOR = {
+  code: "no_organization",
+  message: "No organization selector in request",
 };
 const INVALID_ACCESS_TOKEN = {
   code: "invalid_access_token",
@@ -199,13 +204,22 @@ export const resolveSessionPrincipal = (request: Request) =>
     if (!session) {
       return yield* new NoOrganization(NO_ORGANIZATION_IN_SESSION);
     }
-    // The console URL's org is the scope authority (sent as a header); the
-    // session's own org is the fallback for non-console callers. Membership is
-    // re-checked live either way — the header is a selector, not a trust
-    // boundary (see organization.ts).
-    const selector = orgSelectorFromRequest(request) ?? session.organizationId;
+    // The console URL's org is the scope authority, sent as a header on every
+    // request. FAIL CLOSED when it's missing: the sealed cookie's org is
+    // browser-global and pinned to whichever org WorkOS last touched, so
+    // falling back to it silently serves ANOTHER org's data to a multi-org
+    // user (the wrong-tenant connection-list bug, 2026-07). A header-less
+    // session call gets a clear 403 instead. Membership is re-checked live —
+    // the header is a selector, not a trust boundary (see organization.ts).
+    // A bare-URL first paint (no org in the path yet) may 403 here; that's
+    // the safe outcome — OrgSlugGate immediately canonicalizes the URL onto
+    // an org slug, the org-keyed atom registry remounts, and everything
+    // refetches with the header. `/account/me` — which deliberately DOES fall
+    // back to the session org to pick that landing org — lives on the account
+    // plane, not here.
+    const selector = orgSelectorFromRequest(request);
     if (!selector) {
-      return yield* new NoOrganization(NO_ORGANIZATION_IN_SESSION);
+      return yield* new NoOrganization(NO_ORGANIZATION_SELECTOR);
     }
     const org = yield* authorizeOrganizationSelector(session.userId, selector);
     if (!org) return yield* new NoOrganization(NO_ORGANIZATION_IN_SESSION);

--- a/apps/cloud/src/extensions/billing/route.node.test.ts
+++ b/apps/cloud/src/extensions/billing/route.node.test.ts
@@ -61,21 +61,23 @@ const stubUsers = Layer.succeed(UserStoreService)({
     ),
 });
 
-const run = (headers: Record<string, string>, organizationId: string | null = SESSION_ORG) =>
+const run = (headers: Record<string, string>) =>
   resolveBillingOrganization(
     new Request("https://executor.test/api/billing/customer", { headers }),
-    { userId: MEMBER, organizationId },
+    { userId: MEMBER },
   ).pipe(Effect.provide(Layer.mergeAll(stubWorkOS, stubUsers)));
 
 describe("billing route org selector", () => {
-  it.effect("falls back to the session org when no selector header is sent", () =>
+  it.effect("fails closed when no selector header is sent", () =>
     Effect.gen(function* () {
-      const org = yield* run({});
-      expect(org.id).toBe(SESSION_ORG);
+      // No fallback to the session org: the cookie's org is browser-global
+      // and can name a different org than the tab's URL for a multi-org user.
+      const error = yield* Effect.flip(run({}));
+      expect(error).toMatchObject({ _tag: "HttpResponseError", status: 401 });
     }),
   );
 
-  it.effect("scopes billing to the URL org selector over the session org", () =>
+  it.effect("scopes billing to the URL org selector", () =>
     Effect.gen(function* () {
       const org = yield* run({ "x-executor-organization": URL_SLUG });
       expect(org.id).toBe(URL_ORG);
@@ -86,13 +88,6 @@ describe("billing route org selector", () => {
     Effect.gen(function* () {
       const error = yield* Effect.flip(run({ "x-executor-organization": "outsider-slug" }));
       expect(error).toMatchObject({ _tag: "HttpResponseError", status: 403 });
-    }),
-  );
-
-  it.effect("requires either a selector header or a session org", () =>
-    Effect.gen(function* () {
-      const error = yield* Effect.flip(run({}, null));
-      expect(error).toMatchObject({ _tag: "HttpResponseError", status: 401 });
     }),
   );
 });

--- a/apps/cloud/src/extensions/billing/route.ts
+++ b/apps/cloud/src/extensions/billing/route.ts
@@ -13,12 +13,15 @@ import {
 
 type BillingSession = {
   readonly userId: string;
-  readonly organizationId?: string | null;
 };
 
 export const resolveBillingOrganization = (request: Request, session: BillingSession) =>
   Effect.gen(function* () {
-    const selector = request.headers.get(ORG_SELECTOR_HEADER) ?? session.organizationId;
+    // FAIL CLOSED: no header, no org. The AutumnProvider always sends the
+    // URL-scoped header (see __root.tsx billingHeaders); the sealed cookie's
+    // org is a browser-global that can name a DIFFERENT org for a multi-org
+    // user (see workos-auth-provider.resolveSessionPrincipal).
+    const selector = request.headers.get(ORG_SELECTOR_HEADER);
     if (!selector) {
       return yield* new HttpResponseError({
         status: 401,

--- a/apps/cloud/src/org/auth-middleware.ts
+++ b/apps/cloud/src/org/auth-middleware.ts
@@ -40,7 +40,11 @@ const OrgAuthMiddleware = HttpRouter.middleware<{ provides: AuthContext }>()(
           .pipe(Effect.orElseSucceed(() => null));
         if (!result) return unauthorized();
 
-        const selector = request.headers[ORG_SELECTOR_HEADER] ?? result.organizationId;
+        // FAIL CLOSED: no header, no org — the sealed cookie's org is a
+        // browser-global pinned to whichever org WorkOS last touched, so
+        // falling back to it scopes a multi-org user's request to the WRONG
+        // org (see workos-auth-provider.resolveSessionPrincipal).
+        const selector = request.headers[ORG_SELECTOR_HEADER];
         if (!selector) return noOrganization();
 
         const org = yield* authorizeOrganizationSelector(result.userId, selector).pipe(

--- a/apps/cloud/src/routes/__root.tsx
+++ b/apps/cloud/src/routes/__root.tsx
@@ -10,6 +10,7 @@ import {
   useParams,
 } from "@tanstack/react-router";
 import { AutumnProvider } from "autumn-js/react";
+import { isValidOrgSlug } from "@executor-js/api";
 import posthog from "posthog-js";
 import { PostHogProvider } from "posthog-js/react";
 import type { FrontendErrorReporter } from "@executor-js/react/api/error-reporting";
@@ -214,6 +215,14 @@ function AuthGate({ ssrOrigin }: { ssrOrigin: string | null }) {
   // is scoped to it, so `auth.organization` IS this org when the caller is a
   // member — and `null` when the URL names an org they can't access.
   const urlOrgSlug = (useParams({ strict: false }) as { orgSlug?: string }).orgSlug;
+  // The same slug derived from the PATHNAME instead of the route params: the
+  // params resolve asynchronously (a fresh load renders once with no orgSlug,
+  // then again with it), and anything keyed on them remounts on that flap.
+  // The pathname is synchronously correct on the very first render, and it is
+  // exactly what the request header derives from (getActiveOrgSlug), so the
+  // registry scope below can never disagree with the header scope.
+  const firstSegment = location.pathname.split("/")[1] ?? "";
+  const pathnameOrgSlug = isValidOrgSlug(firstSegment) ? firstSegment : null;
 
   // The SSR gate already bounced fresh org-less document requests to
   // /create-org; this catches the MID-SESSION transitions (org deleted,
@@ -282,26 +291,42 @@ function AuthGate({ ssrOrigin }: { ssrOrigin: string | null }) {
   // /<orgB> while their cookie still points at orgA would briefly render orgA's
   // slug in the copyable URL before /account/me (URL-scoped) corrects it. The
   // URL slug is the actual request scope and is correct on the very first paint,
-  // so sourcing it from there removes that flash. Falls back to the session slug
-  // on a bare URL (which OrgSlugGate is about to canonicalize onto it anyway).
-  const scopeSlug = urlOrgSlug ?? activeSlug;
+  // so sourcing it from there removes that flash. VALIDATED (pathnameOrgSlug,
+  // not the raw route param): the `{-$orgSlug}` param also captures reserved
+  // console roots ("/integrations" → orgSlug "integrations"), which are not
+  // org scopes. Falls back to the auth org on a bare/reserved URL (which
+  // OrgSlugGate canonicalizes onto it below).
+  const scopeSlug = pathnameOrgSlug ?? activeSlug;
   const billingHeaders = scopeSlug ? { [EXECUTOR_ORG_HEADER]: scopeSlug } : undefined;
 
   return (
     <AutumnProvider pathPrefix="/api/billing" headers={billingHeaders}>
       <Sentry.ErrorBoundary fallback={<ShellErrorFallback />} showDialog={false}>
-        <ExecutorProvider connection={connection} onHandledError={captureFrontendError}>
+        {/* scopeKey ties the atom registry to the URL's org: cached query
+            results can never survive an org change, and the bare → slugged
+            canonicalization remounts the registry so anything fetched
+            header-less on first paint (rejected server-side) is refetched
+            with the org header. */}
+        <ExecutorProvider
+          connection={connection}
+          scopeKey={pathnameOrgSlug}
+          onHandledError={captureFrontendError}
+        >
           <React.Suspense fallback={<BlankScreen />}>
             <ExecutorPluginsProvider plugins={clientPlugins}>
               <OrganizationProvider
                 organizationId={auth.organization.id}
                 organizationSlug={scopeSlug}
               >
-                {/* The org header scopes every request to the URL's org, so
-                    reaching here means the caller is a member of `activeSlug`
-                    (a foreign slug already 404'd above). The gate only keeps
-                    the URL canonical — bare → /<slug>. */}
-                <OrgSlugGate activeSlug={activeSlug}>
+                {/* Canonicalize onto the URL's org, not the auth org: on first
+                    paint `auth.organization` is the SSR hint (the COOKIE's
+                    org), and canonicalizing onto that would rewrite a
+                    multi-org user's /<orgB> URL to /<orgA> during the hint
+                    window. `scopeSlug` prefers the URL slug, so a slugged URL
+                    is already canonical (a foreign slug 404'd above) and only
+                    a bare URL gets rewritten — onto the auth org, the one
+                    thing it can mean. */}
+                <OrgSlugGate activeSlug={scopeSlug}>
                   <Shell />
                   <Toaster />
                 </OrgSlugGate>

--- a/e2e/cloud/connection-owner-isolation.test.ts
+++ b/e2e/cloud/connection-owner-isolation.test.ts
@@ -65,16 +65,17 @@ const freshConnectionName = () => ConnectionName.make(`conn${randomBytes(4).toSt
 // These mirror what the product web app does: cookie-authenticated calls whose
 // responses re-seal the session when the active org changes.
 
-const cookieOf = (identity: Identity): string => identity.headers?.["cookie"] ?? "";
-
 const postJson = (target: TargetShape, path: string, identity: Identity, body: unknown) =>
   Effect.promise(async () => {
     const response = await fetch(new URL(path, target.baseUrl), {
       method: "POST",
       headers: {
+        // The identity's own headers (session cookie + org selector) exactly
+        // as its API client would send them — org-scoped endpoints fail
+        // closed without the selector.
+        ...(identity.headers ?? {}),
         "content-type": "application/json",
         origin: new URL(target.baseUrl).origin,
-        cookie: cookieOf(identity),
       },
       body: JSON.stringify(body),
     });
@@ -84,17 +85,34 @@ const postJson = (target: TargetShape, path: string, identity: Identity, body: u
     return response;
   });
 
-/** The identity re-bound to the refreshed session cookie a response set. */
-const withRefreshedSession = (identity: Identity, response: Response): Identity => {
+/** The identity re-bound to the refreshed session cookie a response set,
+ *  scoped to `orgSelector` via the selector header (see switchOrg). */
+const withRefreshedSession = (
+  identity: Identity,
+  response: Response,
+  orgSelector: string,
+): Identity => {
   const refreshed = (response.headers.getSetCookie?.() ?? [])
     .find((header) => header.startsWith("wos-session="))
     ?.split(";")[0];
   if (!refreshed) throw new Error("response did not refresh the session cookie");
-  return { ...identity, headers: { cookie: refreshed } };
+  return {
+    ...identity,
+    headers: { cookie: refreshed, [ORG_SELECTOR_HEADER]: orgSelector },
+  };
+};
+
+/** The org selector this identity's requests carry — the same header the web
+ *  client derives from the console URL (identities minted with an org carry
+ *  it; org-scoped reads fail closed without one). */
+const orgSelectorOf = (identity: Identity): string => {
+  const selector = identity.headers?.[ORG_SELECTOR_HEADER];
+  if (!selector) throw new Error(`identity ${identity.label} carries no org selector header`);
+  return selector;
 };
 
 /** Invite `member` into `admin`'s org and accept — the real invite flow.
- *  Returns the member identity with its session re-bound to that org. */
+ *  Returns the member identity with its requests scoped to that org. */
 const joinOrg = (target: TargetShape, admin: Identity, member: Identity) =>
   Effect.gen(function* () {
     const inviteResponse = yield* postJson(target, "/api/account/members/invite", admin, {
@@ -104,14 +122,15 @@ const joinOrg = (target: TargetShape, admin: Identity, member: Identity) =>
     const acceptResponse = yield* postJson(target, "/api/auth/accept-invitation", member, {
       invitationId: invitation.id,
     });
-    return withRefreshedSession(member, acceptResponse);
+    return withRefreshedSession(member, acceptResponse, orgSelectorOf(admin));
   });
 
 /** Create another org for this account; returns the identity bound to it. */
 const createAnotherOrg = (target: TargetShape, identity: Identity, name: string) =>
   Effect.gen(function* () {
     const response = yield* postJson(target, "/api/auth/create-organization", identity, { name });
-    return withRefreshedSession(identity, response);
+    const created = (yield* Effect.promise(() => response.clone().json())) as { id: string };
+    return withRefreshedSession(identity, response, created.id);
   });
 
 // `/api/auth/switch-organization` (session-cookie-based org switching) was
@@ -119,10 +138,12 @@ const createAnotherOrg = (target: TargetShape, identity: Identity, name: string)
 // the session. A request picks its active org via the `x-executor-organization`
 // header (apps/cloud/src/auth/organization.ts's `ORG_SELECTOR_HEADER`,
 // `EXECUTOR_ORG_SELECTOR_HEADER = "x-executor-organization"` in
-// packages/core/sdk/src/server-connection.ts), falling back to the session's
-// own org when absent. The header is a SELECTOR, not a trust boundary — the
-// server re-checks live membership — so attaching it directly to the identity
-// here is exactly what the real web client does from the console URL's slug.
+// packages/core/sdk/src/server-connection.ts). Org-scoped API reads FAIL
+// CLOSED without it — there is deliberately no fallback to the session's
+// cookie-pinned org (that fallback served wrong-tenant data to multi-org
+// users). The header is a SELECTOR, not a trust boundary — the server
+// re-checks live membership — so attaching it directly to the identity here
+// is exactly what the real web client does from the console URL's slug.
 const ORG_SELECTOR_HEADER = "x-executor-organization";
 
 /** Switch this account's active org; returns the identity scoped to it via
@@ -137,11 +158,12 @@ const switchOrg = (
     headers: { ...identity.headers, [ORG_SELECTOR_HEADER]: organizationId },
   });
 
-/** The org this identity's session is currently bound to. */
+/** The org this identity's requests are scoped to (selector header included,
+ *  mirroring the web client). */
 const activeOrganizationId = (target: TargetShape, identity: Identity) =>
   Effect.promise(async () => {
     const response = await fetch(new URL("/api/auth/me", target.baseUrl), {
-      headers: { cookie: cookieOf(identity) },
+      headers: identity.headers ?? {},
     });
     if (!response.ok) throw new Error(`/api/auth/me failed (${response.status})`);
     const body = (await response.json()) as { organization: { id: string } | null };

--- a/e2e/cloud/spec-update-convergence.test.ts
+++ b/e2e/cloud/spec-update-convergence.test.ts
@@ -106,16 +106,19 @@ const serveMutableSpec = (initial: string) =>
   );
 
 // ── Session plumbing over the real auth endpoints (mirrors the web app) ──────
-const cookieOf = (identity: Identity): string => identity.headers?.["cookie"] ?? "";
+const ORG_SELECTOR_HEADER = "x-executor-organization";
 
 const postJson = (target: TargetShape, path: string, identity: Identity, body: unknown) =>
   Effect.promise(async () => {
     const response = await fetch(new URL(path, target.baseUrl), {
       method: "POST",
       headers: {
+        // The identity's own headers (session cookie + org selector) exactly
+        // as its API client would send them — org-scoped endpoints fail
+        // closed without the selector.
+        ...(identity.headers ?? {}),
         "content-type": "application/json",
         origin: new URL(target.baseUrl).origin,
-        cookie: cookieOf(identity),
       },
       body: JSON.stringify(body),
     });
@@ -125,17 +128,28 @@ const postJson = (target: TargetShape, path: string, identity: Identity, body: u
     return response;
   });
 
-const withRefreshedSession = (identity: Identity, response: Response): Identity => {
+const withRefreshedSession = (
+  identity: Identity,
+  response: Response,
+  orgSelector: string,
+): Identity => {
   const refreshed = (response.headers.getSetCookie?.() ?? [])
     .find((header) => header.startsWith("wos-session="))
     ?.split(";")[0];
   if (!refreshed) throw new Error("response did not refresh the session cookie");
-  return { ...identity, headers: { cookie: refreshed } };
+  return {
+    ...identity,
+    headers: { cookie: refreshed, [ORG_SELECTOR_HEADER]: orgSelector },
+  };
 };
 
-/** Invite `member` into `admin`'s org and accept — the real invite flow. */
+/** Invite `member` into `admin`'s org and accept — the real invite flow.
+ *  The member's requests inherit the admin's org selector (org-scoped reads
+ *  fail closed without the header). */
 const joinOrg = (target: TargetShape, admin: Identity, member: Identity) =>
   Effect.gen(function* () {
+    const adminSelector = admin.headers?.[ORG_SELECTOR_HEADER];
+    if (!adminSelector) throw new Error("admin identity carries no org selector header");
     const inviteResponse = yield* postJson(target, "/api/account/members/invite", admin, {
       email: member.credentials?.email,
     });
@@ -143,7 +157,7 @@ const joinOrg = (target: TargetShape, admin: Identity, member: Identity) =>
     const acceptResponse = yield* postJson(target, "/api/auth/accept-invitation", member, {
       invitationId: invitation.id,
     });
-    return withRefreshedSession(member, acceptResponse);
+    return withRefreshedSession(member, acceptResponse, adminSelector);
   });
 
 const apiKeyTemplate = [

--- a/e2e/targets/cloud.ts
+++ b/e2e/targets/cloud.ts
@@ -76,6 +76,7 @@ export const cloudTarget = (): Target => ({
       const label = `user-${randomUUID().slice(0, 8)}`;
       const email = `${label}@e2e.test`;
       let session = await signIn(email);
+      let orgSlug: string | null = null;
       if (org) {
         // The real create-organization flow; the refreshed sealed session in
         // the response carries the new org.
@@ -92,11 +93,18 @@ export const cloudTarget = (): Target => ({
           throw new Error(`cloud newIdentity: create-organization failed (${response.status})`);
         }
         session = cookiePair(response, "wos-session") ?? session;
+        orgSlug = ((await response.json()) as { slug?: string }).slug ?? null;
       }
       const [name, value] = session.split(/=(.*)/s);
       return {
         label: email,
-        headers: { cookie: session },
+        // The org selector header rides along exactly as the web client sends
+        // it from the console URL's slug: org-scoped API reads fail closed
+        // without it (no session-org fallback).
+        headers: {
+          cookie: session,
+          ...(orgSlug ? { "x-executor-organization": orgSlug } : {}),
+        },
         cookies: [{ name: name!, value: value! }],
         credentials: { email, password: "emulated" },
       };

--- a/packages/react/src/api/provider.tsx
+++ b/packages/react/src/api/provider.tsx
@@ -4,24 +4,52 @@ import * as React from "react";
 import { FrontendErrorReporterProvider, type FrontendErrorReporter } from "./error-reporting";
 import {
   ExecutorServerConnectionProvider,
+  setActiveOrgSlugOverride,
   useExecutorServerConnection,
   type ExecutorServerConnectionInput,
 } from "./server-connection";
 
-function ExecutorRegistryProvider(props: React.PropsWithChildren) {
+function ExecutorRegistryProvider(props: React.PropsWithChildren<{ scopeKey?: string | null }>) {
   const connection = useExecutorServerConnection();
-  return <RegistryProvider key={connection.key}>{props.children}</RegistryProvider>;
+  // The org scope MUST be part of the registry key on org-scoped hosts: query
+  // atoms key their cache entries on the request shape alone (the org selector
+  // header is injected in transformClient, invisible to the atom family key),
+  // so without it a cached result fetched under one org would serve under
+  // another for its TTL. Keying the registry tears the whole cache down
+  // whenever the scope changes — including bare-URL → slugged canonicalization,
+  // which discards any header-less (server-rejected) fetches from first paint.
+  //
+  // The scope also becomes the header authority (setActiveOrgSlugOverride) —
+  // synchronously, during render, BEFORE the keyed registry below mounts and
+  // its atoms fire their first fetches. window.history lags the router during
+  // client-side navigations, so deriving the header from window.location alone
+  // would scope those first fetches to the OLD URL. Browser only: the header
+  // injection never runs during SSR, and the worker's module state is shared
+  // across concurrent requests.
+  if (props.scopeKey !== undefined && globalThis.window) {
+    setActiveOrgSlugOverride(props.scopeKey);
+  }
+  const key = props.scopeKey ? `${connection.key}#${props.scopeKey}` : connection.key;
+  return <RegistryProvider key={key}>{props.children}</RegistryProvider>;
 }
 
 export const ExecutorProvider = (
   props: React.PropsWithChildren<{
     connection?: ExecutorServerConnectionInput;
+    /**
+     * The org scope the atom registry is keyed to — pass the console URL's org
+     * slug on org-scoped hosts (cloud) so cached query results can never
+     * survive an org change. Hosts without org scoping leave it unset.
+     */
+    scopeKey?: string | null;
     onHandledError?: FrontendErrorReporter;
   }>,
 ) => (
   <FrontendErrorReporterProvider reporter={props.onHandledError}>
     <ExecutorServerConnectionProvider connection={props.connection}>
-      <ExecutorRegistryProvider>{props.children}</ExecutorRegistryProvider>
+      <ExecutorRegistryProvider scopeKey={props.scopeKey}>
+        {props.children}
+      </ExecutorRegistryProvider>
     </ExecutorServerConnectionProvider>
   </FrontendErrorReporterProvider>
 );

--- a/packages/react/src/api/server-connection.tsx
+++ b/packages/react/src/api/server-connection.tsx
@@ -91,7 +91,21 @@ let activeConnection = resolveInitialExecutorServerConnection();
 // cloudflare) never produce one either.
 export const EXECUTOR_ORG_HEADER = EXECUTOR_ORG_SELECTOR_HEADER;
 
+// The router-authoritative org scope, set by the host (ExecutorProvider's
+// scopeKey) during render. Preferred over the window.location fallback
+// because the router's pathname can be a tick AHEAD of history during a
+// client-side navigation — a fetch fired in that window would otherwise
+// derive the OLD URL's scope (e.g. none, on the bare → slugged
+// canonicalization) while the atom registry is already keyed to the new one.
+// One value per tab (module state), so tabs stay independent.
+let activeOrgSlugOverride: string | null = null;
+
+export const setActiveOrgSlugOverride = (slug: string | null): void => {
+  activeOrgSlugOverride = slug;
+};
+
 export const getActiveOrgSlug = (): string | null => {
+  if (activeOrgSlugOverride) return activeOrgSlugOverride;
   const pathname = globalThis.window?.location?.pathname;
   if (!pathname) return null;
   const first = pathname.split("/")[1];


### PR DESCRIPTION
Fixes the wrong-tenant connection list: a multi-org user viewing org A's integration page could see org B's connections.

**Root cause.** Every org-scoped read resolved its tenant as `x-executor-organization header ?? session.organizationId`. The sealed cookie's org is browser-global and pinned to whichever org WorkOS last touched, so any request that went out without the header (SSR-time fetches, first paint before route params resolve) silently served the *cookie's* org — while OAuth connection writes, pinned via the callback `state`, landed in the URL's org. Same bug class previously patched per-surface in #1011, #1042, #1043.

**Changes**

- Server: org-scoped reads fail closed — no `x-executor-organization` header → 403 `no_organization`, never the cookie org (`resolveSessionPrincipal`, `orgAuthMiddleware`, account `requireOrganization`, billing route). `/account/me` keeps the fallback deliberately: it's identity, not tenant data, and answers "which org should a bare URL land in".
- Client: the atom registry is keyed on the URL's org (`ExecutorProvider scopeKey`), so cached query results can never survive an org change; the scope also becomes the request-header authority synchronously during render, closing the window where a fetch fired during navigation derived the old URL's scope from `window.location`.
- Client: `OrgSlugGate` canonicalizes onto the URL's org rather than the auth-hint org, so the hint window can no longer rewrite an org-A URL to org B.
- e2e: identities and session helpers now carry the org selector header the way the web client does.

Full cloud e2e suite green (91 files passed, 5 skipped).