### PR TITLE
probe: disable request-seam subject touch

### DIFF
--- a/apps/cloud/src/db/org-deletion.test.ts
+++ b/apps/cloud/src/db/org-deletion.test.ts
@@ -28,6 +28,7 @@ import {
   oauth_client,
   oauth_session,
   plugin_storage,
+  subject,
   tool,
   tool_policy,
 } from "./executor-schema";
@@ -131,6 +132,13 @@ const seedTenant = async (db: DrizzleDb, tenant: string, tag: string) => {
     subject: "s",
   });
 
+  await db.insert(subject).values({
+    external_id: `acct-${tag}`,
+    created_at: now,
+    last_seen_at: BigInt(now.getTime()),
+    tenant,
+  });
+
   const orgNs = `o:${tenant}/plugin`;
   const userNs = `u:${tenant}:subject/plugin`;
   await db.insert(blob).values({
@@ -156,6 +164,7 @@ const TENANT_TABLES = [
   definition,
   tool_policy,
   plugin_storage,
+  subject,
 ] as const;
 
 const countTenantRows = async (db: DrizzleDb, tenant: string): Promise<number> => {

--- a/apps/cloud/src/db/org-deletion.ts
+++ b/apps/cloud/src/db/org-deletion.ts
@@ -23,6 +23,7 @@ import {
   oauth_client,
   oauth_session,
   plugin_storage,
+  subject,
   tool,
   tool_policy,
 } from "./executor-schema";
@@ -48,6 +49,7 @@ export const purgeOrganizationData = (db: DrizzleDb, organizationId: string): Pr
     await tx.delete(oauth_session).where(eq(oauth_session.tenant, organizationId));
     await tx.delete(tool_policy).where(eq(tool_policy.tenant, organizationId));
     await tx.delete(plugin_storage).where(eq(plugin_storage.tenant, organizationId));
+    await tx.delete(subject).where(eq(subject.tenant, organizationId));
 
     // Secrets, OAuth tokens, and cached specs live in `blob`, namespaced by
     // owner: `o:<org>/<plugin>` (org scope) and `u:<org>:<subject>/<plugin>`

--- a/apps/host-selfhost/src/subject-sightings.test.ts
+++ b/apps/host-selfhost/src/subject-sightings.test.ts
@@ -1,0 +1,82 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { Effect, Layer } from "effect";
+import { afterAll, beforeAll, expect, test } from "@effect/vitest";
+import { withQueryContext } from "@executor-js/fumadb/query";
+
+import { makeScopedExecutor } from "@executor-js/api/server";
+
+import { createSelfHostDb, SelfHostDb } from "./db/self-host-db";
+import { SelfHostScopedExecutorSeams } from "./execution";
+import type { SelfHostPlugins } from "./plugins";
+
+// The `subject` table is populated at the request seam: `makeScopedExecutor` is
+// what every HTTP request and MCP session on every host passes through, so
+// building a scoped executor IS a sighting. Exercised here against a real host's
+// seams (long-lived SQLite DbProvider + real plugins) rather than a stub, since
+// the point is that the production wiring reaches the writer at all.
+
+const createScopedExecutor = (accountId: string, organizationId: string) =>
+  makeScopedExecutor<SelfHostPlugins>(accountId, organizationId, "Default").pipe(
+    Effect.provide(SelfHostScopedExecutorSeams),
+  );
+
+const dataDir = mkdtempSync(join(tmpdir(), "eh-subj-"));
+process.env.EXECUTOR_DATA_DIR = dataDir;
+
+let dbLayer!: Layer.Layer<SelfHostDb>;
+let dbHandle: Awaited<ReturnType<typeof createSelfHostDb>> | undefined;
+
+beforeAll(async () => {
+  dbHandle = await createSelfHostDb({
+    path: join(dataDir, "data.db"),
+    namespace: "executor_selfhost",
+    version: "1.0.0",
+  });
+  dbLayer = Layer.succeed(SelfHostDb)(dbHandle);
+});
+afterAll(async () => {
+  await dbHandle?.close();
+});
+
+const subjectsOf = async (tenant: string): Promise<readonly string[]> => {
+  const rows = await withQueryContext(dbHandle!.db, {
+    tenant,
+    subject: null,
+  }).findMany("subject", {
+    orderBy: ["external_id", "asc"],
+  });
+  return rows.map((row) => String(row.external_id));
+};
+
+test("building a scoped executor records the acting principal", async () => {
+  const before = Date.now();
+  await Effect.runPromise(
+    createScopedExecutor("alice", "sightings-org").pipe(Effect.provide(dbLayer), Effect.asVoid),
+  );
+
+  expect(await subjectsOf("sightings-org")).toEqual(["alice"]);
+
+  const [row] = await withQueryContext(dbHandle!.db, {
+    tenant: "sightings-org",
+    subject: null,
+  }).findMany("subject", {});
+  expect(Number(row?.last_seen_at)).toBeGreaterThanOrEqual(before);
+});
+
+test("repeat requests from several members converge on one row each", async () => {
+  const org = "sightings-org-2";
+  await Effect.runPromise(
+    Effect.forEach(
+      ["alice", "alice", "bob", "alice"],
+      (accountId) => createScopedExecutor(accountId, org).pipe(Effect.asVoid),
+      { discard: true },
+    ).pipe(Effect.provide(dbLayer)),
+  );
+
+  // Four requests, two principals, two rows: the sighting is an upsert, and
+  // the repeat sightings are absorbed by the throttle rather than duplicating.
+  expect(await subjectsOf(org)).toEqual(["alice", "bob"]);
+});

--- a/packages/core/api/src/server/scoped-executor.ts
+++ b/packages/core/api/src/server/scoped-executor.ts
@@ -293,7 +293,7 @@ export const makeScopedExecutor = <
     // construction — it returns `Effect<void>`, so a lost sighting logs and the
     // request proceeds. `accountId` is passed verbatim, sentinels ("local")
     // included.
-    yield* touchSubject(db, { tenant: organizationId, externalId: accountId });
+    void touchSubject;
 
     // The seam erases the plugin tuple type; the caller re-narrows via the
     // `TPlugins` phantom. Runtime shape is identical to a typed

--- a/packages/core/api/src/server/scoped-executor.ts
+++ b/packages/core/api/src/server/scoped-executor.ts
@@ -42,7 +42,11 @@ import {
   type Executor,
   type StorageFailure,
 } from "@executor-js/sdk";
-import { makeHostedFetch, makeHostedHttpClientLayer } from "@executor-js/sdk/host-internal";
+import {
+  makeHostedFetch,
+  makeHostedHttpClientLayer,
+  touchSubject,
+} from "@executor-js/sdk/host-internal";
 
 import { DbProvider } from "./executor-fuma-db";
 
@@ -281,6 +285,16 @@ export const makeScopedExecutor = <
         includeProviders: config.exposeCredentialProviders ?? true,
       },
     }).pipe(Effect.withSpan("executor.stack.create_executor"));
+    // Record the sighting. THIS is the seam every HTTP request and MCP session
+    // on every host passes through, so it is where the `subject` table gets
+    // populated: a principal earns a row the first time it authenticates,
+    // whether or not it ever connects anything. Throttled (`touchSubject` only
+    // rewrites `last_seen_at` past a coarse interval) and non-fatal by
+    // construction — it returns `Effect<void>`, so a lost sighting logs and the
+    // request proceeds. `accountId` is passed verbatim, sentinels ("local")
+    // included.
+    yield* touchSubject(db, { tenant: organizationId, externalId: accountId });
+
     // The seam erases the plugin tuple type; the caller re-narrows via the
     // `TPlugins` phantom. Runtime shape is identical to a typed
     // `createExecutor({ plugins })` call.

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -107,6 +107,7 @@ import {
   type UpdateToolPolicyInput,
 } from "./policies";
 import type { CredentialProvider, ProviderEntry } from "./provider";
+import { touchSubject } from "./subject-registry";
 import type {
   AnyPlugin,
   Elicit,
@@ -2427,6 +2428,16 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
             }
           }),
         );
+
+        // Record the sighting. The request seam (`makeScopedExecutor`) already
+        // does this for every hosted call, so this is the belt for direct
+        // SDK/CLI callers that never pass through it — a connecting principal
+        // must always have a subject row. Outside
+        // the transaction above: bookkeeping must not roll back the
+        // connection, and `touchSubject` cannot fail. No-ops on a pure-org
+        // executor (no principal to record), including for `owner: "org"`
+        // connections created by a bound member.
+        yield* touchSubject(rootDbUntyped, { tenant, externalId: subject });
 
         const ref: ConnectionRef = {
           owner: input.owner,

--- a/packages/core/sdk/src/host-internal.ts
+++ b/packages/core/sdk/src/host-internal.ts
@@ -20,6 +20,9 @@
 //     endpoint SSRF guard + default fetch timeout. The SDK's own OAuth flow uses
 //     them; the host's connection-identity handler reuses the same guard/timeout
 //     when fetching OIDC userinfo, so they surface here (not the plugin barrel).
+//   - `touchSubject`: the sole writer of the `subject` table. The SDK writes a
+//     sighting at connection-create; the host layer writes one per request in
+//     `makeScopedExecutor`. Not a plugin-author concern.
 // ---------------------------------------------------------------------------
 
 export {
@@ -30,6 +33,12 @@ export {
 } from "./hosted-http-client";
 
 export { OAUTH2_DEFAULT_TIMEOUT_MS, assertSupportedOAuthEndpointUrl } from "./oauth-helpers";
+
+export {
+  DEFAULT_SUBJECT_LAST_SEEN_THROTTLE_MS,
+  touchSubject,
+  type TouchSubjectInput,
+} from "./subject-registry";
 
 export {
   createExecutorFumaDb,

--- a/packages/core/sdk/src/subject-registry.test.ts
+++ b/packages/core/sdk/src/subject-registry.test.ts
@@ -1,0 +1,286 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+import { withQueryContext } from "@executor-js/fumadb/query";
+
+import { collectTables } from "./executor";
+import { AuthTemplateSlug, ConnectionName, IntegrationSlug, ToolName } from "./ids";
+import type { ExecutorOwnerPolicyContext } from "./owner-policy";
+import { definePlugin } from "./plugin";
+import { createSqliteTestFumaDb, type SqliteTestFumaDb } from "./sqlite-test-db";
+import { touchSubject } from "./subject-registry";
+import { makeTestWorkspaceHarness, memoryCredentialsPlugin } from "./test-config";
+
+// `touchSubject` is the only writer of the `subject` table. Written against the
+// real SQLite bring-up (the same statements local/self-host/D1 boot with) so
+// the tenant policy, the unique index, and the bigint round-trip are all live.
+
+const TENANT = "t1";
+const OTHER_TENANT = "t2";
+const THROTTLE_MS = 60_000;
+
+const withDb = <A, E>(body: (db: SqliteTestFumaDb) => Effect.Effect<A, E>): Effect.Effect<A, E> =>
+  Effect.acquireUseRelease(
+    Effect.promise(() => createSqliteTestFumaDb({ tables: collectTables() })),
+    body,
+    (db) => Effect.promise(() => db.close()),
+  );
+
+// Read the way PR 1.3's readers will: through a tenant-bound query context.
+// `last_seen_at` is a bigint column stored as a SQLite blob, so a raw SQL read
+// would hand back an unusable buffer — the ORM owns the round-trip.
+const scopedTo = (db: SqliteTestFumaDb, tenant: string) =>
+  withQueryContext(db.db, {
+    tenant,
+    subject: null,
+  } satisfies ExecutorOwnerPolicyContext);
+
+const storedSubjects = (
+  db: SqliteTestFumaDb,
+  tenant = TENANT,
+): Effect.Effect<readonly { readonly externalId: string; readonly lastSeenMs: number | null }[]> =>
+  Effect.promise(async () => {
+    const rows = await scopedTo(db, tenant).findMany("subject", {
+      orderBy: ["external_id", "asc"],
+    });
+    return rows.map((row) => ({
+      externalId: String(row.external_id),
+      lastSeenMs: row.last_seen_at == null ? null : Number(row.last_seen_at),
+    }));
+  });
+
+describe("touchSubject", () => {
+  it.effect("creates the row on first sight", () =>
+    withDb((db) =>
+      Effect.gen(function* () {
+        const before = Date.now();
+        yield* touchSubject(db.db, { tenant: TENANT, externalId: "user_a" });
+
+        const rows = yield* storedSubjects(db);
+        expect(rows).toHaveLength(1);
+        expect(rows[0]?.externalId).toBe("user_a");
+        // A first sighting IS a sighting: `last_seen_at` is stamped, not left
+        // null for the next request to fill in.
+        expect(rows[0]?.lastSeenMs).toBeGreaterThanOrEqual(before);
+      }),
+    ),
+  );
+
+  it.effect("leaves last_seen_at alone while the sighting is inside the throttle", () =>
+    withDb((db) =>
+      Effect.gen(function* () {
+        yield* touchSubject(db.db, {
+          tenant: TENANT,
+          externalId: "user_a",
+          lastSeenThrottleMs: THROTTLE_MS,
+        });
+        const [first] = yield* storedSubjects(db);
+
+        // The hot path: N requests in quick succession must cost N reads and
+        // zero writes, so the persisted stamp is unchanged afterwards.
+        yield* Effect.forEach([1, 2, 3], () =>
+          touchSubject(db.db, {
+            tenant: TENANT,
+            externalId: "user_a",
+            lastSeenThrottleMs: THROTTLE_MS,
+          }),
+        );
+
+        const rows = yield* storedSubjects(db);
+        expect(rows).toHaveLength(1);
+        expect(rows[0]?.lastSeenMs).toBe(first?.lastSeenMs);
+      }),
+    ),
+  );
+
+  it.effect("bumps last_seen_at once the sighting falls outside the throttle", () =>
+    withDb((db) =>
+      Effect.gen(function* () {
+        yield* touchSubject(db.db, { tenant: TENANT, externalId: "user_a" });
+        const [first] = yield* storedSubjects(db);
+
+        // Age the row rather than sleeping through the interval. A throttle of
+        // zero would pass even if the staleness comparison were inverted; a row
+        // aged well past the interval only passes if it reads the right way.
+        const stale = (first?.lastSeenMs ?? 0) - 10 * THROTTLE_MS;
+        yield* Effect.promise(() =>
+          scopedTo(db, TENANT).updateMany("subject", {
+            where: (b) => b("external_id", "=", "user_a"),
+            set: { last_seen_at: BigInt(stale) },
+          }),
+        );
+
+        yield* touchSubject(db.db, {
+          tenant: TENANT,
+          externalId: "user_a",
+          lastSeenThrottleMs: THROTTLE_MS,
+        });
+
+        const rows = yield* storedSubjects(db);
+        expect(rows).toHaveLength(1);
+        expect(rows[0]?.lastSeenMs).toBeGreaterThan(stale);
+      }),
+    ),
+  );
+
+  it.effect("records nothing for a pure-org executor", () =>
+    withDb((db) =>
+      Effect.gen(function* () {
+        yield* touchSubject(db.db, { tenant: TENANT, externalId: null });
+        expect(yield* storedSubjects(db)).toEqual([]);
+      }),
+    ),
+  );
+
+  it.effect("records the host sentinel subject id", () =>
+    withDb((db) =>
+      Effect.gen(function* () {
+        // apps/local binds every request to the literal subject "local". It is
+        // a real principal here, not a placeholder to skip.
+        yield* touchSubject(db.db, { tenant: TENANT, externalId: "local" });
+        expect((yield* storedSubjects(db)).map((row) => row.externalId)).toEqual(["local"]);
+      }),
+    ),
+  );
+
+  it.effect("files the same principal separately under each tenant", () =>
+    withDb((db) =>
+      Effect.gen(function* () {
+        // The tenant written is always the one bound to the touch, so the
+        // tenant policy's create check can never reject it — and one account in
+        // two orgs is two rows under two tenants, not a unique-index collision.
+        yield* touchSubject(db.db, { tenant: TENANT, externalId: "user_a" });
+        yield* touchSubject(db.db, {
+          tenant: OTHER_TENANT,
+          externalId: "user_a",
+        });
+
+        expect((yield* storedSubjects(db, TENANT)).map((row) => row.externalId)).toEqual([
+          "user_a",
+        ]);
+        expect((yield* storedSubjects(db, OTHER_TENANT)).map((row) => row.externalId)).toEqual([
+          "user_a",
+        ]);
+      }),
+    ),
+  );
+
+  it.effect("survives a storage failure without failing its caller", () =>
+    withDb((db) =>
+      Effect.gen(function* () {
+        // A sighting is bookkeeping. A storage failure must not take down the
+        // request that produced it — `touchSubject` logs and returns void.
+        // Dropping the table is the real shape of the failure this guards
+        // against (a host whose bring-up hasn't reached the new table yet).
+        yield* Effect.promise(() => db.client.execute("DROP TABLE subject"));
+
+        yield* touchSubject(db.db, { tenant: TENANT, externalId: "user_a" });
+      }),
+    ),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// The second writer: `connections.create`. The request seam covers every hosted
+// call, so this is the belt for a direct SDK/CLI caller that never passes
+// through it.
+// ---------------------------------------------------------------------------
+
+const INTEG = IntegrationSlug.make("vercel");
+const TEMPLATE = AuthTemplateSlug.make("apiKey");
+
+const demoPlugin = definePlugin(() => ({
+  id: "demo" as const,
+  storage: () => ({}),
+  resolveTools: () => Effect.succeed({ tools: [{ name: ToolName.make("deploy") }] }),
+  invokeTool: () => Effect.succeed(null),
+  extension: (ctx) => ({
+    seed: () =>
+      ctx.core.integrations.register({
+        slug: INTEG,
+        description: "Vercel",
+        config: {},
+      }),
+  }),
+}))();
+
+const plugins = [memoryCredentialsPlugin(), demoPlugin] as const;
+
+const subjectsOf = (
+  harness: { readonly config: { readonly db: unknown } },
+  tenant: string,
+): Effect.Effect<readonly string[]> =>
+  Effect.promise(async () => {
+    const rows = await withQueryContext(harness.config.db as never, {
+      tenant,
+      subject: null,
+    } satisfies ExecutorOwnerPolicyContext).findMany("subject", {});
+    return rows.map((row) => String(row.external_id));
+  });
+
+describe("connections.create subject sighting", () => {
+  it.effect("records the bound subject", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const harness = yield* makeTestWorkspaceHarness({
+          plugins,
+          tenant: TENANT,
+        });
+        yield* harness.executor.demo.seed();
+        yield* harness.executor.connections.create({
+          owner: "user",
+          name: ConnectionName.make("main"),
+          integration: INTEG,
+          template: TEMPLATE,
+          value: "secret-token",
+        });
+
+        expect(yield* subjectsOf(harness, TENANT)).toEqual([harness.subject]);
+      }),
+    ),
+  );
+
+  it.effect("records the bound subject even for an org-owned connection", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        // The row names the acting principal, not the connection's owner tier:
+        // a member who only ever creates org connections still exists.
+        const harness = yield* makeTestWorkspaceHarness({
+          plugins,
+          tenant: TENANT,
+        });
+        yield* harness.executor.demo.seed();
+        yield* harness.executor.connections.create({
+          owner: "org",
+          name: ConnectionName.make("shared"),
+          integration: INTEG,
+          template: TEMPLATE,
+          value: "secret-token",
+        });
+
+        expect(yield* subjectsOf(harness, TENANT)).toEqual([harness.subject]);
+      }),
+    ),
+  );
+
+  it.effect("records nothing when the executor has no subject", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const harness = yield* makeTestWorkspaceHarness({
+          plugins,
+          tenant: TENANT,
+          subject: null,
+        });
+        yield* harness.executor.demo.seed();
+        yield* harness.executor.connections.create({
+          owner: "org",
+          name: ConnectionName.make("shared"),
+          integration: INTEG,
+          template: TEMPLATE,
+          value: "secret-token",
+        });
+
+        expect(yield* subjectsOf(harness, TENANT)).toEqual([]);
+      }),
+    ),
+  );
+});

--- a/packages/core/sdk/src/subject-registry.ts
+++ b/packages/core/sdk/src/subject-registry.ts
@@ -1,0 +1,134 @@
+// ---------------------------------------------------------------------------
+// Subject sightings — the ONLY writer of the `subject` table.
+//
+// `subject` is the join between a host's identity system and the `subject`
+// partition key smeared across the owned tables (see `core-schema.ts`). A
+// principal earns a row the first time it is seen, so "which users exist under
+// this tenant" stops being answerable only through their connection rows.
+//
+// Two seams call this, and both hand over their raw (unbound) FumaDB handle so
+// the binding rule lives here rather than at each call site:
+//   - `makeScopedExecutor` (@executor-js/api/server) — every HTTP request and
+//     MCP session on every host passes through it. THE hot path.
+//   - `connections.create` (executor.ts) — so a subject exists even for a
+//     direct SDK/CLI caller that never went through the request seam.
+//
+// Two properties the callers depend on:
+//   - THROTTLED. A sighting on the request path must not cost a write per
+//     request, so `last_seen_at` is only rewritten once the persisted value is
+//     older than the interval. Steady state is one indexed lookup.
+//   - NON-FATAL. A sighting is bookkeeping. Losing one must never fail the
+//     request that produced it — but it is logged, never silently swallowed.
+// ---------------------------------------------------------------------------
+
+import { Effect } from "effect";
+import { withQueryContext, type Condition, type ConditionBuilder } from "@executor-js/fumadb/query";
+import type { AnyColumn } from "@executor-js/fumadb/schema";
+
+import { makeFumaClient, type FumaDb } from "./fuma-runtime";
+import type { ExecutorOwnerPolicyContext } from "./owner-policy";
+
+type AnyCb = ConditionBuilder<Record<string, AnyColumn>>;
+
+// The query surface `touchSubject` needs, loosely typed. `fuma.use` hands back a
+// `FumaQuery<AnySchema>` whose table-name generics can't be resolved against an
+// erased schema; executor.ts narrows the same way (`asLooseStorageDb`).
+type LooseSubjectDb = {
+  readonly create: (tableName: string, row: Record<string, unknown>) => Promise<unknown>;
+  readonly findFirst: (
+    tableName: string,
+    options: unknown,
+  ) => Promise<Record<string, unknown> | null>;
+  readonly updateMany: (tableName: string, options: unknown) => Promise<void>;
+};
+
+const asLooseSubjectDb = (db: unknown): LooseSubjectDb => db as LooseSubjectDb;
+
+/**
+ * How stale `last_seen_at` must be before a sighting rewrites it. Deliberately
+ * coarse: the column answers "is this principal still around", not "when
+ * exactly was their last call", and the request path pays for every write.
+ */
+export const DEFAULT_SUBJECT_LAST_SEEN_THROTTLE_MS = 60 * 60 * 1000;
+
+export interface TouchSubjectInput {
+  /** The tenant the sighting is filed under. Written explicitly — the tenant
+   *  policy REJECTS a create whose `tenant` differs from the bound context. */
+  readonly tenant: string;
+  /** The host-auth principal id, or `null` for a pure-org executor (nothing to
+   *  record). Opaque: it also carries host sentinels like `"local"`. */
+  readonly externalId: string | null;
+  /** Override the `last_seen_at` rewrite interval. Tests use it to pin both
+   *  sides of the throttle; production callers take the default. */
+  readonly lastSeenThrottleMs?: number;
+}
+
+/**
+ * Record that `externalId` was seen under `tenant`: create the row on first
+ * sight, bump `last_seen_at` on later ones (subject to the throttle). Never
+ * fails — a storage error is logged and the caller continues.
+ */
+export const touchSubject = (db: FumaDb<any>, input: TouchSubjectInput): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    const externalId = input.externalId;
+    // A pure-org executor has no principal to record.
+    if (externalId == null) return;
+
+    const throttleMs = input.lastSeenThrottleMs ?? DEFAULT_SUBJECT_LAST_SEEN_THROTTLE_MS;
+    // Bind the tenant policy context. `subject` is inert for this table (it is
+    // tenant-scoped, not owner-scoped) but the context shape is shared, and at
+    // both call sites the bound subject IS this external id.
+    const fuma = makeFumaClient(
+      withQueryContext(db, {
+        tenant: input.tenant,
+        subject: externalId,
+      } satisfies ExecutorOwnerPolicyContext),
+    );
+    // No `tenant` clause: the tenant policy adds it to every read/update.
+    const where = (b: AnyCb): Condition | boolean => b("external_id", "=", externalId);
+    const now = Date.now();
+
+    const existing = yield* fuma.use("subject.findFirst", (query) =>
+      asLooseSubjectDb(query).findFirst("subject", { where }),
+    );
+
+    if (!existing) {
+      yield* fuma
+        .use("subject.create", (query) =>
+          asLooseSubjectDb(query).create("subject", {
+            tenant: input.tenant,
+            external_id: externalId,
+            created_at: new Date(now),
+            last_seen_at: now,
+            status: null,
+          }),
+        )
+        .pipe(
+          // A concurrent first sighting of the same principal wins the unique
+          // index. That IS the row this call wanted, so the loser succeeds.
+          Effect.catchTag("UniqueViolationError", () => Effect.void),
+        );
+      return;
+    }
+
+    const lastSeenAt = existing["last_seen_at"];
+    // bigint on drivers that return one (matches `tools_synced_at`'s read).
+    const lastSeenMs = lastSeenAt == null ? null : Number(lastSeenAt);
+    if (lastSeenMs !== null && now - lastSeenMs < throttleMs) return;
+
+    yield* fuma.use("subject.updateMany", (query) =>
+      asLooseSubjectDb(query).updateMany("subject", {
+        where,
+        set: { last_seen_at: now },
+      }),
+    );
+  }).pipe(
+    Effect.catch((cause) =>
+      Effect.logWarning("executor subject touch failed", {
+        tenant: input.tenant,
+        externalId: input.externalId,
+        cause,
+      }),
+    ),
+    Effect.withSpan("executor.subject.touch"),
+  );


### PR DESCRIPTION
Temporary diagnostic branch. Isolates whether the request-seam subject touch causes the cloud shard 4 e2e failures. Not for merge.