### PR TITLE
Confirm before removing a connection

### DIFF
--- a/e2e/scenarios/connection-remove-confirm.test.ts
+++ b/e2e/scenarios/connection-remove-confirm.test.ts
@@ -1,0 +1,121 @@
+// Cross-target (browser): removing a connection asks for confirmation first.
+// Remove is destructive and irreversible (credentials are immutable, so a
+// removed connection cannot be restored — only re-created), so the row's
+// Remove menu item must open a confirm dialog rather than firing the
+// mutation directly. Cancel keeps the connection; confirming removes it for
+// real (asserted through the API, not just the list).
+import { randomBytes } from "node:crypto";
+
+import { Effect } from "effect";
+import { expect } from "@effect/vitest";
+import { composePluginApi } from "@executor-js/api/server";
+import { openApiHttpPlugin } from "@executor-js/plugin-openapi/api";
+import { AuthTemplateSlug, ConnectionName, IntegrationSlug } from "@executor-js/sdk/shared";
+
+import { scenario } from "../src/scenario";
+import { Api, Browser, Target } from "../src/services";
+
+const api = composePluginApi([openApiHttpPlugin()] as const);
+
+/** Minimal apiKey-authenticated spec — a connection can bind to it; the single
+ *  operation is never invoked here. */
+const pingSpec = JSON.stringify({
+  openapi: "3.0.3",
+  info: { title: "Ping API", version: "1.0.0" },
+  paths: {
+    "/ping": {
+      get: { operationId: "ping", summary: "Ping", responses: { "200": { description: "pong" } } },
+    },
+  },
+});
+
+scenario(
+  "Connections (UI) · Remove asks for confirmation; cancel keeps, confirm removes",
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const browser = yield* Browser;
+    const { client: makeClient } = yield* Api;
+    const identity = yield* target.newIdentity();
+    const client = yield* makeClient(api, identity);
+
+    const slug = IntegrationSlug.make(`rm-confirm-${randomBytes(4).toString("hex")}`);
+    const name = ConnectionName.make("main");
+
+    yield* Effect.ensuring(
+      Effect.gen(function* () {
+        yield* client.openapi.addSpec({
+          payload: {
+            spec: { kind: "blob", value: pingSpec },
+            slug,
+            baseUrl: "http://127.0.0.1:59999", // never contacted
+            authenticationTemplate: [
+              {
+                slug: "apiKey",
+                type: "apiKey",
+                headers: { authorization: ["Bearer ", { type: "variable", name: "token" }] },
+              },
+            ],
+          },
+        });
+        yield* client.connections.create({
+          payload: {
+            owner: "org",
+            name,
+            integration: slug,
+            template: AuthTemplateSlug.make("apiKey"),
+            value: `key_${randomBytes(8).toString("hex")}`,
+          },
+        });
+
+        yield* browser.session(identity, async ({ page, step }) => {
+          const connections = page.locator("section").filter({
+            has: page.getByRole("heading", { level: 3, name: "Connections" }),
+          });
+          const row = connections.getByText("main", { exact: true });
+          const menuTrigger = connections.locator('button[aria-haspopup="menu"]');
+          const confirm = page.getByRole("alertdialog");
+
+          await step("Open the integration's connections", async () => {
+            await page.goto(`/integrations/${slug}`, { waitUntil: "networkidle" });
+            await row.waitFor();
+          });
+
+          await step("Remove asks for confirmation instead of firing", async () => {
+            await menuTrigger.click();
+            await page.getByRole("menuitem", { name: "Remove" }).click();
+            await confirm.getByText("Remove main?").waitFor();
+          });
+
+          await step("Cancel keeps the connection", async () => {
+            await confirm.getByRole("button", { name: "Cancel" }).click();
+            await confirm.waitFor({ state: "detached" });
+            await row.waitFor();
+          });
+
+          await step("Confirming actually removes it", async () => {
+            await menuTrigger.click();
+            await page.getByRole("menuitem", { name: "Remove" }).click();
+            await confirm.getByRole("button", { name: "Remove connection" }).click();
+            await confirm.waitFor({ state: "detached" });
+            await row.waitFor({ state: "detached" });
+          });
+        });
+
+        // Cancel left the removal un-fired and confirm fired it for real: the
+        // connection is gone from the API, not merely from the rendered list.
+        const remaining = yield* client.connections.list({ query: { integration: slug } });
+        expect(
+          remaining.map((connection) => String(connection.name)),
+          "the removed connection is gone from the API",
+        ).not.toContain(String(name));
+      }),
+      Effect.gen(function* () {
+        yield* client.connections
+          .remove({ params: { owner: "org", integration: slug, name } })
+          .pipe(Effect.ignore);
+        yield* client.openapi.removeSpec({ params: { slug } }).pipe(Effect.ignore);
+      }),
+    );
+  }),
+);

--- a/packages/react/src/components/accounts-section.tsx
+++ b/packages/react/src/components/accounts-section.tsx
@@ -30,6 +30,16 @@ import { useOAuthPopupFlow } from "../plugins/oauth-sign-in";
 import { AddAccountModal } from "./add-account-modal";
 import { ConnectionEditSheet } from "./metadata-edit-sheet";
 import type { CreateCustomMethod } from "./add-custom-method-modal";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "./alert-dialog";
 import { Badge } from "./badge";
 import { Button } from "./button";
 import {
@@ -59,6 +69,16 @@ import {
 // ---------------------------------------------------------------------------
 
 const OWNERS: readonly Owner[] = ["org", "user"];
+
+// The confirm dialog names the connection the way the row does — stored
+// identity label first, connection name otherwise. (No live probe identity
+// here; that state lives inside the row.)
+const connectionDisplayLabel = (connection: Connection | null): string => {
+  if (connection === null) return "connection";
+  return connection.identityLabel && connection.identityLabel.length > 0
+    ? connection.identityLabel
+    : String(connection.name);
+};
 
 function AccountRow(props: {
   readonly connection: Connection;
@@ -212,6 +232,10 @@ function OwnerAccounts(props: {
 }) {
   const { integration, owner } = props;
   const connections = useAtomValue(connectionsForIntegrationAtom({ integration, owner }));
+  // Removal confirms in a dialog. State lives here (not in the row) because the
+  // Remove menu item closes its dropdown on click, which would unmount a dialog
+  // nested inside it — so the row only nominates the connection to remove.
+  const [removingConnection, setRemovingConnection] = useState<Connection | null>(null);
   const doRemove = useAtomSet(removeConnectionOptimistic(owner), {
     mode: "promiseExit",
   });
@@ -324,6 +348,7 @@ function OwnerAccounts(props: {
   };
 
   const handleRemove = async (connection: Connection) => {
+    setRemovingConnection(null);
     const exit = await doRemove({
       params: {
         owner: connection.owner,
@@ -354,10 +379,39 @@ function OwnerAccounts(props: {
             showOwnerLabel={props.showOwnerLabels}
             onEdit={() => props.onEdit(connection)}
             onReconnect={() => void handleReconnect(connection)}
-            onRemove={() => void handleRemove(connection)}
+            onRemove={() => setRemovingConnection(connection)}
           />
         ))}
       </CardStackContent>
+      <AlertDialog
+        open={removingConnection !== null}
+        onOpenChange={(open: boolean) => {
+          if (!open) setRemovingConnection(null);
+        }}
+      >
+        <AlertDialogContent size="sm">
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              Remove {connectionDisplayLabel(removingConnection)}?
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              Tools using this connection lose access. This cannot be undone; reconnecting later
+              creates a new connection.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              variant="destructive"
+              onClick={() => {
+                if (removingConnection !== null) void handleRemove(removingConnection);
+              }}
+            >
+              Remove connection
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </CardStack>
   );
 }


### PR DESCRIPTION
Removing a connection from an integration's Accounts section previously fired the destructive mutation immediately from the row's dropdown menu. Remove now opens a confirmation dialog naming the connection; the mutation only runs on confirm.

Includes a cross-target e2e scenario covering both paths: cancel keeps the connection, confirm removes it (verified through the API, not just the list).

![Connections (UI) · Remove asks for confirmation; cancel keeps, confirm removes (selfhost)](https://raw.githubusercontent.com/UsefulSoftwareCo/executor/e2e-media/connections-ui-remove-asks-for-confirmation-cancel-keeps-confirm-removes-b92fcc43.gif)