### PR TITLE
Add anonymous metadata based product analytics for local and self-host

### DIFF
--- a/.changeset/heavy-planets-tell.md
+++ b/.changeset/heavy-planets-tell.md
@@ -1,0 +1,9 @@
+---
+"@executor-js/analytics": patch
+"@executor-js/sdk": patch
+"@executor-js/api": patch
+"@executor-js/host-selfhost": patch
+"executor": patch
+---
+
+Add anonymous product analytics to the local daemon (CLI + desktop) and self-host: execution counts split by MCP/API plane, toolkit usage, and integration add/remove, filed under a persisted per-install anonymous id. Opt out with DO_NOT_TRACK or EXECUTOR_DISABLE_ANALYTICS.

--- a/.changeset/heavy-planets-tell.md
+++ b/.changeset/heavy-planets-tell.md
@@ -6,4 +6,4 @@
 "executor": patch
 ---
 
-Add anonymous product analytics to the local daemon (CLI + desktop) and self-host: execution counts split by MCP/API plane, toolkit usage, and integration add/remove, filed under a persisted per-install anonymous id. Opt out with DO_NOT_TRACK or EXECUTOR_DISABLE_ANALYTICS.
+Add anonymous product analytics to the local daemon (CLI + desktop) and self-host: execution counts split by MCP/API plane, toolkit usage, integration add/remove, and artifact usage (created/viewed/updated/deleted, attributed to agent tools vs the console UI), filed under a persisted per-install anonymous id. Opt out with DO_NOT_TRACK or EXECUTOR_DISABLE_ANALYTICS.

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -1,0 +1,101 @@
+# Telemetry
+
+Executor's local products (the CLI, the desktop app) and self-hosted
+deployments send a small set of anonymous usage events. This document is the
+complete account of what is sent, what is deliberately not sent, why the
+feature exists, and how to turn it off.
+
+The hosted cloud product has its own browser-side analytics, disclosed
+separately in its terms; this document covers the software that runs on your
+machines.
+
+## Why
+
+Executor is used mostly outside our infrastructure. Without some signal from
+local and self-hosted installs, every product decision about them is a guess:
+we cannot tell whether a feature ships broken, whether anyone uses toolkits,
+whether executions fail at unusual rates after a release, or whether the
+product is growing anywhere except cloud.
+
+The events exist to answer exactly one kind of question: **how are product
+features being used?** They are metadata about the product, not about you.
+Anything that would answer "what is this user doing" — which APIs you call,
+what your tools are named, what your code does — is out of scope by design,
+not by omission.
+
+## What is sent
+
+Each event carries its named properties plus, on every event: a random
+per-install id, the product surface (`cli`, `desktop`, or `selfhost`), the
+release channel, and the app version.
+
+| Event                 | Properties                                       | Meaning                                                                                                                                         |
+| --------------------- | ------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `execution_completed` | `ok`, `plane` (`mcp`/`api`), `toolkit` (boolean) | A code execution finished, split by whether an agent (MCP) or a human-facing API triggered it, and whether a toolkit-scoped endpoint served it. |
+| `integration_added`   | `plugin_key`                                     | An integration was added, by kind (`openapi`, `mcp`, `graphql`, ...).                                                                           |
+| `integration_removed` | `plugin_key`                                     | An integration was removed, by kind.                                                                                                            |
+| `artifact_created`    | `via` (`agent`/`ui`)                             | A generative-UI artifact was saved.                                                                                                             |
+| `artifact_viewed`     | `via`                                            | An artifact was opened for its content.                                                                                                         |
+| `artifact_updated`    | `via`                                            | An artifact was overwritten or renamed.                                                                                                         |
+| `artifact_deleted`    | `via`                                            | An artifact was deleted.                                                                                                                        |
+
+That table is exhaustive. The typed catalog the code compiles against is
+[`packages/core/analytics/src/events.ts`](packages/core/analytics/src/events.ts);
+an event that is not in that file cannot be sent.
+
+## What is never sent
+
+- No code, tool arguments, tool results, or error messages.
+- No secrets, tokens, or credentials.
+- No names you typed: no integration slugs, connection names, toolkit slugs,
+  tool names, or artifact titles. The **kind** of integration (`openapi`,
+  `mcp`, ...) is a product question; **which** service you connected it to is
+  your business.
+- No identity: no emails, usernames, hostnames, IP-derived location, or org
+  names. Events are marked so the analytics backend builds no person profile.
+
+## The anonymous id
+
+A random UUID is minted the first time the daemon or server starts and stored
+as `analytics-id` in the data directory (`~/.executor` for local installs, the
+configured data dir for self-host). It exists so that ten events from one
+install count as one install, not ten. It is not derived from your machine,
+account, or network, and deleting the file resets it. When telemetry is
+disabled the file is never created.
+
+## Opting out
+
+Set either environment variable to `1`, `true`, or `yes`:
+
+- `DO_NOT_TRACK` — the [cross-tool convention](https://consoledonottrack.com),
+  which Executor also honors for its other outbound calls (crash reporting,
+  the integrations.sh catalog fetch).
+- `EXECUTOR_DISABLE_ANALYTICS` — telemetry only, if you want the catalog
+  fetch and crash reporting to keep working.
+
+Opting out is total: the analytics service becomes a no-op, nothing is
+buffered, nothing is sent, and no id file is written. The CLI's managed
+service (launchd/systemd) forwards both variables into the supervised
+daemon's environment, so an opted-out install stays opted out.
+
+## Delivery mechanics
+
+Events buffer in memory (bounded) and flush in batches on a fixed cadence,
+plus once at shutdown. Delivery is best-effort: a failed flush re-queues and
+retries later, failures are swallowed, and no user-facing operation ever
+waits on — or can be failed by — analytics. The ingest endpoint is PostHog
+(`us.i.posthog.com`); the project key in the source identifies the project
+and grants no read access.
+
+## Where the line is enforced
+
+Structurally, not by convention:
+
+- The event catalog is a closed, typed interface — adding a property means
+  editing [`events.ts`](packages/core/analytics/src/events.ts) in a reviewed
+  change, next to the property rules at the top of that file.
+- Attribution (`plane`, `via`) is bound where each serving surface is
+  composed, so events cannot carry request-controlled labels.
+- Observers hang off neutral seams (an engine wrapper, post-commit hooks); the
+  core SDK carries no analytics vocabulary and hosts that do not opt in — like
+  every test — compose with no analytics at all.

--- a/apps/cli/src/service.ts
+++ b/apps/cli/src/service.ts
@@ -177,6 +177,10 @@ const serviceEnvironment = (
     "EXECUTOR_SENTRY_RELEASE",
     "EXECUTOR_SENTRY_ENVIRONMENT",
     "EXECUTOR_RUN_ID",
+    // Analytics opt-out must survive into the supervised unit's minimal env,
+    // or an opted-out install would silently re-enable analytics under launchd.
+    "DO_NOT_TRACK",
+    "EXECUTOR_DISABLE_ANALYTICS",
   ] as const;
   const passThrough = Object.fromEntries(
     passThroughKeys.flatMap((key) => {

--- a/apps/host-selfhost/package.json
+++ b/apps/host-selfhost/package.json
@@ -22,6 +22,7 @@
     "@cloudflare/worker-bundler": "0.2.1",
     "@effect/atom-react": "catalog:",
     "@effect/platform-bun": "catalog:",
+    "@executor-js/analytics": "workspace:*",
     "@executor-js/api": "workspace:*",
     "@executor-js/app": "workspace:*",
     "@executor-js/execution": "workspace:*",

--- a/apps/host-selfhost/src/analytics.ts
+++ b/apps/host-selfhost/src/analytics.ts
@@ -1,0 +1,83 @@
+import { Effect, Layer, ManagedRuntime } from "effect";
+
+import {
+  Analytics,
+  defaultLayer as analyticsDefaultLayer,
+  withExecutionAnalytics,
+  type AnalyticsService,
+} from "@executor-js/analytics";
+import { EngineDecorator } from "@executor-js/api/server";
+
+import packageJson from "../package.json" with { type: "json" };
+import { resolveDataDir } from "./config";
+
+// ---------------------------------------------------------------------------
+// Self-host product analytics: one anonymous per-install service for the
+// server lifetime. The anonymous id persists next to the instance's other
+// first-boot state (secret.key) under the data dir, so an instance counts
+// once across restarts. Module-singleton runtime; dispose flushes at shutdown.
+// ---------------------------------------------------------------------------
+
+// Deployed self-host builds are published releases; the prerelease heuristic
+// mirrors apps/local/src/installation.ts.
+const VERSION: string = packageJson.version;
+const CHANNEL = VERSION.includes("-") ? ("beta" as const) : ("stable" as const);
+
+let analyticsRuntime: ManagedRuntime.ManagedRuntime<Analytics, never> | null = null;
+
+const getAnalyticsRuntime = (): ManagedRuntime.ManagedRuntime<Analytics, never> => {
+  if (analyticsRuntime) return analyticsRuntime;
+  analyticsRuntime = ManagedRuntime.make(
+    analyticsDefaultLayer({
+      surface: "selfhost",
+      version: VERSION,
+      channel: CHANNEL,
+      dataDir: resolveDataDir(),
+    }),
+  );
+  return analyticsRuntime;
+};
+
+/**
+ * Lazy facade over the instance's shared service. `record` forks into the
+ * module runtime (fire-and-forget) so no request path ever waits on the
+ * analytics layer; ordering within the runtime preserves event order.
+ */
+export const selfHostAnalytics: AnalyticsService = {
+  record: (name, properties) =>
+    Effect.sync(() => {
+      getAnalyticsRuntime().runFork(
+        Effect.flatMap(Analytics.asEffect(), (analytics) => analytics.record(name, properties)),
+      );
+    }),
+  flush: Effect.promise(() =>
+    getAnalyticsRuntime().runPromise(
+      Effect.flatMap(Analytics.asEffect(), (analytics) => analytics.flush),
+    ),
+  ),
+};
+
+/** Flush and dispose the analytics runtime (server shutdown). */
+export const disposeAnalytics = async (): Promise<void> => {
+  const runtime = analyticsRuntime;
+  if (!runtime) return;
+  analyticsRuntime = null;
+  await Effect.runPromise(Effect.promise(() => runtime.dispose()).pipe(Effect.ignoreCause()));
+};
+
+/**
+ * The execution-analytics `EngineDecorator`: every engine the shared stack
+ * builds gets wrapped once, with the plane derived from what the stack was
+ * built to serve — an MCP session carries its `mcpResource`, the HTTP
+ * executions plane has none. The wrap point IS the plane, so misattribution
+ * is structurally impossible.
+ */
+export const SelfHostAnalyticsEngineDecorator: Layer.Layer<EngineDecorator> = Layer.succeed(
+  EngineDecorator,
+)({
+  decorate: (engine, _identity, context) =>
+    withExecutionAnalytics(engine, selfHostAnalytics, {
+      plane: context.mcpResource === undefined ? "api" : "mcp",
+      toolkit: context.mcpResource?.kind === "toolkit",
+    }),
+});

--- a/apps/host-selfhost/src/app.ts
+++ b/apps/host-selfhost/src/app.ts
@@ -14,6 +14,7 @@ import { makeSelfHostSystemApiLayer } from "./system/handlers";
 import { selfHostAccountMiddleware } from "./account";
 import { loadConfig, SELF_HOST_NAMESPACE, SELF_HOST_SCHEMA_VERSION } from "./config";
 import { createSelfHostDb, SelfHostDb, SelfHostDbProvider } from "./db/self-host-db";
+import { SelfHostAnalyticsEngineDecorator } from "./analytics";
 import {
   SelfHostCodeExecutorProvider,
   SelfHostHostConfig,
@@ -98,7 +99,12 @@ export const makeSelfHostApp = async (options: MakeSelfHostAppOptions = {}) => {
       identity: identityLayer,
       account: selfHostAccountMiddleware(betterAuth),
       db: SelfHostDbProvider,
-      engine: { codeExecutor: SelfHostCodeExecutorProvider }, // decorator defaults to no-op (no metering)
+      engine: {
+        codeExecutor: SelfHostCodeExecutorProvider,
+        // Anonymous execution analytics (this seam is the HTTP plane; the MCP
+        // plane's decorator is wired in mcp/session-store.ts's stack layer).
+        decorator: SelfHostAnalyticsEngineDecorator,
+      },
       mcp: { auth: mcp.auth, sessions: mcp.sessions, reporter: mcp.reporter },
       plugins: { provider: SelfHostPluginsProvider, config: SelfHostHostConfig },
       errorCapture: ErrorCaptureLive,

--- a/apps/host-selfhost/src/app.ts
+++ b/apps/host-selfhost/src/app.ts
@@ -2,7 +2,12 @@ import { HttpApiSwagger } from "effect/unstable/httpapi";
 import { HttpEffect, HttpRouter } from "effect/unstable/http";
 import { Effect, Layer } from "effect";
 
-import { composePluginApi, ExecutorApp, textFailureStrategy } from "@executor-js/api/server";
+import {
+  ArtifactUsageObserver,
+  composePluginApi,
+  ExecutorApp,
+  textFailureStrategy,
+} from "@executor-js/api/server";
 
 import { runSqliteDataMigrations } from "@executor-js/sdk";
 
@@ -14,7 +19,7 @@ import { makeSelfHostSystemApiLayer } from "./system/handlers";
 import { selfHostAccountMiddleware } from "./account";
 import { loadConfig, SELF_HOST_NAMESPACE, SELF_HOST_SCHEMA_VERSION } from "./config";
 import { createSelfHostDb, SelfHostDb, SelfHostDbProvider } from "./db/self-host-db";
-import { SelfHostAnalyticsEngineDecorator } from "./analytics";
+import { selfHostAnalytics, SelfHostAnalyticsEngineDecorator } from "./analytics";
 import {
   SelfHostCodeExecutorProvider,
   SelfHostHostConfig,
@@ -137,8 +142,16 @@ export const makeSelfHostApp = async (options: MakeSelfHostAppOptions = {}) => {
     config: { mountPrefix: "/api", failure: textFailureStrategy },
     // The boot-scoped context provideMerge'd under everything: the long-lived DB
     // handle (read by the DbProvider seam, Better Auth, and the MCP store) + the
-    // resolved identity (captured once by the execution middleware + MCP auth).
-    boot: Layer.merge(Layer.succeed(SelfHostDb)(dbHandle), identityLayer),
+    // resolved identity (captured once by the execution middleware + MCP auth)
+    // + the artifact-usage observer (this HTTP plane is the console UI's data
+    // layer, so operations it serves file as `via: "ui"`).
+    boot: Layer.mergeAll(
+      Layer.succeed(SelfHostDb)(dbHandle),
+      identityLayer,
+      Layer.succeed(ArtifactUsageObserver)((action) =>
+        selfHostAnalytics.record(`artifact_${action}`, { via: "ui" }),
+      ),
+    ),
   });
 
   return {

--- a/apps/host-selfhost/src/execution.ts
+++ b/apps/host-selfhost/src/execution.ts
@@ -58,7 +58,7 @@ export const SelfHostHostConfig: Layer.Layer<HostConfig> = Layer.sync(HostConfig
     onIntegrationChange: (event) =>
       selfHostAnalytics.record(
         event.kind === "added" ? "integration_added" : "integration_removed",
-        { plugin_key: event.pluginKey, integration_slug: String(event.slug) },
+        { plugin_key: event.pluginKey },
       ),
   };
 });

--- a/apps/host-selfhost/src/execution.ts
+++ b/apps/host-selfhost/src/execution.ts
@@ -4,13 +4,13 @@ import {
   CodeExecutorProvider,
   DbProvider,
   EngineDecorator,
-  EngineDecoratorNoop,
   HostConfig,
   PluginsProvider,
 } from "@executor-js/api/server";
 import { makeQuickJsExecutor } from "@executor-js/runtime-quickjs";
 
 import executorConfig from "../executor.config";
+import { selfHostAnalytics, SelfHostAnalyticsEngineDecorator } from "./analytics";
 import { SelfHostDb, SelfHostDbProvider } from "./db/self-host-db";
 import { loadConfig } from "./config";
 
@@ -21,7 +21,7 @@ import { loadConfig } from "./config";
 //   makeScopedExecutor -> createExecutionEngine -> EngineDecorator.decorate.
 // Self-host just supplies the five seam Layers it reads from. Differences from
 // cloud: the QuickJS in-process code substrate (vs the Cloudflare dynamic
-// worker) and a NO-OP engine decorator (no usage metering).
+// worker) and an analytics engine decorator instead of cloud's usage metering.
 //
 //   - DbProvider          -> SelfHostDbProvider: projects the long-lived
 //                            libSQL handle (built once at boot, see db/). The
@@ -33,7 +33,8 @@ import { loadConfig } from "./config";
 //   - HostConfig           -> `{ allowLocalNetwork, webBaseUrl }` from
 //                            `loadConfig()`.
 //   - CodeExecutorProvider -> `makeQuickJsExecutor()`.
-//   - EngineDecorator      -> no-op (self-host does not meter executions).
+//   - EngineDecorator      -> execution analytics (anonymous per-install
+//                             counters; see ./analytics.ts).
 // ---------------------------------------------------------------------------
 
 export { makeExecutionStack } from "@executor-js/api/server";
@@ -54,6 +55,11 @@ export const SelfHostHostConfig: Layer.Layer<HostConfig> = Layer.sync(HostConfig
     allowLocalNetwork: config.allowLocalNetwork,
     webBaseUrl: config.webBaseUrl,
     oauthCallbackPath: "/api/oauth/callback",
+    onIntegrationChange: (event) =>
+      selfHostAnalytics.record(
+        event.kind === "added" ? "integration_added" : "integration_removed",
+        { plugin_key: event.pluginKey, integration_slug: String(event.slug) },
+      ),
   };
 });
 
@@ -82,4 +88,8 @@ export const SelfHostExecutionStackLayer: Layer.Layer<
   DbProvider | PluginsProvider | HostConfig | CodeExecutorProvider | EngineDecorator,
   never,
   SelfHostDb
-> = Layer.mergeAll(SelfHostScopedExecutorSeams, SelfHostCodeExecutorProvider, EngineDecoratorNoop);
+> = Layer.mergeAll(
+  SelfHostScopedExecutorSeams,
+  SelfHostCodeExecutorProvider,
+  SelfHostAnalyticsEngineDecorator,
+);

--- a/apps/host-selfhost/src/mcp/session-store.ts
+++ b/apps/host-selfhost/src/mcp/session-store.ts
@@ -8,6 +8,7 @@ import {
   type InMemoryMcpSessionStore,
 } from "@executor-js/host-mcp/in-memory-session-store";
 
+import { selfHostAnalytics } from "../analytics";
 import { ErrorCaptureLive } from "../observability";
 import { SelfHostDb, type SelfHostDbHandle } from "../db/self-host-db";
 import { SelfHostExecutionStackLayer } from "../execution";
@@ -39,7 +40,13 @@ export const makeSelfHostMcpSessionStore = (
   makeInMemoryMcpSessionStore(
     makeMcpBuildServer(
       SelfHostExecutionStackLayer.pipe(Layer.provide(Layer.succeed(SelfHostDb)(db))),
-      { loadAppShellHtml: loadMcpAppsShellHtml, smokeRenderArtifact },
+      {
+        loadAppShellHtml: loadMcpAppsShellHtml,
+        smokeRenderArtifact,
+        // Artifact operations on the MCP plane come from an agent's tools.
+        onArtifactUsage: (action) =>
+          selfHostAnalytics.record(`artifact_${action}`, { via: "agent" }),
+      },
     ),
     { webBaseUrl },
   );

--- a/apps/host-selfhost/src/serve.ts
+++ b/apps/host-selfhost/src/serve.ts
@@ -26,6 +26,7 @@ import {
 import { BunFileSystem, BunHttpServer, BunPath, BunRuntime } from "@effect/platform-bun";
 import { Effect, Layer } from "effect";
 
+import { disposeAnalytics } from "./analytics";
 import { makeSelfHostApp } from "./app";
 import { loadConfig } from "./config";
 import type { BetterAuthHandle } from "./auth";
@@ -120,6 +121,11 @@ export const startServer = async (): Promise<void> => {
     cacheControl: "no-cache",
   }).pipe(Layer.provide(BunFileSystem.layer), Layer.provide(BunPath.layer));
 
+  // Server-scope finalizer: flush buffered analytics on graceful shutdown.
+  const AnalyticsFlushLive = Layer.effectDiscard(
+    Effect.addFinalizer(() => Effect.promise(() => disposeAnalytics())),
+  );
+
   const ServerLive = HttpRouter.serve(Layer.mergeAll(AppLayer, AssetsLive, SpaLive), {
     middleware: selfHostHttpMiddleware(betterAuth),
   }).pipe(
@@ -128,7 +134,7 @@ export const startServer = async (): Promise<void> => {
     ),
   );
 
-  await BunRuntime.runMain(Layer.launch(ServerLive));
+  await BunRuntime.runMain(Layer.launch(Layer.merge(ServerLive, AnalyticsFlushLive)));
 };
 
 if (import.meta.main) {

--- a/apps/local/package.json
+++ b/apps/local/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@effect/atom-react": "catalog:",
     "@effect/platform-node": "catalog:",
+    "@executor-js/analytics": "workspace:*",
     "@executor-js/api": "workspace:*",
     "@executor-js/app": "workspace:*",
     "@executor-js/config": "workspace:*",

--- a/apps/local/src/analytics.ts
+++ b/apps/local/src/analytics.ts
@@ -1,0 +1,68 @@
+import { Effect, ManagedRuntime } from "effect";
+
+import {
+  Analytics,
+  defaultLayer as analyticsDefaultLayer,
+  type AnalyticsService,
+  type AnalyticsSurface,
+} from "@executor-js/analytics";
+
+import { resolveExecutorDataDir } from "./auth";
+import { CHANNEL, VERSION } from "./installation";
+
+// ---------------------------------------------------------------------------
+// Local product analytics: one anonymous per-install service for the whole
+// daemon lifetime, shared by every surface (HTTP API, in-process MCP, stdio).
+//
+// The surface is cli|desktop — never "local": the desktop main process marks
+// its sidecar via EXECUTOR_CLIENT=desktop (same signal the sidecar sentinels
+// key on), everything else hosting apps/local is the CLI. Module-singleton
+// runtime mirroring ./integrations.ts, so concurrent surfaces share one
+// buffer + one flush loop, and disposeAnalytics() is the shutdown flush.
+// ---------------------------------------------------------------------------
+
+const resolveSurface = (): AnalyticsSurface =>
+  process.env.EXECUTOR_CLIENT === "desktop" ? "desktop" : "cli";
+
+let analyticsRuntime: ManagedRuntime.ManagedRuntime<Analytics, never> | null = null;
+
+const getAnalyticsRuntime = (): ManagedRuntime.ManagedRuntime<Analytics, never> => {
+  if (analyticsRuntime) return analyticsRuntime;
+  analyticsRuntime = ManagedRuntime.make(
+    analyticsDefaultLayer({
+      surface: resolveSurface(),
+      version: VERSION,
+      channel: CHANNEL,
+      dataDir: resolveExecutorDataDir(),
+    }),
+  );
+  return analyticsRuntime;
+};
+
+/**
+ * Lazy facade over the daemon's shared service, usable from boot paths that
+ * compose engines outside Effect. `record` forks into the module runtime
+ * (fire-and-forget, mirroring ./integrations.ts) so callers never wait on the
+ * layer build; ordering within the runtime preserves event order.
+ */
+export const localAnalytics: AnalyticsService = {
+  record: (name, properties) =>
+    Effect.sync(() => {
+      getAnalyticsRuntime().runFork(
+        Effect.flatMap(Analytics.asEffect(), (analytics) => analytics.record(name, properties)),
+      );
+    }),
+  flush: Effect.promise(() =>
+    getAnalyticsRuntime().runPromise(
+      Effect.flatMap(Analytics.asEffect(), (analytics) => analytics.flush),
+    ),
+  ),
+};
+
+/** Flush and dispose the analytics runtime (daemon shutdown). */
+export const disposeAnalytics = async (): Promise<void> => {
+  const runtime = analyticsRuntime;
+  if (!runtime) return;
+  analyticsRuntime = null;
+  await Effect.runPromise(Effect.promise(() => runtime.dispose()).pipe(Effect.ignoreCause()));
+};

--- a/apps/local/src/app.ts
+++ b/apps/local/src/app.ts
@@ -2,6 +2,7 @@ import { HttpApiSwagger } from "effect/unstable/httpapi";
 import { Layer } from "effect";
 
 import {
+  ArtifactUsageObserver,
   composePluginApi,
   ExecutorApp,
   FixedExecutionProvider,
@@ -126,8 +127,16 @@ export const makeLocalApiHandler = async (token: string): Promise<LocalApiHandle
     config: { failure: textFailureStrategy },
     // The boot-scoped context provideMerge'd under everything: the identity
     // provider (captured once by the fixed-execution middleware) + the fixed
-    // execution seam (the one executor + engine + extension map).
-    boot: Layer.merge(identity, fixedExecution),
+    // execution seam (the one executor + engine + extension map) + the
+    // artifact-usage observer (this HTTP plane is the console UI's data layer,
+    // so operations it serves file as `via: "ui"`).
+    boot: Layer.mergeAll(
+      identity,
+      fixedExecution,
+      Layer.succeed(ArtifactUsageObserver)((action) =>
+        localAnalytics.record(`artifact_${action}`, { via: "ui" }),
+      ),
+    ),
   });
 
   const web = toWebHandler();

--- a/apps/local/src/app.ts
+++ b/apps/local/src/app.ts
@@ -7,9 +7,11 @@ import {
   FixedExecutionProvider,
   textFailureStrategy,
 } from "@executor-js/api/server";
+import { withExecutionAnalytics } from "@executor-js/analytics";
 import { createExecutionEngine } from "@executor-js/execution";
 import { makeQuickJsExecutor } from "@executor-js/runtime-quickjs";
 
+import { localAnalytics } from "./analytics";
 import { getExecutorBundle, type LocalExecutor } from "./executor";
 import { makeLocalIdentityLayer } from "./identity";
 import { ErrorCaptureLive } from "./observability";
@@ -53,10 +55,16 @@ import { ErrorCaptureLive } from "./observability";
 const localFixedExecutionLayer = (executor: LocalExecutor): Layer.Layer<FixedExecutionProvider> =>
   Layer.succeed(FixedExecutionProvider)({
     executor,
-    engine: createExecutionEngine({
-      executor,
-      codeExecutor: makeQuickJsExecutor(),
-    }),
+    // This engine serves the HTTP executions API (`executor call`/`resume`,
+    // the web console) — the wrap binds the "api" plane structurally.
+    engine: withExecutionAnalytics(
+      createExecutionEngine({
+        executor,
+        codeExecutor: makeQuickJsExecutor(),
+      }),
+      localAnalytics,
+      { plane: "api", toolkit: false },
+    ),
     // The executor IS its own plugin-extension map (`executor[pluginId]`); the
     // fixed middleware reads `executor[id]` to satisfy each plugin's
     // `*ExtensionService` Tag per request — identical binding to the prior

--- a/apps/local/src/executor.ts
+++ b/apps/local/src/executor.ts
@@ -17,6 +17,7 @@ import { loadPluginsFromJsonc } from "@executor-js/config";
 import type { McpPluginExtension } from "@executor-js/plugin-mcp";
 
 import executorConfig from "../executor.config";
+import { localAnalytics } from "./analytics";
 import { localDataMigrations } from "./db/data-migrations";
 import { openOwnedLocalDatabase } from "./db/owned-database";
 
@@ -195,6 +196,11 @@ const createLocalExecutorLayer = (options: LocalExecutorOptions = {}) => {
         subject: Subject.make(LOCAL_SUBJECT),
         db: sqlite.db,
         plugins,
+        onIntegrationChange: (event) =>
+          localAnalytics.record(
+            event.kind === "added" ? "integration_added" : "integration_removed",
+            { plugin_key: event.pluginKey, integration_slug: String(event.slug) },
+          ),
         onElicitation: "accept-all",
         oauthEndpointUrlPolicy: { allowHttp: true },
         // EXPLICIT OAuth callback — the daemon serves the v2 `/api/oauth/callback`

--- a/apps/local/src/executor.ts
+++ b/apps/local/src/executor.ts
@@ -199,7 +199,7 @@ const createLocalExecutorLayer = (options: LocalExecutorOptions = {}) => {
         onIntegrationChange: (event) =>
           localAnalytics.record(
             event.kind === "added" ? "integration_added" : "integration_removed",
-            { plugin_key: event.pluginKey, integration_slug: String(event.slug) },
+            { plugin_key: event.pluginKey },
           ),
         onElicitation: "accept-all",
         oauthEndpointUrlPolicy: { allowHttp: true },

--- a/apps/local/src/main.ts
+++ b/apps/local/src/main.ts
@@ -1,10 +1,12 @@
 import { Context, Data, Effect, Layer, ManagedRuntime } from "effect";
 
+import { withExecutionAnalytics } from "@executor-js/analytics";
 import { createExecutionEngine } from "@executor-js/execution";
 import { artifactUrlFor } from "@executor-js/host-mcp/create-artifact";
 import { loadMcpAppsShellHtml } from "@executor-js/mcp-apps-shell";
 import { smokeRenderArtifact } from "@executor-js/mcp-apps-shell/smoke-render";
 import { makeQuickJsExecutor } from "@executor-js/runtime-quickjs";
+import { localAnalytics } from "./analytics";
 import { makeLocalApiHandler } from "./app";
 import { createExecutorHandle, disposeExecutor, getExecutorBundle } from "./executor";
 import { createMcpRequestHandler, type McpRequestHandler } from "./mcp";
@@ -85,10 +87,17 @@ export const createServerHandlers = async (token: string): Promise<ServerHandler
     // part of the shared API). Reuse the shared boot bundle so the MCP executor is
     // byte-identical to the one the API serves.
     const { executor, webBaseUrl } = await getExecutorBundle();
-    const engine = createExecutionEngine({
-      executor,
-      codeExecutor: makeQuickJsExecutor(),
-    });
+    // Both engines below serve MCP endpoints, so the wrap binds the "mcp"
+    // plane structurally; the toolkit-scoped engine additionally marks
+    // `toolkit` (the slug itself is a user label and never recorded).
+    const engine = withExecutionAnalytics(
+      createExecutionEngine({
+        executor,
+        codeExecutor: makeQuickJsExecutor(),
+      }),
+      localAnalytics,
+      { plane: "mcp", toolkit: false },
+    );
     // The generative-UI surface, shared by every resource this daemon serves.
     // Each toolkit gets its own executor, so `artifacts` is bound per resource
     // below rather than hoisted with the rest.
@@ -127,10 +136,14 @@ export const createServerHandlers = async (token: string): Promise<ServerHandler
         const handle = await createExecutorHandle({
           activeToolkitSlug: resource.slug,
         });
-        const toolkitEngine = createExecutionEngine({
-          executor: handle.executor,
-          codeExecutor: makeQuickJsExecutor(),
-        });
+        const toolkitEngine = withExecutionAnalytics(
+          createExecutionEngine({
+            executor: handle.executor,
+            codeExecutor: makeQuickJsExecutor(),
+          }),
+          localAnalytics,
+          { plane: "mcp", toolkit: true },
+        );
         return {
           config: {
             engine: toolkitEngine,

--- a/apps/local/src/main.ts
+++ b/apps/local/src/main.ts
@@ -114,6 +114,9 @@ export const createServerHandlers = async (token: string): Promise<ServerHandler
       loadAppShellHtml: loadMcpAppsShellHtml,
       smokeRenderArtifact,
       artifactUrl: artifactUrlFor(webBaseUrl),
+      // Artifact operations on this surface come from an agent's MCP tools.
+      onArtifactUsage: (action: "created" | "viewed" | "updated") =>
+        localAnalytics.record(`artifact_${action}`, { via: "agent" }),
     };
     mcp = createMcpRequestHandler({
       defaultConfig: {

--- a/apps/local/src/serve.ts
+++ b/apps/local/src/serve.ts
@@ -14,6 +14,7 @@ import { setOAuthCompletionListener } from "@executor-js/api";
 import { oauthClientIdMetadataDocumentFromRequest } from "@executor-js/api/server";
 import { loadOrMintLocalAuthToken } from "./auth";
 import { consumeOAuthResult, publishOAuthResult } from "./oauth-result-store";
+import { disposeAnalytics } from "./analytics";
 import { startIntegrationsRefresh } from "./integrations";
 import { disposeServerHandlers, getServerHandlers } from "./main";
 import {
@@ -324,6 +325,8 @@ export async function startServer(opts: StartServerOptions = {}): Promise<Server
     } else {
       await closeProvidedHandlers(handlers);
     }
+    // Final analytics flush; the layer finalizer drains the buffer.
+    await disposeAnalytics();
     if (viteChild) await viteChild.stop();
   };
 

--- a/bun.lock
+++ b/bun.lock
@@ -225,6 +225,7 @@
         "@cloudflare/worker-bundler": "0.2.1",
         "@effect/atom-react": "catalog:",
         "@effect/platform-bun": "catalog:",
+        "@executor-js/analytics": "workspace:*",
         "@executor-js/api": "workspace:*",
         "@executor-js/app": "workspace:*",
         "@executor-js/execution": "workspace:*",
@@ -274,6 +275,7 @@
       "dependencies": {
         "@effect/atom-react": "catalog:",
         "@effect/platform-node": "catalog:",
+        "@executor-js/analytics": "workspace:*",
         "@executor-js/api": "workspace:*",
         "@executor-js/app": "workspace:*",
         "@executor-js/config": "workspace:*",
@@ -454,6 +456,22 @@
         "react-grab": "^0.1.31",
         "typescript": "catalog:",
         "vite": "catalog:",
+      },
+    },
+    "packages/core/analytics": {
+      "name": "@executor-js/analytics",
+      "version": "0.1.0",
+      "dependencies": {
+        "@executor-js/execution": "workspace:*",
+        "effect": "catalog:",
+      },
+      "devDependencies": {
+        "@effect/platform-node": "catalog:",
+        "@effect/vitest": "catalog:",
+        "@executor-js/sdk": "workspace:*",
+        "tsup": "catalog:",
+        "typescript": "catalog:",
+        "vitest": "catalog:",
       },
     },
     "packages/core/api": {
@@ -1734,6 +1752,8 @@
     "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.7", "", { "os": "win32", "cpu": "ia32" }, "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw=="],
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
+
+    "@executor-js/analytics": ["@executor-js/analytics@workspace:packages/core/analytics"],
 
     "@executor-js/api": ["@executor-js/api@workspace:packages/core/api"],
 
@@ -3521,7 +3541,7 @@
 
     "chevrotain-allstar": ["chevrotain-allstar@0.4.1", "", { "dependencies": { "lodash-es": "^4.17.21" }, "peerDependencies": { "chevrotain": "^12.0.0" } }, "sha512-PvVJm3oGqrveUVW2Vt/eZGeiAIsJszYweUcYwcskg9e+IubNYKKD+rHHem7A6XVO22eDAL+inxNIGAzZ/VIWlA=="],
 
-    "chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
+    "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
     "chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
 
@@ -5169,7 +5189,7 @@
 
     "readable-web-to-node-stream": ["readable-web-to-node-stream@3.0.4", "", { "dependencies": { "readable-stream": "^4.7.0" } }, "sha512-9nX56alTf5bwXQ3ZDipHJhusu9NTQJ/CVPtb/XHAJCXihZeitfJvIRS4GqQ/mfIoOE3IelHMrpayVrosdHBuLw=="],
 
-    "readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
+    "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
     "recharts": ["recharts@3.8.0", "", { "dependencies": { "@reduxjs/toolkit": "^1.9.0 || 2.x.x", "clsx": "^2.1.1", "decimal.js-light": "^2.5.1", "es-toolkit": "^1.39.3", "eventemitter3": "^5.0.1", "immer": "^10.1.1", "react-redux": "8.x.x || 9.x.x", "reselect": "5.1.1", "tiny-invariant": "^1.3.3", "use-sync-external-store": "^1.2.2", "victory-vendor": "^37.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Z/m38DX3L73ExO4Tpc9/iZWHmHnlzWG4njQbxsF5aSjwqmHNDDIm0rdEBArkwsBvR8U6EirlEHiQNYWCVh9sGQ=="],
 
@@ -6357,6 +6377,8 @@
 
     "@tanstack/router-plugin/@tanstack/virtual-file-routes": ["@tanstack/virtual-file-routes@1.161.7", "", { "bin": { "intent": "bin/intent.js" } }, "sha512-olW33+Cn+bsCsZKPwEGhlkqS6w3M2slFv11JIobdnCFKMLG97oAI2kWKdx5/zsywTL8flpnoIgaZZPlQTFYhdQ=="],
 
+    "@tanstack/router-plugin/chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
+
     "@tanstack/router-plugin/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@tanstack/router-utils/@babel/parser": ["@babel/parser@7.29.2", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA=="],
@@ -6693,8 +6715,6 @@
 
     "readable-web-to-node-stream/readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
 
-    "readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
-
     "recharts/es-toolkit": ["es-toolkit@1.45.1", "", {}, "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw=="],
 
     "request/form-data": ["form-data@2.3.3", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.6", "mime-types": "^2.1.12" } }, "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ=="],
@@ -6758,8 +6778,6 @@
     "tiny-async-pool/semver": ["semver@5.7.2", "", { "bin": { "semver": "bin/semver" } }, "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="],
 
     "to-regex-range/is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
-
-    "tsup/chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
     "tsup/tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
 
@@ -7163,6 +7181,8 @@
 
     "@tanstack/router-generator/@tanstack/router-utils/@babel/parser": ["@babel/parser@7.29.2", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA=="],
 
+    "@tanstack/router-plugin/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
+
     "@tanstack/start-plugin-core/@tanstack/router-generator/@tanstack/virtual-file-routes": ["@tanstack/virtual-file-routes@1.161.7", "", { "bin": { "intent": "bin/intent.js" } }, "sha512-olW33+Cn+bsCsZKPwEGhlkqS6w3M2slFv11JIobdnCFKMLG97oAI2kWKdx5/zsywTL8flpnoIgaZZPlQTFYhdQ=="],
 
     "@types/better-sqlite3/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
@@ -7515,8 +7535,6 @@
 
     "temp/rimraf/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
-    "tsup/chokidar/readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
-
     "unstorage/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
     "wrangler/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
@@ -7752,6 +7770,8 @@
     "@react-grab/cli/ora/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "@slack/web-api/axios/https-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
+
+    "@tanstack/router-plugin/chokidar/readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
     "agents/yargs/cliui/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -462,11 +462,11 @@
       "name": "@executor-js/analytics",
       "version": "0.1.0",
       "dependencies": {
+        "@effect/platform-node": "catalog:",
         "@executor-js/execution": "workspace:*",
         "effect": "catalog:",
       },
       "devDependencies": {
-        "@effect/platform-node": "catalog:",
         "@effect/vitest": "catalog:",
         "@executor-js/sdk": "workspace:*",
         "tsup": "catalog:",

--- a/packages/core/analytics/CHANGELOG.md
+++ b/packages/core/analytics/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @executor-js/analytics

--- a/packages/core/analytics/package.json
+++ b/packages/core/analytics/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@executor-js/analytics",
+  "version": "0.1.0",
+  "private": true,
+  "homepage": "https://github.com/UsefulSoftwareCo/executor/tree/main/packages/core/analytics",
+  "bugs": {
+    "url": "https://github.com/UsefulSoftwareCo/executor/issues"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/UsefulSoftwareCo/executor.git",
+    "directory": "packages/core/analytics"
+  },
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "import": {
+          "types": "./dist/index.d.ts",
+          "default": "./dist/index.js"
+        }
+      }
+    }
+  },
+  "scripts": {
+    "build": "tsup && (tsc --declaration --emitDeclarationOnly --outDir dist --rootDir src || true)",
+    "test": "vitest run",
+    "typecheck": "tsgo --noEmit",
+    "typecheck:slow": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@executor-js/execution": "workspace:*",
+    "effect": "catalog:"
+  },
+  "devDependencies": {
+    "@effect/platform-node": "catalog:",
+    "@effect/vitest": "catalog:",
+    "@executor-js/sdk": "workspace:*",
+    "tsup": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/core/analytics/package.json
+++ b/packages/core/analytics/package.json
@@ -37,11 +37,11 @@
     "typecheck:slow": "tsc --noEmit"
   },
   "dependencies": {
+    "@effect/platform-node": "catalog:",
     "@executor-js/execution": "workspace:*",
     "effect": "catalog:"
   },
   "devDependencies": {
-    "@effect/platform-node": "catalog:",
     "@effect/vitest": "catalog:",
     "@executor-js/sdk": "workspace:*",
     "tsup": "catalog:",

--- a/packages/core/analytics/src/analytics.test.ts
+++ b/packages/core/analytics/src/analytics.test.ts
@@ -94,10 +94,7 @@ describe("Analytics", () => {
             plane: "mcp",
             toolkit: false,
           });
-          yield* analytics.record("integration_added", {
-            plugin_key: "openapi",
-            integration_slug: "github",
-          });
+          yield* analytics.record("integration_added", { plugin_key: "openapi" });
           yield* analytics.flush;
 
           const batches = yield* Ref.get(http.batches);

--- a/packages/core/analytics/src/analytics.test.ts
+++ b/packages/core/analytics/src/analytics.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it } from "@effect/vitest";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Duration, Effect, Layer, Predicate, Ref, Schema } from "effect";
+import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http";
+import { NodeFileSystem } from "@effect/platform-node";
+
+import { Analytics, isAnalyticsDisabled, layer } from "./analytics";
+
+const PostHogBatchBody = Schema.fromJsonString(
+  Schema.Struct({
+    api_key: Schema.String,
+    batch: Schema.Array(
+      Schema.Struct({
+        event: Schema.String,
+        distinct_id: Schema.String,
+        timestamp: Schema.String,
+        properties: Schema.Record(Schema.String, Schema.Unknown),
+      }),
+    ),
+  }),
+);
+type PostHogBatchBody = typeof PostHogBatchBody.Type;
+const decodePostHogBatchBody = Schema.decodeUnknownEffect(PostHogBatchBody);
+
+interface CapturedBatch {
+  readonly url: string;
+  readonly body: PostHogBatchBody;
+}
+
+const makeRecordingHttpClient = (
+  status: () => number = () => 200,
+): Effect.Effect<{
+  readonly layer: Layer.Layer<HttpClient.HttpClient>;
+  readonly batches: Ref.Ref<ReadonlyArray<CapturedBatch>>;
+}> =>
+  Effect.gen(function* () {
+    const batches = yield* Ref.make<ReadonlyArray<CapturedBatch>>([]);
+    const httpLayer = Layer.succeed(HttpClient.HttpClient)(
+      HttpClient.make((request: HttpClientRequest.HttpClientRequest) =>
+        Effect.gen(function* () {
+          if (!Predicate.isTagged(request.body, "Uint8Array")) {
+            return yield* Effect.die("expected a Uint8Array request body");
+          }
+          const body = yield* decodePostHogBatchBody(
+            new TextDecoder().decode(request.body.body),
+          ).pipe(Effect.orDie);
+          yield* Ref.update(batches, (existing) => [...existing, { url: request.url, body }]);
+          return HttpClientResponse.fromWeb(request, new Response("{}", { status: status() }));
+        }),
+      ),
+    );
+    return { layer: httpLayer, batches };
+  });
+
+const withTempDir = <A, E>(use: (dir: string) => Effect.Effect<A, E>): Effect.Effect<A, E> =>
+  Effect.acquireUseRelease(
+    Effect.promise(() => mkdtemp(join(tmpdir(), "executor-analytics-"))),
+    use,
+    (dir) => Effect.promise(() => rm(dir, { recursive: true, force: true })),
+  );
+
+const testConfig = (dataDir: string) => ({
+  surface: "cli" as const,
+  version: "0.0.0",
+  channel: "dev" as const,
+  dataDir,
+  disabled: false,
+  posthogHost: "https://posthog.test",
+  posthogKey: "phc_test",
+  flushInterval: Duration.hours(1),
+});
+
+describe("isAnalyticsDisabled", () => {
+  it("honors DO_NOT_TRACK and EXECUTOR_DISABLE_ANALYTICS", () => {
+    expect(isAnalyticsDisabled({})).toBe(false);
+    expect(isAnalyticsDisabled({ DO_NOT_TRACK: "1" })).toBe(true);
+    expect(isAnalyticsDisabled({ DO_NOT_TRACK: "true" })).toBe(true);
+    expect(isAnalyticsDisabled({ EXECUTOR_DISABLE_ANALYTICS: "yes" })).toBe(true);
+    expect(isAnalyticsDisabled({ DO_NOT_TRACK: "0" })).toBe(false);
+  });
+});
+
+describe("Analytics", () => {
+  it.effect("buffers events and flushes a PostHog batch with shared properties", () =>
+    withTempDir((dir) =>
+      Effect.gen(function* () {
+        const http = yield* makeRecordingHttpClient();
+        yield* Effect.gen(function* () {
+          const analytics = yield* Analytics;
+          yield* analytics.record("execution_completed", {
+            ok: true,
+            plane: "mcp",
+            toolkit: false,
+          });
+          yield* analytics.record("integration_added", {
+            plugin_key: "openapi",
+            integration_slug: "github",
+          });
+          yield* analytics.flush;
+
+          const batches = yield* Ref.get(http.batches);
+          expect(batches).toHaveLength(1);
+          expect(batches[0]?.url).toBe("https://posthog.test/batch/");
+          // SAFETY: length asserted to be 1 above.
+          const body = batches[0]!.body;
+          expect(body.api_key).toBe("phc_test");
+          expect(body.batch.map((event) => event.event)).toEqual([
+            "execution_completed",
+            "integration_added",
+          ]);
+          for (const event of body.batch) {
+            expect(event.properties["$process_person_profile"]).toBe(false);
+            expect(event.properties["surface"]).toBe("cli");
+            expect(event.properties["channel"]).toBe("dev");
+            expect(event.properties["app_version"]).toBe("0.0.0");
+            expect(event.distinct_id).toBe(body.batch[0]?.distinct_id);
+          }
+        }).pipe(
+          Effect.provide(
+            layer(testConfig(dir)).pipe(
+              Layer.provide(http.layer),
+              Layer.provide(NodeFileSystem.layer),
+            ),
+          ),
+        );
+      }),
+    ),
+  );
+
+  it.effect("mints the anonymous id once and reuses it across runtimes", () =>
+    withTempDir((dir) =>
+      Effect.gen(function* () {
+        const http = yield* makeRecordingHttpClient();
+        const runOnce = Effect.gen(function* () {
+          const analytics = yield* Analytics;
+          yield* analytics.record("execution_completed", {
+            ok: true,
+            plane: "api",
+            toolkit: false,
+          });
+          yield* analytics.flush;
+        }).pipe(
+          Effect.provide(
+            layer(testConfig(dir)).pipe(
+              Layer.provide(http.layer),
+              Layer.provide(NodeFileSystem.layer),
+            ),
+          ),
+        );
+        yield* runOnce;
+        yield* runOnce;
+
+        const persisted = (yield* Effect.promise(() =>
+          readFile(join(dir, "analytics-id"), "utf8"),
+        )).trim();
+        expect(persisted.length).toBeGreaterThan(0);
+
+        const batches = yield* Ref.get(http.batches);
+        expect(batches).toHaveLength(2);
+        const ids = batches.map((batch) => batch.body.batch[0]?.distinct_id);
+        expect(ids[0]).toBe(persisted);
+        expect(ids[1]).toBe(persisted);
+      }),
+    ),
+  );
+
+  it.effect("re-queues the batch when delivery fails and never surfaces the error", () =>
+    withTempDir((dir) =>
+      Effect.gen(function* () {
+        let failing = true;
+        const http = yield* makeRecordingHttpClient(() => (failing ? 500 : 200));
+        yield* Effect.gen(function* () {
+          const analytics = yield* Analytics;
+          yield* analytics.record("execution_completed", {
+            ok: false,
+            plane: "mcp",
+            toolkit: true,
+          });
+          yield* analytics.flush;
+          expect(yield* Ref.get(http.batches)).toHaveLength(1);
+
+          failing = false;
+          yield* analytics.flush;
+          const batches = yield* Ref.get(http.batches);
+          expect(batches).toHaveLength(2);
+          // SAFETY: length asserted to be 2 above.
+          const retried = batches[1]!.body;
+          expect(retried.batch[0]?.event).toBe("execution_completed");
+          expect(retried.batch[0]?.properties["toolkit"]).toBe(true);
+        }).pipe(
+          Effect.provide(
+            layer(testConfig(dir)).pipe(
+              Layer.provide(http.layer),
+              Layer.provide(NodeFileSystem.layer),
+            ),
+          ),
+        );
+      }),
+    ),
+  );
+
+  it.effect("disabled config produces a no-op service that never dials out", () =>
+    withTempDir((dir) =>
+      Effect.gen(function* () {
+        const http = yield* makeRecordingHttpClient();
+        yield* Effect.gen(function* () {
+          const analytics = yield* Analytics;
+          yield* analytics.record("execution_completed", {
+            ok: true,
+            plane: "api",
+            toolkit: false,
+          });
+          yield* analytics.flush;
+          expect(yield* Ref.get(http.batches)).toHaveLength(0);
+        }).pipe(
+          Effect.provide(
+            layer({ ...testConfig(dir), disabled: true }).pipe(
+              Layer.provide(http.layer),
+              Layer.provide(NodeFileSystem.layer),
+            ),
+          ),
+        );
+        // No id file either: a disabled install leaves no analytics trace.
+        const persisted = yield* Effect.promise(() =>
+          readFile(join(dir, "analytics-id"), "utf8").then(
+            () => true,
+            () => false,
+          ),
+        );
+        expect(persisted).toBe(false);
+      }),
+    ),
+  );
+});

--- a/packages/core/analytics/src/analytics.ts
+++ b/packages/core/analytics/src/analytics.ts
@@ -1,0 +1,240 @@
+// ---------------------------------------------------------------------------
+// Anonymous product analytics for the non-cloud hosts (local daemon, self-host).
+//
+// Model (mirrors t3code's server telemetry): a per-install anonymous id is
+// minted once and persisted under the host's data dir; events buffer in memory
+// and flush to PostHog's /batch/ endpoint on a fixed cadence plus a finalizer
+// flush at shutdown. Delivery is best-effort — a failed flush re-queues the
+// batch and never surfaces to the caller; analytics can never fail or slow a
+// user-facing operation.
+//
+// Opt-out is the established cross-cutting convention: DO_NOT_TRACK (see
+// consoledonottrack.com, honored by the desktop diagnostics and the
+// integrations-registry fetch) or the feature-specific
+// EXECUTOR_DISABLE_ANALYTICS. Disabled -> the layer builds a no-op service, so
+// callers never branch.
+// ---------------------------------------------------------------------------
+
+import { Context, DateTime, Duration, Effect, Layer, Ref, Schedule } from "effect";
+import { FileSystem } from "effect";
+import {
+  FetchHttpClient,
+  HttpClient,
+  HttpClientRequest,
+  HttpClientResponse,
+} from "effect/unstable/http";
+import { NodeFileSystem } from "@effect/platform-node";
+
+import type { AnalyticsEventName, AnalyticsEvents } from "./events";
+
+// ---------------------------------------------------------------------------
+// Surface vocabulary
+// ---------------------------------------------------------------------------
+
+/**
+ * Which product hosts the daemon emitting the event. Always explicit at the
+ * composition root — there is deliberately no "local" catch-all and no env
+ * fallback inside this package; a host that cannot say which product it is
+ * has a wiring bug worth surfacing, not papering over.
+ */
+export type AnalyticsSurface = "cli" | "desktop" | "selfhost";
+
+// ---------------------------------------------------------------------------
+// Disable hooks
+// ---------------------------------------------------------------------------
+
+const truthy = (value: string | undefined): boolean => {
+  if (value === undefined) return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes";
+};
+
+export const isAnalyticsDisabled = (
+  env: Readonly<Record<string, string | undefined>> = process.env,
+): boolean => truthy(env.DO_NOT_TRACK) || truthy(env.EXECUTOR_DISABLE_ANALYTICS);
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export interface AnalyticsService {
+  /** Buffer an event for best-effort batched delivery. Never fails. */
+  readonly record: <Name extends AnalyticsEventName>(
+    name: Name,
+    properties: AnalyticsEvents[Name],
+  ) => Effect.Effect<void>;
+  /** Drain the buffer now (shutdown path; the layer also flushes on a cadence). */
+  readonly flush: Effect.Effect<void>;
+}
+
+export class Analytics extends Context.Service<Analytics, AnalyticsService>()(
+  "@executor-js/analytics/Analytics",
+) {}
+
+/** No-op service: what the layer builds when analytics is disabled. */
+export const analyticsNoop: AnalyticsService = {
+  record: () => Effect.void,
+  flush: Effect.void,
+};
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+// The same PostHog project the cloud browser client reports to (the key is
+// public by design — it identifies the project, it grants no read access).
+const DEFAULT_POSTHOG_HOST = "https://us.i.posthog.com";
+const DEFAULT_POSTHOG_KEY = "phc_nNLrNMALpRsfrEkZovUkfMxYbcJvHnsJHeoSPavprgLL";
+
+export interface AnalyticsConfig {
+  /** Which product hosts this daemon. Explicit, decided at the composition root. */
+  readonly surface: AnalyticsSurface;
+  /** Product version (the hosting app's package version). */
+  readonly version: string;
+  /** Release channel, matching the installation user-agent vocabulary. */
+  readonly channel: "stable" | "beta" | "dev";
+  /**
+   * Directory the anonymous install id persists under (the host's data dir:
+   * `~/.executor` for local, the self-host data dir for self-host). The id
+   * file is `<dataDir>/analytics-id`.
+   */
+  readonly dataDir: string;
+  /** Disable entirely. Honors DO_NOT_TRACK and EXECUTOR_DISABLE_ANALYTICS if omitted. */
+  readonly disabled?: boolean;
+  /** Override the PostHog ingest origin (tests). */
+  readonly posthogHost?: string;
+  /** Override the PostHog project key (tests). */
+  readonly posthogKey?: string;
+  /** Override the flush cadence. Defaults to 30 seconds. */
+  readonly flushInterval?: Duration.Input;
+}
+
+const FLUSH_BATCH_SIZE = 50;
+const MAX_BUFFERED_EVENTS = 500;
+
+// ---------------------------------------------------------------------------
+// Anonymous install id
+// ---------------------------------------------------------------------------
+
+const ANALYTICS_ID_FILE = "analytics-id";
+
+// Minted once per install, persisted forever (mirrors self-host's
+// generate-and-persist secret.key shape, minus the secrecy — this id is not a
+// credential, it is the anonymous distinct_id the events file under).
+const loadOrMintAnonymousId = (
+  dataDir: string,
+): Effect.Effect<string, never, FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const idPath = `${dataDir}/${ANALYTICS_ID_FILE}`;
+    const existing = yield* fs.readFileString(idPath).pipe(
+      Effect.map((raw) => raw.trim()),
+      Effect.catch(() => Effect.succeed("")),
+    );
+    if (existing.length > 0) return existing;
+    const minted = crypto.randomUUID();
+    yield* fs.makeDirectory(dataDir, { recursive: true }).pipe(Effect.ignore);
+    yield* fs.writeFileString(idPath, minted).pipe(Effect.ignore);
+    return minted;
+  });
+
+// ---------------------------------------------------------------------------
+// Layer
+// ---------------------------------------------------------------------------
+
+interface BufferedEvent {
+  readonly event: AnalyticsEventName;
+  readonly properties: Record<string, unknown>;
+  readonly timestamp: string;
+}
+
+export const layer = (
+  config: AnalyticsConfig,
+): Layer.Layer<Analytics, never, HttpClient.HttpClient | FileSystem.FileSystem> =>
+  Layer.effect(Analytics)(
+    Effect.gen(function* () {
+      const disabled = config.disabled ?? isAnalyticsDisabled();
+      if (disabled) return analyticsNoop;
+
+      const http = yield* HttpClient.HttpClient;
+      const distinctId = yield* loadOrMintAnonymousId(config.dataDir);
+      const buffer = yield* Ref.make<ReadonlyArray<BufferedEvent>>([]);
+
+      const posthogHost = config.posthogHost ?? DEFAULT_POSTHOG_HOST;
+      const posthogKey = config.posthogKey ?? DEFAULT_POSTHOG_KEY;
+
+      const sendBatch = (events: ReadonlyArray<BufferedEvent>) =>
+        HttpClientRequest.post(`${posthogHost}/batch/`).pipe(
+          HttpClientRequest.bodyJson({
+            api_key: posthogKey,
+            batch: events.map((entry) => ({
+              event: entry.event,
+              distinct_id: distinctId,
+              timestamp: entry.timestamp,
+              properties: {
+                ...entry.properties,
+                // Anonymous events only: never materialize a person profile.
+                $process_person_profile: false,
+                surface: config.surface,
+                channel: config.channel,
+                app_version: config.version,
+              },
+            })),
+          }),
+          Effect.flatMap(http.execute),
+          Effect.flatMap(HttpClientResponse.filterStatusOk),
+          Effect.asVoid,
+          Effect.timeout(Duration.seconds(10)),
+        );
+
+      const flush: Effect.Effect<void> = Effect.gen(function* () {
+        while (true) {
+          const batch = yield* Ref.modify(buffer, (current) => {
+            const next = current.slice(0, FLUSH_BATCH_SIZE);
+            return [next, current.slice(next.length)] as const;
+          });
+          if (batch.length === 0) return;
+          yield* sendBatch(batch).pipe(
+            // Delivery failed: put the batch back for the next cadence tick and
+            // stop draining (the endpoint is unreachable, later batches would
+            // fail the same way).
+            Effect.tapError(() => Ref.update(buffer, (current) => [...batch, ...current])),
+          );
+        }
+      }).pipe(
+        Effect.catchCause((cause) =>
+          Effect.logDebug("Analytics.flush failed").pipe(Effect.annotateLogs("cause", cause)),
+        ),
+      );
+
+      const record: AnalyticsService["record"] = (name, properties) =>
+        Effect.flatMap(DateTime.now, (now) =>
+          Ref.update(buffer, (current) => {
+            const appended = [
+              ...current,
+              {
+                event: name,
+                properties: properties as Record<string, unknown>,
+                timestamp: DateTime.formatIso(now),
+              },
+            ];
+            // Bounded buffer: a dead network must not grow memory forever.
+            return appended.length > MAX_BUFFERED_EVENTS
+              ? appended.slice(appended.length - MAX_BUFFERED_EVENTS)
+              : appended;
+          }),
+        );
+
+      const flushEvery = config.flushInterval ?? Duration.seconds(30);
+      yield* Effect.forkScoped(
+        flush.pipe(Effect.schedule(Schedule.spaced(flushEvery)), Effect.ignore),
+      );
+      yield* Effect.addFinalizer(() => flush);
+
+      return { record, flush };
+    }),
+  );
+
+/** The layer over the default platform services (real HTTP + disk). */
+export const defaultLayer = (config: AnalyticsConfig): Layer.Layer<Analytics> =>
+  layer(config).pipe(Layer.provide(FetchHttpClient.layer), Layer.provide(NodeFileSystem.layer));

--- a/packages/core/analytics/src/engine.test.ts
+++ b/packages/core/analytics/src/engine.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Data, Effect, Result } from "effect";
+
+import { ToolAddress, UrlElicitation, ElicitationId } from "@executor-js/sdk";
+import type { ExecutionEngine, ExecutionResult } from "@executor-js/execution";
+
+import type { AnalyticsEvents, AnalyticsEventName } from "./events";
+import { withExecutionAnalytics } from "./engine";
+
+class FakeExecutionError extends Data.TaggedError("FakeExecutionError")<{}> {}
+
+type Recorded = { readonly name: AnalyticsEventName; readonly properties: unknown };
+
+const makeRecorder = () => {
+  const events: Recorded[] = [];
+  return {
+    events,
+    analytics: {
+      record: <Name extends AnalyticsEventName>(name: Name, properties: AnalyticsEvents[Name]) =>
+        Effect.sync(() => {
+          events.push({ name, properties });
+        }),
+      flush: Effect.void,
+    },
+  };
+};
+
+const completedResult = (error?: string): ExecutionResult => ({
+  status: "completed",
+  result: { result: error ? null : "ok", ...(error ? { error } : {}) },
+});
+
+const pausedResult: ExecutionResult = {
+  status: "paused",
+  execution: {
+    id: "exec-1",
+    elicitationContext: {
+      address: ToolAddress.make("github.issues.create"),
+      args: {},
+      request: UrlElicitation.make({
+        message: "approve",
+        url: "https://example.test/approve",
+        elicitationId: ElicitationId.make("elic-1"),
+      }),
+    },
+  },
+};
+
+const makeFakeEngine = (
+  outcomes: Partial<{
+    execute: Effect.Effect<{ result: unknown; error?: string }, FakeExecutionError>;
+    executeWithPause: Effect.Effect<ExecutionResult, FakeExecutionError>;
+    resume: Effect.Effect<ExecutionResult | null, FakeExecutionError>;
+  }>,
+): ExecutionEngine<FakeExecutionError> => ({
+  execute: () => outcomes.execute ?? Effect.succeed({ result: "ok" }),
+  executeWithPause: () => outcomes.executeWithPause ?? Effect.succeed(completedResult()),
+  resume: () => outcomes.resume ?? Effect.succeed(null),
+  getPausedExecution: () => Effect.succeed(null),
+  pausedExecutionCount: () => Effect.succeed(0),
+  hasPausedExecutions: () => Effect.succeed(false),
+  getDescription: Effect.succeed("fake"),
+});
+
+describe("withExecutionAnalytics", () => {
+  it.effect("records ok on a completed execution", () =>
+    Effect.gen(function* () {
+      const recorder = makeRecorder();
+      const engine = withExecutionAnalytics(makeFakeEngine({}), recorder.analytics, {
+        plane: "mcp",
+        toolkit: false,
+      });
+      yield* engine.executeWithPause("code");
+      expect(recorder.events).toEqual([
+        {
+          name: "execution_completed",
+          properties: { ok: true, plane: "mcp", toolkit: false },
+        },
+      ]);
+    }),
+  );
+
+  it.effect("records not-ok when the sandbox reports an error value", () =>
+    Effect.gen(function* () {
+      const recorder = makeRecorder();
+      const engine = withExecutionAnalytics(
+        makeFakeEngine({ executeWithPause: Effect.succeed(completedResult("boom")) }),
+        recorder.analytics,
+        { plane: "api", toolkit: false },
+      );
+      yield* engine.executeWithPause("code");
+      expect(recorder.events).toEqual([
+        {
+          name: "execution_completed",
+          properties: { ok: false, plane: "api", toolkit: false },
+        },
+      ]);
+    }),
+  );
+
+  it.effect("records not-ok when the engine fails on the error channel", () =>
+    Effect.gen(function* () {
+      const recorder = makeRecorder();
+      const engine = withExecutionAnalytics(
+        makeFakeEngine({ executeWithPause: Effect.fail(new FakeExecutionError()) }),
+        recorder.analytics,
+        { plane: "mcp", toolkit: true },
+      );
+      const result = yield* Effect.result(engine.executeWithPause("code"));
+      expect(Result.isFailure(result)).toBe(true);
+      expect(recorder.events).toEqual([
+        {
+          name: "execution_completed",
+          properties: { ok: false, plane: "mcp", toolkit: true },
+        },
+      ]);
+    }),
+  );
+
+  it.effect("does not record a pause; records when the resume completes", () =>
+    Effect.gen(function* () {
+      const recorder = makeRecorder();
+      const paused = withExecutionAnalytics(
+        makeFakeEngine({ executeWithPause: Effect.succeed(pausedResult) }),
+        recorder.analytics,
+        { plane: "mcp", toolkit: false },
+      );
+      yield* paused.executeWithPause("code");
+      expect(recorder.events).toEqual([]);
+
+      const resumed = withExecutionAnalytics(
+        makeFakeEngine({ resume: Effect.succeed(completedResult()) }),
+        recorder.analytics,
+        { plane: "mcp", toolkit: false },
+      );
+      yield* resumed.resume("exec-1", { action: "accept" });
+      expect(recorder.events).toEqual([
+        {
+          name: "execution_completed",
+          properties: { ok: true, plane: "mcp", toolkit: false },
+        },
+      ]);
+    }),
+  );
+
+  it.effect("resume of an unknown execution records nothing", () =>
+    Effect.gen(function* () {
+      const recorder = makeRecorder();
+      const engine = withExecutionAnalytics(makeFakeEngine({}), recorder.analytics, {
+        plane: "api",
+        toolkit: false,
+      });
+      yield* engine.resume("missing", { action: "accept" });
+      expect(recorder.events).toEqual([]);
+    }),
+  );
+});

--- a/packages/core/analytics/src/engine.ts
+++ b/packages/core/analytics/src/engine.ts
@@ -1,0 +1,63 @@
+// ---------------------------------------------------------------------------
+// Execution-analytics engine wrapper.
+//
+// The same overlay shape as cloud's `withExecutionUsageTracking` billing
+// decorator: wrap the engine once per serving plane, at the composition root.
+// Because the wrap point IS the plane, the `plane` label is bound structurally
+// — misattribution is impossible the way it would be with a header or flag.
+//
+// Outcome semantics: one `execution_completed` per execution reaching a
+// terminal state. A sandbox-level failure lands on the success channel as
+// `ExecuteResult.error`; an infrastructure failure lands on the Effect error
+// channel. Both count as `ok: false`. A pause is not terminal — the execution
+// is recorded when its resume completes, so approve-then-complete counts once.
+// ---------------------------------------------------------------------------
+
+import { Effect } from "effect";
+import type * as Cause from "effect/Cause";
+
+import type { ExecutionEngine, ExecutionResult } from "@executor-js/execution";
+
+import type { AnalyticsService } from "./analytics";
+import type { ExecutionPlane } from "./events";
+
+export interface ExecutionAnalyticsContext {
+  readonly plane: ExecutionPlane;
+  /** Whether this engine serves a toolkit-scoped endpoint. */
+  readonly toolkit: boolean;
+}
+
+export const withExecutionAnalytics = <E extends Cause.YieldableError>(
+  engine: ExecutionEngine<E>,
+  analytics: AnalyticsService,
+  context: ExecutionAnalyticsContext,
+): ExecutionEngine<E> => {
+  const completed = (ok: boolean): Effect.Effect<void> =>
+    analytics.record("execution_completed", {
+      ok,
+      plane: context.plane,
+      toolkit: context.toolkit,
+    });
+
+  const recordOutcome = (result: ExecutionResult | null): Effect.Effect<void> =>
+    result?.status === "completed" ? completed(!result.result.error) : Effect.void;
+
+  return {
+    ...engine,
+    execute: (code, options) =>
+      engine.execute(code, options).pipe(
+        Effect.tap((result) => completed(!result.error)),
+        Effect.tapError(() => completed(false)),
+      ),
+    executeWithPause: (code, options) =>
+      engine.executeWithPause(code, options).pipe(
+        Effect.tap(recordOutcome),
+        Effect.tapError(() => completed(false)),
+      ),
+    resume: (executionId, response) =>
+      engine.resume(executionId, response).pipe(
+        Effect.tap(recordOutcome),
+        Effect.tapError(() => completed(false)),
+      ),
+  };
+};

--- a/packages/core/analytics/src/events.ts
+++ b/packages/core/analytics/src/events.ts
@@ -13,8 +13,11 @@
 //   - Never secrets, tokens, credentials, code, tool arguments or results.
 //   - Never user free text: no connection names, no tool addresses, no
 //     toolkit slugs (user-entered labels — send booleans/counts instead).
-//   - Integration slugs and plugin keys ARE allowed (spec-derived vocabulary,
-//     matching the browser catalog's `integration_slug` / `plugin_key`).
+//   - Plugin keys (`openapi`, `mcp`, `graphql`, ...) ARE allowed: a fixed,
+//     product-defined vocabulary. Integration slugs are NOT — stricter than
+//     the browser catalog: these events leave the user's own infrastructure,
+//     and WHICH integrations someone uses is their business, not ours. The
+//     kind of integration is the product question; the slug is not.
 //   - Identity is the anonymous per-install id only; no emails, no hostnames,
 //     no person or org names.
 // ---------------------------------------------------------------------------
@@ -48,15 +51,9 @@ export interface AnalyticsEvents {
     readonly toolkit: boolean;
   };
   /** An integration row was created (upsert re-registers are not counted). */
-  integration_added: {
-    readonly plugin_key: string;
-    readonly integration_slug: string;
-  };
+  integration_added: { readonly plugin_key: string };
   /** An integration was removed by the user. */
-  integration_removed: {
-    readonly plugin_key: string;
-    readonly integration_slug: string;
-  };
+  integration_removed: { readonly plugin_key: string };
   /** A generative-UI artifact was saved as a new row. */
   artifact_created: { readonly via: ArtifactVia };
   /**

--- a/packages/core/analytics/src/events.ts
+++ b/packages/core/analytics/src/events.ts
@@ -1,0 +1,54 @@
+// ---------------------------------------------------------------------------
+// Server-side product-analytics event catalog.
+//
+// The server analog of the browser catalog in packages/react/src/api/
+// analytics.tsx, which is BROWSER-ONLY by design (its own header says server
+// events need their own seam — this is that seam). Cloud keeps its browser
+// client; this catalog is for the surfaces that had none: the local daemon
+// (CLI + desktop) and self-host.
+//
+// PROPERTY RULES (same line the browser catalog draws):
+//   - Metadata about product usage only — the question these answer is "how
+//     are product features being used", never "what is this user doing".
+//   - Never secrets, tokens, credentials, code, tool arguments or results.
+//   - Never user free text: no connection names, no tool addresses, no
+//     toolkit slugs (user-entered labels — send booleans/counts instead).
+//   - Integration slugs and plugin keys ARE allowed (spec-derived vocabulary,
+//     matching the browser catalog's `integration_slug` / `plugin_key`).
+//   - Identity is the anonymous per-install id only; no emails, no hostnames,
+//     no person or org names.
+// ---------------------------------------------------------------------------
+
+/**
+ * Which door an execution came through. Bound structurally by the host (each
+ * serving plane wraps its engine once), never inferred from a header or flag:
+ *   - `mcp` — an agent invoking over the MCP surface.
+ *   - `api` — the HTTP executions API (CLI `call`/`resume`, the web console).
+ */
+export type ExecutionPlane = "mcp" | "api";
+
+export interface AnalyticsEvents {
+  /**
+   * A code execution reached a terminal outcome. Recorded once per execution
+   * at completion — a paused execution is recorded when its resume completes,
+   * not when it pauses. `toolkit` marks executions served by a toolkit-scoped
+   * MCP endpoint (the toolkit's slug is a user label and deliberately absent).
+   */
+  execution_completed: {
+    readonly ok: boolean;
+    readonly plane: ExecutionPlane;
+    readonly toolkit: boolean;
+  };
+  /** An integration row was created (upsert re-registers are not counted). */
+  integration_added: {
+    readonly plugin_key: string;
+    readonly integration_slug: string;
+  };
+  /** An integration was removed by the user. */
+  integration_removed: {
+    readonly plugin_key: string;
+    readonly integration_slug: string;
+  };
+}
+
+export type AnalyticsEventName = keyof AnalyticsEvents;

--- a/packages/core/analytics/src/events.ts
+++ b/packages/core/analytics/src/events.ts
@@ -27,6 +27,14 @@
  */
 export type ExecutionPlane = "mcp" | "api";
 
+/**
+ * Which door an artifact operation came through: an agent calling the MCP
+ * artifact tools, or a human in the console UI (whose data layer is the
+ * artifacts HTTP API). Bound at each door's composition point, mirroring
+ * `ExecutionPlane`.
+ */
+export type ArtifactVia = "agent" | "ui";
+
 export interface AnalyticsEvents {
   /**
    * A code execution reached a terminal outcome. Recorded once per execution
@@ -49,6 +57,18 @@ export interface AnalyticsEvents {
     readonly plugin_key: string;
     readonly integration_slug: string;
   };
+  /** A generative-UI artifact was saved as a new row. */
+  artifact_created: { readonly via: ArtifactVia };
+  /**
+   * An artifact was opened for its content: the agent's `show-artifact` or
+   * the console detail page. Internal reads (binding resolution inside an
+   * execution) deliberately do not count.
+   */
+  artifact_viewed: { readonly via: ArtifactVia };
+  /** An existing artifact was overwritten in place, or renamed. */
+  artifact_updated: { readonly via: ArtifactVia };
+  /** An artifact was deleted. Only the UI offers deletion today. */
+  artifact_deleted: { readonly via: ArtifactVia };
 }
 
 export type AnalyticsEventName = keyof AnalyticsEvents;

--- a/packages/core/analytics/src/index.ts
+++ b/packages/core/analytics/src/index.ts
@@ -1,0 +1,12 @@
+export {
+  Analytics,
+  analyticsNoop,
+  defaultLayer,
+  isAnalyticsDisabled,
+  layer,
+  type AnalyticsConfig,
+  type AnalyticsService,
+  type AnalyticsSurface,
+} from "./analytics";
+export { withExecutionAnalytics, type ExecutionAnalyticsContext } from "./engine";
+export type { AnalyticsEventName, AnalyticsEvents, ExecutionPlane } from "./events";

--- a/packages/core/analytics/tsconfig.json
+++ b/packages/core/analytics/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "plugins": [
+      {
+        "name": "@effect/language-service",
+        "ignoreEffectSuggestionsInTscExitCode": true,
+        "ignoreEffectWarningsInTscExitCode": true,
+        "diagnosticSeverity": {}
+      }
+    ]
+  },
+  "include": ["src"]
+}

--- a/packages/core/analytics/tsup.config.ts
+++ b/packages/core/analytics/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: {
+    index: "src/index.ts",
+  },
+  format: ["esm"],
+  dts: false,
+  sourcemap: true,
+  clean: true,
+  external: [/^@executor-js\//, /^effect/, /^@effect\//, "vitest"],
+});

--- a/packages/core/analytics/vitest.config.ts
+++ b/packages/core/analytics/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/packages/core/api/src/handlers/artifacts.ts
+++ b/packages/core/api/src/handlers/artifacts.ts
@@ -7,8 +7,16 @@ import {
 } from "@executor-js/sdk";
 
 import { ExecutorApi } from "../api";
-import { ExecutorService } from "../services";
+import { ArtifactUsageObserver, ExecutorService, type ArtifactUsageAction } from "../services";
 import { capture } from "@executor-js/api";
+
+// Best-effort usage observation (see `ArtifactUsageObserver`): notified after
+// the operation succeeded, failures swallowed, so analytics can never fail or
+// slow an artifact request.
+const notifyArtifactUsage = (action: ArtifactUsageAction) =>
+  Effect.flatMap(Effect.service(ArtifactUsageObserver), (observer) =>
+    observer ? observer(action).pipe(Effect.ignoreCause({ log: false })) : Effect.void,
+  );
 
 const summaryToResponse = (a: ArtifactSummary) => ({
   id: a.id,
@@ -42,6 +50,7 @@ export const ArtifactsHandlers = HttpApiBuilder.group(ExecutorApi, "artifacts", 
         Effect.gen(function* () {
           const executor = yield* ExecutorService;
           const artifact = yield* executor.artifacts.get(path.artifactId);
+          yield* notifyArtifactUsage("viewed");
           return artifactToResponse(artifact);
         }),
       ),
@@ -57,6 +66,7 @@ export const ArtifactsHandlers = HttpApiBuilder.group(ExecutorApi, "artifacts", 
             code: payload.code,
             bindings: payload.bindings,
           });
+          yield* notifyArtifactUsage(payload.id === undefined ? "created" : "updated");
           return artifactToResponse(saved);
         }),
       ),
@@ -69,6 +79,7 @@ export const ArtifactsHandlers = HttpApiBuilder.group(ExecutorApi, "artifacts", 
             id: path.artifactId,
             title: payload.title,
           });
+          yield* notifyArtifactUsage("updated");
           return artifactToResponse(renamed);
         }),
       ),
@@ -78,6 +89,7 @@ export const ArtifactsHandlers = HttpApiBuilder.group(ExecutorApi, "artifacts", 
         Effect.gen(function* () {
           const executor = yield* ExecutorService;
           yield* executor.artifacts.remove({ id: path.artifactId });
+          yield* notifyArtifactUsage("deleted");
           return { removed: true };
         }),
       ),

--- a/packages/core/api/src/server.ts
+++ b/packages/core/api/src/server.ts
@@ -1,4 +1,9 @@
-export { ExecutorService, ExecutionEngineService } from "./services";
+export {
+  ArtifactUsageObserver,
+  ExecutorService,
+  ExecutionEngineService,
+  type ArtifactUsageAction,
+} from "./services";
 export {
   CoreHandlers,
   ToolsHandlers,

--- a/packages/core/api/src/server/execution-stack.ts
+++ b/packages/core/api/src/server/execution-stack.ts
@@ -69,7 +69,18 @@ export interface EngineDecoratorShape {
   readonly decorate: <E extends Cause.YieldableError>(
     engine: ExecutionEngine<E>,
     identity: EngineStackIdentity,
+    context: EngineStackContext,
   ) => ExecutionEngine<E>;
+}
+
+/**
+ * What the stack was built to serve, beyond the identity: the MCP resource
+ * when the caller is an MCP session (absent on the HTTP plane). Lets a
+ * decorator distinguish a toolkit-scoped engine without the host threading a
+ * side channel.
+ */
+export interface EngineStackContext {
+  readonly mcpResource?: McpResource;
 }
 
 export class EngineDecorator extends Context.Service<EngineDecorator, EngineDecoratorShape>()(
@@ -116,11 +127,15 @@ export const makeExecutionStack = <
       Effect.withSpan("executor.stack.decorator"),
     );
     const engine = yield* Effect.sync(() =>
-      decorate(createExecutionEngine({ executor, codeExecutor }), {
-        accountId,
-        organizationId,
-        organizationName,
-      }),
+      decorate(
+        createExecutionEngine({ executor, codeExecutor }),
+        {
+          accountId,
+          organizationId,
+          organizationName,
+        },
+        { mcpResource: options?.mcpResource },
+      ),
     ).pipe(Effect.withSpan("executor.stack.engine.init"));
     return { executor, engine };
   }).pipe(Effect.withSpan("executor.stack.build"));

--- a/packages/core/api/src/server/mcp-build.ts
+++ b/packages/core/api/src/server/mcp-build.ts
@@ -74,6 +74,7 @@ export const makeMcpBuildServer =
           ...(hostOptions?.smokeRenderArtifact
             ? { smokeRenderArtifact: hostOptions.smokeRenderArtifact }
             : {}),
+          ...(hostOptions?.onArtifactUsage ? { onArtifactUsage: hostOptions.onArtifactUsage } : {}),
           // Same org pinning as `RequestOrgSlug` above: self-host serves its
           // console under `/<org-slug>` (`default` when unconfigured), so the
           // deep link carries the principal's slug rather than relying on the
@@ -101,6 +102,10 @@ export interface McpBuildHostOptions {
    *  the server pass `smokeRenderArtifact` from `@executor-js/mcp-apps-shell`,
    *  which loads it behind a dynamic import; omitting it skips the check. */
   readonly smokeRenderArtifact?: (code: string) => Promise<ArtifactSmokeRenderResult>;
+  /** Forwarded to the tool server's `onArtifactUsage`: best-effort observation
+   *  of agent-driven artifact operations, for hosts recording product
+   *  analytics. */
+  readonly onArtifactUsage?: (action: "created" | "viewed" | "updated") => Effect.Effect<void>;
 }
 
 /**

--- a/packages/core/api/src/server/scoped-executor.ts
+++ b/packages/core/api/src/server/scoped-executor.ts
@@ -40,6 +40,7 @@ import {
   Tenant,
   type AnyPlugin,
   type Executor,
+  type ExecutorConfig,
   type StorageFailure,
 } from "@executor-js/sdk";
 import {
@@ -90,6 +91,12 @@ export interface HostConfigShape {
    * detail of credential storage.
    */
   readonly exposeCredentialProviders?: boolean;
+  /**
+   * Forwarded to `ExecutorConfig.onIntegrationChange`: best-effort post-commit
+   * observation of durable integration-catalog changes (see the sdk contract).
+   * Hosts that record product analytics supply it; omitted -> no observation.
+   */
+  readonly onIntegrationChange?: ExecutorConfig["onIntegrationChange"];
 }
 
 export class HostConfig extends Context.Service<HostConfig, HostConfigShape>()(
@@ -276,6 +283,7 @@ export const makeScopedExecutor = <
       plugins,
       httpClientLayer,
       fetch: hostedFetch,
+      onIntegrationChange: config.onIntegrationChange,
       onElicitation: "accept-all",
       redirectUri,
       oauthCallbackStateOrgSlug: orgSlug,

--- a/packages/core/api/src/services.ts
+++ b/packages/core/api/src/services.ts
@@ -1,4 +1,4 @@
-import { Context } from "effect";
+import { Context, type Effect } from "effect";
 import type * as Cause from "effect/Cause";
 import type { Executor } from "@executor-js/sdk";
 import type { ExecutionEngine } from "@executor-js/execution";
@@ -6,6 +6,23 @@ import type { ExecutionEngine } from "@executor-js/execution";
 export class ExecutorService extends Context.Service<ExecutorService, Executor>()(
   "ExecutorService",
 ) {}
+
+/** A user-meaningful artifact operation on the HTTP plane — the console UI's
+ *  data layer. `viewed` is the detail read (`get`), not `list`; `updated`
+ *  covers both save-overwrite and rename; `setPreview` is a render side
+ *  effect, not a user action, and deliberately absent. */
+export type ArtifactUsageAction = "created" | "viewed" | "updated" | "deleted";
+
+/**
+ * Optional observer for artifact operations served by the artifacts HTTP
+ * handlers. A `Context.Reference` (default null) rather than a required
+ * service: hosts that record product analytics provide one at boot; every
+ * other host — and every test — composes unchanged. Observers are best-effort:
+ * the handlers swallow their failures.
+ */
+export const ArtifactUsageObserver = Context.Reference<
+  ((action: ArtifactUsageAction) => Effect.Effect<void>) | null
+>("@executor-js/api/ArtifactUsageObserver", { defaultValue: () => null });
 
 // Error channel widened to `Cause.YieldableError` so callers that plug
 // in a runtime-specific tagged error (e.g.

--- a/packages/core/sdk/src/executor.test.ts
+++ b/packages/core/sdk/src/executor.test.ts
@@ -180,6 +180,65 @@ describe("createExecutor", () => {
     }),
   );
 
+  it.effect("notifies onIntegrationChange on create and remove, not on re-register", () =>
+    Effect.gen(function* () {
+      const events: Array<{ kind: string; pluginKey: string; slug: string }> = [];
+      const executor = yield* makeTestExecutor({
+        plugins: [demoPlugin] as const,
+        onIntegrationChange: (event) =>
+          Effect.sync(() => {
+            events.push({
+              kind: event.kind,
+              pluginKey: event.pluginKey,
+              slug: String(event.slug),
+            });
+          }),
+      });
+
+      yield* executor.demo.seed();
+      expect(events).toEqual([{ kind: "added", pluginKey: "demo", slug: String(INTEG) }]);
+
+      // Upsert re-register of the same slug is not a durable change.
+      yield* executor.demo.seed();
+      expect(events).toHaveLength(1);
+
+      yield* executor.integrations.remove(INTEG);
+      expect(events).toEqual([
+        { kind: "added", pluginKey: "demo", slug: String(INTEG) },
+        { kind: "removed", pluginKey: "demo", slug: String(INTEG) },
+      ]);
+
+      // Removing an already-absent slug notifies nothing.
+      yield* executor.integrations.remove(INTEG);
+      expect(events).toHaveLength(2);
+    }),
+  );
+
+  it.effect("a failing onIntegrationChange observer never fails the operation", () =>
+    Effect.gen(function* () {
+      const executor = yield* makeTestExecutor({
+        plugins: [demoPlugin] as const,
+        onIntegrationChange: () => Effect.die("observer exploded"),
+      });
+      yield* executor.demo.seed();
+      const integrations = yield* executor.integrations.list();
+      expect(integrations.map((i) => String(i.slug))).toContain(String(INTEG));
+    }),
+  );
+
+  it.effect("a rolled-back transaction never notifies onIntegrationChange", () =>
+    Effect.gen(function* () {
+      const events: string[] = [];
+      const executor = yield* makeTestExecutor({
+        plugins: [demoPlugin] as const,
+        onIntegrationChange: (event) => Effect.sync(() => void events.push(String(event.slug))),
+      });
+      const result = yield* Effect.result(executor.demo.failAfterPluginAndCoreWrites());
+      expect(Result.isFailure(result)).toBe(true);
+      expect(events).not.toContain("tx-integration");
+    }),
+  );
+
   it.effect("projects core tools as the built-in Executor integration", () =>
     Effect.gen(function* () {
       const executor = yield* makeTestExecutor({

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -7,6 +7,7 @@ import { schema as fumaSchema, type RelationsMap } from "@executor-js/fumadb/sch
 import type { AnyColumn } from "@executor-js/fumadb/schema";
 import {
   StorageError,
+  afterCommit,
   isStorageFailure,
   makeFumaClient,
   type FumaDb,
@@ -97,6 +98,7 @@ import {
 import type {
   AuthMethodDescriptor,
   Integration,
+  IntegrationChangeEvent,
   IntegrationConfig,
   IntegrationDisplayDescriptor,
   RegisterIntegrationInput,
@@ -642,6 +644,14 @@ export interface ExecutorConfig<TPlugins extends readonly AnyPlugin[] = readonly
    * config-revision re-sync still apply).
    */
   readonly toolsSyncTtlMs?: number | null;
+  /**
+   * Notified after a durable integration-catalog change commits (a row
+   * created or removed). Best-effort observation only: the notification runs
+   * AFTER the transaction, its failures are swallowed, and it cannot affect
+   * the operation's outcome. Hosts use it for product analytics; core stays
+   * analytics-agnostic.
+   */
+  readonly onIntegrationChange?: (event: IntegrationChangeEvent) => Effect.Effect<void>;
   /**
    * Opt into the PLATFORM VIEW: a read-only, tenant-wide `executor.admin`
    * surface that reads across every subject in the tenant (see
@@ -2191,6 +2201,15 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
         ),
       );
 
+    // Best-effort post-commit notification for `ExecutorConfig.onIntegrationChange`.
+    // Routed through `afterCommit` so the observer sees only DURABLE changes:
+    // when the write ran inside a (possibly plugin-owned outer) transaction the
+    // notification is queued on the outermost commit and discarded on rollback.
+    // Failures and defects are swallowed so a host's analytics can never fail a
+    // catalog write.
+    const notifyIntegrationChange = (event: IntegrationChangeEvent): Effect.Effect<void> =>
+      config.onIntegrationChange ? afterCommit(config.onIntegrationChange(event)) : Effect.void;
+
     const integrationsRegister = (
       pluginId: string,
       input: RegisterIntegrationInput,
@@ -2213,7 +2232,7 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
                 updated_at: now,
               },
             });
-            return;
+            return false;
           }
           yield* core.create("integration", {
             tenant,
@@ -2227,7 +2246,15 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
             created_at: now,
             updated_at: now,
           });
+          return true;
         }),
+      ).pipe(
+        Effect.tap((created) =>
+          created
+            ? notifyIntegrationChange({ kind: "added", pluginKey: pluginId, slug: input.slug })
+            : Effect.void,
+        ),
+        Effect.asVoid,
       );
 
     const integrationsUpdate = (
@@ -2273,7 +2300,7 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
       transaction(
         Effect.gen(function* () {
           const existing = yield* findIntegrationRow(slug);
-          if (!existing) return;
+          if (!existing) return null;
           if (!existing.can_remove) {
             return yield* new IntegrationRemovalNotAllowedError({ slug });
           }
@@ -2298,7 +2325,15 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
           yield* core.deleteMany("integration", {
             where: (b: AnyCb) => b("slug", "=", String(slug)),
           });
+          return existing.plugin_id;
         }),
+      ).pipe(
+        Effect.tap((removedPluginId) =>
+          removedPluginId !== null
+            ? notifyIntegrationChange({ kind: "removed", pluginKey: removedPluginId, slug })
+            : Effect.void,
+        ),
+        Effect.asVoid,
       );
 
     const integrationsDetect = (

--- a/packages/core/sdk/src/fuma-runtime.ts
+++ b/packages/core/sdk/src/fuma-runtime.ts
@@ -91,6 +91,29 @@ export const activeFumaDbRef = Context.Reference<FumaDb | null>("executor/Active
   defaultValue: () => null,
 });
 
+// Post-commit hooks. `transaction()` nests by pass-through (an inner
+// `transaction()` call inside an active transaction just runs its effect), so
+// an effect that must observe only DURABLE changes cannot simply run "after
+// the transaction" — after an inner pass-through the outer transaction may
+// still roll back. `afterCommit` solves this structurally: while a transaction
+// is active the effect is queued on the outermost transaction's hook list and
+// runs after its commit; with no active transaction it runs immediately.
+// Hooks are best-effort observers: failures and defects are swallowed, and a
+// rolled-back transaction discards its queue.
+const pendingCommitHooksRef = Context.Reference<Array<Effect.Effect<void>> | null>(
+  "executor/PendingCommitHooks",
+  { defaultValue: () => null },
+);
+
+export const afterCommit = (effect: Effect.Effect<void>): Effect.Effect<void> =>
+  Effect.flatMap(Effect.service(pendingCommitHooksRef), (hooks) =>
+    hooks
+      ? Effect.sync(() => {
+          hooks.push(effect);
+        })
+      : effect.pipe(Effect.ignoreCause({ log: false })),
+  );
+
 class TransactionEffectFailure {
   constructor(readonly error: unknown) {}
 }
@@ -158,11 +181,18 @@ export const makeFumaClient = (db: FumaDb, options: MakeFumaClientOptions = {}):
     Effect.flatMap(Effect.service(activeFumaDbRef), (active) => {
       if (active) return effect as Effect.Effect<unknown, unknown>;
 
+      // The outermost transaction owns the post-commit hook queue; hooks
+      // queued anywhere inside (including nested pass-through transactions)
+      // run only after THIS commit, and are discarded on rollback.
+      const commitHooks: Array<Effect.Effect<void>> = [];
       return Effect.tryPromise({
         try: () =>
           db.transaction(async (transactionDb) => {
             const exit = await Effect.runPromiseExit(
-              effect.pipe(Effect.provideService(activeFumaDbRef, transactionDb)),
+              effect.pipe(
+                Effect.provideService(activeFumaDbRef, transactionDb),
+                Effect.provideService(pendingCommitHooksRef, commitHooks),
+              ),
             );
             if (Exit.isSuccess(exit)) return exit.value;
 
@@ -179,7 +209,13 @@ export const makeFumaClient = (db: FumaDb, options: MakeFumaClientOptions = {}):
           }
           return fumaFailureFromCause("transaction", cause);
         },
-      });
+      }).pipe(
+        Effect.tap(() =>
+          Effect.forEach(commitHooks, (hook) => hook.pipe(Effect.ignoreCause({ log: false })), {
+            discard: true,
+          }),
+        ),
+      );
     }).pipe(Effect.withSpan("fumadb.transaction")) as Effect.Effect<A, E | StorageFailure>;
 
   return { use, transaction };

--- a/packages/core/sdk/src/index.ts
+++ b/packages/core/sdk/src/index.ts
@@ -85,6 +85,7 @@ export type {
   AuthMethodOAuthDescriptor,
   AuthPlacementDescriptor,
   Integration,
+  IntegrationChangeEvent,
   IntegrationConfig,
   IntegrationDisplayDescriptor,
   RegisterIntegrationInput,

--- a/packages/core/sdk/src/integration.ts
+++ b/packages/core/sdk/src/integration.ts
@@ -152,6 +152,20 @@ export const mergeAuthTemplates = <T extends { readonly slug: string }>(
   return result;
 };
 
+/**
+ * A durable change to the integration catalog, emitted through
+ * `ExecutorConfig.onIntegrationChange`: a row was created (`added` — upsert
+ * re-registers of an existing slug do not fire) or removed. The hook is a
+ * neutral notification seam — hosts decide what to do with it (the non-cloud
+ * hosts feed product analytics); core carries no analytics vocabulary.
+ */
+export interface IntegrationChangeEvent {
+  readonly kind: "added" | "removed";
+  /** The owning plugin's id (`openapi`, `mcp`, `graphql`, ...). */
+  readonly pluginKey: string;
+  readonly slug: IntegrationSlug;
+}
+
 /** What a plugin's extension method passes to `ctx.core.integrations.register`.
  *  The v2 analog of v1's `SourceInput`, minus the per-source tool list (tools are
  *  produced per-connection now). */

--- a/packages/core/sdk/src/test-config.ts
+++ b/packages/core/sdk/src/test-config.ts
@@ -122,6 +122,7 @@ export type TestConfigOptions<TPlugins extends readonly AnyPlugin[] = readonly [
    *  no OAuth callback (exercises the fail-loud redirect path). */
   readonly redirectUri?: string | null;
   readonly oauthCallbackStateOrgSlug?: string;
+  readonly onIntegrationChange?: ExecutorConfig<TPlugins>["onIntegrationChange"];
 };
 
 export const makeTestConfig = <const TPlugins extends readonly AnyPlugin[] = readonly []>(
@@ -159,6 +160,7 @@ export const makeTestConfig = <const TPlugins extends readonly AnyPlugin[] = rea
     testDb,
     // Tests default to auto-accepting elicitation prompts.
     onElicitation: "accept-all",
+    onIntegrationChange: options?.onIntegrationChange,
     ...(redirectUri != null ? { redirectUri } : {}),
     oauthCallbackStateOrgSlug: options?.oauthCallbackStateOrgSlug,
   };

--- a/packages/hosts/mcp/src/artifacts-tools.test.ts
+++ b/packages/hosts/mcp/src/artifacts-tools.test.ts
@@ -1033,6 +1033,63 @@ describe("MCP host — artifact retrieval", () => {
     );
   });
 
+  it("notifies onArtifactUsage: created on new save, updated on overwrite, viewed on show", async () => {
+    const store = makeArtifactStore();
+    const usage: string[] = [];
+    await withClient(
+      makeStubEngine({}),
+      APPS_CAPS,
+      async (client) => {
+        await client.callTool({
+          name: "create-artifact",
+          arguments: { code: COUNTER_CODE, title: "Dashboard" },
+        });
+        expect(usage).toEqual(["created"]);
+
+        await client.callTool({
+          name: "create-artifact",
+          arguments: { code: COUNTER_CODE, title: "Dashboard v2", artifactId: "art_1" },
+        });
+        expect(usage).toEqual(["created", "updated"]);
+
+        await client.callTool({ name: "show-artifact", arguments: { id: "art_1" } });
+        expect(usage).toEqual(["created", "updated", "viewed"]);
+
+        // A miss is not a view.
+        await client.callTool({ name: "show-artifact", arguments: { id: "art_missing" } });
+        expect(usage).toEqual(["created", "updated", "viewed"]);
+
+        // Listing is not a view either.
+        await client.callTool({ name: "list-artifacts", arguments: {} });
+        expect(usage).toEqual(["created", "updated", "viewed"]);
+      },
+      {
+        artifacts: store.port,
+        onArtifactUsage: (action) => Effect.sync(() => void usage.push(action)),
+      },
+    );
+  });
+
+  it("a failing onArtifactUsage observer never fails the tool", async () => {
+    const store = makeArtifactStore();
+    await withClient(
+      makeStubEngine({}),
+      APPS_CAPS,
+      async (client) => {
+        const result = await client.callTool({
+          name: "create-artifact",
+          arguments: { code: COUNTER_CODE, title: "Dashboard" },
+        });
+        expect(result.isError).toBeFalsy();
+        expect(structuredOf(result)).toEqual({ code: COUNTER_CODE, artifactId: "art_1" });
+      },
+      {
+        artifacts: store.port,
+        onArtifactUsage: () => Effect.die("observer exploded"),
+      },
+    );
+  });
+
   it("delivers a saved artifact as a deep link to clients without apps support", async () => {
     const store = makeArtifactStore();
     await Effect.runPromise(

--- a/packages/hosts/mcp/src/tool-server.ts
+++ b/packages/hosts/mcp/src/tool-server.ts
@@ -202,6 +202,15 @@ type SharedMcpServerConfig = {
    * has no URL to offer.
    */
   readonly artifactUrl?: (artifactId: string) => string;
+  /**
+   * Notified when an agent-facing artifact tool completes a user-meaningful
+   * operation: `create-artifact` (created, or updated when it overwrote an
+   * existing id) and `show-artifact` (viewed). Internal artifact reads —
+   * binding resolution inside `execute-action` — deliberately do not notify.
+   * Best-effort observation: failures are swallowed and cannot affect the tool
+   * result. Hosts recording product analytics supply it; core stays agnostic.
+   */
+  readonly onArtifactUsage?: (action: "created" | "viewed" | "updated") => Effect.Effect<void>;
 };
 
 /**
@@ -1501,6 +1510,12 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
     let executeActionTool: { enable: () => void; disable: () => void } | undefined;
     let executeActionResumeTool: { enable: () => void; disable: () => void } | undefined;
 
+    // Best-effort usage observation; a failing observer never affects the tool.
+    const notifyArtifactUsage = (action: "created" | "viewed" | "updated"): Effect.Effect<void> =>
+      config.onArtifactUsage
+        ? config.onArtifactUsage(action).pipe(Effect.ignoreCause({ log: false }))
+        : Effect.void;
+
     const saveAndDeliverArtifact = (input: {
       readonly code: string;
       readonly title: string;
@@ -1520,6 +1535,7 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
           ...(input.bindings === undefined ? {} : { bindings: input.bindings }),
           preview: input.preview ?? null,
         });
+        yield* notifyArtifactUsage(input.existingId === undefined ? "created" : "updated");
         yield* Effect.annotateCurrentSpan({
           "mcp.artifact.id": saved.id,
           "mcp.artifact.apps_enabled": appsEnabled,
@@ -1689,6 +1705,7 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
           .get(id)
           .pipe(Effect.catchCause(() => Effect.succeed(null)));
         if (!artifact) return artifactNotFoundResult(id);
+        yield* notifyArtifactUsage("viewed");
         return deliverArtifact({
           code: artifact.code,
           artifactId: artifact.id,


### PR DESCRIPTION
Won't be released w/out a proper announcement, respects DO_NOT_TRACK / opt out but the goal is to understand how people are using the product

Tracking metadata, not things like what integrations people are adding
