### PR TITLE
Drop the definition.name narrowing from the artifact migration

### DIFF
--- a/.changeset/lucky-hats-attack.md
+++ b/.changeset/lucky-hats-attack.md
@@ -1,0 +1,5 @@
+---
+"executor": patch
+---
+
+**Fix: the artifact migration no longer narrows `definition.name` to varchar(255), which failed on existing long definition names**

--- a/apps/cloud/drizzle/0013_curly_rocket_racer.sql
+++ b/apps/cloud/drizzle/0013_curly_rocket_racer.sql
@@ -11,5 +11,4 @@ CREATE TABLE "artifact" (
 	"subject" varchar(255) NOT NULL
 );
 --> statement-breakpoint
-ALTER TABLE "definition" ALTER COLUMN "name" SET DATA TYPE varchar(255);--> statement-breakpoint
 CREATE UNIQUE INDEX "artifact_uidx" ON "artifact" USING btree ("tenant","owner","subject","id");

--- a/apps/cloud/drizzle/meta/0013_snapshot.json
+++ b/apps/cloud/drizzle/meta/0013_snapshot.json
@@ -515,7 +515,7 @@
         },
         "name": {
           "name": "name",
-          "type": "varchar(255)",
+          "type": "text",
           "primaryKey": false,
           "notNull": true
         },

--- a/apps/cloud/drizzle/meta/0014_snapshot.json
+++ b/apps/cloud/drizzle/meta/0014_snapshot.json
@@ -521,7 +521,7 @@
         },
         "name": {
           "name": "name",
-          "type": "varchar(255)",
+          "type": "text",
           "primaryKey": false,
           "notNull": true
         },

--- a/apps/cloud/drizzle/meta/0015_snapshot.json
+++ b/apps/cloud/drizzle/meta/0015_snapshot.json
@@ -527,7 +527,7 @@
         },
         "name": {
           "name": "name",
-          "type": "varchar(255)",
+          "type": "text",
           "primaryKey": false,
           "notNull": true
         },

--- a/apps/cloud/src/db/executor-schema.ts
+++ b/apps/cloud/src/db/executor-schema.ts
@@ -181,7 +181,7 @@ export const definition = pgTable(
     integration: varchar("integration", { length: 255 }).notNull(),
     connection: varchar("connection", { length: 255 }).notNull(),
     plugin_id: text("plugin_id").notNull(),
-    name: varchar("name", { length: 255 }).notNull(),
+    name: text("name").notNull(),
     schema: json("schema").notNull(),
     created_at: timestamp("created_at").notNull(),
     row_id: varchar("row_id", { length: 255 })

--- a/packages/core/sdk/src/core-schema.ts
+++ b/packages/core/sdk/src/core-schema.ts
@@ -336,7 +336,12 @@ export const coreTables = defineTables({
       integration: keyColumn("integration"),
       connection: keyColumn("connection"),
       plugin_id: textColumn("plugin_id"),
-      name: keyColumn("name"),
+      // text, NOT keyColumn: $def names exceed 255 chars in production (deep
+      // OpenAPI component paths), and the live cloud column has been TEXT
+      // since the baseline was patched for it. A varchar(255) here re-emits a
+      // narrowing ALTER on every drizzle-kit generate, which fails on real
+      // rows (22001) — that drift broke cloud migration 0013 once already.
+      name: textColumn("name"),
       schema: jsonColumn("schema"),
       created_at: dateColumn("created_at"),
     },


### PR DESCRIPTION
Main's Deploy has been red since #1472: migration 0013 includes `ALTER TABLE "definition" ALTER COLUMN "name" SET DATA TYPE varchar(255)`, and production has definition names longer than 255 chars, so the migration fails with 22001 and rolls back — 0013–0015 never applied, the `artifact` table doesn't exist in prod, and Deploy cloud is skipped on every push (prod is still running pre-#1472 code).

The ALTER is schema drift resurfacing, not an intentional change. `definition.name` was widened to `text` in June ("Allow long definition names in cloud schema", dd7aaf601) because $def names exceed 255, but only the baseline SQL/snapshot was patched — the fumadb source (`core-schema.ts`) kept `keyColumn` → varchar(255). #1251 hit the same drift and hand-dropped the ALTER from its migration; #1472's `drizzle-kit generate` diffed snapshot (`text`) against schema (`varchar(255)`) and faithfully re-emitted the narrowing.

This ends the drift at the source:

- `core-schema.ts`: `definition.name` is now `textColumn`, with a comment explaining why it must never go back to `keyColumn`. `executor-schema.ts` regenerated via `db:schema` (only that one line changes).
- 0013: the narrowing ALTER removed. Editing it in place is safe — it was never stamped anywhere durable (prod rolled back atomically; the release containing it is unpublished; dev/e2e DBs are ephemeral).
- 0013–0015 snapshots: `definition.name` corrected to `text` so future generates diff against reality. `drizzle-kit generate` now reports no changes.

Invariants and failure states considered:

- Prod (column already `text`, rows > 255 chars, journal at 0012): fixed 0013–0015 apply cleanly; verified against PGlite seeded with a 400-char name — migrates, `artifact` created, `name` stays `text`.
- Fresh database (0000→0015): verified clean; baseline creates `name text`, nothing alters it after.
- No data-shape change for readers: the live column type is unchanged everywhere; this only stops a failing narrowing from being applied.
- Portability: the varchar(255) convention exists for MySQL index-prefix limits, but no host ships MySQL (cloud is Postgres, local/desktop are SQLite where varchar is text anyway), and the live tables have indexed `text` since June — the source now records that reality.

Once merged, the Migrate job should stamp 0013–0015 and unblock Deploy cloud (which also needs Cloudflare's "Errors Deploying Workers Scripts" incident resolved).