### PR TITLE
Keep MCP-Apps rendering across a cold session restore

### DIFF
--- a/apps/cloud/src/mcp/session-durable-object.ts
+++ b/apps/cloud/src/mcp/session-durable-object.ts
@@ -280,6 +280,10 @@ export class McpSessionDOSqlite extends McpAgentSessionDOBase<Env, CloudSessionD
         // flag existed carry no value; absent now means off, same as a fresh
         // connection that did not ask for `?artifacts=true`.
         artifactsEnabled: sessionMeta.artifactsEnabled ?? false,
+        // Cold restores rebuild this server with no `initialize` to replay, so
+        // the negotiated apps support comes back from storage instead.
+        restoredAppsEnabled: sessionMeta.appsEnabled ?? false,
+        onAppsEnabledChange: (appsEnabled) => self.persistAppsEnabled(appsEnabled),
         loadAppShellHtml,
         smokeRenderArtifact,
         artifactUrl: artifactUrlFor(

--- a/apps/host-cloudflare/src/mcp/session-durable-object.ts
+++ b/apps/host-cloudflare/src/mcp/session-durable-object.ts
@@ -149,6 +149,10 @@ export class McpSessionDO extends McpAgentSessionDOBase<CloudflareEnv, CfSession
         // flag existed carry no value; absent now means off, same as a fresh
         // connection that did not ask for `?artifacts=true`.
         artifactsEnabled: sessionMeta.artifactsEnabled ?? false,
+        // Cold restores rebuild this server with no `initialize` to replay, so
+        // the negotiated apps support comes back from storage instead.
+        restoredAppsEnabled: sessionMeta.appsEnabled ?? false,
+        onAppsEnabledChange: (appsEnabled) => self.persistAppsEnabled(appsEnabled),
         loadAppShellHtml: self.loadAppShellHtml,
         smokeRenderArtifact,
         ...(artifactOrigin

--- a/packages/hosts/cloudflare/src/mcp/agent-session-durable-object.test.ts
+++ b/packages/hosts/cloudflare/src/mcp/agent-session-durable-object.test.ts
@@ -216,6 +216,96 @@ const makeHarnessSession = async (): Promise<HarnessSession> => {
   return session;
 };
 
+// The negotiated MCP-Apps capability arrives once, at `initialize`, and lives
+// in the rebuilt server's memory. These pin the storage round-trip that lets a
+// cold-restored session rebuild with it instead of silently downgrading every
+// artifact to a deep link.
+describe("McpAgentSessionDOBase apps capability persistence", () => {
+  type CapabilitySession = HarnessSession & {
+    persistAppsEnabled: (appsEnabled: boolean) => Effect.Effect<void>;
+    loadSessionMeta: () => Effect.Effect<SessionMeta | null>;
+    resolveSessionMeta: (token: unknown) => Effect.Effect<SessionMeta>;
+    resolveAndStoreSessionMeta: (token: unknown) => Effect.Effect<SessionMeta>;
+  };
+
+  const baseMeta: SessionMeta = {
+    organizationId: "org-1",
+    organizationName: "Org 1",
+    userId: "user-1",
+    resource: defaultMcpResource,
+  };
+
+  const makeCapabilitySession = async (
+    stored: SessionMeta = baseMeta,
+  ): Promise<{ session: CapabilitySession; storage: MemoryStorage }> => {
+    const storage = new MemoryStorage();
+    await storage.put("session-meta", stored);
+    const session = Object.create(McpAgentSessionDOBase.prototype) as CapabilitySession;
+    session.ctx = storage;
+    session.getSessionId = () => "session-caps";
+    return { session, storage };
+  };
+
+  it("persists the negotiated capability so a later restore can read it back", async () => {
+    const { session, storage } = await makeCapabilitySession();
+
+    await Effect.runPromise(session.persistAppsEnabled(true));
+
+    expect(await storage.get<SessionMeta>("session-meta")).toMatchObject({
+      organizationId: "org-1",
+      appsEnabled: true,
+    });
+  });
+
+  it("records a client that loses apps support just as durably", async () => {
+    const { session, storage } = await makeCapabilitySession({ ...baseMeta, appsEnabled: true });
+
+    await Effect.runPromise(session.persistAppsEnabled(false));
+
+    expect(await storage.get<SessionMeta>("session-meta")).toMatchObject({ appsEnabled: false });
+  });
+
+  // `init` runs again on every cold restore and rebuilds meta from the bearer
+  // token, which carries no capabilities. If that overwrite won, restoring the
+  // session would erase the very bit meant to survive it.
+  it("carries the stored capability through the re-resolve on cold restore", async () => {
+    const { session, storage } = await makeCapabilitySession({ ...baseMeta, appsEnabled: true });
+    // What the token resolves to: no `appsEnabled` anywhere in sight.
+    session.resolveSessionMeta = () => Effect.succeed(baseMeta);
+
+    const resolved = await Effect.runPromise(
+      session.resolveAndStoreSessionMeta({ organizationId: "org-1", userId: "user-1" }),
+    );
+
+    expect(resolved.appsEnabled).toBe(true);
+    expect(await storage.get<SessionMeta>("session-meta")).toMatchObject({ appsEnabled: true });
+  });
+
+  it("leaves a session with no negotiated capability untouched", async () => {
+    const { session, storage } = await makeCapabilitySession();
+    session.resolveSessionMeta = () => Effect.succeed(baseMeta);
+
+    const resolved = await Effect.runPromise(
+      session.resolveAndStoreSessionMeta({ organizationId: "org-1", userId: "user-1" }),
+    );
+
+    expect(resolved.appsEnabled).toBeUndefined();
+    expect(await storage.get<SessionMeta>("session-meta")).not.toHaveProperty("appsEnabled");
+  });
+
+  // Persistence is best-effort observation of a capability, never a reason to
+  // fail the session that was merely trying to render something.
+  it("stays silent when there is no stored meta to merge into", async () => {
+    const storage = new MemoryStorage();
+    const session = Object.create(McpAgentSessionDOBase.prototype) as CapabilitySession;
+    session.ctx = storage;
+    session.getSessionId = () => "session-caps";
+
+    await expect(Effect.runPromise(session.persistAppsEnabled(true))).resolves.toBeUndefined();
+    expect(await storage.get<SessionMeta>("session-meta")).toBeUndefined();
+  });
+});
+
 describe("McpAgentSessionDOBase transport restore", () => {
   it("restores a same-session request after idle disposal leaves a stale server transport", async () => {
     const session = await makeHarnessSession();

--- a/packages/hosts/cloudflare/src/mcp/agent-session-durable-object.ts
+++ b/packages/hosts/cloudflare/src/mcp/agent-session-durable-object.ts
@@ -109,6 +109,17 @@ export interface SessionMeta {
    *  `buildMcpServer` scopes the tool catalog to it. */
   readonly resource: McpResource;
   readonly webOrigin?: string;
+  /**
+   * Whether this session's client advertised MCP-Apps support at `initialize`.
+   *
+   * Capabilities are negotiated once, into the server instance's memory. When
+   * the DO is evicted (deploy, idle) and a later request cold-restores it, the
+   * rebuilt server never sees an `initialize` — so without persisting this, an
+   * apps-capable client silently drops to artifact deep links mid-conversation.
+   * Absent — including for sessions persisted before this field existed — means
+   * unknown, which behaves as disabled until the next `initialize`.
+   */
+  readonly appsEnabled?: boolean;
 }
 
 export interface BuiltMcpServer {
@@ -355,6 +366,28 @@ export abstract class McpAgentSessionDOBase<
     await this.ctx.storage.put(SESSION_META_KEY, sessionMeta);
   }
 
+  /**
+   * Persist the MCP-Apps support negotiated at `initialize`, so a later cold
+   * restore can rebuild the server with it. Subclasses hand this to
+   * `createExecutorMcpServer` as `onAppsEnabledChange`.
+   *
+   * A no-op before meta exists: `initialize` always follows `init`, so there is
+   * nothing to merge into and nothing worth failing the session over.
+   */
+  protected persistAppsEnabled(appsEnabled: boolean): Effect.Effect<void> {
+    const self = this;
+    return Effect.gen(function* () {
+      const stored = yield* self.loadSessionMeta();
+      if (!stored || stored.appsEnabled === appsEnabled) return;
+      yield* Effect.promise(() => self.saveSessionMeta({ ...stored, appsEnabled }));
+    }).pipe(
+      Effect.withSpan("mcp.session.persist_apps_enabled", {
+        attributes: { "mcp.artifact.apps_enabled": appsEnabled },
+      }),
+      Effect.ignoreCause({ log: false }),
+    );
+  }
+
   private async markActivity(now = Date.now()): Promise<void> {
     this.lastActivityMs = now;
     await Promise.all([
@@ -466,9 +499,15 @@ export abstract class McpAgentSessionDOBase<
     const self = this;
     return Effect.gen(function* () {
       const resolved = yield* self.resolveSessionMeta(token);
+      // `init` runs again on every cold restore, and `resolveSessionMeta`
+      // rebuilds meta from the bearer token — which carries no negotiated
+      // capabilities. Carry the stored value forward, or restoring the session
+      // would erase the very bit that survives the restore.
+      const stored = yield* self.loadSessionMeta();
       const sessionMeta: SessionMeta = {
         ...resolved,
         ...(token.webOrigin ? { webOrigin: token.webOrigin } : {}),
+        ...(stored?.appsEnabled === undefined ? {} : { appsEnabled: stored.appsEnabled }),
       };
       yield* Effect.promise(() => self.saveSessionMeta(sessionMeta)).pipe(
         Effect.withSpan("mcp.session.save_meta"),

--- a/packages/hosts/mcp/src/artifacts-tools.test.ts
+++ b/packages/hosts/mcp/src/artifacts-tools.test.ts
@@ -292,6 +292,81 @@ describe("MCP host — artifact tool visibility", () => {
     await serverTransport.close();
   });
 
+  // The restore path the `agents` runtime actually takes, and the one that
+  // reached production. On cold restore it replays the PERSISTED `initialize`
+  // REQUEST (`reinitializeServer`), which does re-establish the server's client
+  // capabilities — but it never replays the `notifications/initialized`
+  // NOTIFICATION, and `oninitialized` (the only hook that re-runs
+  // `syncToolAvailability`) fires solely on that notification. So the rebuilt
+  // server holds full apps capabilities while nothing re-reads them, and the
+  // replay is dispatched un-awaited, so a tool call can also land ahead of it.
+  //
+  // Both orderings are covered here: capabilities present but no hook, and a
+  // tool call dispatched before the replay arrives at all.
+  it("renders inline on a restore that replays initialize without the initialized notification", async () => {
+    const store = makeArtifactStore();
+    const mcpServer = await Effect.runPromise(
+      createExecutorMcpServer({
+        engine: makeStubEngine({}),
+        artifacts: store.port,
+        artifactsEnabled: true,
+        loadAppShellHtml: () => Promise.resolve(SHELL_HTML),
+        // Nothing persisted: the capability must come from the replay alone, so
+        // a passing assertion cannot be coming from the seed.
+        restoredAppsEnabled: false,
+        artifactUrl: artifactUrlFor("https://executor.test"),
+      }),
+    );
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await mcpServer.connect(serverTransport);
+
+    const responses = new Map<string | number, Record<string, unknown>>();
+    clientTransport.onmessage = (message) => {
+      const envelope = message as { id?: string | number; result?: Record<string, unknown> };
+      if (envelope.id !== undefined && envelope.result) responses.set(envelope.id, envelope.result);
+    };
+    await clientTransport.start();
+
+    // Exactly what `agents/mcp` replays: the initialize request under its
+    // restore sentinel id, and no `notifications/initialized` after it.
+    await clientTransport.send({
+      jsonrpc: "2.0",
+      id: "__worker_transport_restore__",
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-06-18",
+        capabilities: APPS_CAPS,
+        clientInfo: { name: "ClaudeAI", version: "1.0.0" },
+      },
+    } as never);
+    await vi.waitFor(() =>
+      expect(mcpServer.server.getClientCapabilities()).toMatchObject(APPS_CAPS),
+    );
+
+    const call = async (id: number, method: string, params: Record<string, unknown>) => {
+      await clientTransport.send({ jsonrpc: "2.0", id, method, params });
+      await vi.waitFor(() => expect(responses.has(id)).toBe(true));
+      return responses.get(id) ?? {};
+    };
+
+    const created = (await call(1, "tools/call", {
+      name: "create-artifact",
+      arguments: { code: COUNTER_CODE, title: "Active users dashboard" },
+    })) as { structuredContent?: Record<string, unknown> };
+    expect(created.structuredContent).toEqual({ code: COUNTER_CODE, artifactId: "art_1" });
+    expect(created.structuredContent).not.toHaveProperty("status", "fallback_url");
+
+    // The widget is useless if it cannot call back in, so visibility has to
+    // reconcile on the same restore.
+    const listed = (await call(2, "tools/list", {})) as { tools: Array<{ name: string }> };
+    const names = listed.tools.map((tool) => tool.name);
+    expect(names).toContain("execute-action");
+    expect(names).toContain("execute-action-resume");
+
+    await clientTransport.close();
+    await serverTransport.close();
+  });
+
   it("still falls back to a deep link when the restored session had no apps support", async () => {
     const store = makeArtifactStore();
     await withClient(

--- a/packages/hosts/mcp/src/artifacts-tools.test.ts
+++ b/packages/hosts/mcp/src/artifacts-tools.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "@effect/vitest";
+import { describe, expect, it, vi } from "@effect/vitest";
 import { Data, Effect } from "effect";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
@@ -234,6 +234,147 @@ describe("MCP host — artifact tool visibility", () => {
       },
       { artifacts: store.port },
     );
+  });
+
+  // A cold restore (deploy, DO eviction) rebuilds the server mid-conversation
+  // on the same session id, and the client — already past `initialize` — never
+  // sends another one. Everything the rebuilt server knows about the client's
+  // capabilities has to come from what the host persisted.
+  it("keeps the app-only tools visible on a cold restore that replays no initialize", async () => {
+    const store = makeArtifactStore();
+    const mcpServer = await Effect.runPromise(
+      createExecutorMcpServer({
+        engine: makeStubEngine({}),
+        artifacts: store.port,
+        artifactsEnabled: true,
+        loadAppShellHtml: () => Promise.resolve(SHELL_HTML),
+        // What the host read back out of DO storage for this session.
+        restoredAppsEnabled: true,
+      }),
+    );
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await mcpServer.connect(serverTransport);
+    // Deliberately NOT an SDK `Client`: `client.connect()` always sends
+    // `initialize`, which is the one thing a cold restore never replays. The
+    // client is mid-conversation and just keeps issuing calls against the same
+    // mcp-session-id, so this drives raw JSON-RPC over the transport.
+    const responses = new Map<number, Record<string, unknown>>();
+    clientTransport.onmessage = (message) => {
+      const envelope = message as { id?: number; result?: Record<string, unknown> };
+      if (typeof envelope.id === "number" && envelope.result) {
+        responses.set(envelope.id, envelope.result);
+      }
+    };
+    await clientTransport.start();
+    const call = async (id: number, method: string, params: Record<string, unknown>) => {
+      await clientTransport.send({ jsonrpc: "2.0", id, method, params });
+      await vi.waitFor(() => expect(responses.has(id)).toBe(true));
+      return responses.get(id) ?? {};
+    };
+
+    const listed = (await call(1, "tools/list", {})) as {
+      tools: Array<{ name: string }>;
+    };
+    const names = listed.tools.map((tool) => tool.name);
+    expect(names).toContain("execute-action");
+    expect(names).toContain("execute-action-resume");
+
+    // The render path is the symptom that took this to production: the same
+    // session rendered inline before the restore and a deep link after.
+    const created = (await call(2, "tools/call", {
+      name: "create-artifact",
+      arguments: { code: COUNTER_CODE, title: "Active users dashboard" },
+    })) as { structuredContent?: Record<string, unknown> };
+    expect(created.structuredContent).toEqual({ code: COUNTER_CODE, artifactId: "art_1" });
+    expect(created.structuredContent).not.toHaveProperty("status", "fallback_url");
+
+    await clientTransport.close();
+    await serverTransport.close();
+  });
+
+  it("still falls back to a deep link when the restored session had no apps support", async () => {
+    const store = makeArtifactStore();
+    await withClient(
+      makeStubEngine({}),
+      NO_APPS_CAPS,
+      async (client) => {
+        const result = await client.callTool({
+          name: "create-artifact",
+          arguments: { code: COUNTER_CODE, title: "Active users dashboard" },
+        });
+        expect(structuredOf(result)).toEqual({
+          status: "fallback_url",
+          url: "https://executor.test/artifacts/art_1",
+          artifactId: "art_1",
+        });
+      },
+      {
+        artifacts: store.port,
+        restoredAppsEnabled: false,
+        artifactUrl: artifactUrlFor("https://executor.test"),
+      },
+    );
+  });
+
+  // The restored value seeds the session; it must never outrank the client in
+  // front of you. A client that reconnects without apps support gets the
+  // fallback, restored bit or not.
+  it("lets a real initialize overrule the restored value in both directions", async () => {
+    const store = makeArtifactStore();
+    await withClient(
+      makeStubEngine({}),
+      NO_APPS_CAPS,
+      async (client) => {
+        const names = await toolNames(client);
+        expect(names).not.toContain("execute-action");
+        const result = await client.callTool({
+          name: "create-artifact",
+          arguments: { code: COUNTER_CODE, title: "Active users dashboard" },
+        });
+        expect(structuredOf(result)).toMatchObject({ status: "fallback_url" });
+      },
+      {
+        artifacts: store.port,
+        restoredAppsEnabled: true,
+        artifactUrl: artifactUrlFor("https://executor.test"),
+      },
+    );
+  });
+
+  it("reports the negotiated value to the host so the next restore can seed itself", async () => {
+    const store = makeArtifactStore();
+    const seen: boolean[] = [];
+    await withClient(
+      makeStubEngine({}),
+      APPS_CAPS,
+      async (client) => {
+        await toolNames(client);
+      },
+      {
+        artifacts: store.port,
+        restoredAppsEnabled: false,
+        onAppsEnabledChange: (appsEnabled) => Effect.sync(() => void seen.push(appsEnabled)),
+      },
+    );
+    expect(seen).toEqual([true]);
+  });
+
+  it("does not re-persist when initialize confirms the restored value", async () => {
+    const store = makeArtifactStore();
+    const seen: boolean[] = [];
+    await withClient(
+      makeStubEngine({}),
+      APPS_CAPS,
+      async (client) => {
+        await toolNames(client);
+      },
+      {
+        artifacts: store.port,
+        restoredAppsEnabled: true,
+        onAppsEnabledChange: (appsEnabled) => Effect.sync(() => void seen.push(appsEnabled)),
+      },
+    );
+    expect(seen).toEqual([]);
   });
 
   it("registers no ui tools at all when no shell loader is configured", async () => {

--- a/packages/hosts/mcp/src/tool-server.ts
+++ b/packages/hosts/mcp/src/tool-server.ts
@@ -211,6 +211,25 @@ type SharedMcpServerConfig = {
    * result. Hosts recording product analytics supply it; core stays agnostic.
    */
   readonly onArtifactUsage?: (action: "created" | "viewed" | "updated") => Effect.Effect<void>;
+  /**
+   * Whether the client this session belongs to can render MCP Apps, as
+   * negotiated at a previous `initialize`.
+   *
+   * Capabilities normally arrive from the client at `initialize` and live only
+   * in the server instance. A session whose host evicted and cold-restored it
+   * (deploy, idle) is rebuilt mid-conversation with no `initialize` to replay,
+   * so without this the rebuilt server assumes no apps support and silently
+   * downgrades every artifact to a deep link. Hosts that persist the
+   * negotiated value pass it back here; the next `initialize`, if one comes,
+   * overwrites it.
+   */
+  readonly restoredAppsEnabled?: boolean;
+  /**
+   * Called when `initialize` negotiates the client's MCP-Apps support, so the
+   * host can persist it for {@link restoredAppsEnabled} on a later cold
+   * restore. Best-effort: failures are swallowed and never affect the session.
+   */
+  readonly onAppsEnabledChange?: (appsEnabled: boolean) => Effect.Effect<void>;
 };
 
 /**
@@ -1505,8 +1524,11 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
     const artifacts = config.artifacts;
 
     // Set from the client's advertised capabilities at `initialize`. Read by
-    // the render handlers to choose inline widget vs. deep link.
-    let appsEnabled = false;
+    // the render handlers to choose inline widget vs. deep link. Seeded from
+    // the host's persisted value so a cold-restored session — rebuilt with no
+    // `initialize` to replay — keeps rendering inline for a client that had
+    // already negotiated apps support.
+    let appsEnabled = config.restoredAppsEnabled ?? false;
     let executeActionTool: { enable: () => void; disable: () => void } | undefined;
     let executeActionResumeTool: { enable: () => void; disable: () => void } | undefined;
 
@@ -1921,7 +1943,28 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
           | (ClientCapabilities & { extensions?: Record<string, unknown> })
           | null,
       );
-      appsEnabled = Boolean(uiCapability?.mimeTypes?.includes(RESOURCE_MIME_TYPE));
+      // Absent capabilities (the SDK returns `undefined`) mean `initialize`
+      // hasn't happened on THIS server instance — the construction-time call
+      // below, or a cold restore that resumed mid-conversation. Neither is
+      // evidence the client lost apps support, so the restored value stands
+      // until a real `initialize` replaces it. Reading `false` off an absent
+      // value here is exactly what made a cold-restored session fall back to
+      // deep links.
+      const negotiated = clientCapabilities
+        ? Boolean(uiCapability?.mimeTypes?.includes(RESOURCE_MIME_TYPE))
+        : appsEnabled;
+      const changed = negotiated !== appsEnabled;
+      appsEnabled = negotiated;
+
+      // Persist only a real negotiation that moved the value, so the next cold
+      // restore seeds itself. Best-effort: the session must not fail on it.
+      const onAppsEnabledChange = config.onAppsEnabledChange;
+      if (clientCapabilities && changed && onAppsEnabledChange) {
+        // oxlint-disable-next-line executor/no-effect-escape-hatch -- boundary: `oninitialized` is a sync SDK hook; persistence is fire-and-forget and its failure must not fail the session
+        void Effect.runPromiseWith(context)(
+          onAppsEnabledChange(negotiated).pipe(Effect.ignoreCause({ log: false })),
+        );
+      }
 
       // `execute-action` is only callable from inside a rendered app, so a
       // client that can't render one should never see it. `create-artifact`,

--- a/packages/hosts/mcp/src/tool-server.ts
+++ b/packages/hosts/mcp/src/tool-server.ts
@@ -1525,12 +1525,34 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
 
     // Set from the client's advertised capabilities at `initialize`. Read by
     // the render handlers to choose inline widget vs. deep link. Seeded from
-    // the host's persisted value so a cold-restored session — rebuilt with no
-    // `initialize` to replay — keeps rendering inline for a client that had
-    // already negotiated apps support.
+    // the host's persisted value so a cold-restored session keeps rendering
+    // inline for a client that had already negotiated apps support.
+    //
+    // This is a cache, not the source of truth: `appsSupported()` below reads
+    // the live server on every render, because a cold restore re-establishes
+    // capabilities without ever running the hook that maintains this variable.
     let appsEnabled = config.restoredAppsEnabled ?? false;
     let executeActionTool: { enable: () => void; disable: () => void } | undefined;
     let executeActionResumeTool: { enable: () => void; disable: () => void } | undefined;
+
+    /**
+     * Move the cached flag and the app-only tools together.
+     *
+     * `execute-action` is only callable from inside a rendered app, so a client
+     * that can't render one should never see it. `create-artifact`,
+     * `list-artifacts` and `show-artifact` stay visible regardless: they still
+     * persist, and still return something useful (a deep link).
+     */
+    const applyAppsEnabled = (next: boolean): void => {
+      appsEnabled = next;
+      if (next) {
+        executeActionTool?.enable();
+        executeActionResumeTool?.enable();
+      } else {
+        executeActionTool?.disable();
+        executeActionResumeTool?.disable();
+      }
+    };
 
     // Best-effort usage observation; a failing observer never affects the tool.
     const notifyArtifactUsage = (action: "created" | "viewed" | "updated"): Effect.Effect<void> =>
@@ -1558,19 +1580,56 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
           preview: input.preview ?? null,
         });
         yield* notifyArtifactUsage(input.existingId === undefined ? "created" : "updated");
+        // Resolve once and report the value actually used, so the span can
+        // never disagree with what the client received.
+        const delivered = deliverArtifact({
+          code: saved.code,
+          artifactId: saved.id,
+          title: saved.title,
+        });
         yield* Effect.annotateCurrentSpan({
           "mcp.artifact.id": saved.id,
           "mcp.artifact.apps_enabled": appsEnabled,
         });
-        return deliverArtifact({ code: saved.code, artifactId: saved.id, title: saved.title });
+        return delivered;
       });
+
+    /**
+     * Whether the client can render an app, resolved at render time.
+     *
+     * `appsEnabled` alone is not enough. On a cold restore the host replays the
+     * persisted `initialize` *request* — which does set the server's client
+     * capabilities — but never the `notifications/initialized` notification,
+     * and `oninitialized` (the only hook that re-runs `syncToolAvailability`)
+     * fires solely on that notification. So a restored session can hold full
+     * apps capabilities while `appsEnabled` still reads its seeded value, and
+     * the replay is dispatched un-awaited, so a tool call can land before it.
+     *
+     * Reading the live server here makes both orderings produce the same
+     * answer, and keeps the seeded value as the fallback for the window before
+     * any capabilities exist.
+     */
+    const appsSupported = (): boolean => {
+      const live = server.server.getClientCapabilities();
+      if (!live) return appsEnabled;
+      const uiCapability = getUiCapability(
+        live as ClientCapabilities & { extensions?: Record<string, unknown> },
+      );
+      const supported = Boolean(uiCapability?.mimeTypes?.includes(RESOURCE_MIME_TYPE));
+      // Reconcile the tools too: a restore that re-established capabilities
+      // without firing `oninitialized` would otherwise render inline while
+      // `execute-action` — the tool that rendered app calls back into — stayed
+      // hidden, leaving the widget unable to do anything.
+      if (supported !== appsEnabled) applyAppsEnabled(supported);
+      return supported;
+    };
 
     const deliverArtifact = (input: {
       readonly code: string;
       readonly artifactId: string;
       readonly title: string;
     }): McpToolResult => {
-      if (appsEnabled) return renderedInAppResult(input);
+      if (appsSupported()) return renderedInAppResult(input);
       const url = config.artifactUrl?.(input.artifactId);
       return url
         ? renderedAsLinkResult({ url, artifactId: input.artifactId, title: input.title })
@@ -1936,6 +1995,11 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
     // answered from whatever is registered at that moment — so app-only tool
     // visibility has to be re-synced from the `oninitialized` hook rather than
     // decided at construction.
+    //
+    // This hook covers live clients only. It does NOT run on a cold restore:
+    // the host replays the persisted `initialize` request, but `oninitialized`
+    // fires on the `notifications/initialized` notification, which is never
+    // persisted. `appsSupported()` is what makes the restored case correct.
     const syncToolAvailability = () => {
       const clientCapabilities = server.server.getClientCapabilities();
       const uiCapability = getUiCapability(
@@ -1954,28 +2018,19 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
         ? Boolean(uiCapability?.mimeTypes?.includes(RESOURCE_MIME_TYPE))
         : appsEnabled;
       const changed = negotiated !== appsEnabled;
-      appsEnabled = negotiated;
+      applyAppsEnabled(negotiated);
 
       // Persist only a real negotiation that moved the value, so the next cold
       // restore seeds itself. Best-effort: the session must not fail on it.
+      // The `clientCapabilities` guard matters beyond skipping a no-op write:
+      // persisting an absent-capability reading would make a downgrade durable
+      // for every future restore of the session.
       const onAppsEnabledChange = config.onAppsEnabledChange;
       if (clientCapabilities && changed && onAppsEnabledChange) {
         // oxlint-disable-next-line executor/no-effect-escape-hatch -- boundary: `oninitialized` is a sync SDK hook; persistence is fire-and-forget and its failure must not fail the session
         void Effect.runPromiseWith(context)(
           onAppsEnabledChange(negotiated).pipe(Effect.ignoreCause({ log: false })),
         );
-      }
-
-      // `execute-action` is only callable from inside a rendered app, so a
-      // client that can't render one should never see it. `create-artifact`,
-      // `list-artifacts` and `show-artifact` stay visible regardless: they
-      // still persist, and still return something useful (a deep link).
-      if (appsEnabled) {
-        executeActionTool?.enable();
-        executeActionResumeTool?.enable();
-      } else {
-        executeActionTool?.disable();
-        executeActionResumeTool?.disable();
       }
 
       console.error(


### PR DESCRIPTION
MCP-Apps rendering was lost on cold session restore: the same session rendered an inline widget before a Durable Object restore and a `fallback_url` deep link after, and once an isolate lost the capability it served fallbacks for the rest of its life.

## What actually happens

The first read of this was that a restored DO has no `initialize` to replay, so `appsEnabled` stays `false`. That is not the mechanism. The `agents` runtime persists the `initialize` request and replays it on restore (`reinitializeServer`), which **does** re-establish the server's client capabilities.

The gap is that capabilities and the hook are set by two different messages:

- `_clientCapabilities` is assigned by the `initialize` **request** handler.
- `oninitialized` — the only hook that re-runs `syncToolAvailability` — fires on the `notifications/initialized` **notification**, which is never persisted or replayed.

So a restored session holds full apps capabilities while the in-memory flag still reads its seeded value, and nothing ever reconciles the two. The replay is also dispatched un-awaited, so a tool call can land before it arrives. Both orderings produced the deep link.

## The fix

`deliverArtifact` resolves capability from the live server on every render rather than trusting the cached flag, and reconciles the app-only tools when the two disagree — otherwise a restored session could render inline while `execute-action`, the tool the widget calls back into, stayed hidden. The persisted seed remains the fallback for the window before any capabilities exist.

The persist path is guarded so a reading taken with no capabilities present is never written back; without that, one such replay would make the downgrade durable for every future restore of the session.

The host side (first commit) still persists the negotiated bit alongside `sessionMeta` and rehydrates it. `resolveAndStoreSessionMeta` carries the stored value forward because `init()` re-resolves meta from the bearer token on every restore, which carries no capabilities and would otherwise erase it.

## Tests

The headline test replays the `initialize` request under the SDK's restore sentinel id and sends no `initialized` notification — the exact shape of a real restore — with `restoredAppsEnabled: false`, so a pass cannot come from the seed. It asserts the inline payload and that `execute-action` is listed. Verified by reverting the fix and watching it fail.
