### PR TITLE
Include the artifact deep link in the inline widget result

### DIFF
--- a/.changeset/olive-poets-wave.md
+++ b/.changeset/olive-poets-wave.md
@@ -1,0 +1,5 @@
+---
+"executor": patch
+---
+
+Artifact tool results now include the web deep link beside the inline widget payload, not just on the no-apps fallback. Clients can lose a rendered widget in ways the server never sees — a reopened transcript that skips the resource re-read shows raw JSON — and the URL in the result is the model's way to point the user back at the artifact.

--- a/packages/hosts/mcp/src/artifacts-tools.test.ts
+++ b/packages/hosts/mcp/src/artifacts-tools.test.ts
@@ -353,7 +353,11 @@ describe("MCP host — artifact tool visibility", () => {
       name: "create-artifact",
       arguments: { code: COUNTER_CODE, title: "Active users dashboard" },
     })) as { structuredContent?: Record<string, unknown> };
-    expect(created.structuredContent).toEqual({ code: COUNTER_CODE, artifactId: "art_1" });
+    expect(created.structuredContent).toEqual({
+      code: COUNTER_CODE,
+      artifactId: "art_1",
+      url: "https://executor.test/artifacts/art_1",
+    });
     expect(created.structuredContent).not.toHaveProperty("status", "fallback_url");
 
     // The widget is useless if it cannot call back in, so visibility has to
@@ -613,6 +617,7 @@ describe("MCP host — create-artifact", () => {
         expect(structuredOf(result)).toEqual({
           code: COUNTER_CODE,
           artifactId: "art_1",
+          url: "https://executor.test/artifacts/art_1",
         });
         expect(result.isError).toBeFalsy();
         expect(store.calls).toEqual([
@@ -624,6 +629,35 @@ describe("MCP host — create-artifact", () => {
             bindings: {},
           },
         ]);
+      },
+      {
+        artifacts: store.port,
+        artifactUrl: artifactUrlFor("https://executor.test"),
+      },
+    );
+  });
+
+  it("includes the deep link beside the inline widget payload when the host knows its URL", async () => {
+    // The widget is not the only consumer of an inline result: clients lose
+    // rendered widgets in ways the server never sees (a reopened transcript
+    // that skips the ui:// re-read shows raw JSON), and then the URL in the
+    // result is the model's only way to point the user back at the artifact.
+    const store = makeArtifactStore();
+    await withClient(
+      makeStubEngine({}),
+      APPS_CAPS,
+      async (client) => {
+        const result = await client.callTool({
+          name: "create-artifact",
+          arguments: { code: COUNTER_CODE, title: "Active users dashboard" },
+        });
+        expect(result.isError).toBeFalsy();
+        expect(structuredOf(result)).toEqual({
+          code: COUNTER_CODE,
+          artifactId: "art_1",
+          url: "https://executor.test/artifacts/art_1",
+        });
+        expect(textOf(result)).toContain("https://executor.test/artifacts/art_1");
       },
       {
         artifacts: store.port,

--- a/packages/hosts/mcp/src/tool-server.ts
+++ b/packages/hosts/mcp/src/tool-server.ts
@@ -905,14 +905,27 @@ const renderedInAppResult = (input: {
   readonly code: string;
   readonly artifactId: string;
   readonly title: string;
+  readonly url?: string | undefined;
 }): McpToolResult => ({
   content: [
     {
       type: "text",
-      text: `Rendered "${input.title}" as an interactive UI component. Saved as artifact ${input.artifactId}.`,
+      text: [
+        `Rendered "${input.title}" as an interactive UI component. Saved as artifact ${input.artifactId}.`,
+        // The link rides along even though the widget rendered: clients lose
+        // rendered widgets in ways the server never sees (a transcript
+        // reopened without re-reading the ui:// resource shows raw JSON), and
+        // when that happens this URL in the conversation is the only path
+        // back to the artifact the model can offer.
+        ...(input.url ? [`It also stays available at ${input.url}`] : []),
+      ].join("\n"),
     },
   ],
-  structuredContent: { code: input.code, artifactId: input.artifactId },
+  structuredContent: {
+    code: input.code,
+    artifactId: input.artifactId,
+    ...(input.url ? { url: input.url } : {}),
+  },
 });
 
 const renderedAsLinkResult = (input: {
@@ -1629,8 +1642,8 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
       readonly artifactId: string;
       readonly title: string;
     }): McpToolResult => {
-      if (appsSupported()) return renderedInAppResult(input);
       const url = config.artifactUrl?.(input.artifactId);
+      if (appsSupported()) return renderedInAppResult({ ...input, url });
       return url
         ? renderedAsLinkResult({ url, artifactId: input.artifactId, title: input.title })
         : renderedWithoutSurfaceResult({ artifactId: input.artifactId, title: input.title });


### PR DESCRIPTION
## Why

The inline `create-artifact` / `show-artifact` result carried only `code` + `artifactId`; the web deep link existed only on the no-apps fallback path. But clients can lose a rendered widget in ways the server never sees — observed live: a reopened Claude Desktop transcript re-establishes the MCP session without ever re-reading `ui://executor/shell.html` (no `resources/read` on the wire) and renders the stored structured content as raw JSON. When that happens the model has no way to point the user back at the artifact.

## What

`deliverArtifact` now resolves the deep link up front and passes it into the inline result too:

- `structuredContent` gains `url` beside `code` and `artifactId` (only when the host knows its web origin — stdio hosts with no `artifactUrl` are unchanged).
- The text content mentions the link, so the model can relay it without parsing the structured payload.
- Fallback paths unchanged.

The shell reads only `code`/`artifactId` from the payload, so the extra field is inert for rendering clients.

## Verification

- New test: inline result carries the URL when `artifactUrl` is configured; existing inline test updated for the new field.
- Full `packages/hosts/mcp` suite 170/170; typecheck, lint, format green.