### PR TITLE
Serve artifacts by default; ?artifacts=false is the opt-out

### DIFF
--- a/.changeset/eight-lions-argue.md
+++ b/.changeset/eight-lions-argue.md
@@ -1,0 +1,5 @@
+---
+"executor": patch
+---
+
+**Artifacts are now on by default for MCP connections.** A plain endpoint URL serves the full artifact surface — the artifact tools, the app shell resource, and the artifact skills. Connections that don't want it opt out with `?artifacts=false` (or `--no-artifacts` on the stdio CLI); `?artifacts=true` remains accepted as the explicit default. Previously the surface required a `?artifacts=true` opt-in.

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -1346,9 +1346,10 @@ const mcpUrlForActiveLocalServer = (input: {
   if (input.elicitationMode === "browser") {
     url.searchParams.set("elicitation_mode", "browser");
   }
-  // Only the opt-in is spelled out; the default endpoint stays clean.
-  if (input.artifacts) {
-    url.searchParams.set("artifacts", "true");
+  // Artifacts are on by default; only the opt-out is spelled out, so the
+  // default endpoint stays clean.
+  if (!input.artifacts) {
+    url.searchParams.set("artifacts", "false");
   }
   return url;
 };
@@ -2802,18 +2803,18 @@ const mcpCommand = Command.make(
           "Choose the stdio approval flow: browser approval or a CLI resume tool exposed to the model.",
         ),
       ),
-    artifacts: Options.boolean("artifacts")
+    noArtifacts: Options.boolean("no-artifacts")
       .pipe(Options.withDefault(false))
       .pipe(
         Options.withDescription(
-          "Serve the artifact surface on this connection: the artifact tools, the app shell resource, and the artifact skills. Withheld by default.",
+          "Withhold the artifact surface from this connection: the artifact tools, the app shell resource, and the artifact skills. Served by default.",
         ),
       ),
   },
-  ({ scope, elicitationMode, artifacts }) =>
+  ({ scope, elicitationMode, noArtifacts }) =>
     Effect.gen(function* () {
       applyScope(scope);
-      yield* runStdioMcpSession({ elicitationMode, artifacts });
+      yield* runStdioMcpSession({ elicitationMode, artifacts: !noArtifacts });
     }),
 ).pipe(Command.withDescription("Start an MCP server over stdio"));
 

--- a/apps/cloud/src/mcp/session-durable-object.ts
+++ b/apps/cloud/src/mcp/session-durable-object.ts
@@ -276,10 +276,10 @@ export class McpSessionDOSqlite extends McpAgentSessionDOBase<Env, CloudSessionD
         description,
         artifacts: executor.artifacts,
         connections: executor.connections,
-        // Artifacts are opt-in per connection. Sessions persisted before the
-        // flag existed carry no value; absent now means off, same as a fresh
-        // connection that did not ask for `?artifacts=true`.
-        artifactsEnabled: sessionMeta.artifactsEnabled ?? false,
+        // Artifacts are on by default, opt-out per connection. A session
+        // persisted without a value restores to the default, same as a fresh
+        // connection whose URL says nothing about `?artifacts=`.
+        artifactsEnabled: sessionMeta.artifactsEnabled ?? true,
         // Cold restores rebuild this server with no `initialize` to replay, so
         // the negotiated apps support comes back from storage instead.
         restoredAppsEnabled: sessionMeta.appsEnabled ?? false,

--- a/apps/host-cloudflare/src/mcp/session-durable-object.ts
+++ b/apps/host-cloudflare/src/mcp/session-durable-object.ts
@@ -145,10 +145,10 @@ export class McpSessionDO extends McpAgentSessionDOBase<CloudflareEnv, CfSession
         engine,
         artifacts: executor.artifacts,
         connections: executor.connections,
-        // Artifacts are opt-in per connection. Sessions persisted before the
-        // flag existed carry no value; absent now means off, same as a fresh
-        // connection that did not ask for `?artifacts=true`.
-        artifactsEnabled: sessionMeta.artifactsEnabled ?? false,
+        // Artifacts are on by default, opt-out per connection. A session
+        // persisted without a value restores to the default, same as a fresh
+        // connection whose URL says nothing about `?artifacts=`.
+        artifactsEnabled: sessionMeta.artifactsEnabled ?? true,
         // Cold restores rebuild this server with no `initialize` to replay, so
         // the negotiated apps support comes back from storage instead.
         restoredAppsEnabled: sessionMeta.appsEnabled ?? false,

--- a/e2e/cloud/mcp-oversize-response.test.ts
+++ b/e2e/cloud/mcp-oversize-response.test.ts
@@ -92,8 +92,8 @@ scenario(
     const mcp = yield* Mcp;
     const identity = yield* target.newIdentity();
     const bearer = yield* mcp.mintBearer(emailOf(identity));
-    // Artifacts opt-in is what registers the shell resource on the session.
-    const mcpUrl = `${target.mcpUrl}?artifacts=true`;
+    // Artifacts are on by default, which registers the shell resource.
+    const mcpUrl = target.mcpUrl;
 
     const sessionId = yield* Effect.promise(() => openSession(mcpUrl, bearer));
 

--- a/e2e/scenarios/artifact-loading-surface.test.ts
+++ b/e2e/scenarios/artifact-loading-surface.test.ts
@@ -197,9 +197,9 @@ scenario(
 
     const identity = yield* target.newIdentity();
     const client = yield* apiClient(api, identity);
-    // Artifacts are opt-in per MCP connection, so this session asks for the
-    // surface it is here to exercise (`?artifacts=true`).
-    const session = mcp.session(identity, { artifacts: true });
+    // Artifacts are on by default; the plain session carries the surface
+    // this scenario exercises.
+    const session = mcp.session(identity);
 
     const suffix = uniqueSuffix();
     const title = `Loading Surface ${suffix}`;

--- a/e2e/scenarios/artifact-preview-gallery.test.ts
+++ b/e2e/scenarios/artifact-preview-gallery.test.ts
@@ -145,9 +145,9 @@ scenario(
     const browser = yield* Browser;
 
     const identity = yield* target.newIdentity();
-    // Artifacts are opt-in per MCP connection, so this session asks for the
-    // surface it is here to exercise (`?artifacts=true`).
-    const session = mcp.session(identity, { artifacts: true });
+    // Artifacts are on by default; the plain session carries the surface
+    // this scenario exercises.
+    const session = mcp.session(identity);
     const suffix = uniqueSuffix();
 
     const seeded = [

--- a/e2e/scenarios/artifacts.test.ts
+++ b/e2e/scenarios/artifacts.test.ts
@@ -166,9 +166,9 @@ scenario(
 
     const identity = yield* target.newIdentity();
     const client = yield* apiClient(api, identity);
-    // Artifacts are opt-in per MCP connection, so this session asks for the
-    // surface it is here to exercise (`?artifacts=true`).
-    const session = mcp.session(identity, { artifacts: true });
+    // Artifacts are on by default; the plain session carries the surface
+    // this scenario exercises.
+    const session = mcp.session(identity);
 
     const suffix = uniqueSuffix();
     const title = `Release Readiness ${suffix}`;
@@ -556,9 +556,9 @@ scenario(
 
     const identity = yield* target.newIdentity();
     const client = yield* apiClient(api, identity);
-    // Artifacts are opt-in per MCP connection, so this session asks for the
-    // surface it is here to exercise (`?artifacts=true`).
-    const session = mcp.session(identity, { artifacts: true });
+    // Artifacts are on by default; the plain session carries the surface
+    // this scenario exercises.
+    const session = mcp.session(identity);
 
     const suffix = uniqueSuffix();
     const originalTitle = `Draft Dashboard ${suffix}`;
@@ -677,9 +677,9 @@ scenario(
 
     const identity = yield* target.newIdentity();
     const client = yield* apiClient(api, identity);
-    // Artifacts are opt-in per MCP connection, so this session asks for the
-    // surface it is here to exercise (`?artifacts=true`).
-    const session = mcp.session(identity, { artifacts: true });
+    // Artifacts are on by default; the plain session carries the surface
+    // this scenario exercises.
+    const session = mcp.session(identity);
 
     const suffix = uniqueSuffix();
     const title = `Iterated Dashboard ${suffix}`;
@@ -773,14 +773,13 @@ function App() {
   }),
 );
 
-// The opt-in. Artifacts are off by default: a plain endpoint URL gets no
-// artifact surface at all — no artifact tools, and no artifact entries in the
-// `skills` inventory to point a model at tools it does not have. A user who
-// wants generated UI says so on the URL (`?artifacts=true`) and that connection
-// gets the whole surface. The proof is comparative: two sessions, same
-// identity, same server, differing only in that query.
+// The opt-out. Artifacts are on by default: a plain endpoint URL gets the full
+// artifact surface. A connection that says `?artifacts=false` gets none of it —
+// no artifact tools, and no artifact entries in the `skills` inventory to point
+// a model at tools it does not have. The proof is comparative: two sessions,
+// same identity, same server, differing only in that query.
 scenario(
-  "Artifacts · only a session connected with artifacts=true sees the artifact surface",
+  "Artifacts · a session connected with artifacts=false loses the artifact surface",
   { timeout: 120_000 },
   Effect.gen(function* () {
     const target = yield* Target;
@@ -788,7 +787,7 @@ scenario(
 
     const identity = yield* target.newIdentity();
     const defaultSession = mcp.session(identity);
-    const optedIn = mcp.session(identity, { artifacts: true });
+    const optedOut = mcp.session(identity, { artifacts: false });
 
     const ARTIFACT_TOOLS = [
       "create-artifact",
@@ -798,32 +797,32 @@ scenario(
       "execute-action-resume",
     ] as const;
 
-    const defaultTools = yield* defaultSession.listTools();
+    const optedOutTools = yield* optedOut.listTools();
     for (const tool of ARTIFACT_TOOLS) {
-      expect(defaultTools, `${tool} is withheld from a default session`).not.toContain(tool);
+      expect(optedOutTools, `${tool} is withheld from an opted-out session`).not.toContain(tool);
     }
     // Only artifacts are withheld — the connection is otherwise a normal one.
-    expect(defaultTools, "execute still works on a default session").toContain("execute");
-    expect(defaultTools, "skills still works on a default session").toContain("skills");
+    expect(optedOutTools, "execute still works on an opted-out session").toContain("execute");
+    expect(optedOutTools, "skills still works on an opted-out session").toContain("skills");
 
-    const defaultSkills = yield* defaultSession.call("skills", {});
-    expect(defaultSkills.ok, `the skills index came back: ${defaultSkills.text}`).toBe(true);
-    expect(defaultSkills.text, "the index still offers the execute skill").toContain("`execute`");
+    const optedOutSkills = yield* optedOut.call("skills", {});
+    expect(optedOutSkills.ok, `the skills index came back: ${optedOutSkills.text}`).toBe(true);
+    expect(optedOutSkills.text, "the index still offers the execute skill").toContain("`execute`");
     expect(
-      defaultSkills.text,
+      optedOutSkills.text,
       "the index does not advertise a how-to for a tool this session lacks",
     ).not.toContain("`create-artifact`");
-    expect(defaultSkills.text, "nor the artifact style guide").not.toContain("`artifact-style`");
+    expect(optedOutSkills.text, "nor the artifact style guide").not.toContain("`artifact-style`");
 
-    // The control: the same identity against the same server, with the query,
-    // gets everything. Without this the assertions above would also pass on a
-    // server that had simply lost artifacts.
-    const optedInTools = yield* optedIn.listTools();
+    // The control: the same identity against the same server, with a clean
+    // URL, gets everything by default. Without this the assertions above would
+    // also pass on a server that had simply lost artifacts.
+    const defaultTools = yield* defaultSession.listTools();
     for (const tool of ["create-artifact", "list-artifacts", "show-artifact"] as const) {
-      expect(optedInTools, `${tool} is present once the session opts in`).toContain(tool);
+      expect(defaultTools, `${tool} is present on a default session`).toContain(tool);
     }
-    const optedInSkills = yield* optedIn.call("skills", {});
-    expect(optedInSkills.text, "the opted-in index offers the create-artifact skill").toContain(
+    const defaultSkills = yield* defaultSession.call("skills", {});
+    expect(defaultSkills.text, "the default index offers the create-artifact skill").toContain(
       "`create-artifact`",
     );
   }),

--- a/e2e/src/surfaces/mcp.ts
+++ b/e2e/src/surfaces/mcp.ts
@@ -164,8 +164,9 @@ export interface McpSurface {
     identity: Identity,
     options?: {
       readonly elicitationMode?: McpElicitationMode;
-      /** Opt this session in to artifacts (`?artifacts=true`). Omitted means
-       *  the product default: no artifact surface at all. */
+      /** Set `false` to opt this session out of artifacts
+       *  (`?artifacts=false`). Omitted means the product default: the full
+       *  artifact surface. */
       readonly artifacts?: boolean;
       readonly url?: string;
     },
@@ -302,12 +303,12 @@ export const makeMcpSurface = (target: Target, runDir?: string): McpSurface => (
     const serverName = `${target.name}-${randomUUID().slice(0, 8)}`;
     // Per-connection settings ride the MCP endpoint query, the ecosystem
     // convention: `elicitation_mode` so a paused execution yields an approvalUrl
-    // instead of letting the model resume inline, and `artifacts=true` to opt
-    // the session in to the artifact surface. Both are non-defaults, so a
+    // instead of letting the model resume inline, and `artifacts=false` to opt
+    // the session out of the artifact surface. Both are non-defaults, so a
     // plain session's URL carries no query at all.
     const sessionQuery = [
       ...(options?.elicitationMode ? [`elicitation_mode=${options.elicitationMode}`] : []),
-      ...(options?.artifacts === true ? ["artifacts=true"] : []),
+      ...(options?.artifacts === false ? ["artifacts=false"] : []),
     ].join("&");
     const sessionUrl = sessionQuery ? `${mcpUrl}?${sessionQuery}` : mcpUrl;
 

--- a/packages/core/execution/src/skills.ts
+++ b/packages/core/execution/src/skills.ts
@@ -609,7 +609,7 @@ export const SKILLS: readonly Skill[] = [
 ];
 
 /** The skills that only make sense when the session serves artifacts. A
- *  connection that did not opt in to artifacts (`?artifacts=true`) has no tool
+ *  connection that opted out of artifacts (`?artifacts=false`) has no tool
  *  to apply them to, so they are dropped from its catalog rather than served as
  *  guidance for a surface it cannot reach. */
 const ARTIFACT_SKILLS: ReadonlySet<Skill> = new Set([CREATE_ARTIFACT_SKILL, ARTIFACT_STYLE_SKILL]);

--- a/packages/hosts/cloudflare/src/mcp/agent-session-durable-object.ts
+++ b/packages/hosts/cloudflare/src/mcp/agent-session-durable-object.ts
@@ -41,7 +41,7 @@ export interface McpSessionInit {
   readonly userId: string;
   readonly elicitationMode: McpElicitationMode;
   /** Whether this session serves artifacts, read off `?artifacts=` at connect
-   *  time. Absent means the default (disabled). */
+   *  time. Absent means the default (enabled). */
   readonly artifactsEnabled?: boolean;
   /** The MCP resource the session was minted against (`/mcp` default vs a
    *  `/mcp/toolkits/<slug>` toolkit), so the tool catalog is scoped to it. */
@@ -103,7 +103,7 @@ export interface SessionMeta {
   readonly elicitationMode?: McpElicitationMode;
   /** Whether the session serves artifacts (carried from {@link McpSessionInit}).
    *  Absent — including for sessions persisted before the flag existed — means
-   *  disabled. */
+   *  the default (enabled). */
   readonly artifactsEnabled?: boolean;
   /** The MCP resource the session serves (carried from {@link McpSessionInit});
    *  `buildMcpServer` scopes the tool catalog to it. */

--- a/packages/hosts/mcp-apps-shell/src/shell/mcp-app.browser.test.ts
+++ b/packages/hosts/mcp-apps-shell/src/shell/mcp-app.browser.test.ts
@@ -1246,7 +1246,7 @@ const startMcpHarnessForEngine = async <E extends Cause.YieldableError>(
       loadAppShellHtml: loadMcpAppsShellHtml,
       artifacts: makeInMemoryArtifacts(),
       // Artifacts are opt-in per connection; this harness drives the artifact
-      // tools, so it connects the way a `?artifacts=true` client does.
+      // tools, the connection default.
       artifactsEnabled: true,
     }),
   );

--- a/packages/hosts/mcp/src/artifacts-tools.test.ts
+++ b/packages/hosts/mcp/src/artifacts-tools.test.ts
@@ -140,11 +140,11 @@ const withClient = async <E extends Cause.YieldableError>(
     createExecutorMcpServer({
       engine,
       loadAppShellHtml: () => Promise.resolve(SHELL_HTML),
-      // Artifacts are opt-in per connection, and nearly every test in this file
-      // exercises the artifact surface — so the helper connects the way a real
-      // `?artifacts=true` client does. The cases that assert the OFF surface
-      // pass `artifactsEnabled: false`, and the default (no flag at all) is
-      // proved by building the server directly below.
+      // Artifacts are on by default and nearly every test in this file
+      // exercises the artifact surface; spelled out here anyway so the cases
+      // that assert the OFF surface (`artifactsEnabled: false`) read as the
+      // deliberate contrast. The default (no flag at all) is proved directly
+      // in the opt-out describe block.
       artifactsEnabled: true,
       ...config,
     } as ExecutorMcpServerConfig<E>),
@@ -479,11 +479,11 @@ describe("MCP host — artifact tool visibility", () => {
     await serverTransport.close();
   });
 
-  // A session that did not opt in (`?artifacts=true`) gets no artifact surface
-  // at all. The host here is fully artifact-capable — shell loader, store, the
-  // apps client capability — so what these assert is the connection default
-  // itself, not a host that never had artifacts.
-  it("registers no artifact tools on a default connection", async () => {
+  // A session that opted out (`?artifacts=false`) gets no artifact surface at
+  // all. The host here is fully artifact-capable — shell loader, store, the
+  // apps client capability — so what these assert is the opt-out itself, not
+  // a host that never had artifacts.
+  it("registers no artifact tools on an opted-out connection", async () => {
     const store = makeArtifactStore();
     await withClient(
       makeStubEngine({}),
@@ -500,9 +500,9 @@ describe("MCP host — artifact tool visibility", () => {
         expect(names).toContain("skills");
         expect(names).toContain("resume");
       },
-      // No `artifactsEnabled` at all: the real shape of a client that connected
-      // to a bare `/mcp` endpoint.
-      { artifacts: store.port, artifactsEnabled: undefined },
+      // The explicit opt-out: the shape of a client that connected with
+      // `?artifacts=false`.
+      { artifacts: store.port, artifactsEnabled: false },
     );
   });
 
@@ -510,7 +510,7 @@ describe("MCP host — artifact tool visibility", () => {
   // The read is what proves it: with no resource registered at all, the SDK
   // does not install a resources handler either, so `resources/list` itself is
   // unavailable — the same shape a host without a shell loader has always had.
-  it("serves no shell resource on a default connection", async () => {
+  it("serves no shell resource on an opted-out connection", async () => {
     const store = makeArtifactStore();
     await withClient(
       makeStubEngine({}),
@@ -518,11 +518,11 @@ describe("MCP host — artifact tool visibility", () => {
       async (client) => {
         await expect(client.readResource({ uri: MCP_APPS_SHELL_RESOURCE_URI })).rejects.toThrow();
       },
-      { artifacts: store.port, artifactsEnabled: undefined },
+      { artifacts: store.port, artifactsEnabled: false },
     );
   });
 
-  it("drops the artifact skills from a default session's inventory", async () => {
+  it("drops the artifact skills from an opted-out session's inventory", async () => {
     const store = makeArtifactStore();
     await withClient(
       makeStubEngine({}),
@@ -542,11 +542,11 @@ describe("MCP host — artifact tool visibility", () => {
         expect(fetched.isError).toBe(true);
         expect(textOf(fetched)).toContain('No skill named "create-artifact"');
       },
-      { artifacts: store.port, artifactsEnabled: undefined },
+      { artifacts: store.port, artifactsEnabled: false },
     );
   });
 
-  it("serves the full artifact surface to a session that opted in", async () => {
+  it("serves the full artifact surface on the connection default (no flag at all)", async () => {
     const store = makeArtifactStore();
     await withClient(
       makeStubEngine({}),
@@ -566,7 +566,9 @@ describe("MCP host — artifact tool visibility", () => {
         expect(index).toContain("`create-artifact`");
         expect(index).toContain("`artifact-style`");
       },
-      { artifacts: store.port },
+      // Overrides the helper's explicit `artifactsEnabled: true` with the real
+      // absent-flag shape, so this pins the DEFAULT, not an opt-in.
+      { artifacts: store.port, artifactsEnabled: undefined },
     );
   });
 
@@ -2235,24 +2237,25 @@ describe("artifactUrlFor", () => {
 // The `?artifacts=` endpoint query
 // ---------------------------------------------------------------------------
 
-describe("artifacts opt-in query", () => {
+describe("artifacts opt-out query", () => {
   const read = (query: string) =>
     readArtifactsEnabled(new Request(`https://executor.example/mcp${query}`));
 
-  it("keeps artifacts off for a clean endpoint", () => {
-    expect(read("")).toBe(false);
-    expect(read("?elicitation_mode=browser")).toBe(false);
+  it("serves artifacts on a clean endpoint", () => {
+    expect(read("")).toBe(true);
+    expect(read("?elicitation_mode=browser")).toBe(true);
   });
 
-  it("turns artifacts on for the documented true values", () => {
+  it("keeps artifacts on for the explicit true values", () => {
     for (const value of ["true", "TRUE", "1", "yes", "on"]) {
       expect(read(`?artifacts=${value}`)).toBe(true);
     }
   });
 
-  // Anything else reads as "not an opt-in", so a typo cannot silently hand a
-  // connection a surface the user never asked for.
-  it("keeps artifacts off for any other value", () => {
+  // Once the flag is present, anything but a documented true value reads as
+  // the opt-out — a user who touched the flag at all was reaching for "off",
+  // so a typo lands on the side they were steering toward.
+  it("turns artifacts off for the opt-out and any other explicit value", () => {
     for (const value of ["false", "0", "no", "ture", ""]) {
       expect(read(`?artifacts=${value}`)).toBe(false);
     }

--- a/packages/hosts/mcp/src/browser-approval.ts
+++ b/packages/hosts/mcp/src/browser-approval.ts
@@ -52,16 +52,17 @@ export const readElicitationMode = (request: Request): McpElicitationMode => {
 };
 
 /**
- * Read the artifacts opt-in off an MCP request's `?artifacts=` query.
- * Artifacts are OFF by default, so a clean endpoint URL serves no artifact
- * surface; only an explicit true value (`?artifacts=true`, and the same truthy
- * spellings the rest of the query vocabulary accepts) turns them on. A session
- * without the opt-in gets no artifact tools, no `ui://` shell resource, and no
- * artifact skills — as if the host had never been configured for them.
+ * Read the artifacts opt-OUT off an MCP request's `?artifacts=` query.
+ * Artifacts are ON by default: a clean endpoint URL gets the full artifact
+ * surface, and only an explicit false value (`?artifacts=false`, or any
+ * spelling that isn't one of the accepted truthy forms) withholds it. A
+ * session that opts out gets no artifact tools, no `ui://` shell resource,
+ * and no artifact skills — as if the host had never been configured for them.
+ * `?artifacts=true` remains accepted and is simply the default made explicit.
  */
 export const readArtifactsEnabled = (request: Request): boolean => {
   const value = new URL(request.url).searchParams.get("artifacts");
-  if (value === null) return false;
+  if (value === null) return true;
   return TRUE_QUERY_VALUES.has(value.toLowerCase());
 };
 

--- a/packages/hosts/mcp/src/in-memory-session-store.ts
+++ b/packages/hosts/mcp/src/in-memory-session-store.ts
@@ -71,9 +71,9 @@ export interface McpBuildServerOptions {
     | { readonly mode: "model" }
     | { readonly mode: "native" };
   readonly browserApprovalStore?: BrowserApprovalStore;
-  /** Whether this session serves artifacts. True only when the client connected
-   *  with `?artifacts=true`; otherwise the built server registers none of the
-   *  artifact tools, resource, or skills. */
+  /** Whether this session serves artifacts. True unless the client connected
+   *  with `?artifacts=false`; opted out, the built server registers none of
+   *  the artifact tools, resource, or skills. */
   readonly artifactsEnabled?: boolean;
 }
 

--- a/packages/hosts/mcp/src/tool-server.ts
+++ b/packages/hosts/mcp/src/tool-server.ts
@@ -156,8 +156,8 @@ type SharedMcpServerConfig = {
    */
   readonly loadAppShellHtml?: () => Promise<string>;
   /**
-   * Per-connection artifacts opt-in. Defaults to false. A client that connects
-   * without `?artifacts=true` gets NO artifact surface at all: none of the five
+   * Per-connection artifacts opt-out. Defaults to true. A client that connects
+   * with `?artifacts=false` gets NO artifact surface at all: none of the five
    * artifact tools, no `ui://` shell resource, and no artifact entries in the
    * `skills` inventory — the same shape a host without `loadAppShellHtml`
    * serves. `execute`, `skills` and `resume` are untouched.
@@ -1037,10 +1037,10 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
     // The same live integration inventory the description carries, re-used by
     // the `skills` tool so the `execute` guide lists what is connected too.
     const executeInventory = extractInventory(description);
-    // Artifacts are off unless this connection opted in (`?artifacts=true`).
+    // Artifacts are on unless this connection opted out (`?artifacts=false`).
     // One flag decides the whole surface: the tools, the shell resource, and
     // the skills catalog below.
-    const artifactsEnabled = config.artifactsEnabled ?? false;
+    const artifactsEnabled = config.artifactsEnabled ?? true;
     const skillCatalog: readonly Skill[] = skillCatalogFor({ artifacts: artifactsEnabled });
 
     // Captured at construction time. SDK callbacks fire later (often
@@ -1812,7 +1812,7 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
       );
 
     // Two independent reasons to serve no artifact surface: the host cannot
-    // (no shell loader), or this connection did not ask for it (`?artifacts=true`).
+    // (no shell loader), or this connection opted out (`?artifacts=false`).
     // Either way nothing below registers, so a disabled session is byte-for-byte
     // a session on a host that never had artifacts.
     const loadAppShellHtml = artifactsEnabled ? config.loadAppShellHtml : undefined;

--- a/packages/react/src/components/mcp-install-card.test.ts
+++ b/packages/react/src/components/mcp-install-card.test.ts
@@ -74,15 +74,15 @@ describe("MCP install command rendering", () => {
     );
   });
 
-  // Artifacts are off by default, so only the opt-in is ever spelled out: a
+  // Artifacts are on by default, so only the opt-out is ever spelled out: a
   // card left alone must still produce the bare endpoint every doc and test
   // asserts.
-  it("emits the artifacts opt-in only when artifacts are enabled", () => {
+  it("emits the artifacts opt-out only when artifacts are disabled", () => {
     expect(
       buildMcpHttpEndpoint({
         origin: "https://executor.example",
         desktop: null,
-        artifacts: false,
+        artifacts: true,
       }),
     ).toBe("https://executor.example/mcp");
 
@@ -90,9 +90,9 @@ describe("MCP install command rendering", () => {
       buildMcpHttpEndpoint({
         origin: "https://executor.example",
         desktop: null,
-        artifacts: true,
+        artifacts: false,
       }),
-    ).toBe("https://executor.example/mcp?artifacts=true");
+    ).toBe("https://executor.example/mcp?artifacts=false");
 
     // Both non-defaults together, in the order the card renders them.
     expect(
@@ -100,25 +100,25 @@ describe("MCP install command rendering", () => {
         origin: "https://executor.example",
         desktop: null,
         elicitationMode: "browser",
-        artifacts: true,
+        artifacts: false,
       }),
-    ).toBe("https://executor.example/mcp?elicitation_mode=browser&artifacts=true");
+    ).toBe("https://executor.example/mcp?elicitation_mode=browser&artifacts=false");
 
     // The unknown-origin placeholder is not a parsable URL, so it is
     // concatenated rather than round-tripped through `URL`.
-    expect(buildMcpHttpEndpoint({ origin: null, desktop: null, artifacts: true })).toBe(
-      "<this-server>/mcp?artifacts=true",
+    expect(buildMcpHttpEndpoint({ origin: null, desktop: null, artifacts: false })).toBe(
+      "<this-server>/mcp?artifacts=false",
     );
   });
 
-  it("passes the artifacts opt-in to the stdio CLI as a flag", () => {
+  it("passes the artifacts opt-out to the stdio CLI as a flag", () => {
     expect(
-      buildMcpInstallCommand({ mode: "stdio", isDev: false, origin: null, artifacts: false }),
+      buildMcpInstallCommand({ mode: "stdio", isDev: false, origin: null, artifacts: true }),
     ).toBe("npx add-mcp 'executor mcp' --name executor");
 
     expect(
-      buildMcpInstallCommand({ mode: "stdio", isDev: false, origin: null, artifacts: true }),
-    ).toBe("npx add-mcp 'executor mcp --artifacts' --name executor");
+      buildMcpInstallCommand({ mode: "stdio", isDev: false, origin: null, artifacts: false }),
+    ).toBe("npx add-mcp 'executor mcp --no-artifacts' --name executor");
   });
 
   it("passes model-managed resume through stdio install commands", () => {

--- a/packages/react/src/components/mcp-install-card.tsx
+++ b/packages/react/src/components/mcp-install-card.tsx
@@ -49,8 +49,8 @@ export const buildMcpHttpEndpoint = (input: {
     readonly port: number;
   } | null;
   readonly elicitationMode?: McpElicitationMode;
-  /** Artifacts are off by default, so only the opt-in is spelled out on the
-   *  URL (`&artifacts=true`) and a default endpoint stays clean. */
+  /** Artifacts are on by default, so only the opt-out is spelled out on the
+   *  URL (`&artifacts=false`) and a default endpoint stays clean. */
   readonly artifacts?: boolean;
   // Cloud only: pins the URL to `/<org-slug>/mcp` (the server also accepts the
   // legacy `/<org_id>/mcp` form). Desktop/local pass nothing and get the bare
@@ -67,12 +67,12 @@ export const buildMcpHttpEndpoint = (input: {
       ? `${input.origin}${mcpPath}`
       : `<this-server>${mcpPath}`;
   // Only non-default choices reach the URL, so the common endpoint has no query
-  // at all: `model` elicitation and artifacts-off are what the server assumes.
+  // at all: `model` elicitation and artifacts-on are what the server assumes.
   const params: Array<readonly [string, string]> = [];
   if (input.elicitationMode && input.elicitationMode !== "model") {
     params.push(["elicitation_mode", input.elicitationMode]);
   }
-  if (input.artifacts === true) params.push(["artifacts", "true"]);
+  if (input.artifacts === false) params.push(["artifacts", "false"]);
   if (params.length === 0) return endpoint;
 
   const query = params.map(([key, value]) => `${key}=${value}`).join("&");
@@ -127,8 +127,8 @@ export const buildMcpInstallCommand = (input: {
   if (input.elicitationMode && input.elicitationMode !== "model") {
     innerArgs.push("--elicitation-mode", input.elicitationMode);
   }
-  if (input.artifacts === true) {
-    innerArgs.push("--artifacts");
+  if (input.artifacts === false) {
+    innerArgs.push("--no-artifacts");
   }
   return `npx add-mcp ${shellQuoteWord(innerArgs.map(shellQuoteWord).join(" "))} --name executor`;
 };
@@ -137,7 +137,7 @@ export function McpInstallCard(props: { className?: string }) {
   const [mode, setMode] = useState<TransportMode>("http");
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const [httpElicitationMode, setHttpElicitationMode] = useState<McpElicitationMode>("model");
-  const [artifacts, setArtifacts] = useState(false);
+  const [artifacts, setArtifacts] = useState(true);
   const organizationSlug = useOrganizationSlug();
   const serverConnection = useExecutorServerConnection();
   // Desktop hosts ship Electron without putting an `executor` binary on
@@ -208,7 +208,7 @@ export function McpInstallCard(props: { className?: string }) {
             <div className="mt-0.5 text-xs leading-5 text-muted-foreground">
               {artifacts
                 ? "Generated UI components are saved to your workspace."
-                : "Enable to let agents create saved UI components."}
+                : "Disabled: this connection serves no artifact tools."}
             </div>
           </div>
           <Switch


### PR DESCRIPTION
## What

Artifacts flip from opt-in to opt-out per MCP connection. A plain endpoint URL now serves the full artifact surface — the five artifact tools, the `ui://executor/shell.html` resource, and the artifact skills. `?artifacts=false` (or `--no-artifacts` on the stdio CLI) withholds it; `?artifacts=true` remains accepted as the explicit default.

## Changes

- `readArtifactsEnabled`: an absent flag reads **true**; any explicit value that isn't a documented truthy form reads false — a user who touched the flag at all was reaching for "off", so typos land on the side they were steering toward.
- `createExecutorMcpServer`'s `artifactsEnabled` config default flips to true, as do both Cloudflare DOs' restore defaults (a session persisted without a value restores to the default).
- Install card: the Artifacts toggle defaults on; only the opt-out is spelled out on the URL and the stdio install command, so the common endpoint stays clean.
- CLI: `--artifacts` becomes `--no-artifacts`; the stdio bridge appends `?artifacts=false` only when opted out.
- e2e: the comparative surface scenario now proves the opt-out direction (clean URL has the surface, `artifacts=false` loses it); artifact scenarios connect with plain sessions since that's the surface-bearing default now.

## Verification

- `packages/hosts/mcp` 169/169, `packages/react` install-card 13/13, `packages/hosts/cloudflare` 56/56, shell smoke test green.
- e2e `scenarios/artifacts.test.ts` (cloud target) 4/4 with plain-session connections.
- typecheck across mcp/react/cli/cloud/host-cloudflare/e2e, lint, format all green.