### PR TITLE
Classify non-conform OAuth refresh rejections and stop retrying dead grants

### DIFF
--- a/.changeset/oauth-dead-grant-classification.md
+++ b/.changeset/oauth-dead-grant-classification.md
@@ -1,0 +1,5 @@
+---
+"executor": patch
+---
+
+**Fix: OAuth refresh rejections with non-spec error bodies (e.g. Datadog) now surface as expired connections with a reconnect path, and definitively dead refresh tokens are no longer retried against the authorization server**

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -730,6 +730,19 @@ const missingOAuthScopesFromProviderState = (value: unknown): readonly string[] 
     : [];
 };
 
+/** Epoch ms of the definitive refresh rejection recorded on `provider_state`,
+ *  or null. Set when the AS rejects the grant itself (RFC 6749 invalid_grant —
+ *  retrying cannot change the verdict); cleared by the reconnect mint, which
+ *  rewrites `provider_state` wholesale. While set, refresh attempts are
+ *  skipped: the pre-fix behavior re-sent a known-dead grant to the AS every
+ *  proactive cycle, forever, and surfaced nothing to the user. */
+const oauthReauthRequiredAtFromProviderState = (value: unknown): number | null => {
+  const decoded = decodeJsonColumn(value);
+  if (decoded == null || typeof decoded !== "object" || Array.isArray(decoded)) return null;
+  const at = (decoded as Record<string, unknown>).oauthReauthRequiredAt;
+  return typeof at === "number" ? at : null;
+};
+
 const rowToConnection = (row: ConnectionRow): Connection => {
   const owner = row.owner as Owner;
   const integration = IntegrationSlug.make(row.integration);
@@ -1691,6 +1704,44 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
      *  upstream 401 on a token we believed was still valid (`reactive`). */
     type RefreshTrigger = "proactive" | "reactive";
 
+    /** Record the AS's invalid_grant verdict on the row so later refreshes
+     *  skip the doomed token request, and stamp `last_health` expired so the
+     *  accounts list shows the dead connection at a glance instead of only
+     *  after a manual probe. Merges into `provider_state` (preserving
+     *  `missingOAuthScopes`); the reconnect mint rewrites the column wholesale,
+     *  which is what re-arms refresh. Best-effort: a bookkeeping write failure
+     *  must not mask the refresh failure being reported. */
+    const markRefreshGrantDead = (
+      row: ConnectionRow,
+      detail: string,
+    ): Effect.Effect<void, never> => {
+      const existingState = decodeJsonColumn(row.provider_state);
+      const mergedState =
+        existingState != null && typeof existingState === "object" && !Array.isArray(existingState)
+          ? (existingState as Record<string, unknown>)
+          : {};
+      const health: HealthCheckResult = {
+        status: "expired",
+        checkedAt: Date.now(),
+        detail,
+      };
+      return core
+        .updateMany("connection", {
+          where: (b: AnyCb) =>
+            b.and(
+              byOwner(row.owner as Owner)(b),
+              b("integration", "=", String(row.integration)),
+              b("name", "=", String(row.name)),
+            ),
+          set: {
+            provider_state: { ...mergedState, oauthReauthRequiredAt: Date.now() },
+            last_health: health,
+            updated_at: new Date(),
+          },
+        })
+        .pipe(Effect.ignore);
+    };
+
     // Perform the actual refresh-token grant and persist the rotated material.
     const performTokenRefresh = (
       row: ConnectionRow,
@@ -1707,6 +1758,20 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
             message,
             reauthRequired: true,
           });
+
+        // A recorded invalid_grant is the AS's standing verdict on this grant:
+        // re-sending it cannot succeed, so don't. Fail as reauth-required
+        // without a token request — the reconnect mint rewrites
+        // `provider_state` and thereby re-arms refresh. Without this gate a
+        // dead connection re-sent its dead grant on every proactive cycle,
+        // indefinitely (owner.com's Datadog connections: 100+ identical
+        // rejections over two days, surfacing nothing).
+        if (oauthReauthRequiredAtFromProviderState(row.provider_state) !== null) {
+          yield* Effect.annotateCurrentSpan({ "executor.oauth.refresh.skipped_known_dead": true });
+          return yield* reauth(
+            "The authorization server rejected this connection's refresh token (invalid_grant). Reconnect to continue.",
+          );
+        }
 
         // Load the backing app by the owner STORED on the connection (a Personal
         // connection may be backed by a shared Workspace app) — no derivation.
@@ -1813,6 +1878,16 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
                       cause,
                     });
                   }),
+                  // Persist the definitive verdict so the NEXT refresh skips
+                  // the doomed grant (see the known-dead gate above) and the
+                  // connection shows `expired` without waiting for a probe.
+                  Effect.tapError((error) =>
+                    Predicate.isTagged(error, "CredentialResolutionError") &&
+                    error.reauthRequired === true
+                      ? // oxlint-disable-next-line executor/no-unknown-error-message -- boundary: CredentialResolutionError carries a typed `message` field
+                        markRefreshGrantDead(row, error.message)
+                      : Effect.void,
+                  ),
                 );
               });
 
@@ -1879,6 +1954,12 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
         ),
         Effect.withSpan("executor.oauth.refresh", {
           attributes: {
+            // Tenant + subject make refresh outcomes answerable PER CUSTOMER
+            // ("is org X's Datadog refresh healthy?") — without them the only
+            // grouping dimensions were integration-wide. Opaque ids, never
+            // emails or org names.
+            "executor.tenant": tenant,
+            ...(subject != null ? { "executor.subject": subject } : {}),
             "executor.integration": String(row.integration),
             "executor.connection": String(row.name),
             // Which path drove this refresh: the expiry check ahead of a call,
@@ -3199,6 +3280,8 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
       }).pipe(
         Effect.withSpan("executor.connection.health.check", {
           attributes: {
+            "executor.tenant": tenant,
+            ...(subject != null ? { "executor.subject": subject } : {}),
             "executor.integration": String(ref.integration),
             "executor.connection": String(ref.name),
           },
@@ -3254,7 +3337,11 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
         return result;
       }).pipe(
         Effect.withSpan("executor.connection.validate", {
-          attributes: { "executor.integration": String(input.integration) },
+          attributes: {
+            "executor.tenant": tenant,
+            ...(subject != null ? { "executor.subject": subject } : {}),
+            "executor.integration": String(input.integration),
+          },
         }),
       );
 

--- a/packages/core/sdk/src/oauth-flow.test.ts
+++ b/packages/core/sdk/src/oauth-flow.test.ts
@@ -962,6 +962,116 @@ describe("oauth token refresh in resolveConnectionValue", () => {
     ),
   );
 
+  it.effect("a definitively rejected grant is not re-sent to the AS on later refreshes", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const server = yield* serveOAuthTestServer({
+          scopes: ["read"],
+          supportRefresh: false,
+          tokenExpiresInSeconds: 0,
+          invalidRefreshTokenDescription: "Grant revoked",
+        });
+        const harness = yield* makeTestWorkspaceHarness({ plugins });
+        const { executor, config } = harness;
+        yield* executor.acme.seed();
+
+        yield* executor.oauth.createClient({
+          owner: "org",
+          slug: CLIENT,
+          authorizationUrl: server.authorizationEndpoint,
+          tokenUrl: server.tokenEndpoint,
+          grant: "authorization_code",
+          clientId: "test-client",
+          clientSecret: "test-secret",
+          resource: server.mcpResourceUrl,
+        });
+
+        const started = yield* executor.oauth.start({
+          owner: "org",
+          client: CLIENT,
+          clientOwner: "org",
+          name: ConnectionName.make("main"),
+          integration: INTEG,
+          template: TEMPLATE,
+        });
+        expect(started.status).toBe("redirect");
+        if (started.status !== "redirect") return;
+        const callback = yield* server.completeAuthorizationCodeFlow({
+          authorizationUrl: started.authorizationUrl,
+        });
+        yield* executor.oauth.complete({ state: started.state, code: callback.code });
+
+        yield* Effect.promise(() =>
+          config.db.updateMany("connection", {
+            where: (b) => b("name", "=", "main"),
+            set: { expires_at: Date.now() - 60_000 },
+          }),
+        );
+        yield* server.clearRequests;
+
+        // First resolve: the refresh grant reaches the AS and is rejected
+        // with invalid_grant — the AS's definitive verdict.
+        const first = yield* Effect.flip(
+          executor.execute(ToolAddress.make("tools.acme.org.main.whoami"), {}),
+        );
+        expect(JSON.stringify(first)).toContain("invalid_grant");
+
+        // The verdict is persisted: the dead-grant marker plus an expired
+        // health record, without waiting for a probe.
+        const row = yield* Effect.promise(() =>
+          config.db.findFirst("connection", { where: (b) => b("name", "=", "main") }),
+        );
+        expect(
+          (row?.provider_state as { oauthReauthRequiredAt?: number } | null)?.oauthReauthRequiredAt,
+        ).toEqual(expect.any(Number));
+        expect(row?.last_health).toMatchObject({ status: "expired" });
+
+        const grantRequests = () =>
+          server.requests.pipe(
+            Effect.map(
+              (all) =>
+                all.filter((r) => r.path === "/token" && r.body.includes("refresh_token")).length,
+            ),
+          );
+        const sentBefore = yield* grantRequests();
+        expect(sentBefore).toBe(1);
+
+        // Later resolves still fail reauth-required, but WITHOUT re-sending
+        // the dead grant: the token endpoint sees no further traffic.
+        const second = yield* Effect.flip(
+          executor.execute(ToolAddress.make("tools.acme.org.main.whoami"), {}),
+        );
+        expect(JSON.stringify(second)).toContain("Reconnect");
+        expect(yield* grantRequests()).toBe(sentBefore);
+
+        // Reconnecting mints a fresh grant and re-arms refresh: the marker is
+        // gone and resolution works again.
+        const restarted = yield* executor.oauth.start({
+          owner: "org",
+          client: CLIENT,
+          clientOwner: "org",
+          name: ConnectionName.make("main"),
+          integration: INTEG,
+          template: TEMPLATE,
+        });
+        expect(restarted.status).toBe("redirect");
+        if (restarted.status !== "redirect") return;
+        const reCallback = yield* server.completeAuthorizationCodeFlow({
+          authorizationUrl: restarted.authorizationUrl,
+        });
+        yield* executor.oauth.complete({ state: restarted.state, code: reCallback.code });
+
+        const cleared = yield* Effect.promise(() =>
+          config.db.findFirst("connection", { where: (b) => b("name", "=", "main") }),
+        );
+        expect(
+          (cleared?.provider_state as { oauthReauthRequiredAt?: number } | null)
+            ?.oauthReauthRequiredAt,
+        ).toBeUndefined();
+      }),
+    ),
+  );
+
   it.effect(
     "checkHealth reports healthy from OAuth credential resolution when no probe is configured",
     () =>

--- a/packages/core/sdk/src/oauth-helpers.test.ts
+++ b/packages/core/sdk/src/oauth-helpers.test.ts
@@ -871,6 +871,68 @@ describe("refreshAccessToken", () => {
       }),
     ),
   );
+
+  // Datadog answers refresh grants with a non-conform envelope; the §5.2 code
+  // must still be recovered so invalid_grant classifies as reauth-required
+  // instead of a retried-forever transient (owner.com prod, 2026-07-30).
+  it.effect("recovers invalid_grant from Datadog's non-conform errors array", () =>
+    withTokenEndpoint(
+      () =>
+        json(400, {
+          errors: ["invalid_grant - Invalid or expired refresh token or code verifier."],
+        }),
+      ({ tokenUrl }) =>
+        Effect.gen(function* () {
+          const error = yield* Effect.flip(
+            refreshAccessToken({ tokenUrl, clientId: "cid", refreshToken: "old" }),
+          );
+          expect(error).toBeInstanceOf(OAuth2Error);
+          expect((error as OAuth2Error).error).toBe("invalid_grant");
+        }),
+    ),
+  );
+
+  it.effect("recovers a bare non-conform `error` string outside the spec envelope shape", () =>
+    withTokenEndpoint(
+      () => json(400, { error: "invalid_grant", detail: 42 }),
+      ({ tokenUrl }) =>
+        Effect.gen(function* () {
+          const error = yield* Effect.flip(
+            refreshAccessToken({ tokenUrl, clientId: "cid", refreshToken: "old" }),
+          );
+          expect(error).toBeInstanceOf(OAuth2Error);
+          expect((error as OAuth2Error).error).toBe("invalid_grant");
+        }),
+    ),
+  );
+
+  it.effect("does not invent a code from free-text error bodies", () =>
+    withTokenEndpoint(
+      () => json(400, { errors: ["something went wrong, try again later"] }),
+      ({ tokenUrl }) =>
+        Effect.gen(function* () {
+          const error = yield* Effect.flip(
+            refreshAccessToken({ tokenUrl, clientId: "cid", refreshToken: "old" }),
+          );
+          expect(error).toBeInstanceOf(OAuth2Error);
+          expect((error as OAuth2Error).error).toBeUndefined();
+        }),
+    ),
+  );
+
+  it.effect("does not probe non-conform bodies on 5xx responses", () =>
+    withTokenEndpoint(
+      () => json(502, { errors: ["invalid_grant - upstream proxy noise"] }),
+      ({ tokenUrl }) =>
+        Effect.gen(function* () {
+          const error = yield* Effect.flip(
+            refreshAccessToken({ tokenUrl, clientId: "cid", refreshToken: "old" }),
+          );
+          expect(error).toBeInstanceOf(OAuth2Error);
+          expect((error as OAuth2Error).error).toBeUndefined();
+        }),
+    ),
+  );
 });
 
 describe("shouldRefreshToken", () => {

--- a/packages/core/sdk/src/oauth-helpers.ts
+++ b/packages/core/sdk/src/oauth-helpers.ts
@@ -320,6 +320,55 @@ const bodyPreviewFromResponse = async (response: Response): Promise<string | und
   return redacted.length > 500 ? `${redacted.slice(0, 500)}...` : redacted;
 };
 
+// RFC 6749 §5.2's closed set. Only these are ever recovered from a
+// non-conform body: a free-text match against an open set would let an
+// arbitrary error message masquerade as an AS verdict.
+const RFC6749_TOKEN_ERROR_CODES = [
+  "invalid_request",
+  "invalid_client",
+  "invalid_grant",
+  "unauthorized_client",
+  "unsupported_grant_type",
+  "invalid_scope",
+] as const;
+
+const rfc6749CodeFromCandidate = (candidate: unknown): string | undefined => {
+  if (typeof candidate !== "string") return undefined;
+  const trimmed = candidate.trim();
+  return RFC6749_TOKEN_ERROR_CODES.find(
+    (code) => trimmed === code || trimmed.startsWith(`${code} `) || trimmed.startsWith(`${code}:`),
+  );
+};
+
+/** Recover the AS's §5.2 verdict from an error body oauth4webapi refused to
+ *  parse. Some ASes wrap the code in a non-conform envelope — Datadog answers
+ *  refresh grants with `{"errors": ["invalid_grant - Invalid or expired
+ *  refresh token or code verifier."]}` — and without this probe a definitive
+ *  `invalid_grant` (dead refresh token, reconnect required) is classified as
+ *  a transient failure and retried forever instead of surfacing a re-auth. */
+const oauthErrorCodeFromNonConformBody = (text: string): string | undefined => {
+  const parsed: unknown = (() => {
+    // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: probing an untrusted upstream body that already failed spec parsing; a parse failure just means "no recoverable code"
+    try {
+      // oxlint-disable-next-line executor/no-json-parse -- boundary: same untrusted-body probe; the value is only structurally inspected against the closed §5.2 code set, never decoded into domain types
+      return JSON.parse(text) as unknown;
+    } catch {
+      return undefined;
+    }
+  })();
+  if (typeof parsed !== "object" || parsed === null) return undefined;
+  const envelope = parsed as { readonly error?: unknown; readonly errors?: unknown };
+  const direct = rfc6749CodeFromCandidate(envelope.error);
+  if (direct) return direct;
+  if (Array.isArray(envelope.errors)) {
+    for (const entry of envelope.errors) {
+      const code = rfc6749CodeFromCandidate(entry);
+      if (code) return code;
+    }
+  }
+  return undefined;
+};
+
 const toOAuth2Error = (cause: unknown): OAuth2Error => {
   if (isOAuth2Error(cause)) return cause;
   if (typeof cause === "object" && cause !== null) {
@@ -352,16 +401,28 @@ const toOAuth2ErrorWithHttpSummary = (cause: unknown): Effect.Effect<OAuth2Error
   const base = toOAuth2Error(cause);
   const response = responseFromOAuthErrorCause(cause);
   if (!response) return Effect.succeed(base);
-  return Effect.promise(() => tokenEndpointHttpSummary(response)).pipe(
-    Effect.map(
-      (summary) =>
-        new OAuth2Error({
-          message: `${base.message} (${summary})`,
-          error: base.error,
-          cause,
-        }),
-    ),
-  );
+  return Effect.promise(async () => {
+    const summary = await tokenEndpointHttpSummary(response);
+    // A 4xx the spec parser refused may still carry the AS's verdict in a
+    // non-conform envelope; recover it so classification (invalid_grant →
+    // reauth-required) sees the code instead of a code-less "transient".
+    const recovered =
+      base.error === undefined && response.status >= 400 && response.status < 500
+        ? oauthErrorCodeFromNonConformBody(
+            await Promise.resolve()
+              .then(() => response.clone().text())
+              .then(
+                (value) => value,
+                () => "",
+              ),
+          )
+        : undefined;
+    return new OAuth2Error({
+      message: `${base.message} (${summary})`,
+      error: base.error ?? recovered,
+      cause,
+    });
+  });
 };
 
 const failOAuth2WithHttpSummary = (cause: unknown): Effect.Effect<never, OAuth2Error> =>

--- a/packages/core/sdk/src/oauth-service.ts
+++ b/packages/core/sdk/src/oauth-service.ts
@@ -1392,7 +1392,13 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
       return connection;
     }).pipe(
       Effect.withSpan("executor.oauth.complete", {
-        attributes: { "executor.oauth.grant": "authorization_code" },
+        attributes: {
+          "executor.oauth.grant": "authorization_code",
+          // Same per-customer dimensions as executor.oauth.refresh, so a
+          // connect and its later refresh failures group under one tenant.
+          "executor.tenant": deps.tenant,
+          ...(deps.subject != null ? { "executor.subject": deps.subject } : {}),
+        },
       }),
     );
 


### PR DESCRIPTION
Some authorization servers return refresh-grant rejections in a non-spec error envelope (e.g. `{"errors": ["invalid_grant - ..."]}`). The spec parser refuses the shape, no RFC 6749 code is extracted, and the definitive `invalid_grant` is classified as a transient storage failure — so the dead grant is re-sent to the AS on every proactive cycle forever, the connection never flips to expired, and the user is never told to reconnect.

- Probe non-conform 4xx token-endpoint bodies for a code from the closed RFC 6749 §5.2 set (top-level `error` string or provider `errors` arrays) and feed it into the existing classification, so `invalid_grant` → reauth-required → expired health.
- Persist the definitive rejection as a dead-grant marker on `provider_state` (plus an `expired` `last_health`); later refreshes skip the doomed token request and fail reauth-required immediately. Reconnecting rewrites `provider_state` and re-arms refresh.
- Add tenant/subject attribution to the `executor.oauth.refresh` / `complete` and `executor.connection.health.check` / `validate` spans so refresh outcomes are answerable per customer.