### PR TITLE
feat(selfhost): browser reverse bridge for Chrome extension (path B)

### DIFF
--- a/.github/workflows/selfhost-image.yml
+++ b/.github/workflows/selfhost-image.yml
@@ -1,0 +1,61 @@
+# Build self-host image for lab / public GHCR.
+# Tags: ghcr.io/tzarebczan/executor-selfhost:lab and :sha-<short>
+name: selfhost-image
+
+on:
+  push:
+    branches: [lab, feat/browser-bridge-reverse, main]
+    paths:
+      - "apps/host-selfhost/**"
+      - "packages/**"
+      - "package.json"
+      - "bun.lock"
+      - ".github/workflows/selfhost-image.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE: ghcr.io/tzarebczan/executor-selfhost
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=raw,value=lab,enable=${{ github.ref == 'refs/heads/lab' || github.ref == 'refs/heads/feat/browser-bridge-reverse' || github.event_name == 'workflow_dispatch' }}
+            type=sha,prefix=sha-,format=short
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/lab' }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apps/host-selfhost/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          # Lab hosts are amd64
+          platforms: linux/amd64

--- a/apps/host-selfhost/executor.config.ts
+++ b/apps/host-selfhost/executor.config.ts
@@ -12,6 +12,7 @@ import { mcpHttpPlugin } from "@executor-js/plugin-mcp/api";
 import { graphqlHttpPlugin } from "@executor-js/plugin-graphql/api";
 import { encryptedSecretsPlugin } from "@executor-js/plugin-encrypted-secrets";
 import { toolkitsPlugin } from "@executor-js/plugin-toolkits/server";
+import { browserBridgePlugin } from "@executor-js/plugin-browser-bridge/server";
 
 import { resolveSecretKey } from "./src/config";
 
@@ -42,6 +43,8 @@ export default defineExecutorConfig({
       mcpHttpPlugin({ dangerouslyAllowStdioMCP: false }),
       graphqlHttpPlugin(),
       toolkitsPlugin({ activeToolkitSlug }),
+      // Reverse Chrome bridge (Executor Browser extension path B).
+      browserBridgePlugin(),
       // First writable secret provider -> the default for `secrets.set`.
       encryptedSecretsPlugin({ key: resolveSecretKey() }),
     ] as const,

--- a/apps/host-selfhost/package.json
+++ b/apps/host-selfhost/package.json
@@ -29,6 +29,7 @@
     "@executor-js/fumadb": "workspace:*",
     "@executor-js/host-mcp": "workspace:*",
     "@executor-js/mcp-apps-shell": "workspace:*",
+    "@executor-js/plugin-browser-bridge": "workspace:*",
     "@executor-js/plugin-encrypted-secrets": "workspace:*",
     "@executor-js/plugin-graphql": "workspace:*",
     "@executor-js/plugin-mcp": "workspace:*",

--- a/apps/host-selfhost/src/app.ts
+++ b/apps/host-selfhost/src/app.ts
@@ -29,6 +29,7 @@ import { makeSelfHostMcpSeams } from "./mcp";
 import { selfHostPlugins } from "./plugins";
 import { ErrorCaptureLive } from "./observability";
 import { oauthCallbackSignInRedirectLocation } from "./auth/oauth-callback-login";
+import { makeBrowserBridgeHandler } from "@executor-js/plugin-browser-bridge/http";
 
 // ===========================================================================
 // The self-hosted Executor app, as ONE `ExecutorApp.make` call.
@@ -79,6 +80,32 @@ export const makeSelfHostApp = async (options: MakeSelfHostAppOptions = {}) => {
   // Pass the pinned public origin so browser-approval URLs are reachable behind
   // a reverse proxy (not the internal 127.0.0.1 bind from the request URL).
   const mcp = makeSelfHostMcpSeams(dbHandle, betterAuth, config.webBaseUrl);
+
+  // Browser reverse bridge (Executor Browser extension path B).
+  // Same auth as API: cookie, Bearer session, or API key as Bearer / x-api-key.
+  const browserBridgeHandler = makeBrowserBridgeHandler({
+    getSession: async (request) => {
+      try {
+        let session = await betterAuth.auth.api.getSession({ headers: request.headers });
+        if (!session) {
+          const authz = request.headers.get("authorization") || "";
+          const m = authz.match(/^Bearer\s+(.+)$/i);
+          if (m?.[1]) {
+            session = await betterAuth.auth.api.getSession({
+              headers: { "x-api-key": m[1] },
+            });
+          }
+        }
+        if (!session?.user?.id) return null;
+        return session as {
+          user: { id: string; name?: string | null; email?: string | null };
+          session?: { activeOrganizationId?: string | null };
+        };
+      } catch {
+        return null;
+      }
+    },
+  });
 
   // CLI device-login discovery (`executor login`). Points the CLI at Better
   // Auth's device endpoints; `requestFormat: "json"` because those endpoints
@@ -135,6 +162,17 @@ export const makeSelfHostApp = async (options: MakeSelfHostAppOptions = {}) => {
         makeSelfHostAdminUsersApiLayer({ betterAuth, db: dbHandle, mountPrefix: "/api" }),
         // Public system API: /api/health + /api/setup-status (unauthenticated).
         makeSelfHostSystemApiLayer({ betterAuth, db: dbHandle, mountPrefix: "/api" }),
+        // Browser reverse bridge for Executor Browser extension (API-key auth).
+        HttpRouter.add(
+          "*",
+          "/api/browser-bridge",
+          HttpEffect.fromWebHandler(browserBridgeHandler),
+        ),
+        HttpRouter.add(
+          "*",
+          "/api/browser-bridge/*",
+          HttpEffect.fromWebHandler(browserBridgeHandler),
+        ),
         // Swagger UI at /docs, over the /api-prefixed spec (matches the served paths).
         HttpApiSwagger.layer(composePluginApi(selfHostPlugins).prefix("/api"), { path: "/docs" }),
       ],

--- a/apps/host-selfhost/src/app.ts
+++ b/apps/host-selfhost/src/app.ts
@@ -163,11 +163,8 @@ export const makeSelfHostApp = async (options: MakeSelfHostAppOptions = {}) => {
         // Public system API: /api/health + /api/setup-status (unauthenticated).
         makeSelfHostSystemApiLayer({ betterAuth, db: dbHandle, mountPrefix: "/api" }),
         // Browser reverse bridge for Executor Browser extension (API-key auth).
-        HttpRouter.add(
-          "*",
-          "/api/browser-bridge",
-          HttpEffect.fromWebHandler(browserBridgeHandler),
-        ),
+        // Subpaths only (…/session, …/sessions, …/call). Do not also register
+        // the bare prefix — find-my-way treats that as a duplicate ACL route.
         HttpRouter.add(
           "*",
           "/api/browser-bridge/*",

--- a/bun.lock
+++ b/bun.lock
@@ -232,6 +232,7 @@
         "@executor-js/fumadb": "workspace:*",
         "@executor-js/host-mcp": "workspace:*",
         "@executor-js/mcp-apps-shell": "workspace:*",
+        "@executor-js/plugin-browser-bridge": "workspace:*",
         "@executor-js/plugin-encrypted-secrets": "workspace:*",
         "@executor-js/plugin-graphql": "workspace:*",
         "@executor-js/plugin-mcp": "workspace:*",
@@ -856,6 +857,17 @@
         "@effect/vitest": "catalog:",
         "@types/node": "catalog:",
         "bun-types": "catalog:",
+        "vitest": "catalog:",
+      },
+    },
+    "packages/plugins/browser-bridge": {
+      "name": "@executor-js/plugin-browser-bridge",
+      "version": "0.1.0",
+      "dependencies": {
+        "@executor-js/sdk": "workspace:*",
+      },
+      "devDependencies": {
+        "typescript": "catalog:",
         "vitest": "catalog:",
       },
     },
@@ -1804,6 +1816,8 @@
     "@executor-js/mcporter": ["@executor-js/mcporter@0.11.4", "", { "dependencies": { "@iarna/toml": "^2.2.5", "@modelcontextprotocol/sdk": "^1.29.0", "acorn": "^8.16.0", "commander": "^14.0.3", "es-toolkit": "^1.47.0", "jsonc-parser": "^3.3.1", "ora": "^9.4.0", "rolldown": "1.0.1", "zod": "^4.3.6" }, "bin": { "mcporter": "dist/cli.js" } }, "sha512-KewlNnqmzSkJAH7JS/2le9WxPWzL/ND7Pt/G5KGgfrSK9K9cE8UPIsEYZYZUJYoFnbCBzhlU9ugg59ptv1h3Ow=="],
 
     "@executor-js/motel": ["@executor-js/motel@0.2.5-executor.1", "", { "dependencies": { "@effect/atom-react": "^4.0.0-beta.49", "@effect/opentelemetry": "^4.0.0-beta.49", "@effect/platform-bun": "^4.0.0-beta.50", "@opentelemetry/api": "^1.9.0", "@opentelemetry/exporter-logs-otlp-http": "^0.214.0", "@opentelemetry/exporter-trace-otlp-http": "^0.211.0", "@opentelemetry/sdk-logs": "^0.214.0", "@opentelemetry/sdk-node": "^0.214.0", "@opentelemetry/sdk-trace-base": "^2.5.0", "@opentelemetry/sdk-trace-node": "^2.6.1", "@opentui/core": "^0.1.99", "@opentui/react": "^0.1.99", "effect": "^4.0.0-beta.49", "react": "^19.2.5", "scheduler": "^0.27.0" }, "bin": { "motel": "src/motel.ts", "motel-mcp": "src/mcp.ts" } }, "sha512-fLGJ5FIIBYd+4L2OurpYFjWzvcCbACvmdNofh6THXQJE1Gku93EKURtgn27/XddyM9SKGST6/znTRcmwKiYdXw=="],
+
+    "@executor-js/plugin-browser-bridge": ["@executor-js/plugin-browser-bridge@workspace:packages/plugins/browser-bridge"],
 
     "@executor-js/plugin-desktop-settings": ["@executor-js/plugin-desktop-settings@workspace:packages/plugins/desktop-settings"],
 

--- a/bun.lock
+++ b/bun.lock
@@ -865,6 +865,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@executor-js/sdk": "workspace:*",
+        "effect": "catalog:",
       },
       "devDependencies": {
         "typescript": "catalog:",

--- a/packages/plugins/browser-bridge/README.md
+++ b/packages/plugins/browser-bridge/README.md
@@ -1,0 +1,38 @@
+# Browser bridge (path B reverse)
+
+Completes the loop between **Executor Browser** (Chrome extension) and self-hosted Executor:
+
+```text
+Agent  →  tools.chrome.*  →  callTool(store)
+                                 │
+Extension ← long-poll jobs ←─────┘
+    │
+    └── POST result
+```
+
+## HTTP (extension)
+
+All routes require the same auth as `/api/*` (API key as `Authorization: Bearer` or `x-api-key`).
+
+| Method | Path | Role |
+|--------|------|------|
+| `POST` | `/api/browser-bridge/session` | Open reverse session |
+| `GET` | `/api/browser-bridge/session/:id/jobs?waitMs=25000` | Long-poll jobs |
+| `POST` | `/api/browser-bridge/session/:id/result` | `{ jobId, result }` |
+| `DELETE` | `/api/browser-bridge/session/:id` | Close |
+| `GET` | `/api/browser-bridge/sessions` | List mine |
+| `POST` | `/api/browser-bridge/call` | Agent HTTP: enqueue + wait |
+
+## Agent tools (MCP / execute)
+
+Static integration **`chrome`**:
+
+- `status` — live sessions
+- `call` — `{ tool, args }` generic
+- `snapshot` / `navigate` / `click` / `type` — convenience
+
+Requires a live extension reverse session for the **same user** as the API key.
+
+## Deploy
+
+Enabled on `apps/host-selfhost` via `executor.config.ts`. Rebuild and restart the lab container / process after merging.

--- a/packages/plugins/browser-bridge/package.json
+++ b/packages/plugins/browser-bridge/package.json
@@ -15,7 +15,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@executor-js/sdk": "workspace:*"
+    "@executor-js/sdk": "workspace:*",
+    "effect": "catalog:"
   },
   "devDependencies": {
     "typescript": "catalog:",

--- a/packages/plugins/browser-bridge/package.json
+++ b/packages/plugins/browser-bridge/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@executor-js/plugin-browser-bridge",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Reverse browser bridge: extension dials out; agents call tools.chrome.* via live desktop sessions.",
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    "./server": "./src/server.ts",
+    "./store": "./src/store.ts",
+    "./http": "./src/http.ts"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@executor-js/sdk": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/plugins/browser-bridge/src/http.ts
+++ b/packages/plugins/browser-bridge/src/http.ts
@@ -1,0 +1,166 @@
+/**
+ * HTTP surface for Executor Browser extension reverse channel.
+ *
+ *   POST   /api/browser-bridge/session
+ *   GET    /api/browser-bridge/session/:id/jobs?waitMs=
+ *   POST   /api/browser-bridge/session/:id/result
+ *   DELETE /api/browser-bridge/session/:id
+ *   GET    /api/browser-bridge/sessions
+ *   POST   /api/browser-bridge/call
+ */
+
+import {
+  callTool,
+  createSession,
+  deleteSession,
+  getSession,
+  listSessionsForUser,
+  postResult,
+  sessionPublicView,
+  takeJobs,
+} from "./store";
+
+export type AuthSession = {
+  user: { id: string; name?: string | null; email?: string | null };
+  session?: { activeOrganizationId?: string | null };
+};
+
+export type BrowserBridgeHttpDeps = {
+  /** Resolve Bearer / API key / cookie session. Return null if unauthenticated. */
+  readonly getSession: (request: Request) => Promise<AuthSession | null>;
+};
+
+const json = (value: unknown, status = 200) =>
+  new Response(JSON.stringify(value), {
+    status,
+    headers: {
+      "content-type": "application/json",
+      "cache-control": "no-store",
+    },
+  });
+
+const unauthorized = () => json({ error: "unauthorized" }, 401);
+const notFound = (msg = "not found") => json({ error: msg }, 404);
+const badRequest = (msg: string) => json({ error: msg }, 400);
+
+async function readJson(request: Request): Promise<unknown> {
+  try {
+    return await request.json();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Mount at `/api/browser-bridge/*` (and exact `/api/browser-bridge`).
+ */
+export function makeBrowserBridgeHandler(deps: BrowserBridgeHttpDeps) {
+  return async (request: Request): Promise<Response> => {
+    const url = new URL(request.url);
+    // Normalize path: strip /api/browser-bridge prefix
+    let path = url.pathname;
+    const markers = ["/api/browser-bridge", "/browser-bridge"];
+    for (const m of markers) {
+      if (path === m || path.startsWith(m + "/")) {
+        path = path.slice(m.length) || "/";
+        break;
+      }
+    }
+
+    const auth = await deps.getSession(request);
+    if (!auth?.user?.id) return unauthorized();
+    const userId = auth.user.id;
+    const organizationId = auth.session?.activeOrganizationId || undefined;
+
+    // POST /session
+    if (path === "/session" && request.method === "POST") {
+      const body = (await readJson(request)) as Record<string, unknown> | null;
+      const session = createSession({
+        userId,
+        organizationId,
+        kind: typeof body?.kind === "string" ? body.kind : "chrome-extension",
+        transport: typeof body?.transport === "string" ? body.transport : "reverse-longpoll",
+        client: (body?.client as Record<string, unknown>) || undefined,
+        capabilities: body?.capabilities,
+        connection: (body?.connection as Record<string, unknown>) || undefined,
+      });
+      return json({
+        sessionId: session.id,
+        id: session.id,
+        pollPath: `/api/browser-bridge/session/${session.id}/jobs`,
+        resultPath: `/api/browser-bridge/session/${session.id}/result`,
+        ...sessionPublicView(session),
+      });
+    }
+
+    // GET /sessions
+    if (path === "/sessions" && request.method === "GET") {
+      return json({
+        sessions: listSessionsForUser(userId).map(sessionPublicView),
+      });
+    }
+
+    // POST /call  — agent/HTTP convenience
+    if (path === "/call" && request.method === "POST") {
+      const body = (await readJson(request)) as {
+        tool?: string;
+        args?: Record<string, unknown>;
+        sessionId?: string;
+        timeoutMs?: number;
+      } | null;
+      if (!body?.tool) return badRequest("tool required");
+      try {
+        const result = await callTool({
+          userId,
+          tool: body.tool,
+          args: body.args,
+          sessionId: body.sessionId,
+          timeoutMs: body.timeoutMs,
+        });
+        return json({ ok: true, result });
+      } catch (e) {
+        return json({ ok: false, error: String((e as Error)?.message || e) }, 504);
+      }
+    }
+
+    // /session/:id/...
+    const sessionMatch = path.match(/^\/session\/([^/]+)(?:\/(jobs|result))?$/);
+    if (sessionMatch) {
+      const sessionId = decodeURIComponent(sessionMatch[1]!);
+      const sub = sessionMatch[2];
+
+      if (!sub && request.method === "DELETE") {
+        const ok = deleteSession(sessionId, userId);
+        return ok ? json({ ok: true }) : notFound("session not found");
+      }
+
+      if (!sub && request.method === "GET") {
+        const s = getSession(sessionId);
+        if (!s || s.userId !== userId) return notFound("session not found");
+        return json(sessionPublicView(s));
+      }
+
+      if (sub === "jobs" && request.method === "GET") {
+        const waitMs = Number(url.searchParams.get("waitMs") || "25000");
+        try {
+          const jobs = await takeJobs(sessionId, userId, waitMs);
+          return json({ jobs });
+        } catch (e) {
+          return notFound(String((e as Error)?.message || e));
+        }
+      }
+
+      if (sub === "result" && request.method === "POST") {
+        const body = (await readJson(request)) as {
+          jobId?: string;
+          result?: unknown;
+        } | null;
+        if (!body?.jobId) return badRequest("jobId required");
+        const ok = postResult(sessionId, userId, body.jobId, body.result);
+        return ok ? json({ ok: true }) : notFound("job not found");
+      }
+    }
+
+    return notFound(`unknown browser-bridge path ${path}`);
+  };
+}

--- a/packages/plugins/browser-bridge/src/server.ts
+++ b/packages/plugins/browser-bridge/src/server.ts
@@ -1,0 +1,236 @@
+/**
+ * @executor-js/plugin-browser-bridge/server
+ *
+ * Static integration `chrome` — reverse desktop bridge tools.
+ * Requires a live extension session (path B). Agents call e.g. tools.chrome.snapshot.
+ */
+
+import { Effect, Schema } from "effect";
+
+import { definePlugin, tool, type StaticToolSchema } from "@executor-js/sdk/core";
+
+import { callTool, listSessionsForUser, sessionPublicView } from "./store";
+
+export interface BrowserBridgePluginOptions {
+  readonly callTimeoutMs?: number;
+}
+
+const schemaToStaticToolSchema = <A, I>(schema: Schema.Decoder<A, I>): StaticToolSchema<A, I> =>
+  Schema.toStandardSchemaV1(Schema.toStandardJSONSchemaV1(schema) as never) as StaticToolSchema<
+    A,
+    I
+  >;
+
+const AnyObject = Schema.Record(Schema.String, Schema.Unknown);
+
+const CallInput = Schema.Struct({
+  tool: Schema.String,
+  args: Schema.optional(AnyObject),
+  sessionId: Schema.optional(Schema.String),
+  timeoutMs: Schema.optional(Schema.Number),
+});
+const CallInputStd = schemaToStaticToolSchema(CallInput);
+
+const StatusOutput = Schema.Struct({
+  sessions: Schema.Array(
+    Schema.Struct({
+      sessionId: Schema.String,
+      kind: Schema.String,
+      transport: Schema.String,
+      createdAt: Schema.Number,
+      lastSeenAt: Schema.Number,
+      pending: Schema.Number,
+      inflight: Schema.Number,
+    }),
+  ),
+  note: Schema.String,
+});
+const StatusOutputStd = schemaToStaticToolSchema(StatusOutput);
+
+const CallOutput = Schema.Struct({
+  ok: Schema.Boolean,
+  result: Schema.optional(Schema.Unknown),
+  error: Schema.optional(Schema.String),
+});
+const CallOutputStd = schemaToStaticToolSchema(CallOutput);
+
+type ExecCtx = {
+  readonly ctx: {
+    readonly owner: { readonly tenant: string; readonly subject: string | null };
+  };
+};
+
+function userIdFrom(context: ExecCtx): string {
+  // Prefer subject (API key / user). Fall back to tenant so org-only scopes still key something.
+  return String(context.ctx.owner.subject || context.ctx.owner.tenant || "anonymous");
+}
+
+async function invoke(
+  userId: string,
+  toolName: string,
+  args: Record<string, unknown> | undefined,
+  sessionId: string | undefined,
+  timeoutMs: number,
+): Promise<{ ok: boolean; result?: unknown; error?: string }> {
+  try {
+    const result = await callTool({
+      userId,
+      sessionId,
+      tool: toolName,
+      args: args || {},
+      timeoutMs,
+    });
+    return { ok: true, result };
+  } catch (e) {
+    return { ok: false, error: String((e as Error)?.message || e) };
+  }
+}
+
+export const browserBridgePlugin = definePlugin((options: BrowserBridgePluginOptions = {}) => {
+  const defaultTimeout = options.callTimeoutMs ?? 45_000;
+
+  return {
+    id: "browser-bridge" as const,
+    packageName: "@executor-js/plugin-browser-bridge",
+    storage: () => ({}),
+    staticIntegrations: () => [
+      {
+        id: "chrome",
+        kind: "executor",
+        name: "Chrome (desktop reverse)",
+        description:
+          "Drive the user's real Chrome via Executor Browser extension reverse channel. Requires a live bridge session (extension Connect, path B).",
+        tools: [
+          tool({
+            name: "status",
+            description:
+              "List live desktop browser-bridge sessions. Empty means the extension is not connected with reverse drive.",
+            outputSchema: StatusOutputStd,
+            execute: (_args, context) =>
+              Effect.sync(() => {
+                const userId = userIdFrom(context as ExecCtx);
+                const sessions = listSessionsForUser(userId).map(sessionPublicView);
+                return {
+                  sessions,
+                  note:
+                    sessions.length === 0
+                      ? "No live reverse session. Open Executor Browser → Connect (Extension B)."
+                      : `${sessions.length} session(s) live`,
+                };
+              }),
+          }),
+          tool({
+            name: "call",
+            description:
+              "Invoke a browser tool on the live extension session. Tools: ping, tabs.list, tabs.open, navigate, snapshot, click, type, screenshot. Prefer snapshot over screenshot.",
+            inputSchema: CallInputStd,
+            outputSchema: CallOutputStd,
+            execute: (input, context) =>
+              Effect.promise(() => {
+                const userId = userIdFrom(context as ExecCtx);
+                const body = input as {
+                  tool: string;
+                  args?: Record<string, unknown>;
+                  sessionId?: string;
+                  timeoutMs?: number;
+                };
+                return invoke(
+                  userId,
+                  body.tool,
+                  body.args,
+                  body.sessionId,
+                  body.timeoutMs ?? defaultTimeout,
+                );
+              }),
+          }),
+          tool({
+            name: "snapshot",
+            description:
+              "A11y-ish DOM snapshot of the active agent tab. Prefer this over screenshot.",
+            inputSchema: schemaToStaticToolSchema(
+              Schema.Struct({
+                tabId: Schema.optional(Schema.Number),
+                sessionId: Schema.optional(Schema.String),
+              }),
+            ),
+            outputSchema: CallOutputStd,
+            execute: (input, context) =>
+              Effect.promise(() => {
+                const userId = userIdFrom(context as ExecCtx);
+                const args = { ...((input as Record<string, unknown>) || {}) };
+                const sessionId = args.sessionId as string | undefined;
+                delete args.sessionId;
+                return invoke(userId, "snapshot", args, sessionId, defaultTimeout);
+              }),
+          }),
+          tool({
+            name: "navigate",
+            description: "Navigate a tab (or open newTab) to a URL in the user's Chrome.",
+            inputSchema: schemaToStaticToolSchema(
+              Schema.Struct({
+                url: Schema.String,
+                tabId: Schema.optional(Schema.Number),
+                newTab: Schema.optional(Schema.Boolean),
+                sessionId: Schema.optional(Schema.String),
+              }),
+            ),
+            outputSchema: CallOutputStd,
+            execute: (input, context) =>
+              Effect.promise(() => {
+                const userId = userIdFrom(context as ExecCtx);
+                const args = { ...((input as Record<string, unknown>) || {}) };
+                const sessionId = args.sessionId as string | undefined;
+                delete args.sessionId;
+                return invoke(userId, "navigate", args, sessionId, defaultTimeout);
+              }),
+          }),
+          tool({
+            name: "click",
+            description: "Click by coordinates, CSS selector, or snapshot nodeIndex.",
+            inputSchema: schemaToStaticToolSchema(
+              Schema.Struct({
+                x: Schema.optional(Schema.Number),
+                y: Schema.optional(Schema.Number),
+                selector: Schema.optional(Schema.String),
+                nodeIndex: Schema.optional(Schema.Number),
+                tabId: Schema.optional(Schema.Number),
+                sessionId: Schema.optional(Schema.String),
+              }),
+            ),
+            outputSchema: CallOutputStd,
+            execute: (input, context) =>
+              Effect.promise(() => {
+                const userId = userIdFrom(context as ExecCtx);
+                const args = { ...((input as Record<string, unknown>) || {}) };
+                const sessionId = args.sessionId as string | undefined;
+                delete args.sessionId;
+                return invoke(userId, "click", args, sessionId, defaultTimeout);
+              }),
+          }),
+          tool({
+            name: "type",
+            description: "Type text into the focused input (or selector). Optional submit.",
+            inputSchema: schemaToStaticToolSchema(
+              Schema.Struct({
+                text: Schema.String,
+                selector: Schema.optional(Schema.String),
+                submit: Schema.optional(Schema.Boolean),
+                tabId: Schema.optional(Schema.Number),
+                sessionId: Schema.optional(Schema.String),
+              }),
+            ),
+            outputSchema: CallOutputStd,
+            execute: (input, context) =>
+              Effect.promise(() => {
+                const userId = userIdFrom(context as ExecCtx);
+                const args = { ...((input as Record<string, unknown>) || {}) };
+                const sessionId = args.sessionId as string | undefined;
+                delete args.sessionId;
+                return invoke(userId, "type", args, sessionId, defaultTimeout);
+              }),
+          }),
+        ],
+      },
+    ],
+  };
+});

--- a/packages/plugins/browser-bridge/src/server.ts
+++ b/packages/plugins/browser-bridge/src/server.ts
@@ -5,9 +5,13 @@
  * Requires a live extension session (path B). Agents call e.g. tools.chrome.snapshot.
  */
 
-import { Effect, Schema } from "effect";
-
-import { definePlugin, tool, type StaticToolSchema } from "@executor-js/sdk/core";
+import {
+  definePlugin,
+  tool,
+  Effect,
+  Schema,
+  type StaticToolSchema,
+} from "@executor-js/sdk/core";
 
 import { callTool, listSessionsForUser, sessionPublicView } from "./store";
 

--- a/packages/plugins/browser-bridge/src/store.test.ts
+++ b/packages/plugins/browser-bridge/src/store.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  _resetStoreForTests,
+  callTool,
+  createSession,
+  listSessionsForUser,
+  postResult,
+  takeJobs,
+} from "./store";
+
+beforeEach(() => {
+  _resetStoreForTests();
+});
+
+describe("browser-bridge store", () => {
+  it("creates a session and replaces prior for same user", () => {
+    const a = createSession({ userId: "u1" });
+    const b = createSession({ userId: "u1" });
+    expect(listSessionsForUser("u1")).toHaveLength(1);
+    expect(listSessionsForUser("u1")[0]!.id).toBe(b.id);
+    expect(a.id).not.toBe(b.id);
+  });
+
+  it("round-trips a tool call via long-poll + result", async () => {
+    const s = createSession({ userId: "u1" });
+
+    const callP = callTool({ userId: "u1", tool: "ping", args: {} });
+    const jobs = await takeJobs(s.id, "u1", 2000);
+    expect(jobs).toHaveLength(1);
+    expect(jobs[0]!.tool).toBe("ping");
+
+    postResult(s.id, "u1", jobs[0]!.id, { ok: true, mode: "extension-reverse" });
+    const result = await callP;
+    expect(result).toEqual({ ok: true, mode: "extension-reverse" });
+  });
+
+  it("rejects call without session", async () => {
+    await expect(callTool({ userId: "nobody", tool: "ping" })).rejects.toThrow(/No live/);
+  });
+});

--- a/packages/plugins/browser-bridge/src/store.ts
+++ b/packages/plugins/browser-bridge/src/store.ts
@@ -1,0 +1,303 @@
+/**
+ * In-process reverse browser-bridge sessions.
+ *
+ * Extension (path B) opens a session and long-polls for jobs.
+ * Agents enqueue tools via plugin tools or POST /call and wait for results.
+ */
+
+export type BridgeJob = {
+  id: string;
+  tool: string;
+  args: Record<string, unknown>;
+  createdAt: number;
+  resolve: (result: unknown) => void;
+  reject: (err: Error) => void;
+  delivered: boolean;
+};
+
+export type BridgeSession = {
+  id: string;
+  userId: string;
+  organizationId?: string;
+  kind: string;
+  transport: string;
+  client?: Record<string, unknown>;
+  capabilities?: unknown;
+  connection?: Record<string, unknown>;
+  createdAt: number;
+  lastSeenAt: number;
+  /** Jobs waiting to be picked up by the extension */
+  pending: BridgeJob[];
+  /** Jobs delivered, waiting for result */
+  inflight: Map<string, BridgeJob>;
+  /** Waiters blocked on empty queue (long-poll) */
+  waiters: Array<{
+    resolve: (jobs: BridgeJob[]) => void;
+    timer: ReturnType<typeof setTimeout>;
+  }>;
+};
+
+const SESSION_TTL_MS = 15 * 60 * 1000;
+const DEFAULT_CALL_TIMEOUT_MS = 45_000;
+
+const sessions = new Map<string, BridgeSession>();
+
+function newId(prefix: string): string {
+  return `${prefix}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function touch(session: BridgeSession): void {
+  session.lastSeenAt = Date.now();
+}
+
+function gc(): void {
+  const now = Date.now();
+  for (const [id, s] of sessions) {
+    if (now - s.lastSeenAt > SESSION_TTL_MS) {
+      for (const j of s.pending) j.reject(new Error("session expired"));
+      for (const j of s.inflight.values()) j.reject(new Error("session expired"));
+      for (const w of s.waiters) {
+        clearTimeout(w.timer);
+        w.resolve([]);
+      }
+      sessions.delete(id);
+    }
+  }
+}
+
+export type CreateSessionInput = {
+  userId: string;
+  organizationId?: string;
+  kind?: string;
+  transport?: string;
+  client?: Record<string, unknown>;
+  capabilities?: unknown;
+  connection?: Record<string, unknown>;
+};
+
+export function createSession(input: CreateSessionInput): BridgeSession {
+  gc();
+  // One live desktop session per user (replace prior)
+  for (const [id, s] of sessions) {
+    if (s.userId === input.userId) {
+      for (const j of s.pending) j.reject(new Error("session replaced"));
+      for (const j of s.inflight.values()) j.reject(new Error("session replaced"));
+      for (const w of s.waiters) {
+        clearTimeout(w.timer);
+        w.resolve([]);
+      }
+      sessions.delete(id);
+    }
+  }
+
+  const session: BridgeSession = {
+    id: newId("bbs"),
+    userId: input.userId,
+    organizationId: input.organizationId,
+    kind: input.kind || "chrome-extension",
+    transport: input.transport || "reverse-longpoll",
+    client: input.client,
+    capabilities: input.capabilities,
+    connection: input.connection,
+    createdAt: Date.now(),
+    lastSeenAt: Date.now(),
+    pending: [],
+    inflight: new Map(),
+    waiters: [],
+  };
+  sessions.set(session.id, session);
+  return session;
+}
+
+export function getSession(id: string): BridgeSession | undefined {
+  gc();
+  const s = sessions.get(id);
+  if (s) touch(s);
+  return s;
+}
+
+export function listSessionsForUser(userId: string): BridgeSession[] {
+  gc();
+  return [...sessions.values()].filter((s) => s.userId === userId);
+}
+
+export function deleteSession(id: string, userId?: string): boolean {
+  const s = sessions.get(id);
+  if (!s) return false;
+  if (userId && s.userId !== userId) return false;
+  for (const j of s.pending) j.reject(new Error("session closed"));
+  for (const j of s.inflight.values()) j.reject(new Error("session closed"));
+  for (const w of s.waiters) {
+    clearTimeout(w.timer);
+    w.resolve([]);
+  }
+  sessions.delete(id);
+  return true;
+}
+
+/** Extension long-poll: wait up to waitMs for jobs. */
+export function takeJobs(
+  sessionId: string,
+  userId: string,
+  waitMs = 25_000,
+): Promise<Array<{ id: string; tool: string; args: Record<string, unknown> }>> {
+  const s = getSession(sessionId);
+  if (!s || s.userId !== userId) {
+    return Promise.reject(new Error("session not found"));
+  }
+  touch(s);
+
+  if (s.pending.length > 0) {
+    return Promise.resolve(drainPending(s));
+  }
+
+  const ms = Math.min(Math.max(waitMs, 0), 30_000);
+  if (ms === 0) return Promise.resolve([]);
+
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      s.waiters = s.waiters.filter((w) => w.resolve !== resolveJobs);
+      resolve([]);
+    }, ms);
+
+    const resolveJobs = (jobs: BridgeJob[]) => {
+      clearTimeout(timer);
+      // jobs already moved to inflight by notifyWaiters or drain
+      resolve(
+        jobs.map((j) => ({
+          id: j.id,
+          tool: j.tool,
+          args: j.args,
+        })),
+      );
+    };
+
+    s.waiters.push({ resolve: resolveJobs, timer });
+  });
+}
+
+function drainPending(
+  s: BridgeSession,
+): Array<{ id: string; tool: string; args: Record<string, unknown> }> {
+  const batch = s.pending.splice(0, s.pending.length);
+  for (const j of batch) {
+    j.delivered = true;
+    s.inflight.set(j.id, j);
+  }
+  return batch.map((j) => ({ id: j.id, tool: j.tool, args: j.args }));
+}
+
+function notifyWaiters(s: BridgeSession): void {
+  if (s.waiters.length === 0 || s.pending.length === 0) return;
+  const waiter = s.waiters.shift();
+  if (!waiter) return;
+  clearTimeout(waiter.timer);
+  const jobs = s.pending.splice(0, s.pending.length);
+  for (const j of jobs) {
+    j.delivered = true;
+    s.inflight.set(j.id, j);
+  }
+  waiter.resolve(jobs);
+}
+
+export function postResult(
+  sessionId: string,
+  userId: string,
+  jobId: string,
+  result: unknown,
+): boolean {
+  const s = getSession(sessionId);
+  if (!s || s.userId !== userId) return false;
+  touch(s);
+  const job = s.inflight.get(jobId);
+  if (!job) {
+    // maybe still pending (race)
+    const idx = s.pending.findIndex((j) => j.id === jobId);
+    if (idx >= 0) {
+      const j = s.pending.splice(idx, 1)[0]!;
+      j.resolve(result);
+      return true;
+    }
+    return false;
+  }
+  s.inflight.delete(jobId);
+  job.resolve(result);
+  return true;
+}
+
+export type CallToolInput = {
+  userId: string;
+  sessionId?: string;
+  tool: string;
+  args?: Record<string, unknown>;
+  timeoutMs?: number;
+};
+
+/** Agent path: enqueue tool, wait for extension result. */
+export function callTool(input: CallToolInput): Promise<unknown> {
+  gc();
+  let s: BridgeSession | undefined;
+  if (input.sessionId) {
+    s = getSession(input.sessionId);
+    if (s && s.userId !== input.userId) s = undefined;
+  } else {
+    s = listSessionsForUser(input.userId)[0];
+  }
+  if (!s) {
+    return Promise.reject(
+      new Error(
+        "No live browser bridge session. Open Executor Browser extension → Connect (path B reverse).",
+      ),
+    );
+  }
+  touch(s);
+
+  const timeoutMs = input.timeoutMs ?? DEFAULT_CALL_TIMEOUT_MS;
+  const jobId = newId("job");
+
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      s!.pending = s!.pending.filter((j) => j.id !== jobId);
+      s!.inflight.delete(jobId);
+      reject(new Error(`browser tool timeout after ${timeoutMs}ms (${input.tool})`));
+    }, timeoutMs);
+
+    const job: BridgeJob = {
+      id: jobId,
+      tool: input.tool,
+      args: input.args || {},
+      createdAt: Date.now(),
+      delivered: false,
+      resolve: (result) => {
+        clearTimeout(timer);
+        resolve(result);
+      },
+      reject: (err) => {
+        clearTimeout(timer);
+        reject(err);
+      },
+    };
+
+    s!.pending.push(job);
+    notifyWaiters(s!);
+  });
+}
+
+export function sessionPublicView(s: BridgeSession) {
+  return {
+    sessionId: s.id,
+    kind: s.kind,
+    transport: s.transport,
+    createdAt: s.createdAt,
+    lastSeenAt: s.lastSeenAt,
+    pending: s.pending.length,
+    inflight: s.inflight.size,
+    client: s.client,
+    capabilities: s.capabilities,
+  };
+}
+
+/** Test helper */
+export function _resetStoreForTests(): void {
+  for (const id of [...sessions.keys()]) deleteSession(id);
+}


### PR DESCRIPTION
## Summary
Adds reverse browser-bridge so **Executor Browser** (Chrome extension) can drive real Chrome without a local companion script.

- \POST/GET /api/browser-bridge/*\ session + long-poll jobs + results (API key auth)
- Static integration \chrome\ tools: status, call, snapshot, navigate, click, type
- Shared in-process job store; extension dials out over Tailscale

## Why
Completes the loop with [executor-browser](https://github.com/tzarebczan/executor-browser) path B reverse channel. Aligns with typed browser tools via the user's real profile (passkeys/OAuth).

## Test plan
- [ ] Unit: store round-trip (createSession → callTool → takeJobs → postResult)
- [ ] Deploy host-selfhost with plugin enabled
- [ ] Extension Connect → reverse session mode \everse\ (not local-ready)
- [ ] Agent: tools.chrome.status / snapshot against live extension
