### PR TITLE
Expose Coolify environment lifecycle flags

### DIFF
--- a/.changeset/coolify-env-lifecycle-schema.md
+++ b/.changeset/coolify-env-lifecycle-schema.md
@@ -1,0 +1,5 @@
+---
+"@executor-js/plugin-openapi": patch
+---
+
+**Fix: Repair Coolify application environment-variable write schemas so `is_runtime` and `is_buildtime` are exposed to normal Executor tools and preserved in JSON requests.**

--- a/packages/plugins/openapi/src/sdk/backing.ts
+++ b/packages/plugins/openapi/src/sdk/backing.ts
@@ -225,6 +225,278 @@ const FILE_OUTPUT_HINT =
 const withFileEmitHint = (description: string, returnsFile: boolean): string =>
   returnsFile ? `${description}\n\n${FILE_OUTPUT_HINT}` : description;
 
+// ---------------------------------------------------------------------------
+// Coolify environment-variable request-schema compatibility
+// ---------------------------------------------------------------------------
+
+type CoolifyApplicationEnvironmentWriteKind = "single" | "batch";
+
+type CoolifyApplicationEnvironmentWriteSignature = {
+  readonly kind: CoolifyApplicationEnvironmentWriteKind;
+  readonly method: "post" | "patch";
+  readonly pathTemplate: string;
+};
+
+const COOLIFY_APPLICATION_ENV_WRITE_SIGNATURES = new Map<
+  string,
+  CoolifyApplicationEnvironmentWriteSignature
+>([
+  [
+    "applications.createEnvByApplicationUuid",
+    { kind: "single", method: "post", pathTemplate: "/applications/{uuid}/envs" },
+  ],
+  [
+    "applications.updateEnvByApplicationUuid",
+    { kind: "single", method: "patch", pathTemplate: "/applications/{uuid}/envs" },
+  ],
+  [
+    "applications.updateEnvsByApplicationUuid",
+    { kind: "batch", method: "patch", pathTemplate: "/applications/{uuid}/envs/bulk" },
+  ],
+]);
+
+const COOLIFY_ENVIRONMENT_LIFECYCLE_PROPERTIES = {
+  is_runtime: {
+    type: "boolean",
+    description: "Whether this environment variable is available to the running application.",
+  },
+  is_buildtime: {
+    type: "boolean",
+    description: "Whether this environment variable is available while the application builds.",
+  },
+} as const;
+
+const COOLIFY_LEGACY_ENVIRONMENT_PROPERTIES = {
+  key: "string",
+  value: "string",
+  is_preview: "boolean",
+  is_literal: "boolean",
+  is_multiline: "boolean",
+  is_shown_once: "boolean",
+} as const;
+
+const COOLIFY_ENVIRONMENT_PROPERTIES: Readonly<Record<string, string>> = {
+  ...COOLIFY_LEGACY_ENVIRONMENT_PROPERTIES,
+  is_runtime: "boolean",
+  is_buildtime: "boolean",
+};
+
+const asRecord = (value: unknown): Record<string, unknown> | undefined =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+
+const hasExactPropertyTypes = (
+  schema: unknown,
+  expected: Readonly<Record<string, string>>,
+): boolean => {
+  const object = asRecord(schema);
+  const properties = asRecord(object?.properties);
+  const expectedNames = Object.keys(expected);
+  if (
+    object?.type !== "object" ||
+    !properties ||
+    Object.keys(properties).length !== expectedNames.length
+  ) {
+    return false;
+  }
+  return expectedNames.every((name) => asRecord(properties[name])?.type === expected[name]);
+};
+
+const hasExactRequiredProperties = (schema: Record<string, unknown>, names: readonly string[]) => {
+  const required = schema.required;
+  return (
+    Array.isArray(required) &&
+    required.length === names.length &&
+    names.every((name) => required.includes(name))
+  );
+};
+
+const isLegacyCoolifyEnvironmentVariableSchema = (schema: unknown): boolean => {
+  const object = asRecord(schema);
+  const properties = asRecord(object?.properties);
+  if (
+    object?.type !== "object" ||
+    !properties ||
+    !Object.entries(COOLIFY_LEGACY_ENVIRONMENT_PROPERTIES).every(
+      ([name, type]) => asRecord(properties[name])?.type === type,
+    )
+  ) {
+    return false;
+  }
+  // An upstream schema may gain either lifecycle field before the other, but
+  // no unrelated property may turn a similarly named tenant endpoint into a
+  // compatibility candidate.
+  return Object.entries(properties).every(
+    ([name, property]) => asRecord(property)?.type === COOLIFY_ENVIRONMENT_PROPERTIES[name],
+  );
+};
+
+const isCoolifyEnvironmentWriteInputShape = (
+  kind: CoolifyApplicationEnvironmentWriteKind,
+  inputSchema: unknown,
+): boolean => {
+  const root = asRecord(inputSchema);
+  const rootProperties = asRecord(root?.properties);
+  if (
+    !root ||
+    root.additionalProperties !== false ||
+    !rootProperties ||
+    !hasExactRequiredProperties(root, ["uuid", "body"]) ||
+    !hasExactPropertyTypes(root, { uuid: "string", body: "object" })
+  ) {
+    return false;
+  }
+
+  const body = rootProperties.body;
+  if (kind === "single") return isLegacyCoolifyEnvironmentVariableSchema(body);
+
+  const bodyObject = asRecord(body);
+  const bodyProperties = asRecord(bodyObject?.properties);
+  const data = bodyProperties?.data;
+  const dataObject = asRecord(data);
+  return (
+    bodyObject?.type === "object" &&
+    bodyProperties !== undefined &&
+    Object.keys(bodyProperties).length === 1 &&
+    dataObject?.type === "array" &&
+    isLegacyCoolifyEnvironmentVariableSchema(dataObject.items)
+  );
+};
+
+const isCoolifyEnvironmentWriteOperation = (
+  signature: CoolifyApplicationEnvironmentWriteSignature,
+  operation:
+    | {
+        readonly method: string;
+        readonly pathTemplate: string;
+        readonly parameters: readonly {
+          readonly name: string;
+          readonly location: string;
+          readonly required: boolean;
+        }[];
+      }
+    | undefined,
+): boolean =>
+  operation?.method === signature.method &&
+  operation.pathTemplate === signature.pathTemplate &&
+  hasRequiredApplicationUuidPathParameter(operation.parameters);
+
+const hasRequiredApplicationUuidPathParameter = (
+  parameters: readonly {
+    readonly name: string;
+    readonly location: string;
+    readonly required: boolean;
+  }[],
+): boolean =>
+  parameters.some(
+    (parameter) => parameter.name === "uuid" && parameter.location === "path" && parameter.required,
+  );
+
+/** Whether this is one of the only tool names that can need the compatibility repair. */
+export const isCoolifyApplicationEnvironmentWriteTool = (toolName: string): boolean =>
+  COOLIFY_APPLICATION_ENV_WRITE_SIGNATURES.has(toolName);
+
+/** Add only the lifecycle fields absent from an inline object schema. */
+const withCoolifyEnvironmentLifecycleProperties = (schema: unknown): unknown => {
+  const object = asRecord(schema);
+  const properties = asRecord(object?.properties);
+  if (!object || !properties) return schema;
+
+  const additions = Object.fromEntries(
+    Object.entries(COOLIFY_ENVIRONMENT_LIFECYCLE_PROPERTIES).filter(
+      ([name]) => !Object.hasOwn(properties, name),
+    ),
+  );
+  if (Object.keys(additions).length === 0) return schema;
+
+  return {
+    ...object,
+    properties: {
+      ...properties,
+      ...additions,
+    },
+  };
+};
+
+/**
+ * Coolify accepts `is_runtime` and `is_buildtime` on its application env
+ * create, update, and bulk-update endpoints, but its public OpenAPI request
+ * schemas currently omit both fields while its `EnvironmentVariable` response
+ * schema documents them. Catalog slugs are tenant-defined, so there is no
+ * trustworthy "coolify" slug to gate on: the repair instead requires the
+ * exact target operation method/path and the complete legacy inline request
+ * body fingerprint. The normal OpenAPI request path already serializes the
+ * caller's JSON `body` unchanged, so this is schema discoverability and
+ * validation metadata, not a parallel transport protocol.
+ *
+ * This is deliberately applied at the final tool-schema projection as well as
+ * connection refresh: deployed Executor instances can immediately describe
+ * existing persisted Coolify tool rows correctly. Remove this compatibility
+ * mapping once Coolify's published request schemas include both fields and a
+ * refresh regression proves new and legacy bindings no longer require it.
+ */
+export const repairCoolifyApplicationEnvInputSchema = (
+  toolName: string,
+  inputSchema: unknown,
+  operation?: {
+    readonly method: string;
+    readonly pathTemplate: string;
+    readonly parameters: readonly {
+      readonly name: string;
+      readonly location: string;
+      readonly required: boolean;
+    }[];
+  },
+): unknown => {
+  const signature = COOLIFY_APPLICATION_ENV_WRITE_SIGNATURES.get(toolName);
+  if (!signature || !isCoolifyEnvironmentWriteOperation(signature, operation)) return inputSchema;
+  if (!isCoolifyEnvironmentWriteInputShape(signature.kind, inputSchema)) return inputSchema;
+
+  const root = asRecord(inputSchema);
+  const rootProperties = asRecord(root?.properties);
+  const body = rootProperties?.body;
+  if (!root || !rootProperties || body === undefined) return inputSchema;
+
+  if (signature.kind === "single") {
+    const repairedBody = withCoolifyEnvironmentLifecycleProperties(body);
+    if (repairedBody === body) return inputSchema;
+    return {
+      ...root,
+      properties: {
+        ...rootProperties,
+        body: repairedBody,
+      },
+    };
+  }
+
+  const bodyObject = asRecord(body);
+  const bodyProperties = asRecord(bodyObject?.properties);
+  const data = bodyProperties?.data;
+  const dataObject = asRecord(data);
+  const items = dataObject?.items;
+  if (!bodyObject || !bodyProperties || !dataObject || items === undefined) return inputSchema;
+
+  const repairedItems = withCoolifyEnvironmentLifecycleProperties(items);
+  if (repairedItems === items) return inputSchema;
+  return {
+    ...root,
+    properties: {
+      ...rootProperties,
+      body: {
+        ...bodyObject,
+        properties: {
+          ...bodyProperties,
+          data: {
+            ...dataObject,
+            items: repairedItems,
+          },
+        },
+      },
+    },
+  };
+};
+
 export interface CompiledOpenApiSpec {
   readonly definitions: readonly ToolDefinition[];
   readonly hoistedDefs: Record<string, unknown>;
@@ -318,7 +590,15 @@ export const openApiToolDefsFromCompiled = (compiled: CompiledOpenApiSpec): read
     return {
       name: ToolName.make(def.toolPath),
       description: withFileEmitHint(descriptionFor(def), returnsFile),
-      inputSchema: normalizeOpenApiRefs(Option.getOrUndefined(def.operation.inputSchema)),
+      inputSchema: repairCoolifyApplicationEnvInputSchema(
+        def.toolPath,
+        normalizeOpenApiRefs(Option.getOrUndefined(def.operation.inputSchema)),
+        {
+          method: def.operation.method,
+          pathTemplate: def.operation.pathTemplate,
+          parameters: def.operation.parameters,
+        },
+      ),
       outputSchema: returnsFile
         ? ToolFileJsonSchema
         : normalizeOpenApiRefs(Option.getOrUndefined(def.operation.outputSchema)),
@@ -409,12 +689,20 @@ const toolDefFromStoredOperation = (op: StoredOperation): ToolDef => {
       op.description ?? `${binding.method.toUpperCase()} ${binding.pathTemplate}`,
       returnsFile,
     ),
-    inputSchema: normalizeOpenApiRefs(
-      buildInputSchema(
-        binding.parameters,
-        Option.getOrUndefined(binding.requestBody),
-        binding.servers ?? [],
+    inputSchema: repairCoolifyApplicationEnvInputSchema(
+      op.toolName,
+      normalizeOpenApiRefs(
+        buildInputSchema(
+          binding.parameters,
+          Option.getOrUndefined(binding.requestBody),
+          binding.servers ?? [],
+        ),
       ),
+      {
+        method: binding.method,
+        pathTemplate: binding.pathTemplate,
+        parameters: binding.parameters,
+      },
     ),
     outputSchema: returnsFile
       ? ToolFileJsonSchema
@@ -609,7 +897,10 @@ export const resolveOpenApiBackedTools = ({
             .listOperations(String(integration.slug))
             .pipe(Effect.catch(() => Effect.succeed(null)));
           if (ops == null) return incomplete("OpenAPI operation bindings could not be loaded.");
-          return { tools: ops.map(toolDefFromStoredOperation), definitions };
+          return {
+            tools: ops.map(toolDefFromStoredOperation),
+            definitions,
+          };
         }
       }
     }

--- a/packages/plugins/openapi/src/sdk/coolify-env-schema.test.ts
+++ b/packages/plugins/openapi/src/sdk/coolify-env-schema.test.ts
@@ -1,0 +1,474 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Ref, Schema } from "effect";
+import { HttpServerResponse } from "effect/unstable/http";
+
+import { ConnectionName, createExecutor, IntegrationSlug } from "@executor-js/sdk";
+import {
+  makeTestConfig,
+  memoryCredentialsPlugin,
+  serveTestHttpApp,
+} from "@executor-js/sdk/testing";
+
+import { addOpenApiTestConnection } from "../testing";
+import { repairCoolifyApplicationEnvInputSchema } from "./backing";
+import { openApiPlugin } from "./plugin";
+
+type CapturedRequest = {
+  readonly method: string;
+  readonly url: string;
+  readonly body: string;
+};
+
+const environmentVariableProperties = {
+  key: { type: "string" },
+  value: { type: "string" },
+  is_preview: { type: "boolean" },
+  is_literal: { type: "boolean" },
+  is_multiline: { type: "boolean" },
+  is_shown_once: { type: "boolean" },
+};
+
+const nonTargetOperationName = "applications.updateEnvironmentMetadataByApplicationUuid";
+
+const environmentVariableRequestSchema = () => ({
+  type: "object",
+  properties: { ...environmentVariableProperties },
+});
+
+const bulkEnvironmentVariableRequestSchema = () => ({
+  type: "object",
+  properties: {
+    data: {
+      type: "array",
+      items: environmentVariableRequestSchema(),
+    },
+  },
+});
+
+const operation = (operationId: string, bodySchema: Record<string, unknown>) => ({
+  operationId,
+  tags: ["Applications"],
+  parameters: [
+    {
+      name: "uuid",
+      in: "path",
+      required: true,
+      schema: { type: "string" },
+    },
+  ],
+  requestBody: {
+    required: true,
+    content: {
+      "application/json": {
+        schema: bodySchema,
+      },
+    },
+  },
+  responses: {
+    "200": {
+      description: "OK",
+      content: {
+        "application/json": {
+          schema: { type: "object" },
+        },
+      },
+    },
+  },
+});
+
+const coolifySpec = (baseUrl: string) =>
+  JSON.stringify({
+    openapi: "3.0.0",
+    info: { title: "Coolify API", version: "1.0.0" },
+    servers: [{ url: baseUrl }],
+    paths: {
+      "/applications/{uuid}/envs": {
+        post: operation("createEnvByApplicationUuid", environmentVariableRequestSchema()),
+        patch: operation("updateEnvByApplicationUuid", environmentVariableRequestSchema()),
+      },
+      "/applications/{uuid}/envs/bulk": {
+        patch: operation("updateEnvsByApplicationUuid", bulkEnvironmentVariableRequestSchema()),
+      },
+      // This has the same legacy body shape but is not one of Coolify's
+      // lifecycle-compatible endpoints. It proves the repair is not a broad
+      // "any applications env tool" rewrite.
+      "/applications/{uuid}/envs/metadata": {
+        patch: operation(
+          "updateEnvironmentMetadataByApplicationUuid",
+          environmentVariableRequestSchema(),
+        ),
+      },
+    },
+  });
+
+const tenantLocalCollisionSpec = (baseUrl: string) =>
+  JSON.stringify({
+    openapi: "3.0.0",
+    info: { title: "Tenant-local API", version: "1.0.0" },
+    servers: [{ url: baseUrl }],
+    paths: {
+      "/applications/{uuid}/envs": {
+        patch: operation("updateEnvByApplicationUuid", {
+          type: "object",
+          properties: {
+            ...environmentVariableProperties,
+            enabled: { type: "boolean" },
+          },
+        }),
+      },
+    },
+  });
+
+const legacySingleInputSchema = () => ({
+  type: "object",
+  properties: {
+    uuid: { type: "string" },
+    body: environmentVariableRequestSchema(),
+  },
+  required: ["uuid", "body"],
+  additionalProperties: false,
+});
+
+const legacyBatchInputSchema = () => ({
+  type: "object",
+  properties: {
+    uuid: { type: "string" },
+    body: bulkEnvironmentVariableRequestSchema(),
+  },
+  required: ["uuid", "body"],
+  additionalProperties: false,
+});
+
+const accepted = {
+  onElicitation: () => Effect.succeed({ action: "accept" as const, content: {} }),
+};
+
+const decodeJson = Schema.decodeUnknownSync(Schema.fromJsonString(Schema.Unknown));
+const encodeJson = Schema.encodeUnknownSync(Schema.UnknownFromJsonString);
+
+const serveCoolifyFixture = () =>
+  Effect.gen(function* () {
+    const requests = yield* Ref.make<readonly CapturedRequest[]>([]);
+    const server = yield* serveTestHttpApp((request) =>
+      Effect.gen(function* () {
+        const body = yield* request.text.pipe(Effect.catch(() => Effect.succeed("")));
+        yield* Ref.update(requests, (all) => [
+          ...all,
+          {
+            method: request.method,
+            url: request.url ?? "/",
+            body,
+          },
+        ]);
+        return HttpServerResponse.jsonUnsafe({ ok: true });
+      }),
+    );
+
+    return {
+      ...server,
+      specJson: coolifySpec(server.baseUrl),
+      requests: Ref.get(requests),
+    };
+  });
+
+describe("Coolify application environment variable schema compatibility", () => {
+  it.effect("republishes legacy bindings with lifecycle flags and sends them unchanged", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fixture = yield* serveCoolifyFixture();
+        const plugins = [
+          openApiPlugin({ httpClientLayer: fixture.httpClientLayer }),
+          memoryCredentialsPlugin(),
+        ] as const;
+        const config = makeTestConfig({ plugins });
+        const executor = yield* createExecutor(config);
+        const connection = yield* addOpenApiTestConnection(executor, fixture, {
+          slug: "coolify",
+        });
+
+        const legacySchemas = {
+          "applications.createEnvByApplicationUuid": legacySingleInputSchema(),
+          "applications.updateEnvByApplicationUuid": legacySingleInputSchema(),
+          "applications.updateEnvsByApplicationUuid": legacyBatchInputSchema(),
+        } as const;
+
+        const fresh = yield* Effect.promise(() =>
+          config.db.findMany("tool", {
+            where: (b) =>
+              b.and(b("integration", "=", "coolify"), b("connection", "=", connection.connection)),
+          }),
+        );
+        expect(fresh).toHaveLength(4);
+        for (const name of Object.keys(legacySchemas)) {
+          const row = fresh.find((candidate) => candidate.name === name);
+          expect(encodeJson(row?.input_schema)).toContain('"is_runtime"');
+          expect(encodeJson(row?.input_schema)).toContain('"is_buildtime"');
+        }
+        const freshNonTarget = fresh.find((candidate) => candidate.name === nonTargetOperationName);
+        expect(encodeJson(freshNonTarget?.input_schema)).not.toContain('"is_runtime"');
+        expect(encodeJson(freshNonTarget?.input_schema)).not.toContain('"is_buildtime"');
+
+        for (const [name, inputSchema] of Object.entries(legacySchemas)) {
+          yield* Effect.promise(() =>
+            config.db.updateMany("tool", {
+              where: (b) =>
+                b.and(
+                  b("integration", "=", "coolify"),
+                  b("connection", "=", connection.connection),
+                  b("name", "=", name),
+                ),
+              set: { input_schema: inputSchema },
+            }),
+          );
+        }
+
+        // A deployed Executor must describe old persisted rows correctly before
+        // anyone manually refreshes a connection.
+        for (const name of Object.keys(legacySchemas)) {
+          const schema = yield* executor.tools.schema(connection.address(name));
+          expect(schema?.inputTypeScript).toContain("is_runtime?: boolean");
+          expect(schema?.inputTypeScript).toContain("is_buildtime?: boolean");
+        }
+        const nonTargetSchema = yield* executor.tools.schema(
+          connection.address(nonTargetOperationName),
+        );
+        expect(nonTargetSchema?.inputTypeScript).not.toContain("is_runtime?: boolean");
+        expect(nonTargetSchema?.inputTypeScript).not.toContain("is_buildtime?: boolean");
+
+        const stillLegacy = yield* Effect.promise(() =>
+          config.db.findMany("tool", {
+            where: (b) =>
+              b.and(b("integration", "=", "coolify"), b("connection", "=", connection.connection)),
+          }),
+        );
+        for (const name of Object.keys(legacySchemas)) {
+          const row = stillLegacy.find((candidate) => candidate.name === name);
+          const schema = encodeJson(row?.input_schema);
+          expect(schema).not.toContain('"is_runtime"');
+          expect(schema).not.toContain('"is_buildtime"');
+        }
+
+        // Refresh also writes the repaired schema back into the persisted tool
+        // catalog so future reads do not depend on the legacy projection.
+        yield* executor.connections.refresh({
+          owner: connection.owner,
+          integration: IntegrationSlug.make(connection.slug),
+          name: ConnectionName.make(connection.connection),
+        });
+
+        const republished = yield* Effect.promise(() =>
+          config.db.findMany("tool", {
+            where: (b) =>
+              b.and(b("integration", "=", "coolify"), b("connection", "=", connection.connection)),
+          }),
+        );
+        expect(republished).toHaveLength(4);
+        for (const name of Object.keys(legacySchemas)) {
+          const row = republished.find((candidate) => candidate.name === name);
+          const schema = encodeJson(row?.input_schema);
+          expect(schema).toContain('"is_runtime"');
+          expect(schema).toContain('"is_buildtime"');
+        }
+        const republishedNonTarget = republished.find(
+          (candidate) => candidate.name === nonTargetOperationName,
+        );
+        const nonTargetPersistedSchema = encodeJson(republishedNonTarget?.input_schema);
+        expect(nonTargetPersistedSchema).not.toContain('"is_runtime"');
+        expect(nonTargetPersistedSchema).not.toContain('"is_buildtime"');
+
+        yield* executor.execute(
+          connection.address("applications.createEnvByApplicationUuid"),
+          {
+            uuid: "app-1",
+            body: {
+              key: "CREATE_ONLY",
+              value: "one",
+              is_runtime: true,
+              is_buildtime: false,
+            },
+          },
+          accepted,
+        );
+        yield* executor.execute(
+          connection.address("applications.updateEnvByApplicationUuid"),
+          {
+            uuid: "app-1",
+            body: {
+              key: "UPDATE_ONLY",
+              value: "two",
+              is_runtime: false,
+              is_buildtime: true,
+            },
+          },
+          accepted,
+        );
+        yield* executor.execute(
+          connection.address("applications.updateEnvsByApplicationUuid"),
+          {
+            uuid: "app-1",
+            body: {
+              data: [
+                {
+                  key: "BATCH_ONLY",
+                  value: "three",
+                  is_runtime: false,
+                  is_buildtime: false,
+                },
+              ],
+            },
+          },
+          accepted,
+        );
+
+        const requests = yield* fixture.requests;
+        const writes = requests.filter(
+          (request) => request.method === "POST" || request.method === "PATCH",
+        );
+        expect(writes).toHaveLength(3);
+        expect(writes.map((request) => decodeJson(request.body))).toEqual([
+          {
+            key: "CREATE_ONLY",
+            value: "one",
+            is_runtime: true,
+            is_buildtime: false,
+          },
+          {
+            key: "UPDATE_ONLY",
+            value: "two",
+            is_runtime: false,
+            is_buildtime: true,
+          },
+          {
+            data: [
+              {
+                key: "BATCH_ONLY",
+                value: "three",
+                is_runtime: false,
+                is_buildtime: false,
+              },
+            ],
+          },
+        ]);
+      }),
+    ),
+  );
+
+  it.effect("leaves a tenant-local integration named coolify untouched", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fixture = yield* serveCoolifyFixture();
+        const plugins = [
+          openApiPlugin({ httpClientLayer: fixture.httpClientLayer }),
+          memoryCredentialsPlugin(),
+        ] as const;
+        const config = makeTestConfig({ plugins });
+        const executor = yield* createExecutor(config);
+        const connection = yield* addOpenApiTestConnection(
+          executor,
+          { ...fixture, specJson: tenantLocalCollisionSpec(fixture.baseUrl) },
+          { slug: "coolify" },
+        );
+        const toolName = "applications.updateEnvByApplicationUuid";
+
+        const fresh = yield* Effect.promise(() =>
+          config.db.findFirst("tool", {
+            where: (b) =>
+              b.and(
+                b("integration", "=", "coolify"),
+                b("connection", "=", connection.connection),
+                b("name", "=", toolName),
+              ),
+          }),
+        );
+        expect(encodeJson(fresh?.input_schema)).not.toContain('"is_runtime"');
+        expect(encodeJson(fresh?.input_schema)).not.toContain('"is_buildtime"');
+
+        const projected = yield* executor.tools.schema(connection.address(toolName));
+        expect(projected?.inputTypeScript).not.toContain("is_runtime?: boolean");
+        expect(projected?.inputTypeScript).not.toContain("is_buildtime?: boolean");
+
+        yield* executor.connections.refresh({
+          owner: connection.owner,
+          integration: IntegrationSlug.make(connection.slug),
+          name: ConnectionName.make(connection.connection),
+        });
+        const refreshed = yield* Effect.promise(() =>
+          config.db.findFirst("tool", {
+            where: (b) =>
+              b.and(
+                b("integration", "=", "coolify"),
+                b("connection", "=", connection.connection),
+                b("name", "=", toolName),
+              ),
+          }),
+        );
+        expect(encodeJson(refreshed?.input_schema)).not.toContain('"is_runtime"');
+        expect(encodeJson(refreshed?.input_schema)).not.toContain('"is_buildtime"');
+      }),
+    ),
+  );
+
+  it("leaves a target-named operation on another route untouched", () => {
+    const legacy = legacySingleInputSchema();
+    expect(
+      repairCoolifyApplicationEnvInputSchema("applications.updateEnvByApplicationUuid", legacy, {
+        method: "patch",
+        pathTemplate: "/tenant-applications/{uuid}/envs",
+        parameters: [{ name: "uuid", location: "path", required: true }],
+      }),
+    ).toBe(legacy);
+  });
+
+  it("adds only the lifecycle field still absent from a matching upstream schema", () => {
+    const partial = legacySingleInputSchema();
+    const body = partial.properties.body as {
+      properties: Record<string, unknown>;
+    };
+    body.properties.is_runtime = { type: "boolean" };
+
+    const repaired = repairCoolifyApplicationEnvInputSchema(
+      "applications.updateEnvByApplicationUuid",
+      partial,
+      {
+        method: "patch",
+        pathTemplate: "/applications/{uuid}/envs",
+        parameters: [{ name: "uuid", location: "path", required: true }],
+      },
+    ) as {
+      properties: { body: { properties: Record<string, unknown> } };
+    };
+
+    expect(repaired.properties.body.properties.is_runtime).toEqual({ type: "boolean" });
+    expect(repaired.properties.body.properties.is_buildtime).toEqual({
+      type: "boolean",
+      description: "Whether this environment variable is available while the application builds.",
+    });
+  });
+
+  it("is inert once Coolify publishes the lifecycle fields itself", () => {
+    const current = {
+      type: "object",
+      properties: {
+        uuid: { type: "string" },
+        body: {
+          type: "object",
+          properties: {
+            ...environmentVariableProperties,
+            is_runtime: { type: "boolean" },
+            is_buildtime: { type: "boolean" },
+          },
+        },
+      },
+      required: ["uuid", "body"],
+      additionalProperties: false,
+    };
+
+    expect(
+      repairCoolifyApplicationEnvInputSchema("applications.updateEnvByApplicationUuid", current, {
+        method: "patch",
+        pathTemplate: "/applications/{uuid}/envs",
+        parameters: [{ name: "uuid", location: "path", required: true }],
+      }),
+    ).toBe(current);
+  });
+});

--- a/packages/plugins/openapi/src/sdk/plugin.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.ts
@@ -55,8 +55,10 @@ import {
   compileAndPersistOpenApiSpecStreaming,
   compileOpenApiSpec,
   invokeOpenApiBackedTool,
+  isCoolifyApplicationEnvironmentWriteTool,
   listHealthCheckCandidatesOpenApi,
   openApiStoredOperationsFromCompiled,
+  repairCoolifyApplicationEnvInputSchema,
   resolveOpenApiBackedAnnotations,
   resolveOpenApiBackedTools,
   validateOpenApiBackedToolArgs,
@@ -1282,6 +1284,29 @@ export const openApiPlugin = definePlugin<
     // catalog config points at.
     resolveTools: ({ integration, config, storage }) =>
       resolveOpenApiBackedTools({ integration, config, storage }),
+
+    projectToolSchema: ({ ctx, toolRow, inputSchema }) => {
+      if (!isCoolifyApplicationEnvironmentWriteTool(toolRow.name)) return Effect.succeed({});
+      return ctx.storage.getOperation(toolRow.integration, toolRow.name).pipe(
+        Effect.map((operation) => {
+          const repaired = repairCoolifyApplicationEnvInputSchema(
+            toolRow.name,
+            inputSchema,
+            operation
+              ? {
+                  method: operation.binding.method,
+                  pathTemplate: operation.binding.pathTemplate,
+                  parameters: operation.binding.parameters,
+                }
+              : undefined,
+          );
+          return repaired === inputSchema ? {} : { inputSchema: repaired };
+        }),
+        // A missing/corrupt legacy operation binding must leave describe usable;
+        // a later refresh can rebuild it from the saved spec.
+        Effect.catch(() => Effect.succeed({})),
+      );
+    },
 
     invokeTool: ({ ctx: invokeCtx, toolRow, credential, args }) => {
       const httpClientLayer = options?.httpClientLayer ?? invokeCtx.httpClientLayer;


### PR DESCRIPTION
## Summary
- repair the three Coolify application environment-variable write schemas that omit `is_runtime` and `is_buildtime`
- apply a fail-closed operation/path/parameter/body fingerprint across fresh compilation, stored refresh, and legacy tool-schema projection
- preserve the normal OpenAPI JSON request path and become a no-op once the upstream schemas expose both fields

## Verification
- OpenAPI plugin suite: 46 files, 269 tests passed
- plugin and workspace typecheck
- root format and lint
- collision, non-target, fresh persistence, legacy projection, refresh persistence, and JSON transport regressions

## Risk and rollback
The compatibility repair is limited to exact Coolify environment write fingerprints. Reverting this commit restores the current schemas; no credential storage or transport path changes.