### PR TITLE
Fix Cloudflare native elicitation routing

### DIFF
--- a/apps/host-cloudflare/src/worker.e2e.node.test.ts
+++ b/apps/host-cloudflare/src/worker.e2e.node.test.ts
@@ -6,6 +6,9 @@ import { fileURLToPath } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "@effect/vitest";
 import { Schema } from "effect";
 import { unstable_dev, type Unstable_DevWorker } from "wrangler";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { ElicitRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { microsoftCatalog } from "@executor-js/plugin-openapi/providers/microsoft";
 
 // ---------------------------------------------------------------------------
@@ -384,6 +387,43 @@ describe("cloudflare host e2e (workerd/miniflare)", () => {
       result?: { structuredContent?: { result?: number } };
     }>(call);
     expect(result.result?.structuredContent?.result).toBe(42);
+  }, 60_000);
+
+  it("delivers native elicitation on the approval-gated tool call stream", async () => {
+    const client = new Client(
+      { name: "native-elicitation-test", version: "1.0.0" },
+      { capabilities: { elicitation: { form: {}, url: {} } } },
+    );
+    let receivedElicitation = false;
+    client.setRequestHandler(ElicitRequestSchema, async () => {
+      receivedElicitation = true;
+      return { action: "accept" as const, content: {} };
+    });
+    const transport = new StreamableHTTPClientTransport(
+      new URL("/mcp?elicitation_mode=native", `http://${worker.address}:${worker.port}`),
+    );
+    await client.connect(transport);
+
+    const result = await client.callTool(
+      {
+        name: "execute",
+        arguments: {
+          code: [
+            "return await tools.executor.coreTools.policies.create({",
+            '  owner: "org",',
+            `  pattern: "native-elicitation-${runId}.*",`,
+            '  action: "require_approval"',
+            "});",
+          ].join("\n"),
+        },
+      },
+      undefined,
+      { timeout: 5_000 },
+    );
+
+    expect(receivedElicitation).toBe(true);
+    expect(result.isError).toBeFalsy();
+    await client.close();
   }, 60_000);
 
   it("resumes a model-paused execution from a fresh MCP session", async () => {

--- a/e2e/cloudflare/mcp-native-elicitation.test.ts
+++ b/e2e/cloudflare/mcp-native-elicitation.test.ts
@@ -1,0 +1,108 @@
+// Cloudflare self-host native elicitation through the real Streamable HTTP
+// transport. A policy gates a built-in read tool, so the test observes both
+// directions on the same tools/call stream: elicitation/create reaches the
+// client, and accept/decline decisions return to the execution engine.
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { ElicitRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import { composePluginApi } from "@executor-js/api/server";
+
+import { scenario } from "../src/scenario";
+import { Api, Mcp, Target } from "../src/services";
+
+const coreApi = composePluginApi([] as const);
+const GATED_TOOL = "executor.coreTools.policies.list";
+const GATED_CODE = `
+const result = await tools.executor.coreTools.policies.list({});
+return JSON.stringify(result);
+`;
+
+scenario(
+  "Cloudflare · native MCP elicitation carries approval decisions on the tool call stream",
+  { timeout: 120_000 },
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const api = yield* Api;
+    const mcp = yield* Mcp;
+    const identity = yield* target.newIdentity();
+    const apiClient = yield* api.client(coreApi, identity);
+    const policy = yield* apiClient.policies.create({
+      payload: { owner: "org", pattern: GATED_TOOL, action: "require_approval" },
+    });
+
+    yield* Effect.gen(function* () {
+      let decision: "accept" | "decline" | "cancel" = "accept";
+      let elicitationCount = 0;
+      const client = yield* Effect.acquireRelease(
+        Effect.promise(async () => {
+          const connectedClient = new Client(
+            { name: "executor-cloudflare-native-elicitation-e2e", version: "1.0.0" },
+            { capabilities: { elicitation: { form: {}, url: {} } } },
+          );
+          connectedClient.setRequestHandler(ElicitRequestSchema, async () => {
+            elicitationCount += 1;
+            return decision === "accept"
+              ? { action: "accept" as const, content: {} }
+              : { action: decision };
+          });
+          const url = new URL(mcp.url);
+          url.searchParams.set("elicitation_mode", "native");
+          await connectedClient.connect(new StreamableHTTPClientTransport(url));
+          return connectedClient;
+        }),
+        (connectedClient) => Effect.promise(() => connectedClient.close()),
+      );
+
+      const accepted = yield* Effect.promise(() =>
+        client.callTool({ name: "execute", arguments: { code: GATED_CODE } }, undefined, {
+          timeout: 10_000,
+        }),
+      );
+      expect(elicitationCount, "the native elicitation reached the client").toBe(1);
+      expect(accepted.isError, "accepting lets the gated tool complete").toBeFalsy();
+      expect(
+        JSON.stringify(accepted.content),
+        "the gated tool returned its policy listing",
+      ).toContain(policy.id);
+
+      decision = "decline";
+      const declined = yield* Effect.promise(() =>
+        client.callTool({ name: "execute", arguments: { code: GATED_CODE } }, undefined, {
+          timeout: 10_000,
+        }),
+      );
+      expect(elicitationCount, "the second native elicitation also reached the client").toBe(2);
+      expect(declined.isError, "declining blocks the gated tool").toBe(true);
+      expect(
+        JSON.stringify(declined.content),
+        "the engine reports the client's decline decision",
+      ).toContain("declined by the user");
+      expect(
+        JSON.stringify(declined.content),
+        "the declined tool did not return its output",
+      ).not.toContain(policy.id);
+
+      decision = "cancel";
+      const cancelled = yield* Effect.promise(() =>
+        client.callTool({ name: "execute", arguments: { code: GATED_CODE } }, undefined, {
+          timeout: 10_000,
+        }),
+      );
+      expect(elicitationCount, "the cancel elicitation also reached the client").toBe(3);
+      expect(cancelled.isError, "cancelling blocks the gated tool").toBe(true);
+      expect(
+        JSON.stringify(cancelled.content),
+        "the engine reports the client's cancel decision",
+      ).toContain("cancelled by the user");
+    }).pipe(
+      Effect.scoped,
+      Effect.ensuring(
+        apiClient.policies
+          .remove({ params: { policyId: policy.id }, payload: { owner: "org" } })
+          .pipe(Effect.ignore),
+      ),
+    );
+  }),
+);

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -783,18 +783,19 @@ const missingOAuthScopesFromProviderState = (value: unknown): readonly string[] 
     : [];
 };
 
-/** Epoch ms of the definitive refresh rejection recorded on `provider_state`,
- *  or null. Set when the AS rejects the grant itself (RFC 6749 invalid_grant —
- *  retrying cannot change the verdict); cleared by the reconnect mint, which
- *  rewrites `provider_state` wholesale. While set, refresh attempts are
- *  skipped: the pre-fix behavior re-sent a known-dead grant to the AS every
- *  proactive cycle, forever, and surfaced nothing to the user. */
-const oauthReauthRequiredAtFromProviderState = (value: unknown): number | null => {
-  const decoded = decodeJsonColumn(value);
-  if (decoded == null || typeof decoded !== "object" || Array.isArray(decoded)) return null;
-  const at = (decoded as Record<string, unknown>).oauthReauthRequiredAt;
-  return typeof at === "number" ? at : null;
-};
+/** The definitive refresh rejection recorded on `provider_state`, or null.
+ *  Set when the AS rejects the grant itself (RFC 6749 invalid_grant — retrying
+ *  cannot change the verdict); cleared by the reconnect mint, which rewrites
+ *  `provider_state` wholesale. While set, refresh attempts are skipped. */
+const decodeOAuthReauthRequiredProviderState = Schema.decodeUnknownOption(
+  Schema.Struct({
+    oauthReauthRequiredAt: Schema.Number,
+    oauthReauthRequiredDetail: Schema.optional(Schema.String),
+  }),
+);
+
+const oauthReauthRequiredFromProviderState = (value: unknown) =>
+  Option.getOrNull(decodeOAuthReauthRequiredProviderState(decodeJsonColumn(value)));
 
 const rowToConnection = (row: ConnectionRow): Connection => {
   const owner = row.owner as Owner;
@@ -1787,7 +1788,11 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
               b("name", "=", String(row.name)),
             ),
           set: {
-            provider_state: { ...mergedState, oauthReauthRequiredAt: Date.now() },
+            provider_state: {
+              ...mergedState,
+              oauthReauthRequiredAt: Date.now(),
+              oauthReauthRequiredDetail: detail,
+            },
             last_health: health,
             updated_at: new Date(),
           },
@@ -1819,11 +1824,20 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
         // dead connection re-sent its dead grant on every proactive cycle,
         // indefinitely (owner.com's Datadog connections: 100+ identical
         // rejections over two days, surfacing nothing).
-        if (oauthReauthRequiredAtFromProviderState(row.provider_state) !== null) {
+        const reauthState = oauthReauthRequiredFromProviderState(row.provider_state);
+        if (reauthState !== null) {
           yield* Effect.annotateCurrentSpan({ "executor.oauth.refresh.skipped_known_dead": true });
-          return yield* reauth(
-            "The authorization server rejected this connection's refresh token (invalid_grant). Reconnect to continue.",
-          );
+          const recordedHealth = Option.getOrNull(decodeLastHealth(row.last_health));
+          const recordedDetail =
+            reauthState.oauthReauthRequiredDetail ??
+            (recordedHealth?.status === "expired" ? recordedHealth.detail : undefined);
+          const detail =
+            recordedDetail === undefined
+              ? "The authorization server rejected this connection's refresh token (invalid_grant). Reconnect to continue."
+              : recordedDetail.endsWith("Reconnect to continue.")
+                ? recordedDetail
+                : `${recordedDetail} Reconnect to continue.`;
+          return yield* reauth(detail);
         }
 
         // Load the backing app by the owner STORED on the connection (a Personal

--- a/packages/core/sdk/src/oauth-flow.test.ts
+++ b/packages/core/sdk/src/oauth-flow.test.ts
@@ -958,6 +958,16 @@ describe("oauth token refresh in resolveConnectionValue", () => {
           (r) => r.path === "/token" && r.method === "POST" && r.body.includes("refresh_token"),
         );
         expect(refreshRequest).toBeDefined();
+
+        yield* server.clearRequests;
+        const repeated = yield* executor.connections.checkHealth({
+          owner: "org",
+          integration: INTEG,
+          name: ConnectionName.make("main"),
+        });
+        expect(repeated.status).toBe("expired");
+        expect(repeated.detail).toContain("Grant not found");
+        expect(yield* server.requests).toHaveLength(0);
       }),
     ),
   );

--- a/packages/hosts/mcp/src/tool-server.test.ts
+++ b/packages/hosts/mcp/src/tool-server.test.ts
@@ -1644,7 +1644,7 @@ describe("MCP host server — client without elicitation (pause/resume)", () => 
 // ---------------------------------------------------------------------------
 
 describe("MCP host server — elicitation error handling", () => {
-  it("elicitInput failure falls back to cancel", async () => {
+  it("elicitInput failure is not reported as user cancellation", async () => {
     const engine = makeElicitingEngine(
       FormElicitation.make({
         message: "will fail",
@@ -1666,7 +1666,15 @@ describe("MCP host server — elicitation error handling", () => {
         name: "execute",
         arguments: { code: "fail" },
       });
-      expect(result.content).toEqual([{ type: "text", text: "fallback:cancel" }]);
+      expect(result.isError).toBe(true);
+      expect(textOf(result)).toMatch(
+        /^Error: Native elicitation transport failed \[[0-9a-f]{8}\]\. Reconnect the MCP client and try again\.$/,
+      );
+      expect(result.structuredContent).toMatchObject({
+        status: "error",
+        errorCode: "native_elicitation_transport_failed",
+      });
+      expect(textOf(result)).not.toContain("fallback:cancel");
     });
   });
 });

--- a/packages/hosts/mcp/src/tool-server.ts
+++ b/packages/hosts/mcp/src/tool-server.ts
@@ -1,4 +1,4 @@
-import { Duration, Effect, Match, Option, Schema } from "effect";
+import { Data, Duration, Effect, Match, Option, Predicate, Result, Schema } from "effect";
 import * as Cause from "effect/Cause";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
@@ -318,6 +318,12 @@ const capabilitySnapshot = (server: McpServer) => ({
   elicitationSupport: getElicitationSupport(server),
 });
 
+class McpNativeElicitationTransportError extends Data.TaggedError(
+  "McpNativeElicitationTransportError",
+)<{
+  readonly cause: unknown;
+}> {}
+
 type ElicitInputParams =
   | {
       mode?: "form";
@@ -374,6 +380,7 @@ const elicitationRequestToParams: (request: ElicitationRequest) => ElicitInputPa
 const makeMcpElicitationHandler =
   (
     server: McpServer,
+    relatedRequestId: string | number,
     debugLog?: (event: string, data: Record<string, unknown>) => void,
   ): ElicitationHandler =>
   (ctx: ElicitationContext): Effect.Effect<typeof ElicitationResponse.Type> => {
@@ -407,35 +414,39 @@ const makeMcpElicitationHandler =
         clientCapabilities: server.server.getClientCapabilities() ?? null,
       });
 
-      // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: MCP SDK elicitInput is a Promise API; failures become a cancel response
-      try {
-        const response = await server.server.elicitInput(
-          params as Parameters<typeof server.server.elicitInput>[0],
-        );
+      const response = await server.server.elicitInput(
+        params as Parameters<typeof server.server.elicitInput>[0],
+        { relatedRequestId },
+      );
 
-        debugLog?.("elicitation.response", {
-          requestTag,
-          action: response.action,
-          hasContent:
-            typeof response.content === "object" &&
-            response.content !== null &&
-            Object.keys(response.content).length > 0,
-        });
+      debugLog?.("elicitation.response", {
+        requestTag,
+        action: response.action,
+        hasContent:
+          typeof response.content === "object" &&
+          response.content !== null &&
+          Object.keys(response.content).length > 0,
+      });
 
-        return {
-          action: response.action as typeof ElicitationResponse.Type.action,
-          content: response.content,
-        };
-      } catch (err) {
-        const error = formatBoundaryError(err);
-        debugLog?.("elicitation.error", {
-          requestTag,
-          error,
-          clientCapabilities: server.server.getClientCapabilities() ?? null,
-        });
-        return { action: "cancel" as const } as ElicitationResponse;
-      }
-    });
+      return {
+        action: response.action as typeof ElicitationResponse.Type.action,
+        content: response.content,
+      };
+    }).pipe(
+      Effect.tapDefect((defect) =>
+        Effect.sync(() => {
+          debugLog?.("elicitation.error", {
+            requestTag: elicitationRequestTag(ctx.request),
+            error: formatBoundaryError(defect),
+            clientCapabilities: server.server.getClientCapabilities() ?? null,
+          });
+        }),
+      ),
+      Effect.catchDefect((cause) =>
+        // oxlint-disable-next-line executor/no-effect-escape-hatch -- boundary: ElicitationHandler has no error channel, so retain a classified defect for the MCP result boundary.
+        Effect.die(new McpNativeElicitationTransportError({ cause })),
+      ),
+    );
   };
 
 const formatBoundaryError = (err: unknown): { name?: string; message: string; stack?: string } => {
@@ -662,6 +673,10 @@ const formatResumeApprovalRequired = (input: {
 
 const toMcpFailureResult = (cause: Cause.Cause<unknown>): McpToolResult => {
   const correlationId = newCorrelationId();
+  const defect = Cause.findDefect(cause);
+  const nativeElicitationFailed =
+    Result.isSuccess(defect) &&
+    Predicate.isTagged("McpNativeElicitationTransportError")(defect.success);
   // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: best-effort defect logging must tolerate non-serializable causes
   try {
     console.error(
@@ -671,10 +686,16 @@ const toMcpFailureResult = (cause: Cause.Cause<unknown>): McpToolResult => {
   } catch {
     /* ignore logger failures */
   }
-  const text = `Internal tool error [${correlationId}]`;
+  const text = nativeElicitationFailed
+    ? `Native elicitation transport failed [${correlationId}]. Reconnect the MCP client and try again.`
+    : `Internal tool error [${correlationId}]`;
   return {
     content: [{ type: "text", text: `Error: ${text}` }],
-    structuredContent: { status: "error", error: text },
+    structuredContent: {
+      status: "error",
+      error: text,
+      ...(nativeElicitationFailed ? { errorCode: "native_elicitation_transport_failed" } : {}),
+    },
     isError: true,
   };
 };
@@ -1162,6 +1183,16 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
         ),
     ).pipe(Effect.withSpan("mcp.host.create_server"));
 
+    const executeWithNativeElicitation = (
+      code: string,
+      extra: McpRequestJoinKeys,
+    ): Effect.Effect<McpToolResult, E> =>
+      engine
+        .execute(code, {
+          onElicitation: makeMcpElicitationHandler(server, extra.requestId, debugLog),
+        })
+        .pipe(Effect.map(toMcpResult));
+
     const executeCode = (
       code: string,
       extra: McpRequestJoinKeys,
@@ -1178,10 +1209,7 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
           codeLength: code.length,
         });
         if (elicitationMode.mode === "native") {
-          const result = yield* engine.execute(code, {
-            onElicitation: makeMcpElicitationHandler(server, debugLog),
-          });
-          return toMcpResult(result);
+          return yield* executeWithNativeElicitation(code, extra);
         }
         const outcome = yield* engine.executeWithPause(code);
         debugLog("execute.paused_flow_result", {
@@ -1265,6 +1293,7 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
     const executeCodeFromApp = (
       code: string,
       artifactId: string | undefined,
+      extra: McpRequestJoinKeys,
     ): Effect.Effect<McpToolResult, E> =>
       Effect.gen(function* () {
         const resolution = yield* resolveArtifactAction({ code, artifactId, loadArtifact });
@@ -1297,10 +1326,7 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
         const boundCode = resolution.code;
 
         if (elicitationMode.mode === "native") {
-          const result = yield* engine.execute(boundCode, {
-            onElicitation: makeMcpElicitationHandler(server, debugLog),
-          });
-          return toMcpResult(result);
+          return yield* executeWithNativeElicitation(boundCode, extra);
         }
         const outcome = yield* engine.executeWithPause(boundCode);
         debugLog("execute_action.paused_flow_result", {
@@ -2128,7 +2154,8 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
               ui: { resourceUri: MCP_APPS_SHELL_RESOURCE_URI, visibility: ["app"] },
             },
           },
-          ({ code, artifactId }) => runToolEffect(executeCodeFromApp(code, artifactId)),
+          ({ code, artifactId }, extra) =>
+            runToolEffect(executeCodeFromApp(code, artifactId, extra)),
         );
 
         executeActionResumeTool = registerAppTool(


### PR DESCRIPTION
## Summary

- route native `elicitation/create` requests on the originating `tools/call` Streamable HTTP response stream
- classify MCP elicitation protocol and transport failures separately from user cancellation
- cover accepted, declined, and cancelled decisions through the Cloudflare host

## Verification

- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun run --cwd packages/hosts/mcp test -- src/tool-server.test.ts`
- `bun run --cwd apps/host-cloudflare test -- src/worker.e2e.node.test.ts -t "delivers native elicitation"`
- `bun run --cwd e2e test:cloudflare -- cloudflare/mcp-native-elicitation.test.ts`

The full test run also encountered three unrelated existing failures in `apps/cloud/src/account/org-api-key-revoke.node.test.ts` (`AccountNoOrganization`).

Closes #1521
