### PR TITLE
Add opt-in OTLP export to the self-hosted server

### DIFF
--- a/.changeset/selfhost-otlp-export.md
+++ b/.changeset/selfhost-otlp-export.md
@@ -1,0 +1,5 @@
+---
+"@executor-js/host-selfhost": patch
+---
+
+Export self-host traces to an OpenTelemetry collector when `OTEL_EXPORTER_OTLP_ENDPOINT` is set, so a slow request can be read as a waterfall rather than a wall-clock number. Off by default; logs are a separate opt-in via `EXECUTOR_OTEL_EXPORT_LOGS`.

--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -33,7 +33,7 @@
       },
       {
         "group": "Hosted",
-        "pages": ["hosted/cloud", "hosted/docker", "hosted/cloudflare"]
+        "pages": ["hosted/cloud", "hosted/docker", "hosted/cloudflare", "hosted/tracing"]
       },
       {
         "group": "Concepts",

--- a/apps/docs/hosted/docker.mdx
+++ b/apps/docs/hosted/docker.mdx
@@ -69,6 +69,35 @@ the container defaults.
 | `EXECUTOR_ORG_SLUG`                 | `default`                       | URL slug for that org.                                                                          |
 | `EXECUTOR_ALLOW_LOCAL_NETWORK`      | `false`                         | Allow sandboxed code to reach loopback / private addresses. Keep off unless you trust the code. |
 
+## Tracing
+
+If a request is slow, point the server at an OpenTelemetry collector and the
+answer is a waterfall instead of a stopwatch: which phase of the request took
+the time — building the executor stack, initializing plugins, a storage query,
+or the upstream integration itself.
+
+Export is off by default and stays off until you set an endpoint. Nothing leaves
+the container otherwise.
+
+```bash
+docker run -d \
+  -p 4788:4788 \
+  -v executor-data:/data \
+  -e OTEL_EXPORTER_OTLP_ENDPOINT=http://collector.local:4318 \
+  ghcr.io/usefulsoftwareco/executor-selfhost:latest
+```
+
+| Variable                             | Default | Purpose                                                                     |
+| ------------------------------------ | ------- | --------------------------------------------------------------------------- |
+| `OTEL_EXPORTER_OTLP_ENDPOINT`        | unset   | Collector base URL. Turns on trace export; `/v1/traces` is appended.        |
+| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | unset   | Full traces URL, used as-is. Overrides the base for this signal.            |
+| `OTEL_EXPORTER_OTLP_HEADERS`         | unset   | `key=value,key2=value2` headers, for a collector that needs authentication. |
+| `EXECUTOR_OTEL_EXPORT_LOGS`          | `false` | Also export logs. Separate opt-in — logs carry more than timings.           |
+| `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`   | unset   | Full logs URL. Required if only the traces endpoint is set.                 |
+
+The exporter speaks OTLP over HTTP with a JSON payload, which every collector
+accepts on port `4318`.
+
 ## Behind a domain or TLS
 
 <Warning>

--- a/apps/docs/hosted/docker.mdx
+++ b/apps/docs/hosted/docker.mdx
@@ -69,34 +69,8 @@ the container defaults.
 | `EXECUTOR_ORG_SLUG`                 | `default`                       | URL slug for that org.                                                                          |
 | `EXECUTOR_ALLOW_LOCAL_NETWORK`      | `false`                         | Allow sandboxed code to reach loopback / private addresses. Keep off unless you trust the code. |
 
-## Tracing
-
-If a request is slow, point the server at an OpenTelemetry collector and the
-answer is a waterfall instead of a stopwatch: which phase of the request took
-the time — building the executor stack, initializing plugins, a storage query,
-or the upstream integration itself.
-
-Export is off by default and stays off until you set an endpoint. Nothing leaves
-the container otherwise.
-
-```bash
-docker run -d \
-  -p 4788:4788 \
-  -v executor-data:/data \
-  -e OTEL_EXPORTER_OTLP_ENDPOINT=http://collector.local:4318 \
-  ghcr.io/usefulsoftwareco/executor-selfhost:latest
-```
-
-| Variable                             | Default | Purpose                                                                     |
-| ------------------------------------ | ------- | --------------------------------------------------------------------------- |
-| `OTEL_EXPORTER_OTLP_ENDPOINT`        | unset   | Collector base URL. Turns on trace export; `/v1/traces` is appended.        |
-| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | unset   | Full traces URL, used as-is. Overrides the base for this signal.            |
-| `OTEL_EXPORTER_OTLP_HEADERS`         | unset   | `key=value,key2=value2` headers, for a collector that needs authentication. |
-| `EXECUTOR_OTEL_EXPORT_LOGS`          | `false` | Also export logs. Separate opt-in — logs carry more than timings.           |
-| `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`   | unset   | Full logs URL. Required if only the traces endpoint is set.                 |
-
-The exporter speaks OTLP over HTTP with a JSON payload, which every collector
-accepts on port `4318`.
+Tracing is configured separately, and off unless you turn it on — see
+[Tracing](/hosted/tracing).
 
 ## Behind a domain or TLS
 

--- a/apps/docs/hosted/tracing.mdx
+++ b/apps/docs/hosted/tracing.mdx
@@ -1,0 +1,115 @@
+---
+title: Tracing
+description: "Export traces from a self-hosted server to an OpenTelemetry collector, so a slow request becomes a waterfall instead of a stopwatch."
+---
+
+When a request through your server is slow, the useful question is which part was
+slow: building the executor stack, initializing plugins, a storage query, or the
+upstream integration answering. The server already produces spans for all of
+that — pointing it at a collector is what makes them readable.
+
+Export is off by default and stays off until you set an endpoint. With none set
+there is no exporter and no buffer, and nothing leaves the process.
+
+## Turn it on
+
+Set the collector's base URL. The server appends `/v1/traces`.
+
+```bash
+docker run -d \
+  -p 4788:4788 \
+  -v executor-data:/data \
+  -e OTEL_EXPORTER_OTLP_ENDPOINT=http://collector.local:4318 \
+  ghcr.io/usefulsoftwareco/executor-selfhost:latest
+```
+
+Traces are sent as OTLP over HTTP with a JSON payload, which every collector
+accepts — the OpenTelemetry Collector, Grafana Alloy, Jaeger, or a hosted backend.
+Port `4318` is the OTLP/HTTP convention, but the URL is whatever you point it at.
+
+| Variable                             | Default | Purpose                                                                     |
+| ------------------------------------ | ------- | --------------------------------------------------------------------------- |
+| `OTEL_EXPORTER_OTLP_ENDPOINT`        | unset   | Collector base URL. Turns on trace export; `/v1/traces` is appended.        |
+| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | unset   | Full traces URL, used as-is. Overrides the base for this signal.            |
+| `OTEL_EXPORTER_OTLP_HEADERS`         | unset   | `key=value,key2=value2` headers, for a collector that needs authentication. |
+| `EXECUTOR_OTEL_EXPORT_LOGS`          | `false` | Also export logs. A separate opt-in — logs carry more than timings.         |
+| `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`   | unset   | Full logs URL. Required if only the traces endpoint is set.                 |
+
+Traces report under the service name `executor-selfhost`. On boot the server logs
+the endpoint it will export to, so a missing line means export is off.
+
+For a hosted backend, put the credential in the headers:
+
+```bash
+-e OTEL_EXPORTER_OTLP_ENDPOINT=https://collector.example.com \
+-e OTEL_EXPORTER_OTLP_HEADERS='authorization=Bearer <token>'
+```
+
+## Using motel locally
+
+[motel](https://github.com/kitlangton/motel) is a local OTLP store and viewer: one
+command, a SQLite file, no Docker and no account. It is the quickest way to look at
+a trace on your own machine.
+
+It needs [Bun](https://bun.sh/), and listens on port `27686`:
+
+```bash
+bunx @kitlangton/motel
+```
+
+That starts the ingest server and opens the terminal UI. For ingest without the
+UI, run `bunx @kitlangton/motel server`.
+
+If Executor runs directly on the same machine, point it at motel:
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:27686
+```
+
+From a container, motel is on the host, not in the container's network — and it
+binds loopback by default, so it also has to listen on an address the container
+can reach:
+
+```bash
+# start motel so it accepts connections from outside the host
+MOTEL_OTEL_HOST=0.0.0.0 bunx @kitlangton/motel server
+
+docker run -d \
+  -p 4788:4788 \
+  -v executor-data:/data \
+  --add-host host.docker.internal:host-gateway \
+  -e OTEL_EXPORTER_OTLP_ENDPOINT=http://host.docker.internal:27686 \
+  ghcr.io/usefulsoftwareco/executor-selfhost:latest
+```
+
+<Warning>
+  `MOTEL_OTEL_HOST=0.0.0.0` exposes the trace store to your whole network. Traces carry request URLs
+  and timings, and logs carry more. Use it on a trusted network, or publish the port only to the
+  container.
+</Warning>
+
+## Reading a trace
+
+A single API request looks like this — each line a span, indented under its parent,
+with the time it took:
+
+```
+http.server GET                        31ms
+  executor.stack.http.resolve          28ms
+    executor.stack.build               28ms
+      executor.stack.scoped_executor   27ms
+        executor.plugins.init          16ms
+        executor.stack.create_executor  2ms
+        executor.subject.touch          7ms
+          fumadb.subject.findFirst      2ms
+          fumadb.subject.create         5ms
+  fumadb.integration.findMany           1ms
+```
+
+The indentation is where the answer lives. Time held by `http.server` but not by
+any child is time spent outside the instrumented code — the network in front of
+the server, or a tunnel. Time inside a single child is the phase to look at next.
+
+Requests arriving with a `traceparent` header continue that trace rather than
+starting a new one, so a request through a proxy or tunnel keeps one trace id from
+end to end.

--- a/apps/host-selfhost/src/serve.ts
+++ b/apps/host-selfhost/src/serve.ts
@@ -35,6 +35,7 @@ import {
   oauthCallbackSignInRedirectLocation,
 } from "./auth/oauth-callback-login";
 import { MCP_ORIGINAL_PATH_HEADER, stripMcpOrgSegment } from "./mcp/org-path";
+import { makeTelemetryLive } from "./telemetry";
 
 const distDir = fileURLToPath(new URL("../dist/", import.meta.url));
 const assetsDir = fileURLToPath(new URL("../dist/assets/", import.meta.url));
@@ -126,6 +127,15 @@ export const startServer = async (): Promise<void> => {
     Effect.addFinalizer(() => Effect.promise(() => disposeAnalytics())),
   );
 
+  // OTLP export, or `Layer.empty` when no collector is configured (see
+  // ./telemetry). The `http.server` envelope span each request's `withSpan`
+  // children parent under is NOT wired here: `HttpEffect.toHandled` already
+  // wraps every served app in `HttpMiddleware.tracer`, which also continues an
+  // inbound `traceparent` so a request arriving through a tunnel keeps one
+  // trace id. Adding it here as well produced two identical `http.server`
+  // spans per request, one the parent of the other.
+  const TelemetryLive = makeTelemetryLive();
+
   const ServerLive = HttpRouter.serve(Layer.mergeAll(AppLayer, AssetsLive, SpaLive), {
     middleware: selfHostHttpMiddleware(betterAuth),
   }).pipe(
@@ -134,7 +144,12 @@ export const startServer = async (): Promise<void> => {
     ),
   );
 
-  await BunRuntime.runMain(Layer.launch(Layer.merge(ServerLive, AnalyticsFlushLive)));
+  // Provided UNDER the server, not merged beside it: the tracer must already be
+  // in scope while the app's layers build, or spans created during construction
+  // resolve the default no-op tracer and are silently dropped.
+  await BunRuntime.runMain(
+    Layer.launch(Layer.merge(ServerLive, AnalyticsFlushLive).pipe(Layer.provide(TelemetryLive))),
+  );
 };
 
 if (import.meta.main) {

--- a/apps/host-selfhost/src/telemetry.test.ts
+++ b/apps/host-selfhost/src/telemetry.test.ts
@@ -1,0 +1,142 @@
+import { expect, test } from "@effect/vitest";
+import { FetchHttpClient } from "effect/unstable/http";
+import { Effect, Layer } from "effect";
+
+import { makeTelemetryLive } from "./telemetry";
+
+// The layer is opaque, so these assert the observable consequence rather than
+// its shape: what the exporter puts on the wire, and — for the default — that
+// nothing goes on the wire at all.
+test("sends nothing when no OTLP endpoint is configured", async () => {
+  expect(await captureExports({}, { log: true })).toEqual([]);
+});
+
+test("exports spans when the base endpoint is set", async () => {
+  const requests = await captureExports({ OTEL_EXPORTER_OTLP_ENDPOINT: "http://collector.test" });
+  expect(requests).toHaveLength(1);
+  expect(requests[0]?.method).toBe("POST");
+});
+
+// The signal endpoint is already a full URL; appending /v1/traces to it would
+// POST to /v1/traces/v1/traces, which a collector answers with a 404 the
+// operator never sees. Asserted on the request the exporter actually makes.
+test("does not append a second signal path to an explicit traces endpoint", async () => {
+  const urls = await captureExportUrls({
+    OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: "http://collector.test/v1/traces",
+  });
+  expect(urls).toEqual(["http://collector.test/v1/traces"]);
+});
+
+test("appends the signal path to a base endpoint, trailing slash or not", async () => {
+  expect(await captureExportUrls({ OTEL_EXPORTER_OTLP_ENDPOINT: "http://collector.test" })).toEqual(
+    ["http://collector.test/v1/traces"],
+  );
+  expect(
+    await captureExportUrls({ OTEL_EXPORTER_OTLP_ENDPOINT: "http://collector.test///" }),
+  ).toEqual(["http://collector.test/v1/traces"]);
+});
+
+test("sends configured headers so a hosted collector can authenticate", async () => {
+  const headers = await captureExportHeaders({
+    OTEL_EXPORTER_OTLP_ENDPOINT: "http://collector.test",
+    OTEL_EXPORTER_OTLP_HEADERS: "authorization=Bearer tok, x-dataset=executor",
+  });
+  expect(headers?.authorization).toBe("Bearer tok");
+  expect(headers?.["x-dataset"]).toBe("executor");
+});
+
+// A collector that is down, unreachable through the tunnel, or answering 500
+// must never take the request that produced the span with it — the operator
+// enabled tracing to diagnose a problem, not to acquire a new one.
+test("a failing collector does not fail the traced effect", async () => {
+  const result = await Effect.runPromise(
+    Effect.succeed("served").pipe(
+      Effect.withSpan("probe"),
+      Effect.provide(
+        makeTelemetryLive({ OTEL_EXPORTER_OTLP_ENDPOINT: "http://collector.test" }).pipe(
+          Layer.provide(stubFetch(() => new Response("boom", { status: 500 }))),
+        ),
+      ),
+      Effect.scoped,
+    ),
+  );
+  expect(result).toBe("served");
+});
+
+test("log export stays off unless separately opted in", async () => {
+  const base = { OTEL_EXPORTER_OTLP_ENDPOINT: "http://collector.test" };
+  expect(await captureExportUrls(base, { log: true })).toEqual(["http://collector.test/v1/traces"]);
+  expect(
+    await captureExportUrls({ ...base, EXECUTOR_OTEL_EXPORT_LOGS: "true" }, { log: true }),
+  ).toEqual(
+    expect.arrayContaining(["http://collector.test/v1/traces", "http://collector.test/v1/logs"]),
+  );
+});
+
+// With only a traces endpoint there is no base to derive a logs URL from.
+// Guessing one would POST logs to a path the operator never named.
+test("log export needs its own endpoint when only traces is configured", async () => {
+  const urls = await captureExportUrls(
+    {
+      OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: "http://collector.test/v1/traces",
+      EXECUTOR_OTEL_EXPORT_LOGS: "true",
+    },
+    { log: true },
+  );
+  expect(urls).toEqual(["http://collector.test/v1/traces"]);
+});
+
+// --- helpers ---------------------------------------------------------------
+
+// `Fetch` is a Context.Reference with `globalThis.fetch` as its default, so
+// setting it discharges no requirement — the layer is `Layer<never>` and works
+// by overriding the default in whatever context it is provided to.
+const stubFetch = (respond: (request: Request) => Response): Layer.Layer<never> =>
+  Layer.succeed(FetchHttpClient.Fetch)(((input: RequestInfo | URL, init?: RequestInit) =>
+    Promise.resolve(
+      respond(input instanceof Request ? input : new Request(String(input), init)),
+    )) as typeof globalThis.fetch);
+
+/**
+ * Runs a traced effect against a recording fetch and returns the URLs the
+ * exporter posted to. The layer's shutdown flush is what forces the export, so
+ * the effect is scoped and the scope closed before reading.
+ */
+const captureExportUrls = async (
+  env: Record<string, string | undefined>,
+  options?: { readonly log?: boolean },
+): Promise<Array<string>> => (await captureExports(env, options)).map((request) => request.url);
+
+const captureExportHeaders = async (
+  env: Record<string, string | undefined>,
+): Promise<Record<string, string> | undefined> => {
+  const requests = await captureExports(env);
+  const headers = requests[0]?.headers;
+  return headers ? Object.fromEntries(headers.entries()) : undefined;
+};
+
+const captureExports = async (
+  env: Record<string, string | undefined>,
+  options?: { readonly log?: boolean },
+): Promise<Array<Request>> => {
+  const seen: Array<Request> = [];
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      if (options?.log) yield* Effect.logInfo("probe log");
+    }).pipe(
+      Effect.withSpan("probe"),
+      Effect.provide(
+        makeTelemetryLive(env).pipe(
+          Layer.provide(
+            stubFetch((request) => {
+              seen.push(request);
+              return new Response(null, { status: 200 });
+            }),
+          ),
+        ),
+      ),
+      Effect.scoped,
+    ),
+  );
+  return seen;
+};

--- a/apps/host-selfhost/src/telemetry.ts
+++ b/apps/host-selfhost/src/telemetry.ts
@@ -1,0 +1,122 @@
+// ---------------------------------------------------------------------------
+// Self-host OTLP export.
+//
+// The shared packages this server runs are already instrumented — `withSpan`
+// wraps tool execution, OAuth, connection health, and storage — but without a
+// tracer those spans go nowhere. That is why a slow request on someone else's
+// hardware can only be reported as "it takes five seconds": nothing the
+// operator can read says which phase the time went to. Pointing this at a local
+// collector turns that into a waterfall.
+//
+// Export is opt-in and off by default. Self-host runs on the operator's own
+// machine, so sending their traces anywhere without being asked is not ours to
+// decide; the default is no exporter, no HTTP client, no buffer.
+//
+// This uses Effect's own OTLP modules rather than the OpenTelemetry SDK. Cloud
+// needs `@effect/opentelemetry` because workerd forces a hand-built
+// WebTracerProvider, but self-host has no such constraint, and the built-in
+// path needs only an HttpClient — no `@opentelemetry/*` dependencies, nothing
+// extra in the container image.
+// ---------------------------------------------------------------------------
+
+import { FetchHttpClient } from "effect/unstable/http";
+import { OtlpLogger, OtlpSerialization, OtlpTracer } from "effect/unstable/observability";
+import { Layer } from "effect";
+
+import packageJson from "../package.json" with { type: "json" };
+
+const SERVICE_NAME = "executor-selfhost";
+const SERVICE_VERSION: string = packageJson.version;
+
+/** Resolved OTLP export settings, or `undefined` when export is off. */
+interface TelemetryTarget {
+  readonly tracesUrl: string;
+  /** `undefined` when log export is off, or when no URL can be built for it. */
+  readonly logsUrl: string | undefined;
+  readonly headers: Record<string, string> | undefined;
+}
+
+// Signal URLs follow the OTLP spec: OTEL_EXPORTER_OTLP_ENDPOINT is a base that
+// each signal appends its own path to, while OTEL_EXPORTER_OTLP_<SIGNAL>_ENDPOINT
+// is already the full URL for that one signal. Appending unconditionally would
+// POST to /v1/traces/v1/traces, which a collector answers with a 404 that never
+// reaches the operator — the export just silently produces nothing.
+const resolveTarget = (env: Record<string, string | undefined>): TelemetryTarget | undefined => {
+  const base = env.OTEL_EXPORTER_OTLP_ENDPOINT?.trim().replace(/\/+$/, "");
+  const tracesUrl =
+    env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT?.trim() ?? (base ? `${base}/v1/traces` : undefined);
+  if (!tracesUrl) return undefined;
+  // Logs are opt-in separately from traces: they are the noisier and more
+  // sensitive of the two, carrying every request line and whatever the
+  // operator's own log calls hold. Traces answer "where did the time go" by
+  // themselves, so shipping logs stays a second, deliberate choice. Set the
+  // signal endpoint explicitly if only the traces endpoint is configured —
+  // there is no base to derive a logs URL from, and guessing one would export
+  // to a path the operator never named.
+  const logsUrl = isTruthy(env.EXECUTOR_OTEL_EXPORT_LOGS)
+    ? (env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT?.trim() ?? (base ? `${base}/v1/logs` : undefined))
+    : undefined;
+  return { tracesUrl, logsUrl, headers: parseHeaders(env.OTEL_EXPORTER_OTLP_HEADERS) };
+};
+
+const isTruthy = (value: string | undefined): boolean =>
+  value === "1" || value === "true" || value === "yes";
+
+// OTEL_EXPORTER_OTLP_HEADERS carries auth for a hosted collector, in the spec's
+// "k=v,k2=v2" form. A malformed pair is skipped rather than failing the boot:
+// losing traces must never cost the operator their server.
+const parseHeaders = (raw: string | undefined): Record<string, string> | undefined => {
+  const entries = (raw ?? "")
+    .split(",")
+    .map((pair) => pair.trim())
+    .filter((pair) => pair.length > 0)
+    .flatMap((pair) => {
+      const separator = pair.indexOf("=");
+      if (separator <= 0) return [];
+      return [[pair.slice(0, separator).trim(), pair.slice(separator + 1).trim()] as const];
+    });
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+};
+
+/**
+ * OTLP export layer for the self-hosted server, or {@link Layer.empty} when no
+ * endpoint is configured — so the default deployment neither exports nor pays
+ * for an exporter it will not use.
+ *
+ * Provide this UNDER the app layer (`Layer.provide`), not merged beside it: the
+ * tracer has to be in scope while the app's own layers build, or spans created
+ * during construction find the no-op tracer instead.
+ */
+export const makeTelemetryLive = (
+  env: Record<string, string | undefined> = process.env,
+): Layer.Layer<never> => {
+  const target = resolveTarget(env);
+  if (!target) return Layer.empty;
+
+  const resource = { serviceName: SERVICE_NAME, serviceVersion: SERVICE_VERSION };
+
+  const TracerLive = OtlpTracer.layer({
+    url: target.tracesUrl,
+    resource,
+    headers: target.headers,
+  });
+
+  const logsUrl = target.logsUrl;
+  const LoggerLive = logsUrl
+    ? OtlpLogger.layer({ url: logsUrl, resource, headers: target.headers })
+    : Layer.empty;
+
+  console.info(
+    `[executor] exporting traces to ${target.tracesUrl}${logsUrl ? ` and logs to ${logsUrl}` : ""}`,
+  );
+
+  return Layer.merge(TracerLive, LoggerLive).pipe(
+    Layer.provide(OtlpSerialization.layerJson),
+    // The exporter gets a plain fetch client, deliberately not the guarded
+    // hosted client: the collector is an address the operator configured, so
+    // the SSRF guard's job (stopping agent-chosen URLs from reaching the
+    // private network) does not apply, and applying it would block the most
+    // common setup of all — a collector on localhost.
+    Layer.provide(FetchHttpClient.layer),
+  );
+};


### PR DESCRIPTION
Self-host already produces spans — the shared packages wrap stack build, plugin init, subject touch, storage queries, and tool execution in `withSpan` — but with no tracer configured they go nowhere. That is why a slow request on someone else's hardware can only be reported as a wall-clock number, with no way to say which phase the time went to.

Setting `OTEL_EXPORTER_OTLP_ENDPOINT` now exports traces to a collector. Logs are a separate opt-in (`EXECUTOR_OTEL_EXPORT_LOGS`), since they carry more than timings.

Export is off by default: with no endpoint set, `makeTelemetryLive` returns `Layer.empty` — no exporter, no HTTP client, no buffer.

Uses Effect's built-in OTLP modules rather than the OpenTelemetry SDK. Cloud needs `@effect/opentelemetry` because workerd forces a hand-built `WebTracerProvider`; self-host has no such constraint and the built-in path needs only an `HttpClient`. No new dependencies, nothing added to the container image.

### Notes

- The layer is provided **under** the server layer, not merged beside it — the tracer has to be in scope while the app's layers build, or spans created during construction resolve the no-op tracer.
- No `HttpMiddleware.tracer` is added: `HttpEffect.toHandled` already applies it, and it also continues an inbound `traceparent`, so a request arriving through a tunnel keeps one trace id. Adding it explicitly produced two identical `http.server` spans per request.
- The exporter gets a plain fetch client, deliberately not the guarded hosted client — the collector is an address the operator configured, and the SSRF guard would block the most common setup of all, a collector on localhost.

### Verification

- 8 unit tests, all asserting on what the exporter actually puts on the wire via a recording fetch. Mutation tested: 6 mutations, 6/6 killed.
- Live run against a real OTLP collector: booted the server, bootstrapped an admin, drove real API traffic. 3 requests produced exactly 3 root `http.server` spans, each with the full waterfall beneath it — `executor.stack.http.resolve` → `executor.stack.build` → `executor.stack.scoped_executor` → `executor.plugins.init` / `executor.subject.touch` → `fumadb.subject.findFirst`/`create`.
- Default-off confirmed on the same real server: no export log line, request served 200, collector received nothing.
- `format:check`, `lint`, `typecheck`, and the full `host-selfhost` suite (23 files, 94 tests) pass.