### PR TITLE
Report real surface and version in registry user-agent

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -18,7 +18,8 @@
       "@executor-js/plugin-openapi",
       "@executor-js/plugin-example",
       "@executor-js/plugin-desktop-settings",
-      "@executor-js/desktop"
+      "@executor-js/desktop",
+      "@executor-js/local"
     ]
   ],
   "linked": [],
@@ -29,7 +30,6 @@
     "onlyUpdatePeerDependentsWhenOutOfRange": true
   },
   "ignore": [
-    "@executor-js/local",
     "@executor-js/host-mcp",
     "@executor-js/ir",
     "@executor-js/runtime-deno-subprocess",

--- a/.changeset/tidy-donkeys-repeat.md
+++ b/.changeset/tidy-donkeys-repeat.md
@@ -1,0 +1,6 @@
+---
+"executor": patch
+"@executor-js/local": patch
+---
+
+Report the real product surface and version in the integrations.sh registry user-agent. The daemon previously sent `local` with a version frozen at 1.4.4; it now reports `cli` or `desktop` (matching analytics surfaces) and `@executor-js/local` is versioned with the release train.

--- a/apps/local/src/installation.ts
+++ b/apps/local/src/installation.ts
@@ -15,11 +15,12 @@ const resolveChannel = (version: string): InstallationChannel => {
   return "stable";
 };
 
-// The desktop main process sets `EXECUTOR_CLIENT=desktop` when it spawns the
-// sidecar so PostHog can slice desktop installs from headless apps/local
-// (CLI `executor web`, `daemon run --foreground`, etc.).
+// The surface is cli|desktop — never a "local" catch-all: the desktop main
+// process marks its sidecar via EXECUTOR_CLIENT=desktop; everything else
+// hosting apps/local (`executor web`, `daemon run --foreground`, stdio MCP)
+// is the CLI. Mirrors resolveSurface in ./analytics.ts.
 const resolveClient = (): SurfaceClient =>
-  process.env.EXECUTOR_CLIENT === "desktop" ? "desktop" : "local";
+  process.env.EXECUTOR_CLIENT === "desktop" ? "desktop" : "cli";
 
 export const CHANNEL: InstallationChannel = resolveChannel(LOCAL_VERSION);
 export const VERSION: string = LOCAL_VERSION;

--- a/packages/core/integrations-registry/src/registry.test.ts
+++ b/packages/core/integrations-registry/src/registry.test.ts
@@ -49,8 +49,8 @@ describe("buildUserAgent", () => {
     expect(buildUserAgent({ channel: "stable", version: "1.2.3", client: "cli" })).toBe(
       "executor/stable/1.2.3/cli",
     );
-    expect(buildUserAgent({ channel: "beta", version: "1.2.3-beta.0", client: "local" })).toBe(
-      "executor/beta/1.2.3-beta.0/local",
+    expect(buildUserAgent({ channel: "beta", version: "1.2.3-beta.0", client: "desktop" })).toBe(
+      "executor/beta/1.2.3-beta.0/desktop",
     );
   });
 

--- a/packages/core/integrations-registry/src/registry.ts
+++ b/packages/core/integrations-registry/src/registry.ts
@@ -11,7 +11,7 @@ import { NodeFileSystem } from "@effect/platform-node";
 // ---------------------------------------------------------------------------
 
 export type InstallationChannel = "stable" | "beta" | "dev";
-export type SurfaceClient = "cli" | "local" | "desktop";
+export type SurfaceClient = "cli" | "desktop";
 
 export const DEFAULT_INTEGRATIONS_URL = "https://integrations.sh/api.json";
 


### PR DESCRIPTION
The daemon (apps/local) sent `executor/stable/1.4.4/local` on every integrations.sh registry fetch:

- **`local` surface**: the daemon is always hosted by the CLI or the desktop app, so a third `local` surface just split the same installs across two labels. It now resolves `cli`/`desktop` exactly like the analytics surface in `apps/local/src/analytics.ts` (desktop marks its sidecar with `EXECUTOR_CLIENT=desktop`). `SurfaceClient` drops the `local` variant.
- **Frozen 1.4.4 version**: `@executor-js/local` was in the changesets `ignore` list, so Version Packages never bumped it and the user-agent read a stale `package.json` version. It's now in the fixed group with the CLI/desktop, so it versions with the release train.

No behavior change beyond the user-agent string sent to integrations.sh.