### PR TITLE
Show and mint organization API keys in the console

### DIFF
--- a/apps/cloud/src/routes/app/api-keys.tsx
+++ b/apps/cloud/src/routes/app/api-keys.tsx
@@ -1,8 +1,14 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { ApiKeysPage } from "@executor-js/react/pages/api-keys";
+import { ApiKeysPage, OrgApiKeysSection } from "@executor-js/react/pages/api-keys";
 
 // Cloud renders the SHARED API-keys page over the provider-neutral
-// `/account/api-keys` surface — identical UI to self-host.
+// `/account/api-keys` surface — identical UI to self-host, plus the
+// cloud-only Organization keys section (self-host's provider refuses
+// org keys; its admin plane is session-gated instead).
 export const Route = createFileRoute("/{-$orgSlug}/api-keys")({
-  component: ApiKeysPage,
+  component: CloudApiKeysPage,
 });
+
+function CloudApiKeysPage() {
+  return <ApiKeysPage orgKeysSection={<OrgApiKeysSection />} />;
+}

--- a/bun.lock
+++ b/bun.lock
@@ -355,7 +355,7 @@
       "version": "0.0.36",
       "dependencies": {
         "@executor-js/api": "workspace:*",
-        "@executor-js/emulate": "^0.13.6",
+        "@executor-js/emulate": "^0.13.9",
         "@executor-js/mcporter": "^0.11.4",
         "@executor-js/plugin-graphql": "workspace:*",
         "@executor-js/plugin-mcp": "workspace:*",
@@ -1774,7 +1774,7 @@
 
     "@executor-js/e2e": ["@executor-js/e2e@workspace:e2e"],
 
-    "@executor-js/emulate": ["@executor-js/emulate@0.13.6", "", { "dependencies": { "@aws-sdk/client-s3": "^3.1031.0", "@aws-sdk/client-sqs": "^3.1075.0", "@azure/msal-node": "^5.3.0", "@clerk/backend": "^3.8.4", "@octokit/rest": "^22.0.1", "@okta/okta-auth-js": "^8.0.1", "@slack/web-api": "^7.16.0", "@vercel/sdk": "^1.28.4", "@workos-inc/node": "^8.13.0", "atlas-api-client": "^0.3.0", "autumn-js": "^1.2.8", "commander": "^14", "googleapis": "^173.0.0", "graphql": "^16.9.0", "graphql-request": "^7.4.0", "openid-client": "^6.8.4", "picocolors": "^1.1.1", "resend": "^6.16.0", "spotify-web-api-node": "^5.0.2", "stripe": "^22.3.0", "twitter-api-v2": "^1.29.0", "yaml": "^2" }, "bin": { "emulate": "dist/index.js" } }, "sha512-FwR2RvO5DnwYgGO2w3JKPCpUx8o+AzSPJeei/oYMIrb4PYg2bQceucxiw52698t9SDEDwAOHkdC/Vv1Tv1+MJQ=="],
+    "@executor-js/emulate": ["@executor-js/emulate@0.13.9", "", { "dependencies": { "@aws-sdk/client-s3": "^3.1031.0", "@aws-sdk/client-sqs": "^3.1075.0", "@azure/msal-node": "^5.3.0", "@clerk/backend": "^3.8.4", "@octokit/rest": "^22.0.1", "@okta/okta-auth-js": "^8.0.1", "@slack/web-api": "^7.16.0", "@vercel/sdk": "^1.28.4", "@workos-inc/node": "^8.13.0", "atlas-api-client": "^0.3.0", "autumn-js": "^1.2.8", "commander": "^14", "googleapis": "^173.0.0", "graphql": "^16.9.0", "graphql-request": "^7.4.0", "openid-client": "^6.8.4", "picocolors": "^1.1.1", "resend": "^6.16.0", "spotify-web-api-node": "^5.0.2", "stripe": "^22.3.0", "twitter-api-v2": "^1.29.0", "yaml": "^2" }, "bin": { "emulate": "dist/index.js" } }, "sha512-GXuooRKtJPrWp5AEdcE6w0DeIt+TF/bonV1bzuZHX0khx2bsUrE4z7gKK/5IMxYEr+ifgVk7HWnxLnhx8BHNGg=="],
 
     "@executor-js/example-all-plugins": ["@executor-js/example-all-plugins@workspace:examples/all-plugins"],
 

--- a/e2e/cloud/org-api-keys-console.test.ts
+++ b/e2e/cloud/org-api-keys-console.test.ts
@@ -1,0 +1,141 @@
+// Cloud-only: the Organization keys SECTION of the API keys page — the console
+// surface over `/api/account/org-api-keys`, minting the machine credential for
+// the tenant-wide admin plane.
+//
+// Two members are built through the real flows. The guarantees pinned here:
+//
+//   1. an ADMIN sees the section, mints an org key through the dialog, gets the
+//      one-time reveal, and the minted value ACTUALLY authenticates the admin
+//      API (the whole point of the credential);
+//   2. the listing shows the key afterward and revoke asks for confirmation
+//      before killing it — after which the value stops authenticating;
+//   3. a PLAIN MEMBER never sees the section at all.
+//
+// Runs against emulate >= 0.13.9, whose WorkOS emulator serves the org-key
+// routes (list/mint via /organizations/:id/api_keys, org-owner validation) —
+// the gap that previously kept this scenario impossible.
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+
+import { scenario } from "../src/scenario";
+import { Browser, Target } from "../src/services";
+import { forBrowser, joinOrg } from "./support/session";
+
+declare global {
+  interface Window {
+    __e2eCopied?: Array<string>;
+  }
+}
+
+scenario(
+  "Admin · organization keys are minted in the console and authenticate the admin API",
+  { timeout: 180_000 },
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const browser = yield* Browser;
+
+    const admin = yield* target.newIdentity();
+    const invitee = yield* target.newIdentity({ org: false });
+    const member = yield* joinOrg(target, admin, invitee);
+
+    let mintedValue = "";
+
+    // ── The admin's view: mint, verify, revoke ──────────────────────────────
+    yield* browser.session(forBrowser(admin), async ({ page, step }) => {
+      let slug = "";
+
+      await step("Land in the workspace and open the API keys page", async () => {
+        await page.goto("/", { waitUntil: "networkidle" });
+        await page.waitForURL((url) => /^\/[a-z0-9-]+\/?$/.test(url.pathname), {
+          timeout: 30_000,
+        });
+        slug = new URL(page.url()).pathname.split("/").filter(Boolean)[0] ?? "";
+        await page.getByRole("link", { name: "API keys" }).click();
+        await page.waitForURL((url) => url.pathname === `/${slug}/api-keys`, { timeout: 30_000 });
+      });
+
+      await step("The admin is offered the Organization keys section", async () => {
+        await page
+          .getByRole("heading", { name: "Organization keys", exact: true })
+          .waitFor({ state: "visible", timeout: 30_000 });
+      });
+
+      await step("Mint an org key through the dialog and capture the reveal", async () => {
+        await page.getByRole("button", { name: "New org key" }).click();
+        const dialog = page.getByRole("dialog");
+        await dialog.getByLabel("Name").fill("e2e backend reader");
+        await dialog.getByRole("button", { name: "Create key" }).click();
+
+        // The one-time secret panel renders once the key exists; its first
+        // input holds the plaintext value (same shape the personal-key
+        // feedback scenario reads).
+        await dialog.getByText("It is only shown once").waitFor({ timeout: 30_000 });
+        mintedValue = await dialog.locator("input").first().inputValue();
+        expect(mintedValue, "a real key value is revealed once").toMatch(/^sk_/);
+        await dialog.getByRole("button", { name: "Close", exact: true }).first().click();
+      });
+
+      await step("The minted key appears in the org listing", async () => {
+        await page
+          .getByText("e2e backend reader")
+          .first()
+          .waitFor({ state: "visible", timeout: 30_000 });
+      });
+
+      await step("The minted value authenticates the tenant-wide admin API", async () => {
+        // The credential's purpose, proven from outside the browser: a backend
+        // holding ONLY this value can read the admin plane.
+        const response = await fetch(new URL("/api/admin/users", target.baseUrl), {
+          headers: { authorization: `Bearer ${mintedValue}` },
+        });
+        expect(response.status, "the org key reads the admin plane").toBe(200);
+        const body = (await response.json()) as {
+          users: ReadonlyArray<{ email: string | null }>;
+        };
+        expect(
+          body.users.map((user) => user.email),
+          "and sees the workspace's members",
+        ).toContain(admin.credentials?.email);
+      });
+
+      await step("Revoke asks for confirmation, then the key stops working", async () => {
+        await page.getByRole("button", { name: "Revoke e2e backend reader" }).click();
+        // The confirm dialog names the key and warns; nothing is revoked yet.
+        await page
+          .getByRole("heading", { name: "Revoke organization key" })
+          .waitFor({ state: "visible", timeout: 30_000 });
+        await page.getByRole("button", { name: "Revoke key" }).click();
+        await page
+          .getByRole("heading", { name: "Revoke organization key" })
+          .waitFor({ state: "hidden", timeout: 30_000 });
+
+        // The revoked value no longer authenticates.
+        const after = await fetch(new URL("/api/admin/users", target.baseUrl), {
+          headers: { authorization: `Bearer ${mintedValue}` },
+        });
+        expect(after.status, "the revoked key is refused").toBe(401);
+      });
+    });
+
+    // ── The plain member's view ───────────────────────────────────────────
+    yield* browser.session(forBrowser(member), async ({ page, step }) => {
+      await step("A plain member is not shown the Organization keys section", async () => {
+        await page.goto("/", { waitUntil: "networkidle" });
+        await page.waitForURL((url) => /^\/[a-z0-9-]+\/?$/.test(url.pathname), {
+          timeout: 30_000,
+        });
+        const slug = new URL(page.url()).pathname.split("/").filter(Boolean)[0] ?? "";
+        await page.goto(`/${slug}/api-keys`, { waitUntil: "networkidle" });
+        // The personal half renders for everyone…
+        await page
+          .getByRole("heading", { name: "Personal keys" })
+          .waitFor({ state: "visible", timeout: 30_000 });
+        // …the org section does not exist for a non-admin.
+        expect(
+          await page.getByRole("heading", { name: "Organization keys", exact: true }).count(),
+          "a plain member is not shown a section that would only refuse them",
+        ).toBe(0);
+      });
+    });
+  }),
+);

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@executor-js/api": "workspace:*",
-    "@executor-js/emulate": "^0.13.6",
+    "@executor-js/emulate": "^0.13.9",
     "@executor-js/mcporter": "^0.11.4",
     "@executor-js/plugin-graphql": "workspace:*",
     "@executor-js/plugin-mcp": "workspace:*",

--- a/packages/react/src/api/account-atoms.tsx
+++ b/packages/react/src/api/account-atoms.tsx
@@ -26,6 +26,19 @@ export const apiKeysAtom = AccountApiClient.query("account", "listApiKeys", {
 export const createApiKey = AccountApiClient.mutation("account", "createApiKey");
 export const revokeApiKey = AccountApiClient.mutation("account", "revokeApiKey");
 
+// ── Org API keys ────────────────────────────────────────────────────────────
+
+// Admin-gated on the server (403 for a plain member) and refused entirely on
+// self-host. The page only reads this atom for an admin on a host that mints
+// org keys, so a failure here renders as the section's error state, not as a
+// role probe.
+export const orgApiKeysAtom = AccountApiClient.query("account", "listOrgApiKeys", {
+  reactivityKeys: [ReactivityKey.orgApiKeys],
+});
+
+export const createOrgApiKey = AccountApiClient.mutation("account", "createOrgApiKey");
+export const revokeOrgApiKey = AccountApiClient.mutation("account", "revokeOrgApiKey");
+
 // ── Organization members ─────────────────────────────────────────────────────
 
 // `refreshOnWindowFocus` is BROWSER-ONLY: its signal atom subscribes to

--- a/packages/react/src/api/analytics.tsx
+++ b/packages/react/src/api/analytics.tsx
@@ -129,6 +129,9 @@ export interface AnalyticsEvents {
   api_key_created: { success: boolean };
   api_key_revoked: { success: boolean };
   api_key_copied: { kind: "value" | "bearer_header" };
+  org_api_key_created: { success: boolean };
+  org_api_key_revoked: { success: boolean };
+  org_api_key_copied: { kind: "value" | "bearer_header" };
 
   // ── Organization ─────────────────────────────────────────────────────────
   org_renamed: { success: boolean };

--- a/packages/react/src/api/reactivity-keys.tsx
+++ b/packages/react/src/api/reactivity-keys.tsx
@@ -37,6 +37,9 @@ export const ReactivityKey = {
   orgDomains: "org:domains",
   orgInfo: "org:info",
   apiKeys: "api-keys",
+  /** Org-owned keys (the platform credential) — separate from `apiKeys` so
+   *  minting one does not refetch every member's personal-key list. */
+  orgApiKeys: "org:api-keys",
   auth: "auth",
   /** The tenant-wide admin users view. Read-only today (the admin plane has no
    *  writes), so nothing invalidates it — it exists so the pages refresh
@@ -88,6 +91,9 @@ export const orgInfoWriteKeys = [ReactivityKey.orgInfo, ReactivityKey.auth] as c
 
 /** Cloud-only: user API key mutations. */
 export const apiKeyWriteKeys = [ReactivityKey.apiKeys] as const;
+
+/** Cloud-only: org API key mutations. */
+export const orgApiKeyWriteKeys = [ReactivityKey.orgApiKeys] as const;
 
 /** Cloud-only: auth mutations (org switch/create) — invalidate everything user-visible. */
 export const authWriteKeys = [

--- a/packages/react/src/pages/api-keys.tsx
+++ b/packages/react/src/pages/api-keys.tsx
@@ -1,8 +1,9 @@
 import { useState, type ReactNode } from "react";
-import { Exit } from "effect";
+import { Cause, Exit, Option, Predicate } from "effect";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 import { useAtomRefresh, useAtomSet, useAtomValue } from "@effect/atom-react";
 import { toast } from "sonner";
+import type { ApiKeySummary as ApiKeySummarySchema } from "@executor-js/api";
 import { apiKeyWriteKeys, orgApiKeyWriteKeys } from "../api/reactivity-keys";
 import { trackEvent } from "../api/analytics";
 import {
@@ -38,18 +39,14 @@ import { isAsyncResultLoading } from "../lib/async-result";
 // Auth). API keys are how a user authenticates the Executor API + MCP endpoint
 // from scripts/agents (Authorization: Bearer <key>).
 //
-// `orgKeysSection` is a host slot (the OrgPage pattern): cloud passes
-// `<OrgApiKeysSection />` below; self-host passes nothing because its provider
-// refuses org keys (`/admin/*` there is gated on an owner/admin session).
+// `orgKeysSection` is a host slot: the section component lives in this file
+// (its contract is the shared account API), but only hosts that mint org keys
+// mount it — cloud passes `<OrgApiKeysSection />`, self-host passes nothing
+// because its provider refuses org keys (`/admin/*` there is gated on an
+// owner/admin session instead).
 // ---------------------------------------------------------------------------
 
-type ApiKeySummary = {
-  readonly id: string;
-  readonly name: string;
-  readonly obfuscatedValue: string;
-  readonly createdAt: string;
-  readonly lastUsedAt: string | null;
-};
+type ApiKeySummary = typeof ApiKeySummarySchema.Type;
 
 type CreatedKey = ApiKeySummary & { readonly value: string };
 
@@ -65,8 +62,8 @@ const formatDate = (value: string | null): string => {
       }).format(date);
 };
 
-const defaultApiKeyName = (): string =>
-  `API key ${new Intl.DateTimeFormat(undefined, {
+const defaultKeyName = (kind: string): string =>
+  `${kind} ${new Intl.DateTimeFormat(undefined, {
     month: "short",
     day: "numeric",
     year: "numeric",
@@ -153,32 +150,99 @@ function CreatedKeyReveal(props: {
   );
 }
 
-export function ApiKeysPage(props: { readonly orgKeysSection?: ReactNode } = {}) {
+/**
+ * The create dialog's state-bearing body, shared by both key kinds. Remounted
+ * per open via a key bump (self-contained modal): form and in-flight state are
+ * destroyed on close instead of hand-reset, while the Dialog shell stays
+ * mounted so Radix's exit animation keeps its last frame. A create resolving
+ * after close therefore lands on an unmounted component instead of wedging the
+ * next open on the previous key's reveal.
+ */
+function CreateKeyDialogBody(props: {
+  readonly title: string;
+  readonly description: string;
+  readonly defaultName: string;
+  readonly placeholder: string;
+  readonly onCreate: (name: string) => Promise<CreatedKey | null>;
+  readonly onCopy: (kind: "value" | "bearer_header") => void;
+}) {
+  const [name, setName] = useState(props.defaultName);
+  const [createdKey, setCreatedKey] = useState<CreatedKey | null>(null);
+  const [creating, setCreating] = useState(false);
+
+  const handleCreate = async () => {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    setCreating(true);
+    const created = await props.onCreate(trimmed);
+    setCreating(false);
+    if (created) setCreatedKey(created);
+  };
+
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle className="font-display text-xl">{props.title}</DialogTitle>
+        <DialogDescription className="text-sm leading-relaxed">
+          {props.description}
+        </DialogDescription>
+      </DialogHeader>
+
+      {createdKey ? (
+        <CreatedKeyReveal value={createdKey.value} onCopy={props.onCopy} />
+      ) : (
+        <div className="grid gap-4 py-3">
+          <div className="grid gap-1.5">
+            <Label htmlFor="create-key-name" className="text-sm font-medium text-foreground">
+              Name
+            </Label>
+            <Input
+              id="create-key-name"
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              placeholder={props.placeholder}
+              maxLength={80}
+              autoFocus
+            />
+          </div>
+        </div>
+      )}
+
+      <DialogFooter>
+        <DialogClose asChild>
+          <Button variant="ghost">Close</Button>
+        </DialogClose>
+        {!createdKey && (
+          <Button onClick={handleCreate} disabled={creating || !name.trim()}>
+            {creating ? "Creating..." : "Create key"}
+          </Button>
+        )}
+      </DialogFooter>
+    </>
+  );
+}
+
+export function ApiKeysPage(props: { readonly orgKeysSection?: ReactNode }) {
   useExecutorDocumentTitle("API keys");
   const result = useAtomValue(apiKeysAtom);
   const refreshApiKeys = useAtomRefresh(apiKeysAtom);
   const doCreate = useAtomSet(createApiKey, { mode: "promiseExit" });
   const doRevoke = useAtomSet(revokeApiKey, { mode: "promiseExit" });
   const [createOpen, setCreateOpen] = useState(false);
-  const [name, setName] = useState("");
-  const [createdKey, setCreatedKey] = useState<CreatedKey | null>(null);
-  const [creating, setCreating] = useState(false);
+  // Bumped per open so the dialog body remounts with fresh state; the shell
+  // stays mounted for Radix's exit animation (see CreateKeyDialogBody).
+  const [openCount, setOpenCount] = useState(0);
   const [revokingId, setRevokingId] = useState<string | null>(null);
 
-  const handleCreate = async () => {
-    const trimmed = name.trim();
-    if (!trimmed) return;
-    setCreating(true);
-    const exit = await doCreate({ payload: { name: trimmed }, reactivityKeys: apiKeyWriteKeys });
-    setCreating(false);
+  const handleCreate = async (name: string): Promise<CreatedKey | null> => {
+    const exit = await doCreate({ payload: { name }, reactivityKeys: apiKeyWriteKeys });
     trackEvent("api_key_created", { success: Exit.isSuccess(exit) });
     if (Exit.isSuccess(exit)) {
-      setCreatedKey(exit.value);
-      setName("");
       toast.success("API key created");
-      return;
+      return exit.value;
     }
     toast.error("Failed to create API key");
+    return null;
   };
 
   const handleRevoke = async (key: ApiKeySummary) => {
@@ -193,24 +257,15 @@ export function ApiKeysPage(props: { readonly orgKeysSection?: ReactNode } = {})
     toast.error("Failed to revoke API key");
   };
 
-  const closeCreate = (open: boolean) => {
-    setCreateOpen(open);
-    if (!open) {
-      setName("");
-      setCreatedKey(null);
-      setCreating(false);
-    }
-  };
-
   return (
     <PageContainer>
       <PageHeader
         title="API keys"
-        description="User keys for accessing the Executor API and MCP endpoint from scripts and tools."
+        description="Keys for accessing the Executor API and MCP endpoint from scripts and tools."
         actions={
           <Button
             onClick={() => {
-              setName(defaultApiKeyName());
+              setOpenCount((count) => count + 1);
               setCreateOpen(true);
             }}
           >
@@ -225,84 +280,57 @@ export function ApiKeysPage(props: { readonly orgKeysSection?: ReactNode } = {})
           </code>
           <CopyButton value="Authorization: Bearer <api-key>" />
         </div>
-        <p className="mt-2 max-w-2xl text-xs leading-5 text-muted-foreground">
-          API keys work like personal access tokens: they act as you, in this organization, with
-          full access to your own account.
-        </p>
       </PageHeader>
 
-      {isAsyncResultLoading(result) ? (
-        <div className="rounded-md border border-border bg-card p-6 text-sm text-muted-foreground">
-          Loading API keys...
-        </div>
-      ) : (
-        AsyncResult.match(result, {
-          onInitial: () => (
-            <div className="rounded-md border border-border bg-card p-6 text-sm text-muted-foreground">
-              Loading API keys...
-            </div>
-          ),
-          onFailure: () => (
-            <ErrorState message="Failed to load API keys" onRetry={refreshApiKeys} />
-          ),
-          onSuccess: ({ value }) =>
-            value.apiKeys.length === 0 ? (
-              <div className="rounded-md border border-dashed border-border bg-card p-8">
-                <h2 className="text-base font-semibold text-foreground">No API keys</h2>
-                <p className="mt-2 max-w-xl text-sm leading-6 text-muted-foreground">
-                  Create a key and send it in the Authorization Bearer header.
-                </p>
+      <section>
+        <h2 className="text-sm font-medium text-foreground">Personal keys</h2>
+        <p className="mb-4 mt-0.5 max-w-2xl text-sm text-muted-foreground">
+          Personal keys work like personal access tokens: they act as you, in this organization,
+          with full access to your own account.
+        </p>
+
+        {isAsyncResultLoading(result) ? (
+          <div className="rounded-md border border-border bg-card p-6 text-sm text-muted-foreground">
+            Loading API keys...
+          </div>
+        ) : (
+          AsyncResult.match(result, {
+            onInitial: () => (
+              <div className="rounded-md border border-border bg-card p-6 text-sm text-muted-foreground">
+                Loading API keys...
               </div>
-            ) : (
-              <KeyTable keys={value.apiKeys} revokingId={revokingId} onRevoke={handleRevoke} />
             ),
-        })
-      )}
+            onFailure: () => (
+              <ErrorState message="Failed to load API keys" onRetry={refreshApiKeys} />
+            ),
+            onSuccess: ({ value }) =>
+              value.apiKeys.length === 0 ? (
+                <div className="rounded-md border border-dashed border-border bg-card p-8">
+                  <h3 className="text-base font-semibold text-foreground">No API keys</h3>
+                  <p className="mt-2 max-w-xl text-sm leading-6 text-muted-foreground">
+                    Create a key and send it in the Authorization Bearer header.
+                  </p>
+                </div>
+              ) : (
+                <KeyTable keys={value.apiKeys} revokingId={revokingId} onRevoke={handleRevoke} />
+              ),
+          })
+        )}
+      </section>
 
       {props.orgKeysSection}
 
-      <Dialog open={createOpen} onOpenChange={closeCreate}>
+      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
         <DialogContent className="sm:max-w-[480px]">
-          <DialogHeader>
-            <DialogTitle className="font-display text-xl">Create API key</DialogTitle>
-            <DialogDescription className="text-sm leading-relaxed">
-              The key will act as your user in the current organization.
-            </DialogDescription>
-          </DialogHeader>
-
-          {createdKey ? (
-            <CreatedKeyReveal
-              value={createdKey.value}
-              onCopy={(kind) => trackEvent("api_key_copied", { kind })}
-            />
-          ) : (
-            <div className="grid gap-4 py-3">
-              <div className="grid gap-1.5">
-                <Label htmlFor="api-key-name" className="text-sm font-medium text-foreground">
-                  Name
-                </Label>
-                <Input
-                  id="api-key-name"
-                  value={name}
-                  onChange={(event) => setName(event.target.value)}
-                  placeholder="Local CLI"
-                  maxLength={80}
-                  autoFocus
-                />
-              </div>
-            </div>
-          )}
-
-          <DialogFooter>
-            <DialogClose asChild>
-              <Button variant="ghost">Close</Button>
-            </DialogClose>
-            {!createdKey && (
-              <Button onClick={handleCreate} disabled={creating || !name.trim()}>
-                {creating ? "Creating..." : "Create key"}
-              </Button>
-            )}
-          </DialogFooter>
+          <CreateKeyDialogBody
+            key={openCount}
+            title="Create API key"
+            description="The key will act as your user in the current organization."
+            defaultName={defaultKeyName("API key")}
+            placeholder="Local CLI"
+            onCreate={handleCreate}
+            onCopy={(kind) => trackEvent("api_key_copied", { kind })}
+          />
         </DialogContent>
       </Dialog>
     </PageContainer>
@@ -316,11 +344,23 @@ export function ApiKeysPage(props: { readonly orgKeysSection?: ReactNode } = {})
 // acts AS the member who minted it on the product plane; an org key has no
 // member behind it and reads the whole tenant.
 //
-// Rendered via the page's `orgKeysSection` slot by hosts that mint org keys
-// (cloud). The admin gate here only HIDES the section — the server enforces
-// the real one (403 for a plain member) and the section renders that refusal
-// as an error state if it arrives anyway.
+// The admin gate here only HIDES the section — the server enforces the real
+// one (403 for a plain member), and that refusal renders as an explicit
+// denial below, never as a retryable failure.
 // ---------------------------------------------------------------------------
+
+/** 403 (or no-org) from the org-key surface: the caller is not an active admin
+ *  of this org. A denial, not a transient failure — the client-side role gate
+ *  can disagree with the server (role change inside the member list's TTL;
+ *  `owner` accepted client-side where cloud requires `admin`), and offering
+ *  Retry on a refusal would only re-fail forever. */
+const isOrgKeysAccessDenied = (cause: Cause.Cause<unknown>): boolean =>
+  Option.match(Cause.findErrorOption(cause), {
+    onNone: () => false,
+    onSome: (error) =>
+      Predicate.isTagged(error, "AccountForbidden") ||
+      Predicate.isTagged(error, "AccountNoOrganization"),
+  });
 
 export function OrgApiKeysSection() {
   // Gate BEFORE mounting the body: `orgApiKeysAtom` starts its fetch when the
@@ -334,15 +374,27 @@ export function OrgApiKeysSection() {
 function OrgApiKeysSectionBody() {
   const result = useAtomValue(orgApiKeysAtom);
   const refresh = useAtomRefresh(orgApiKeysAtom);
+  const doCreate = useAtomSet(createOrgApiKey, { mode: "promiseExit" });
   const doRevoke = useAtomSet(revokeOrgApiKey, { mode: "promiseExit" });
   const [createOpen, setCreateOpen] = useState(false);
-  // Remount the dialog body per open (self-contained modal): its form and
-  // created-key state are destroyed on close instead of hand-reset, while the
-  // Dialog shell stays mounted for the exit animation.
+  // Same remount-per-open discipline as the personal dialog above.
   const [openCount, setOpenCount] = useState(0);
+  const [confirmRevoke, setConfirmRevoke] = useState<ApiKeySummary | null>(null);
   const [revokingId, setRevokingId] = useState<string | null>(null);
 
+  const handleCreate = async (name: string): Promise<CreatedKey | null> => {
+    const exit = await doCreate({ payload: { name }, reactivityKeys: orgApiKeyWriteKeys });
+    trackEvent("org_api_key_created", { success: Exit.isSuccess(exit) });
+    if (Exit.isSuccess(exit)) {
+      toast.success("Organization key created");
+      return exit.value;
+    }
+    toast.error("Failed to create organization key");
+    return null;
+  };
+
   const handleRevoke = async (key: ApiKeySummary) => {
+    setConfirmRevoke(null);
     setRevokingId(key.id);
     const exit = await doRevoke({
       params: { apiKeyId: key.id },
@@ -359,7 +411,7 @@ function OrgApiKeysSectionBody() {
 
   return (
     <section className="mt-10">
-      <div className="mb-4 flex items-center justify-between gap-4">
+      <div className="mb-4 flex items-start justify-between gap-4">
         <div>
           <h2 className="text-sm font-medium text-foreground">Organization keys</h2>
           <p className="mt-0.5 max-w-2xl text-sm text-muted-foreground">
@@ -391,9 +443,23 @@ function OrgApiKeysSectionBody() {
               Loading organization keys...
             </div>
           ),
-          onFailure: () => (
-            <ErrorState message="Failed to load organization keys" onRetry={refresh} />
-          ),
+          onFailure: ({ cause }) =>
+            isOrgKeysAccessDenied(cause) ? (
+              <div className="rounded-md border border-border bg-card p-8">
+                <p className="font-mono text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
+                  Admin only
+                </p>
+                <h3 className="mt-2 text-base font-semibold text-foreground">
+                  You don&apos;t have access to this organization&apos;s keys
+                </h3>
+                <p className="mt-2 max-w-xl text-sm leading-6 text-muted-foreground">
+                  Managing organization keys requires an active admin role. Ask an admin of this
+                  organization if you need one.
+                </p>
+              </div>
+            ) : (
+              <ErrorState message="Failed to load organization keys" onRetry={refresh} />
+            ),
           onSuccess: ({ value }) =>
             value.apiKeys.length === 0 ? (
               <div className="rounded-md border border-dashed border-border bg-card p-8">
@@ -403,87 +469,61 @@ function OrgApiKeysSectionBody() {
                 </p>
               </div>
             ) : (
-              <KeyTable keys={value.apiKeys} revokingId={revokingId} onRevoke={handleRevoke} />
+              <KeyTable
+                keys={value.apiKeys}
+                revokingId={revokingId}
+                onRevoke={(key) => setConfirmRevoke(key)}
+              />
             ),
         })
       )}
 
       <Dialog open={createOpen} onOpenChange={setCreateOpen}>
         <DialogContent className="sm:max-w-[480px]">
-          {createOpen ? <CreateOrgKeyDialogBody key={openCount} /> : null}
+          <CreateKeyDialogBody
+            key={openCount}
+            title="Create organization key"
+            description="The key will belong to the organization itself, not to you. It grants read-only access to the admin API across the whole organization."
+            defaultName={defaultKeyName("Organization key")}
+            placeholder="Backend admin reader"
+            onCreate={handleCreate}
+            onCopy={(kind) => trackEvent("org_api_key_copied", { kind })}
+          />
+        </DialogContent>
+      </Dialog>
+
+      {/* Revoking an org key breaks every backend using it, so it is the one
+          revoke on this page that asks first. */}
+      <Dialog
+        open={confirmRevoke !== null}
+        onOpenChange={(open) => {
+          if (!open) setConfirmRevoke(null);
+        }}
+      >
+        <DialogContent className="sm:max-w-[480px]">
+          <DialogHeader>
+            <DialogTitle className="font-display text-xl">Revoke organization key</DialogTitle>
+            <DialogDescription className="text-sm leading-relaxed">
+              {confirmRevoke
+                ? `Revoke ${confirmRevoke.name}? Anything authenticating with it loses admin API access immediately. This cannot be undone.`
+                : ""}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button variant="ghost">Cancel</Button>
+            </DialogClose>
+            <Button
+              variant="destructive"
+              onClick={() => {
+                if (confirmRevoke) void handleRevoke(confirmRevoke);
+              }}
+            >
+              Revoke key
+            </Button>
+          </DialogFooter>
         </DialogContent>
       </Dialog>
     </section>
-  );
-}
-
-function CreateOrgKeyDialogBody() {
-  const doCreate = useAtomSet(createOrgApiKey, { mode: "promiseExit" });
-  const [name, setName] = useState(defaultApiKeyName());
-  const [createdKey, setCreatedKey] = useState<CreatedKey | null>(null);
-  const [creating, setCreating] = useState(false);
-
-  const handleCreate = async () => {
-    const trimmed = name.trim();
-    if (!trimmed) return;
-    setCreating(true);
-    const exit = await doCreate({
-      payload: { name: trimmed },
-      reactivityKeys: orgApiKeyWriteKeys,
-    });
-    setCreating(false);
-    trackEvent("org_api_key_created", { success: Exit.isSuccess(exit) });
-    if (Exit.isSuccess(exit)) {
-      setCreatedKey(exit.value);
-      toast.success("Organization key created");
-      return;
-    }
-    toast.error("Failed to create organization key");
-  };
-
-  return (
-    <>
-      <DialogHeader>
-        <DialogTitle className="font-display text-xl">Create organization key</DialogTitle>
-        <DialogDescription className="text-sm leading-relaxed">
-          The key will belong to the organization itself — not to you — with read-only access to the
-          admin API across the whole organization.
-        </DialogDescription>
-      </DialogHeader>
-
-      {createdKey ? (
-        <CreatedKeyReveal
-          value={createdKey.value}
-          onCopy={(kind) => trackEvent("org_api_key_copied", { kind })}
-        />
-      ) : (
-        <div className="grid gap-4 py-3">
-          <div className="grid gap-1.5">
-            <Label htmlFor="org-api-key-name" className="text-sm font-medium text-foreground">
-              Name
-            </Label>
-            <Input
-              id="org-api-key-name"
-              value={name}
-              onChange={(event) => setName(event.target.value)}
-              placeholder="Backend admin reader"
-              maxLength={80}
-              autoFocus
-            />
-          </div>
-        </div>
-      )}
-
-      <DialogFooter>
-        <DialogClose asChild>
-          <Button variant="ghost">Close</Button>
-        </DialogClose>
-        {!createdKey && (
-          <Button onClick={handleCreate} disabled={creating || !name.trim()}>
-            {creating ? "Creating..." : "Create key"}
-          </Button>
-        )}
-      </DialogFooter>
-    </>
   );
 }

--- a/packages/react/src/pages/api-keys.tsx
+++ b/packages/react/src/pages/api-keys.tsx
@@ -1,11 +1,19 @@
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
 import { Exit } from "effect";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 import { useAtomRefresh, useAtomSet, useAtomValue } from "@effect/atom-react";
 import { toast } from "sonner";
-import { apiKeyWriteKeys } from "../api/reactivity-keys";
+import { apiKeyWriteKeys, orgApiKeyWriteKeys } from "../api/reactivity-keys";
 import { trackEvent } from "../api/analytics";
-import { apiKeysAtom, createApiKey, revokeApiKey } from "../api/account-atoms";
+import {
+  apiKeysAtom,
+  createApiKey,
+  createOrgApiKey,
+  orgApiKeysAtom,
+  revokeApiKey,
+  revokeOrgApiKey,
+} from "../api/account-atoms";
+import { useIsTenantAdmin } from "../multiplayer/use-admin-nav";
 import { Button } from "../components/button";
 import { PageContainer, PageHeader } from "../components/page";
 import { CopyButton } from "../components/copy-button";
@@ -29,6 +37,10 @@ import { isAsyncResultLoading } from "../lib/async-result";
 // surface, so it works identically on cloud (WorkOS) and self-host (Better
 // Auth). API keys are how a user authenticates the Executor API + MCP endpoint
 // from scripts/agents (Authorization: Bearer <key>).
+//
+// `orgKeysSection` is a host slot (the OrgPage pattern): cloud passes
+// `<OrgApiKeysSection />` below; self-host passes nothing because its provider
+// refuses org keys (`/admin/*` there is gated on an owner/admin session).
 // ---------------------------------------------------------------------------
 
 type ApiKeySummary = {
@@ -60,7 +72,88 @@ const defaultApiKeyName = (): string =>
     year: "numeric",
   }).format(new Date())}`;
 
-export function ApiKeysPage() {
+/** The shared list markup — both key sections render the same columns. */
+function KeyTable(props: {
+  readonly keys: readonly ApiKeySummary[];
+  readonly revokingId: string | null;
+  readonly onRevoke: (key: ApiKeySummary) => void;
+}) {
+  return (
+    <div className="overflow-hidden rounded-md border border-border bg-card">
+      <div className="grid grid-cols-[1fr_auto] gap-4 border-b border-border px-4 py-3 text-xs font-medium uppercase tracking-wider text-muted-foreground md:grid-cols-[1.4fr_1fr_1fr_auto]">
+        <span>Name</span>
+        <span className="hidden md:block">Created</span>
+        <span className="hidden md:block">Last used</span>
+        <span className="text-right">Actions</span>
+      </div>
+      {props.keys.map((key) => (
+        <div
+          key={key.id}
+          className="grid grid-cols-[1fr_auto] items-center gap-4 border-b border-border px-4 py-4 last:border-b-0 md:grid-cols-[1.4fr_1fr_1fr_auto]"
+        >
+          <div className="min-w-0">
+            <p className="truncate text-sm font-medium text-foreground">{key.name}</p>
+            <p className="mt-1 font-mono text-xs text-muted-foreground">{key.obfuscatedValue}</p>
+          </div>
+          <p className="hidden text-sm text-muted-foreground md:block">
+            {formatDate(key.createdAt)}
+          </p>
+          <p className="hidden text-sm text-muted-foreground md:block">
+            {formatDate(key.lastUsedAt)}
+          </p>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            onClick={() => props.onRevoke(key)}
+            disabled={props.revokingId === key.id}
+            title={`Revoke ${key.name}`}
+            className="text-muted-foreground hover:text-destructive"
+          >
+            <span aria-hidden="true">×</span>
+          </Button>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/** The one-time reveal of a freshly minted key's value + Bearer header. */
+function CreatedKeyReveal(props: {
+  readonly value: string;
+  readonly onCopy: (kind: "value" | "bearer_header") => void;
+}) {
+  return (
+    <div className="grid gap-4 py-3">
+      <div className="grid gap-1.5">
+        <Label className="text-sm font-medium text-foreground">New key</Label>
+        <div className="flex items-center gap-2">
+          <Input value={props.value} readOnly className="font-mono text-xs" data-ph-mask />
+          <CopyButton value={props.value} onCopy={() => props.onCopy("value")} />
+        </div>
+      </div>
+      <div className="grid gap-1.5">
+        <Label className="text-sm font-medium text-foreground">Bearer header</Label>
+        <div className="flex items-center gap-2">
+          <Input
+            value={`Authorization: Bearer ${props.value}`}
+            readOnly
+            className="font-mono text-xs"
+            data-ph-mask
+          />
+          <CopyButton
+            value={`Authorization: Bearer ${props.value}`}
+            onCopy={() => props.onCopy("bearer_header")}
+          />
+        </div>
+      </div>
+      <p className="text-sm leading-6 text-muted-foreground">
+        Send this value as a Bearer token. It is only shown once.
+      </p>
+    </div>
+  );
+}
+
+export function ApiKeysPage(props: { readonly orgKeysSection?: ReactNode } = {}) {
   useExecutorDocumentTitle("API keys");
   const result = useAtomValue(apiKeysAtom);
   const refreshApiKeys = useAtomRefresh(apiKeysAtom);
@@ -133,7 +226,8 @@ export function ApiKeysPage() {
           <CopyButton value="Authorization: Bearer <api-key>" />
         </div>
         <p className="mt-2 max-w-2xl text-xs leading-5 text-muted-foreground">
-          API keys work like personal access tokens and have full access to your account.
+          API keys work like personal access tokens: they act as you, in this organization, with
+          full access to your own account.
         </p>
       </PageHeader>
 
@@ -160,46 +254,12 @@ export function ApiKeysPage() {
                 </p>
               </div>
             ) : (
-              <div className="overflow-hidden rounded-md border border-border bg-card">
-                <div className="grid grid-cols-[1fr_auto] gap-4 border-b border-border px-4 py-3 text-xs font-medium uppercase tracking-wider text-muted-foreground md:grid-cols-[1.4fr_1fr_1fr_auto]">
-                  <span>Name</span>
-                  <span className="hidden md:block">Created</span>
-                  <span className="hidden md:block">Last used</span>
-                  <span className="text-right">Actions</span>
-                </div>
-                {value.apiKeys.map((key: ApiKeySummary) => (
-                  <div
-                    key={key.id}
-                    className="grid grid-cols-[1fr_auto] items-center gap-4 border-b border-border px-4 py-4 last:border-b-0 md:grid-cols-[1.4fr_1fr_1fr_auto]"
-                  >
-                    <div className="min-w-0">
-                      <p className="truncate text-sm font-medium text-foreground">{key.name}</p>
-                      <p className="mt-1 font-mono text-xs text-muted-foreground">
-                        {key.obfuscatedValue}
-                      </p>
-                    </div>
-                    <p className="hidden text-sm text-muted-foreground md:block">
-                      {formatDate(key.createdAt)}
-                    </p>
-                    <p className="hidden text-sm text-muted-foreground md:block">
-                      {formatDate(key.lastUsedAt)}
-                    </p>
-                    <Button
-                      variant="ghost"
-                      size="icon-sm"
-                      onClick={() => handleRevoke(key)}
-                      disabled={revokingId === key.id}
-                      title={`Revoke ${key.name}`}
-                      className="text-muted-foreground hover:text-destructive"
-                    >
-                      <span aria-hidden="true">×</span>
-                    </Button>
-                  </div>
-                ))}
-              </div>
+              <KeyTable keys={value.apiKeys} revokingId={revokingId} onRevoke={handleRevoke} />
             ),
         })
       )}
+
+      {props.orgKeysSection}
 
       <Dialog open={createOpen} onOpenChange={closeCreate}>
         <DialogContent className="sm:max-w-[480px]">
@@ -211,41 +271,10 @@ export function ApiKeysPage() {
           </DialogHeader>
 
           {createdKey ? (
-            <div className="grid gap-4 py-3">
-              <div className="grid gap-1.5">
-                <Label className="text-sm font-medium text-foreground">New key</Label>
-                <div className="flex items-center gap-2">
-                  <Input
-                    value={createdKey.value}
-                    readOnly
-                    className="font-mono text-xs"
-                    data-ph-mask
-                  />
-                  <CopyButton
-                    value={createdKey.value}
-                    onCopy={() => trackEvent("api_key_copied", { kind: "value" })}
-                  />
-                </div>
-              </div>
-              <div className="grid gap-1.5">
-                <Label className="text-sm font-medium text-foreground">Bearer header</Label>
-                <div className="flex items-center gap-2">
-                  <Input
-                    value={`Authorization: Bearer ${createdKey.value}`}
-                    readOnly
-                    className="font-mono text-xs"
-                    data-ph-mask
-                  />
-                  <CopyButton
-                    value={`Authorization: Bearer ${createdKey.value}`}
-                    onCopy={() => trackEvent("api_key_copied", { kind: "bearer_header" })}
-                  />
-                </div>
-              </div>
-              <p className="text-sm leading-6 text-muted-foreground">
-                Send this value as a Bearer token. It is only shown once.
-              </p>
-            </div>
+            <CreatedKeyReveal
+              value={createdKey.value}
+              onCopy={(kind) => trackEvent("api_key_copied", { kind })}
+            />
           ) : (
             <div className="grid gap-4 py-3">
               <div className="grid gap-1.5">
@@ -277,5 +306,184 @@ export function ApiKeysPage() {
         </DialogContent>
       </Dialog>
     </PageContainer>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Organization keys — the admin-only, org-owned credentials for the read-only
+// admin API (`/api/admin/*`). A separate section rather than rows in the table
+// above because the two key kinds answer different questions: a personal key
+// acts AS the member who minted it on the product plane; an org key has no
+// member behind it and reads the whole tenant.
+//
+// Rendered via the page's `orgKeysSection` slot by hosts that mint org keys
+// (cloud). The admin gate here only HIDES the section — the server enforces
+// the real one (403 for a plain member) and the section renders that refusal
+// as an error state if it arrives anyway.
+// ---------------------------------------------------------------------------
+
+export function OrgApiKeysSection() {
+  // Gate BEFORE mounting the body: `orgApiKeysAtom` starts its fetch when the
+  // reading component mounts, and for a plain member that request is a
+  // guaranteed 403. Fail-closed like the admin nav — while the member list is
+  // loading, show nothing rather than a section that will refuse.
+  const isAdmin = useIsTenantAdmin();
+  return isAdmin ? <OrgApiKeysSectionBody /> : null;
+}
+
+function OrgApiKeysSectionBody() {
+  const result = useAtomValue(orgApiKeysAtom);
+  const refresh = useAtomRefresh(orgApiKeysAtom);
+  const doRevoke = useAtomSet(revokeOrgApiKey, { mode: "promiseExit" });
+  const [createOpen, setCreateOpen] = useState(false);
+  // Remount the dialog body per open (self-contained modal): its form and
+  // created-key state are destroyed on close instead of hand-reset, while the
+  // Dialog shell stays mounted for the exit animation.
+  const [openCount, setOpenCount] = useState(0);
+  const [revokingId, setRevokingId] = useState<string | null>(null);
+
+  const handleRevoke = async (key: ApiKeySummary) => {
+    setRevokingId(key.id);
+    const exit = await doRevoke({
+      params: { apiKeyId: key.id },
+      reactivityKeys: orgApiKeyWriteKeys,
+    });
+    setRevokingId(null);
+    trackEvent("org_api_key_revoked", { success: Exit.isSuccess(exit) });
+    if (Exit.isSuccess(exit)) {
+      toast.success(`Revoked ${key.name}`);
+      return;
+    }
+    toast.error("Failed to revoke organization key");
+  };
+
+  return (
+    <section className="mt-10">
+      <div className="mb-4 flex items-center justify-between gap-4">
+        <div>
+          <h2 className="text-sm font-medium text-foreground">Organization keys</h2>
+          <p className="mt-0.5 max-w-2xl text-sm text-muted-foreground">
+            Read-only keys owned by the organization, not a member. They authenticate the admin API
+            (who are my users, what have they connected) and cannot act as anyone or write anything.
+            Admins only.
+          </p>
+        </div>
+        <Button
+          size="sm"
+          onClick={() => {
+            setOpenCount((count) => count + 1);
+            setCreateOpen(true);
+          }}
+        >
+          <span aria-hidden="true">+</span>
+          New org key
+        </Button>
+      </div>
+
+      {isAsyncResultLoading(result) ? (
+        <div className="rounded-md border border-border bg-card p-6 text-sm text-muted-foreground">
+          Loading organization keys...
+        </div>
+      ) : (
+        AsyncResult.match(result, {
+          onInitial: () => (
+            <div className="rounded-md border border-border bg-card p-6 text-sm text-muted-foreground">
+              Loading organization keys...
+            </div>
+          ),
+          onFailure: () => (
+            <ErrorState message="Failed to load organization keys" onRetry={refresh} />
+          ),
+          onSuccess: ({ value }) =>
+            value.apiKeys.length === 0 ? (
+              <div className="rounded-md border border-dashed border-border bg-card p-8">
+                <h3 className="text-base font-semibold text-foreground">No organization keys</h3>
+                <p className="mt-2 max-w-xl text-sm leading-6 text-muted-foreground">
+                  Create one to call the admin API from your backend.
+                </p>
+              </div>
+            ) : (
+              <KeyTable keys={value.apiKeys} revokingId={revokingId} onRevoke={handleRevoke} />
+            ),
+        })
+      )}
+
+      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+        <DialogContent className="sm:max-w-[480px]">
+          {createOpen ? <CreateOrgKeyDialogBody key={openCount} /> : null}
+        </DialogContent>
+      </Dialog>
+    </section>
+  );
+}
+
+function CreateOrgKeyDialogBody() {
+  const doCreate = useAtomSet(createOrgApiKey, { mode: "promiseExit" });
+  const [name, setName] = useState(defaultApiKeyName());
+  const [createdKey, setCreatedKey] = useState<CreatedKey | null>(null);
+  const [creating, setCreating] = useState(false);
+
+  const handleCreate = async () => {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    setCreating(true);
+    const exit = await doCreate({
+      payload: { name: trimmed },
+      reactivityKeys: orgApiKeyWriteKeys,
+    });
+    setCreating(false);
+    trackEvent("org_api_key_created", { success: Exit.isSuccess(exit) });
+    if (Exit.isSuccess(exit)) {
+      setCreatedKey(exit.value);
+      toast.success("Organization key created");
+      return;
+    }
+    toast.error("Failed to create organization key");
+  };
+
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle className="font-display text-xl">Create organization key</DialogTitle>
+        <DialogDescription className="text-sm leading-relaxed">
+          The key will belong to the organization itself — not to you — with read-only access to the
+          admin API across the whole organization.
+        </DialogDescription>
+      </DialogHeader>
+
+      {createdKey ? (
+        <CreatedKeyReveal
+          value={createdKey.value}
+          onCopy={(kind) => trackEvent("org_api_key_copied", { kind })}
+        />
+      ) : (
+        <div className="grid gap-4 py-3">
+          <div className="grid gap-1.5">
+            <Label htmlFor="org-api-key-name" className="text-sm font-medium text-foreground">
+              Name
+            </Label>
+            <Input
+              id="org-api-key-name"
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              placeholder="Backend admin reader"
+              maxLength={80}
+              autoFocus
+            />
+          </div>
+        </div>
+      )}
+
+      <DialogFooter>
+        <DialogClose asChild>
+          <Button variant="ghost">Close</Button>
+        </DialogClose>
+        {!createdKey && (
+          <Button onClick={handleCreate} disabled={creating || !name.trim()}>
+            {creating ? "Creating..." : "Create key"}
+          </Button>
+        )}
+      </DialogFooter>
+    </>
   );
 }


### PR DESCRIPTION
Adds an admin-only **Organization keys** section to the API keys page on cloud: list, mint, and revoke over the existing `/api/account/org-api-keys` endpoints, with copy that states the distinction (a personal key acts as you on the product plane; an org key belongs to the org, has no member behind it, and reads the admin API tenant-wide).

- Section is hidden for non-admins (fail-closed, same derivation as the Users nav) and not rendered on self-host, whose provider refuses org keys.
- Create dialog remounts per open so the one-time key reveal and form state are destroyed on close.
- Shared `KeyTable` / `CreatedKeyReveal` extracted from the personal-keys markup rather than duplicated.
- New `org:api-keys` reactivity key so org-key mutations don't refetch personal keys, and `org_api_key_*` analytics events.

The WorkOS emulator has no org-key routes yet (known gap from #1467), so there is no browser e2e for the mint flow in this PR; the server behavior stays covered by the existing unit tests (`org-api-key-mint`, `org-api-key-revoke`).