### PR TITLE
Serve tenant-level product reads to organization API keys

### DIFF
--- a/apps/cloud/src/api/protected-api-key-auth.node.test.ts
+++ b/apps/cloud/src/api/protected-api-key-auth.node.test.ts
@@ -89,6 +89,7 @@ describe("protected API key auth", () => {
       );
 
       expect(identity).toEqual({
+        kind: "member",
         accountId: "user_123",
         organizationId: "org_123",
         organizationName: "Org org_123",

--- a/apps/cloud/src/api/protected-jwt-auth.node.test.ts
+++ b/apps/cloud/src/api/protected-jwt-auth.node.test.ts
@@ -110,6 +110,7 @@ describe("protected JWT (device-login) auth", () => {
       const identity = yield* run(request(token), config);
 
       expect(identity).toEqual({
+        kind: "member",
         accountId: "user_123",
         organizationId: "org_123",
         organizationName: "Org org_123",

--- a/apps/cloud/src/auth/org-api-key-auth.node.test.ts
+++ b/apps/cloud/src/auth/org-api-key-auth.node.test.ts
@@ -124,19 +124,25 @@ describe("org-level API keys", () => {
     }),
   );
 
-  it.effect("are REJECTED on the product surface rather than bound to a subject", () =>
+  it.effect("resolve on the product surface as a platform principal, never a subject", () =>
     Effect.gen(function* () {
-      // THE security property of the api-key half: a product request carrying
-      // an org key must fail, not silently act as some user.
-      const error = yield* Effect.flip(
-        resolveApiKeyPrincipal(bearer("valid_org_key")).pipe(Effect.provide(layers)),
+      // THE security property of the api-key half, updated for platform reads:
+      // a product request carrying an org key resolves to the NEUTRAL platform
+      // shape — which the shared middleware routes to the subject-less,
+      // GET-only platform executor — and must never carry an accountId a
+      // handler could bind as an acting member.
+      const principal = yield* resolveApiKeyPrincipal(bearer("valid_org_key")).pipe(
+        Effect.provide(layers),
       );
 
-      expect(error).toMatchObject({
-        _tag: "Unauthorized",
-        code: "invalid_api_key",
-        message: "Organization API keys cannot be used on this endpoint",
+      expect(principal).toEqual({
+        kind: "platform",
+        organizationId: "org_123",
+        organizationName: "Org org_123",
+        organizationSlug: "org-slug-org_123",
+        keyId: "api_key_org",
       });
+      expect(principal).not.toHaveProperty("accountId");
     }),
   );
 

--- a/apps/cloud/src/auth/workos-auth-provider.ts
+++ b/apps/cloud/src/auth/workos-auth-provider.ts
@@ -38,7 +38,13 @@ import {
   Unauthorized,
   Unavailable,
 } from "@executor-js/api/server";
-import type { FailureRenderingStrategy, IdentityFailure, Principal } from "@executor-js/api/server";
+import type {
+  FailureRenderingStrategy,
+  IdentityFailure,
+  PlatformPrincipal,
+  Principal,
+  ResolvedPrincipal,
+} from "@executor-js/api/server";
 
 import { ApiKeyService } from "./api-keys";
 import { workosApiJwtBearerConfig } from "./api-jwt-bearer";
@@ -104,14 +110,6 @@ const NO_ORGANIZATION_IN_ACCESS_TOKEN = {
   code: "no_organization",
   message: "No organization in access token",
 };
-// An org-level key resolves to the PLATFORM view, which has no acting member.
-// The product endpoints are bound to one subject, so they reject it outright
-// rather than inventing a subject for it to act as.
-const ORG_KEY_ON_PRODUCT_SURFACE = {
-  code: "invalid_api_key",
-  message: "Organization API keys cannot be used on this endpoint",
-};
-
 // A bearer value with three dot-separated segments is a JWT (a WorkOS access
 // token from the CLI device-login); anything else is treated as an API key.
 // Same discriminator the MCP plane uses (`mcp/auth.ts`).
@@ -257,23 +255,36 @@ export const resolveBearerAuth = (
   });
 
 /**
- * The PRODUCT-view bearer resolver: as {@link resolveBearerAuth}, but an
- * org-level key is REJECTED rather than downgraded. The product endpoints are
- * bound to one acting subject, so there is no honest way to serve them an
- * org key — those belong at the `/admin/*` mount instead. (Kept the historical
- * name; the re-export and resolver tests reference it.)
+ * The PRODUCT-plane bearer resolver. An org-level key resolves to the neutral
+ * seam's {@link PlatformPrincipal} — NOT a member `Principal` — and the shared
+ * middleware routes it to the subject-less, read-only platform executor
+ * (refusing non-GET up front). Previously the product plane rejected org keys
+ * outright; serving tenant-level READS to them is deliberate: the catalog,
+ * tools, policies, and org-owned connection listings are tenant-shared answers
+ * a machine credential can honestly receive, while everything subject-bound
+ * stays structurally out of reach (a platform executor binds no subject, so no
+ * member's personal rows resolve). (Kept the historical name; the re-export and
+ * resolver tests reference it.)
  */
 export const resolveApiKeyPrincipal = (
   request: Request,
   jwt: JwtBearerConfig | null = null,
 ): Effect.Effect<
-  Principal | null,
+  ResolvedPrincipal | null,
   Unauthorized | NoOrganization | Unavailable | UserStoreError | WorkOSError,
   WorkOSClient | ApiKeyService | UserStoreService
 > =>
   Effect.gen(function* () {
     const auth = yield* resolveBearerAuth(request, jwt);
-    if (isPlatformAuth(auth)) return yield* new Unauthorized(ORG_KEY_ON_PRODUCT_SURFACE);
+    if (isPlatformAuth(auth)) {
+      return {
+        kind: "platform",
+        organizationId: auth.organizationId,
+        organizationName: auth.organizationName,
+        ...(auth.organizationSlug === undefined ? {} : { organizationSlug: auth.organizationSlug }),
+        keyId: auth.keyId,
+      } satisfies PlatformPrincipal;
+    }
     return auth;
   });
 
@@ -330,7 +341,7 @@ export const resolveProtectedPrincipal = (
   request: Request,
   jwt: JwtBearerConfig | null = null,
 ): Effect.Effect<
-  Principal,
+  ResolvedPrincipal,
   Unauthorized | NoOrganization | Unavailable | UserStoreError | WorkOSError,
   WorkOSClient | ApiKeyService | UserStoreService
 > =>
@@ -410,6 +421,11 @@ export const cloudIdentityFailureStrategy: FailureRenderingStrategy<IdentityFail
           503,
           "service_unavailable",
           "Service temporarily unavailable",
+        ),
+        ReadOnlyCredential: renderIdentityFailure(
+          403,
+          "read_only_credential",
+          "Organization API keys are read-only",
         ),
       }),
     ),

--- a/apps/cloud/src/auth/workos-auth-provider.ts
+++ b/apps/cloud/src/auth/workos-auth-provider.ts
@@ -145,6 +145,7 @@ const resolveJwtPrincipal = (token: string, jwt: JwtBearerConfig) =>
     if (!org) return yield* new NoOrganization(NO_ORGANIZATION_IN_ACCESS_TOKEN);
 
     return {
+      kind: "member",
       accountId: verified.accountId,
       organizationId: org.id,
       organizationName: org.name,
@@ -243,6 +244,7 @@ export const resolveBearerAuth = (
     if (!org) return yield* new NoOrganization(NO_ORGANIZATION_IN_API_KEY);
 
     return {
+      kind: "member",
       accountId: owner.accountId,
       organizationId: org.id,
       organizationName: org.name,
@@ -315,6 +317,7 @@ export const resolveSessionPrincipal = (request: Request) =>
     const org = yield* authorizeOrganizationSelector(session.userId, selector);
     if (!org) return yield* new NoOrganization(NO_ORGANIZATION_IN_SESSION);
     return {
+      kind: "member",
       accountId: session.userId,
       organizationId: org.id,
       organizationName: org.name,

--- a/apps/cloud/src/org/handlers.test.ts
+++ b/apps/cloud/src/org/handlers.test.ts
@@ -70,6 +70,7 @@ const provide = (auth: typeof adminAuth, workosOverrides: StubOverrides = {}) =>
 // Mirrors `org/handlers.ts` `requireAdmin`.
 const requireAdmin = Effect.gen(function* () {
   const auth = yield* AuthContext;
+  if (auth.accountId === null) return yield* new Forbidden();
   const workos = yield* WorkOSClient;
   const current = yield* workos.getUserOrgMembership(auth.organizationId, auth.accountId);
   if (!current || current.role?.slug !== "admin") {

--- a/apps/cloud/src/org/handlers.ts
+++ b/apps/cloud/src/org/handlers.ts
@@ -17,6 +17,11 @@ import { Forbidden, OrgHttpApi } from "./api";
 
 const requireAdmin = Effect.gen(function* () {
   const auth = yield* AuthContext;
+  // This plane is mounted behind the session-only `orgAuthMiddleware`, so the
+  // caller is always a member — but `AuthContext.accountId` is nullable for the
+  // platform credential, and membership of "no member" is not a question worth
+  // asking WorkOS. Refuse rather than assert.
+  if (auth.accountId === null) return yield* new Forbidden();
   const workos = yield* WorkOSClient;
   const currentMembership = yield* workos.getUserOrgMembership(auth.organizationId, auth.accountId);
   if (!currentMembership || currentMembership.role?.slug !== "admin") {

--- a/apps/host-cloudflare/src/auth/cloudflare-access.ts
+++ b/apps/host-cloudflare/src/auth/cloudflare-access.ts
@@ -38,6 +38,7 @@ export const principalFromAccessClaims = (
   const isAdmin = email.length > 0 && config.adminEmails.includes(email.toLowerCase());
 
   return {
+    kind: "member",
     accountId: sub || email || commonName,
     organizationId: config.organizationId,
     organizationName: config.organizationName,
@@ -68,6 +69,7 @@ export const makeAccessVerifier = (config: CloudflareConfig) => {
   // fixed admin. Only when explicitly enabled (and the instance is otherwise
   // unprotected). Mirrors the local app's single-user model.
   const devPrincipal: Principal = {
+    kind: "member",
     accountId: "dev",
     organizationId: config.organizationId,
     organizationName: config.organizationName,

--- a/apps/host-selfhost/src/auth/identity.ts
+++ b/apps/host-selfhost/src/auth/identity.ts
@@ -67,6 +67,7 @@ export const betterAuthIdentityLayer: Layer.Layer<IdentityProvider, never, Bette
             // default to the seeded org rather than rejecting with NoOrganization.
             const resolvedOrganizationId = resolved.session.activeOrganizationId ?? organizationId;
             return {
+              kind: "member" as const,
               accountId: resolved.user.id,
               organizationId: resolvedOrganizationId,
               organizationName,

--- a/apps/host-selfhost/src/mcp/auth.ts
+++ b/apps/host-selfhost/src/mcp/auth.ts
@@ -1,7 +1,7 @@
 import { Effect, Layer } from "effect";
 import { oAuthDiscoveryMetadata, oAuthProtectedResourceMetadata } from "better-auth/plugins";
 
-import { IdentityProvider } from "@executor-js/api/server";
+import { IdentityProvider, isPlatformPrincipal } from "@executor-js/api/server";
 import {
   authenticated,
   McpAuthProvider,
@@ -233,12 +233,17 @@ export const selfHostMcpAuth: Layer.Layer<McpAuthProvider, never, BetterAuth | I
         }).pipe(Effect.orElseSucceed(() => null));
 
       /** (b) The existing cookie / bearer-session / x-api-key path. The fallback's
-       * api `Principal` shape is byte-identical to host-mcp's `Principal`. */
+       * api `Principal` shape is byte-identical to host-mcp's `Principal`. The
+       * neutral seam can also resolve a platform credential, which self-host's
+       * identity never produces — narrowed away rather than asserted, so an MCP
+       * session can never bind to a subject-less credential if that changes. */
       const authenticateSession = (request: Request): Effect.Effect<Principal | null> =>
         fallback.authenticate(request).pipe(
+          Effect.map((principal) => (isPlatformPrincipal(principal) ? null : principal)),
           Effect.catchTags({
             Unauthorized: () => Effect.succeed(null),
             NoOrganization: () => Effect.succeed(null),
+            ReadOnlyCredential: () => Effect.succeed(null),
           }),
         );
 

--- a/apps/host-selfhost/src/platform-credential.test.ts
+++ b/apps/host-selfhost/src/platform-credential.test.ts
@@ -1,0 +1,196 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterAll, beforeAll, expect, test } from "@effect/vitest";
+
+process.env.EXECUTOR_DATA_DIR = mkdtempSync(join(tmpdir(), "eh-platform-"));
+
+// ---------------------------------------------------------------------------
+// The shared middleware's PLATFORM branch, end-to-end over the real router: an
+// org-level credential (the shape cloud's org-scoped API key resolves to) gets
+// tenant-level READS on the ordinary product paths, and nothing else.
+//
+// Served through the self-host test app because it runs the SAME
+// `makeExecutionStackMiddleware` cloud's protected plane uses — the branch
+// under test is host-neutral, and this is the harness that can drive it
+// without WorkOS. The `x-test-platform-org` header resolves the platform
+// principal (see testing/test-app.ts).
+//
+// Pinned here:
+//   1. GET /api/integrations answers the tenant catalog — the read that used
+//      to require a second, member credential (the customer-reported gap);
+//   2. GET /api/connections answers org-owned rows WITHOUT any member's
+//      personal connections (bound reach, no subject);
+//   3. any non-GET is refused 403 before a handler runs;
+//   4. the credential mints NO subject row — an org key must never appear as a
+//      user of the workspace it observes.
+// ---------------------------------------------------------------------------
+
+let handler!: (request: Request) => Promise<Response>;
+let dispose: () => Promise<void> = async () => {};
+
+beforeAll(async () => {
+  const { makeSelfHostTestApp, headerIdentityLayer } = await import("./testing/test-app");
+  const app = await makeSelfHostTestApp({
+    identity: headerIdentityLayer,
+  });
+  handler = app.handler;
+  dispose = app.dispose;
+});
+afterAll(() => dispose());
+
+const ORG = "platform-org";
+const MEMBER = "member-user";
+
+const TINY_SPEC = JSON.stringify({
+  openapi: "3.0.0",
+  info: { title: "Tiny", version: "1.0.0" },
+  servers: [{ url: "https://httpbin.org" }],
+  paths: {
+    "/get": {
+      get: {
+        operationId: "httpGet",
+        summary: "GET",
+        responses: { "200": { description: "ok" } },
+      },
+    },
+  },
+});
+
+const memberHeaders: Record<string, string> = {
+  "x-test-user": MEMBER,
+  "x-test-org": ORG,
+  "content-type": "application/json",
+};
+
+const platformHeaders: Record<string, string> = {
+  "x-test-platform-org": ORG,
+  "content-type": "application/json",
+};
+
+/** Seed as the MEMBER: a catalog row, an org-owned connection, and a personal
+ *  one — so the platform reads below have both a hit and a must-miss. */
+beforeAll(async () => {
+  const add = await handler(
+    new Request("http://localhost/api/openapi/specs", {
+      method: "POST",
+      headers: memberHeaders,
+      body: JSON.stringify({ spec: { kind: "blob", value: TINY_SPEC }, slug: "cat", baseUrl: "" }),
+    }),
+  );
+  expect(add.status).toBe(200);
+  const orgConn = await handler(
+    new Request("http://localhost/api/connections", {
+      method: "POST",
+      headers: memberHeaders,
+      body: JSON.stringify({
+        owner: "org",
+        name: "shared",
+        integration: "cat",
+        template: "bearer",
+        value: "org-shared-token",
+      }),
+    }),
+  );
+  expect(orgConn.status).toBe(200);
+  const userConn = await handler(
+    new Request("http://localhost/api/connections", {
+      method: "POST",
+      headers: memberHeaders,
+      body: JSON.stringify({
+        owner: "user",
+        name: "personal",
+        integration: "cat",
+        template: "bearer",
+        value: "member-personal-token",
+      }),
+    }),
+  );
+  expect(userConn.status).toBe(200);
+});
+
+test("a platform credential reads the tenant catalog on the ordinary product path", async () => {
+  const res = await handler(
+    new Request("http://localhost/api/integrations", { headers: platformHeaders }),
+  );
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as ReadonlyArray<{ readonly slug: string }>;
+  expect(
+    body.map((integration) => integration.slug),
+    "the catalog the member configured is readable with the org credential alone",
+  ).toContain("cat");
+});
+
+test("connection reads answer org-owned rows and never a member's personal ones", async () => {
+  const res = await handler(
+    new Request("http://localhost/api/connections", { headers: platformHeaders }),
+  );
+  expect(res.status).toBe(200);
+  const raw = await res.text();
+  // oxlint-disable-next-line executor/no-json-parse -- boundary: test asserts on the raw wire body (for the token sweep) and its parsed form together
+  const body = JSON.parse(raw) as ReadonlyArray<{ readonly name: string }>;
+  expect(
+    body.map((connection) => connection.name),
+    "the org-owned connection is visible",
+  ).toContain("shared");
+  expect(
+    body.map((connection) => connection.name),
+    "a member's personal connection is not — the platform view binds no subject",
+  ).not.toContain("personal");
+  expect(raw, "no credential material either way").not.toContain("token");
+});
+
+test("every non-GET is refused before a handler runs", async () => {
+  const post = await handler(
+    new Request("http://localhost/api/connections", {
+      method: "POST",
+      headers: platformHeaders,
+      body: JSON.stringify({
+        owner: "org",
+        name: "sneaky",
+        integration: "cat",
+        template: "bearer",
+        value: "nope",
+      }),
+    }),
+  );
+  expect(post.status, "a write with a read-only credential is a clear 403").toBe(403);
+  expect(await post.text()).toContain("read-only");
+
+  const del = await handler(
+    new Request("http://localhost/api/integrations/cat", {
+      method: "DELETE",
+      headers: platformHeaders,
+    }),
+  );
+  expect(del.status).toBe(403);
+
+  // The refusal happened before any handler: the connection it tried to write
+  // does not exist.
+  const after = await handler(
+    new Request("http://localhost/api/connections", { headers: platformHeaders }),
+  );
+  const names = ((await after.json()) as ReadonlyArray<{ readonly name: string }>).map(
+    (connection) => connection.name,
+  );
+  expect(names).not.toContain("sneaky");
+});
+
+test("the credential never mints a subject row in the workspace it observes", async () => {
+  // Several platform reads have run by now. If any of them touched the subject
+  // table, the org would report a phantom user; only the seeding member may
+  // appear.
+  const { withQueryContext } = await import("@executor-js/fumadb/query");
+  const { createSelfHostDb } = await import("./db/self-host-db");
+  const { loadConfig } = await import("./config");
+  const db = await createSelfHostDb({ path: loadConfig().dbPath });
+  const rows = await withQueryContext(db.db, { tenant: ORG, subject: null }).findMany("subject", {
+    orderBy: ["external_id", "asc"],
+  });
+  await db.close();
+  expect(
+    rows.map((row) => String(row.external_id)),
+    "only the member has a footprint",
+  ).toEqual([MEMBER]);
+});

--- a/apps/host-selfhost/src/platform-credential.test.ts
+++ b/apps/host-selfhost/src/platform-credential.test.ts
@@ -127,9 +127,8 @@ test("connection reads answer org-owned rows and never a member's personal ones"
     new Request("http://localhost/api/connections", { headers: platformHeaders }),
   );
   expect(res.status).toBe(200);
-  const raw = await res.text();
-  // oxlint-disable-next-line executor/no-json-parse -- boundary: test asserts on the raw wire body (for the token sweep) and its parsed form together
-  const body = JSON.parse(raw) as ReadonlyArray<{ readonly name: string }>;
+  const body = (await res.json()) as ReadonlyArray<{ readonly name: string }>;
+  const raw = JSON.stringify(body);
   expect(
     body.map((connection) => connection.name),
     "the org-owned connection is visible",
@@ -139,6 +138,21 @@ test("connection reads answer org-owned rows and never a member's personal ones"
     "a member's personal connection is not — the platform view binds no subject",
   ).not.toContain("personal");
   expect(raw, "no credential material either way").not.toContain("token");
+});
+
+test("the OAuth callback is refused despite being a GET", async () => {
+  // The one core GET with side effects: completing it would burn an org-owned
+  // in-flight authorization code in an outbound token exchange before the
+  // storage policy could refuse the final write. The safe-request gate excludes
+  // it by name; a platform credential landing here is a clear 403, not a
+  // half-executed flow.
+  const res = await handler(
+    new Request("http://localhost/api/oauth/callback?code=x&state=y", {
+      headers: platformHeaders,
+    }),
+  );
+  expect(res.status, "the callback is not a safe read").toBe(403);
+  expect(await res.text()).toContain("read-only");
 });
 
 test("every non-GET is refused before a handler runs", async () => {

--- a/apps/host-selfhost/src/testing/test-app.ts
+++ b/apps/host-selfhost/src/testing/test-app.ts
@@ -81,6 +81,7 @@ export const singleAdminIdentityLayer = (
     IdentityProvider.of({
       authenticate: () =>
         Effect.succeed<Principal>({
+          kind: "member",
           accountId: options.userId,
           organizationId: options.organizationId,
           organizationName: options.organizationName,
@@ -117,6 +118,7 @@ export const headerIdentityLayer: Layer.Layer<IdentityProvider> = Layer.succeed(
       const organizationId = request.headers.get("x-test-org");
       if (!userId || !organizationId) return Effect.fail(new Unauthorized());
       return Effect.succeed<Principal>({
+        kind: "member",
         accountId: userId,
         organizationId,
         organizationName: `Org ${organizationId}`,

--- a/apps/host-selfhost/src/testing/test-app.ts
+++ b/apps/host-selfhost/src/testing/test-app.ts
@@ -5,8 +5,10 @@ import {
   composePluginApi,
   ExecutorApp,
   IdentityProvider,
+  isPlatformPrincipal,
   PluginsProvider,
   type Principal,
+  type ResolvedPrincipal,
   textFailureStrategy,
   Unauthorized,
 } from "@executor-js/api/server";
@@ -98,6 +100,19 @@ export const headerIdentityLayer: Layer.Layer<IdentityProvider> = Layer.succeed(
   IdentityProvider,
   IdentityProvider.of({
     authenticate: (request) => {
+      // `x-test-platform-org` resolves the org-level PLATFORM credential — the
+      // neutral shape cloud's org-scoped API key produces — so the shared
+      // middleware's platform branch is testable against this harness even
+      // though self-host's real identity never mints one.
+      const platformOrg = request.headers.get("x-test-platform-org");
+      if (platformOrg) {
+        return Effect.succeed<ResolvedPrincipal>({
+          kind: "platform",
+          organizationId: platformOrg,
+          organizationName: `Org ${platformOrg}`,
+          keyId: "test_platform_key",
+        });
+      }
       const userId = request.headers.get("x-test-user");
       const organizationId = request.headers.get("x-test-org");
       if (!userId || !organizationId) return Effect.fail(new Unauthorized());
@@ -143,12 +158,17 @@ const stubMcpAuth: Layer.Layer<McpAuthProvider, never, IdentityProvider> = Layer
       resourceMetadataUrl: resourceMetadataUrlFor,
       authenticate: (request: Request): Effect.Effect<AuthOutcome> =>
         fallback.authenticate(request).pipe(
+          // The test identity never resolves a platform credential; narrow it
+          // away (as the production selfHostMcpAuth does) rather than asserting.
           Effect.map((principal) =>
-            principal ? authenticated(principal) : unauthorized(challengeFor(request)),
+            principal && !isPlatformPrincipal(principal)
+              ? authenticated(principal)
+              : unauthorized(challengeFor(request)),
           ),
           Effect.catchTags({
             Unauthorized: () => Effect.succeed(unauthorized(challengeFor(request))),
             NoOrganization: () => Effect.succeed(unauthorized(challengeFor(request))),
+            ReadOnlyCredential: () => Effect.succeed(unauthorized(challengeFor(request))),
           }),
         ),
     };

--- a/apps/local/src/identity.ts
+++ b/apps/local/src/identity.ts
@@ -31,6 +31,7 @@ import { safeEqual } from "./serve-shared";
  * cwd-derived (in `app.ts`), independent of these ids.
  */
 export const LOCAL_PRINCIPAL: Principal = {
+  kind: "member",
   accountId: "local",
   organizationId: "local",
   organizationName: "Local",

--- a/packages/core/api/src/server.ts
+++ b/packages/core/api/src/server.ts
@@ -48,6 +48,7 @@ export { RouterConfigLive } from "./server/router-config";
 export { consoleErrorCapture } from "./server/console-error-capture";
 export {
   makeExecutionStack,
+  makePlatformExecutionStack,
   CodeExecutorProvider,
   EngineDecorator,
   EngineDecoratorNoop,
@@ -95,8 +96,13 @@ export {
   Unauthorized,
   NoOrganization,
   Unavailable,
+  ReadOnlyCredential,
   authContextFromPrincipal,
+  authContextFromPlatform,
+  isPlatformPrincipal,
   type Principal,
+  type PlatformPrincipal,
+  type ResolvedPrincipal,
   type IdentityProviderShape,
   type IdentityFailure,
 } from "./server/identity";

--- a/packages/core/api/src/server/execution-stack-middleware.ts
+++ b/packages/core/api/src/server/execution-stack-middleware.ts
@@ -36,8 +36,10 @@
 
 import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http";
 import { Context, Effect, Layer } from "effect";
+import type * as Cause from "effect/Cause";
 
 import type { AnyPlugin } from "@executor-js/sdk";
+import type { ExecutionEngine } from "@executor-js/execution";
 
 import type { DbProvider } from "./executor-fuma-db";
 import {
@@ -49,13 +51,17 @@ import {
 import { ExecutionEngineService, ExecutorService } from "../services";
 import { providePluginExtensions, type PluginExtensionServices } from "../plugin-routes";
 import {
+  authContextFromPlatform,
   authContextFromPrincipal,
   AuthContext,
+  isPlatformPrincipal,
+  ReadOnlyCredential,
   type IdentityFailure,
-  type Principal,
+  type ResolvedPrincipal,
 } from "./identity";
 import {
   makeExecutionStack,
+  makePlatformExecutionStack,
   type CodeExecutorProvider,
   type EngineDecorator,
 } from "./execution-stack";
@@ -68,9 +74,9 @@ import {
  * residual requirement the strategy adds (always `never` in practice).
  */
 export interface FailureRenderingStrategy<E, RR = never> {
-  readonly renderFailure: <R>(
-    effect: Effect.Effect<Principal, E, R>,
-  ) => Effect.Effect<Principal | HttpServerResponse.HttpServerResponse, E, R | RR>;
+  readonly renderFailure: <A extends ResolvedPrincipal, R>(
+    effect: Effect.Effect<A, E, R>,
+  ) => Effect.Effect<A | HttpServerResponse.HttpServerResponse, E, R | RR>;
 }
 
 /**
@@ -98,6 +104,15 @@ export const textFailureStrategy: FailureRenderingStrategy<IdentityFailure> = {
               status: 503,
             }),
           ),
+        // Self-host/local identity never resolves a platform credential, but the
+        // method gate raises this tag on the SHARED channel, so total coverage
+        // requires rendering it (and keeps the strategy honest if that changes).
+        ReadOnlyCredential: () =>
+          Effect.succeed(
+            HttpServerResponse.text("Organization API keys are read-only", {
+              status: 403,
+            }),
+          ),
       }),
     ),
 };
@@ -112,12 +127,14 @@ export interface MakeExecutionStackMiddlewareOptions<
   /** The host's plugin tuple — drives the typed extension Services and binding. */
   readonly plugins: TPlugins;
   /**
-   * Resolve the inbound web `Request` to a neutral `Principal`. Adapter-specific
-   * credential precedence stays inside this function.
+   * Resolve the inbound web `Request` to a neutral `Principal` — or, for an
+   * org-level credential (cloud's org-scoped API key), a `PlatformPrincipal`
+   * that the middleware routes to the read-only platform branch.
+   * Adapter-specific credential precedence stays inside this function.
    */
-  readonly authenticate: (request: Request) => Effect.Effect<Principal, E, RLong>;
+  readonly authenticate: (request: Request) => Effect.Effect<ResolvedPrincipal, E, RLong>;
   /** Render `authenticate` failures (passthrough for cloud, text for self-host). */
-  readonly strategy: FailureRenderingStrategy<E, RStrategy>;
+  readonly strategy: FailureRenderingStrategy<E | ReadOnlyCredential, RStrategy>;
   /** The host's `makeExecutionStack` seam Layer. */
   readonly stackLayer: Layer.Layer<
     DbProvider | PluginsProvider | HostConfig | CodeExecutorProvider | EngineDecorator,
@@ -166,9 +183,52 @@ export const makeExecutionStackMiddleware = <
         Effect.gen(function* () {
           const request = yield* HttpServerRequest.HttpServerRequest;
           const webRequest = yield* HttpServerRequest.toWeb(request);
-          const resolved = yield* options.strategy.renderFailure(options.authenticate(webRequest));
+          const resolved = yield* options.strategy.renderFailure(
+            options.authenticate(webRequest).pipe(
+              // The PLATFORM branch's method gate lives here, before any
+              // handler: an org credential is read-only by construction, so a
+              // non-GET request is refused as a typed 403 rather than reaching
+              // a handler that would bind it to a subject or attempt a write
+              // (the storage policy would refuse the write anyway — this makes
+              // the refusal a clear response instead of a 500).
+              Effect.filterOrFail(
+                (principal): principal is ResolvedPrincipal =>
+                  !isPlatformPrincipal(principal) || webRequest.method === "GET",
+                () =>
+                  new ReadOnlyCredential({
+                    code: "read_only_credential",
+                    message: "Organization API keys are read-only",
+                  }),
+              ),
+            ),
+          );
           // The strategy recovered the failure into a Response — return it.
           if (!isPrincipal(resolved)) return resolved;
+
+          if (isPlatformPrincipal(resolved)) {
+            // Org credential: the subject-less, write-refusing platform stack.
+            // No `touchSubject` runs, so the credential never mints a phantom
+            // user row in the very lists the admin plane serves.
+            const { executor } = yield* makePlatformExecutionStack<TPlugins>(
+              resolved.organizationId,
+            ).pipe(
+              Effect.provide(options.stackLayer),
+              Effect.provideService(RequestWebOrigin, {
+                origin: requestWebOriginFromRequest(webRequest),
+              }),
+              Effect.withSpan("executor.stack.http.resolve_platform"),
+            );
+            return yield* httpEffect.pipe(
+              Effect.provideService(AuthContext, AuthContext.of(authContextFromPlatform(resolved))),
+              Effect.provideService(ExecutorService, executor),
+              // The engine runs code as an acting member; the platform view has
+              // none, and owns no executions. GET readers get the honest empty
+              // answers; the execute/resume paths sit behind the method gate
+              // above and are unreachable.
+              Effect.provideService(ExecutionEngineService, readOnlyExecutionEngine),
+              provideExecutorExtensions(executor),
+            );
+          }
           const auth = AuthContext.of(authContextFromPrincipal(resolved));
           // The public origin the caller actually hit, so a host with no static
           // web base URL (a Worker) derives one zero-config. An explicit
@@ -206,13 +266,33 @@ export const makeExecutionStackMiddleware = <
   );
 };
 
-// `renderFailure` yields either the resolved `Principal` (proceed) or an
-// already-built `HttpServerResponse` (the strategy recovered the failure). A
-// `Principal` is a plain object with `accountId`; a response is tagged. Discern
-// by the marker the response framework brands its values with.
+// `renderFailure` yields either the resolved principal (proceed) or an
+// already-built `HttpServerResponse` (the strategy recovered the failure).
+// Discern by the marker the response framework brands its values with.
 const isPrincipal = (
-  value: Principal | HttpServerResponse.HttpServerResponse,
-): value is Principal => !HttpServerResponse.isHttpServerResponse(value);
+  value: ResolvedPrincipal | HttpServerResponse.HttpServerResponse,
+): value is ResolvedPrincipal => !HttpServerResponse.isHttpServerResponse(value);
+
+/**
+ * The engine the platform branch provides: every read answers "nothing here",
+ * honestly — the platform view owns no executions and pauses none. The
+ * execute/resume members exist only to satisfy the service shape; they sit
+ * behind the middleware's GET-only gate, so reaching one is a wiring bug and
+ * dies as a defect rather than failing with a typed error a client could
+ * mistake for a product answer.
+ */
+const readOnlyExecutionEngine: ExecutionEngine<Cause.YieldableError> = {
+  // oxlint-disable-next-line executor/no-effect-escape-hatch -- boundary: unreachable behind the middleware's GET-only gate; reaching it is a wiring bug, not a typed product outcome
+  execute: () => Effect.die("platform credential: execution engine unavailable"),
+  // oxlint-disable-next-line executor/no-effect-escape-hatch -- boundary: unreachable behind the middleware's GET-only gate; reaching it is a wiring bug, not a typed product outcome
+  executeWithPause: () => Effect.die("platform credential: execution engine unavailable"),
+  // oxlint-disable-next-line executor/no-effect-escape-hatch -- boundary: unreachable behind the middleware's GET-only gate; reaching it is a wiring bug, not a typed product outcome
+  resume: () => Effect.die("platform credential: execution engine unavailable"),
+  getPausedExecution: () => Effect.succeed(null),
+  pausedExecutionCount: () => Effect.succeed(0),
+  hasPausedExecutions: () => Effect.succeed(false),
+  getDescription: Effect.succeed(""),
+};
 
 const LOOPBACK_HOSTNAMES = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
 

--- a/packages/core/api/src/server/execution-stack-middleware.ts
+++ b/packages/core/api/src/server/execution-stack-middleware.ts
@@ -35,7 +35,7 @@
 // ---------------------------------------------------------------------------
 
 import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http";
-import { Context, Effect, Layer } from "effect";
+import { Context, Data, Effect, Layer } from "effect";
 import type * as Cause from "effect/Cause";
 
 import type { AnyPlugin } from "@executor-js/sdk";
@@ -185,15 +185,16 @@ export const makeExecutionStackMiddleware = <
           const webRequest = yield* HttpServerRequest.toWeb(request);
           const resolved = yield* options.strategy.renderFailure(
             options.authenticate(webRequest).pipe(
-              // The PLATFORM branch's method gate lives here, before any
-              // handler: an org credential is read-only by construction, so a
-              // non-GET request is refused as a typed 403 rather than reaching
-              // a handler that would bind it to a subject or attempt a write
-              // (the storage policy would refuse the write anyway — this makes
-              // the refusal a clear response instead of a 500).
+              // The PLATFORM branch's gate lives here, before any handler: an
+              // org credential is read-only by construction, so anything that
+              // is not a safe read is refused as a typed 403 rather than
+              // reaching a handler that would bind it to a subject or attempt
+              // a write (the storage policy would refuse the write anyway —
+              // this makes the refusal a clear response instead of a 500).
               Effect.filterOrFail(
-                (principal): principal is ResolvedPrincipal =>
-                  !isPlatformPrincipal(principal) || webRequest.method === "GET",
+                (principal) =>
+                  !isPlatformPrincipal(principal) ||
+                  isPlatformSafeRequest(webRequest.method, new URL(webRequest.url).pathname),
                 () =>
                   new ReadOnlyCredential({
                     code: "read_only_credential",
@@ -208,14 +209,14 @@ export const makeExecutionStackMiddleware = <
           if (isPlatformPrincipal(resolved)) {
             // Org credential: the subject-less, write-refusing platform stack.
             // No `touchSubject` runs, so the credential never mints a phantom
-            // user row in the very lists the admin plane serves.
+            // user row in the very lists the admin plane serves. Neither
+            // `RequestWebOrigin` nor `RequestOrgSlug` is provided: both feed
+            // browser-handoff URL construction, which only interactive member
+            // flows perform, and `makePlatformExecutor` reads neither.
             const { executor } = yield* makePlatformExecutionStack<TPlugins>(
               resolved.organizationId,
             ).pipe(
               Effect.provide(options.stackLayer),
-              Effect.provideService(RequestWebOrigin, {
-                origin: requestWebOriginFromRequest(webRequest),
-              }),
               Effect.withSpan("executor.stack.http.resolve_platform"),
             );
             return yield* httpEffect.pipe(
@@ -274,24 +275,48 @@ const isPrincipal = (
 ): value is ResolvedPrincipal => !HttpServerResponse.isHttpServerResponse(value);
 
 /**
- * The engine the platform branch provides: every read answers "nothing here",
- * honestly — the platform view owns no executions and pauses none. The
- * execute/resume members exist only to satisfy the service shape; they sit
- * behind the middleware's GET-only gate, so reaching one is a wiring bug and
- * dies as a defect rather than failing with a typed error a client could
- * mistake for a product answer.
+ * Whether a request is a SAFE READ the platform branch may serve. The method
+ * check (GET, plus HEAD — the router serves HEAD off the GET route) is
+ * necessary but NOT sufficient: `GET /oauth/callback` is the one core GET with
+ * side effects — completing it reads an org-owned oauth session, performs an
+ * outbound authorization-code exchange with the org's client credentials, and
+ * then attempts the connection write. A read-only credential must be refused
+ * BEFORE that exchange burns the in-flight code, not after the storage policy
+ * rejects the final write, so the callback path is excluded by name. It is a
+ * browser-redirect surface — no legitimate machine-credential caller lands on
+ * it with a Bearer header.
+ */
+const isPlatformSafeRequest = (method: string, pathname: string): boolean =>
+  (method === "GET" || method === "HEAD") && !pathname.endsWith("/oauth/callback");
+
+/** Reaching an engine member the platform branch cannot honestly serve is a
+ *  wiring bug (the safe-request gate keeps those paths unreachable), so it
+ *  dies as a tagged defect rather than failing with a typed error a client
+ *  could mistake for a product answer. */
+class PlatformEngineUnavailable extends Data.TaggedError("PlatformEngineUnavailable")<{
+  readonly member: string;
+}> {}
+
+/**
+ * The engine the platform branch provides. The one member a safe read can
+ * actually reach — `getPausedExecution`, via `GET /executions/:id` — answers
+ * null (a 404), honestly: the platform view owns no executions. The paused
+ * counters answer the same empty story for any future reader. Everything else
+ * (execute, resume, the MCP tool description) exists to satisfy the service
+ * shape, sits behind the middleware's safe-request gate, and dies if reached.
  */
 const readOnlyExecutionEngine: ExecutionEngine<Cause.YieldableError> = {
-  // oxlint-disable-next-line executor/no-effect-escape-hatch -- boundary: unreachable behind the middleware's GET-only gate; reaching it is a wiring bug, not a typed product outcome
-  execute: () => Effect.die("platform credential: execution engine unavailable"),
-  // oxlint-disable-next-line executor/no-effect-escape-hatch -- boundary: unreachable behind the middleware's GET-only gate; reaching it is a wiring bug, not a typed product outcome
-  executeWithPause: () => Effect.die("platform credential: execution engine unavailable"),
-  // oxlint-disable-next-line executor/no-effect-escape-hatch -- boundary: unreachable behind the middleware's GET-only gate; reaching it is a wiring bug, not a typed product outcome
-  resume: () => Effect.die("platform credential: execution engine unavailable"),
+  // oxlint-disable-next-line executor/no-effect-escape-hatch -- boundary: unreachable behind the middleware's safe-request gate; reaching it is a wiring bug, not a typed product outcome
+  execute: () => Effect.die(new PlatformEngineUnavailable({ member: "execute" })),
+  // oxlint-disable-next-line executor/no-effect-escape-hatch -- boundary: unreachable behind the middleware's safe-request gate; reaching it is a wiring bug, not a typed product outcome
+  executeWithPause: () => Effect.die(new PlatformEngineUnavailable({ member: "executeWithPause" })),
+  // oxlint-disable-next-line executor/no-effect-escape-hatch -- boundary: unreachable behind the middleware's safe-request gate; reaching it is a wiring bug, not a typed product outcome
+  resume: () => Effect.die(new PlatformEngineUnavailable({ member: "resume" })),
   getPausedExecution: () => Effect.succeed(null),
   pausedExecutionCount: () => Effect.succeed(0),
   hasPausedExecutions: () => Effect.succeed(false),
-  getDescription: Effect.succeed(""),
+  // oxlint-disable-next-line executor/no-effect-escape-hatch -- boundary: only the MCP tool server reads this, and the MCP plane never serves a platform credential
+  getDescription: Effect.die(new PlatformEngineUnavailable({ member: "getDescription" })),
 };
 
 const LOOPBACK_HOSTNAMES = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);

--- a/packages/core/api/src/server/execution-stack.ts
+++ b/packages/core/api/src/server/execution-stack.ts
@@ -35,7 +35,12 @@ import {
 } from "@executor-js/execution";
 
 import { DbProvider } from "./executor-fuma-db";
-import { HostConfig, PluginsProvider, makeScopedExecutor } from "./scoped-executor";
+import {
+  HostConfig,
+  PluginsProvider,
+  makePlatformExecutor,
+  makeScopedExecutor,
+} from "./scoped-executor";
 
 // ---------------------------------------------------------------------------
 // CodeExecutorProvider seam — the host's code-execution substrate. Typed to the
@@ -139,3 +144,29 @@ export const makeExecutionStack = <
     ).pipe(Effect.withSpan("executor.stack.engine.init"));
     return { executor, engine };
   }).pipe(Effect.withSpan("executor.stack.build"));
+
+// ---------------------------------------------------------------------------
+// makePlatformExecutionStack — the org-credential sibling: a subject-less,
+// write-refusing executor (`makePlatformExecutor`) and NO engine. An org key is
+// an observer; the execution engine exists to run code as an acting member, so
+// rather than building one that would fail on use, the middleware refuses
+// non-GET requests up front and never provides `ExecutionEngineService` on this
+// branch. Read-only handlers never read the engine, so the platform branch
+// serves them unchanged.
+// ---------------------------------------------------------------------------
+
+export const makePlatformExecutionStack = <
+  const TPlugins extends readonly AnyPlugin[] = readonly AnyPlugin[],
+>(
+  organizationId: string,
+): Effect.Effect<
+  { readonly executor: Executor<TPlugins> },
+  StorageFailure,
+  DbProvider | PluginsProvider | HostConfig
+> =>
+  makePlatformExecutor(organizationId).pipe(
+    // The platform executor is built against the erased plugin set; re-narrow
+    // via the same phantom cast `makeScopedExecutor` performs for the scoped one.
+    Effect.map((executor) => ({ executor: executor as Executor<TPlugins> })),
+    Effect.withSpan("executor.stack.platform.build"),
+  );

--- a/packages/core/api/src/server/execution-stack.ts
+++ b/packages/core/api/src/server/execution-stack.ts
@@ -147,12 +147,13 @@ export const makeExecutionStack = <
 
 // ---------------------------------------------------------------------------
 // makePlatformExecutionStack — the org-credential sibling: a subject-less,
-// write-refusing executor (`makePlatformExecutor`) and NO engine. An org key is
-// an observer; the execution engine exists to run code as an acting member, so
-// rather than building one that would fail on use, the middleware refuses
-// non-GET requests up front and never provides `ExecutionEngineService` on this
-// branch. Read-only handlers never read the engine, so the platform branch
-// serves them unchanged.
+// write-refusing executor (`makePlatformExecutor`) and no REAL engine. An org
+// key is an observer; the execution engine exists to run code as an acting
+// member, so no engine is built here. The middleware still provides
+// `ExecutionEngineService` (handlers' service requirements demand one) — as a
+// stub whose reachable reads answer "nothing here" and whose execute/resume
+// members sit behind the middleware's safe-request gate (see
+// `readOnlyExecutionEngine` in ./execution-stack-middleware.ts).
 // ---------------------------------------------------------------------------
 
 export const makePlatformExecutionStack = <

--- a/packages/core/api/src/server/executor-app.ts
+++ b/packages/core/api/src/server/executor-app.ts
@@ -69,7 +69,12 @@ import {
   type FailureRenderingStrategy,
 } from "./execution-stack-middleware";
 import { makeFixedExecutionMiddleware, FixedExecutionProvider } from "./fixed-execution-middleware";
-import { IdentityProvider, type IdentityFailure, type Principal } from "./identity";
+import {
+  IdentityProvider,
+  type IdentityFailure,
+  type Principal,
+  type ResolvedPrincipal,
+} from "./identity";
 import {
   makeAccountApiLayer,
   makeProtectedApiLayer,
@@ -418,7 +423,7 @@ export const make = <
   // `Unauthorized | NoOrganization | Unavailable`.
   const authenticate = (
     request: Request,
-  ): Effect.Effect<Principal, IdentityFailure, IdentityProvider> =>
+  ): Effect.Effect<ResolvedPrincipal, IdentityFailure, IdentityProvider> =>
     Effect.flatMap(IdentityProvider.asEffect(), (provider) => provider.authenticate(request));
 
   // The per-request layer combined into the middleware: cloud's `requestScoped`

--- a/packages/core/api/src/server/fixed-execution-middleware.ts
+++ b/packages/core/api/src/server/fixed-execution-middleware.ts
@@ -35,7 +35,14 @@ import type { ExecutionEngine } from "@executor-js/execution";
 
 import { ExecutionEngineService, ExecutorService } from "../services";
 import { providePluginExtensions, type PluginExtensionServices } from "../plugin-routes";
-import { authContextFromPrincipal, AuthContext, type Principal } from "./identity";
+import {
+  authContextFromPrincipal,
+  AuthContext,
+  isPlatformPrincipal,
+  ReadOnlyCredential,
+  type Principal,
+  type ResolvedPrincipal,
+} from "./identity";
 import type { FailureRenderingStrategy } from "./execution-stack-middleware";
 
 /**
@@ -66,11 +73,13 @@ export interface MakeFixedExecutionMiddlewareOptions<
   /**
    * Resolve the inbound web `Request` to a neutral `Principal`. The credential
    * shape stays inside this function; local's single-user provider always
-   * resolves the one local Principal.
+   * resolves the one local Principal. (The seam's type admits a platform
+   * credential, but a fixed-executor host has no platform view — one resolving
+   * here is refused below.)
    */
-  readonly authenticate: (request: Request) => Effect.Effect<Principal, E, RLong>;
+  readonly authenticate: (request: Request) => Effect.Effect<ResolvedPrincipal, E, RLong>;
   /** Render `authenticate` failures (text for local, matching self-host). */
-  readonly strategy: FailureRenderingStrategy<E, RStrategy>;
+  readonly strategy: FailureRenderingStrategy<E | ReadOnlyCredential, RStrategy>;
 }
 
 /**
@@ -108,7 +117,21 @@ export const makeFixedExecutionMiddleware = <
         Effect.gen(function* () {
           const request = yield* HttpServerRequest.HttpServerRequest;
           const webRequest = yield* HttpServerRequest.toWeb(request);
-          const resolved = yield* options.strategy.renderFailure(options.authenticate(webRequest));
+          const resolved = yield* options.strategy.renderFailure(
+            options.authenticate(webRequest).pipe(
+              // The fixed executor binds ONE subject at boot; there is no
+              // platform view to serve an org credential, so it is refused
+              // rather than silently acting as the boot subject.
+              Effect.filterOrFail(
+                (principal): principal is Principal => !isPlatformPrincipal(principal),
+                () =>
+                  new ReadOnlyCredential({
+                    code: "read_only_credential",
+                    message: "Organization API keys are not accepted on this host",
+                  }),
+              ),
+            ),
+          );
           // The strategy recovered the failure into a Response — return it.
           if (!isPrincipal(resolved)) return resolved;
           const auth = AuthContext.of(authContextFromPrincipal(resolved));

--- a/packages/core/api/src/server/identity.ts
+++ b/packages/core/api/src/server/identity.ts
@@ -29,6 +29,11 @@ import { Context, Effect, Schema } from "effect";
  * resolver already yielded it) AND `roles` (cloud supplies `[]`).
  */
 export interface Principal {
+  /** Discriminant of {@link ResolvedPrincipal}: an acting member, as opposed
+   *  to the org-level `"platform"` credential. Required so every construction
+   *  site declares which arm it is, and the union matches on a literal tag
+   *  instead of probing for a property's presence. */
+  readonly kind: "member";
   readonly accountId: string;
   readonly organizationId: string;
   readonly organizationName: string;
@@ -73,24 +78,26 @@ export interface PlatformPrincipal {
 export type ResolvedPrincipal = Principal | PlatformPrincipal;
 
 export const isPlatformPrincipal = (value: ResolvedPrincipal): value is PlatformPrincipal =>
-  "kind" in value && value.kind === "platform";
+  value.kind === "platform";
 
 /**
  * The single `AuthContext` every executor-API handler reads. The roles-bearing
  * tag from self-host is the model; cloud now provides `roles: []` on it, which
  * is forward-compatible (cloud handlers never read roles today).
  *
- * `accountId` is `null` for an org-level platform credential — there is no
- * acting member behind it. Nullable rather than a sentinel so any handler that
- * needs a member has to say so (and refuse), instead of silently acting as a
- * user that does not exist.
+ * `accountId` and `email` are `null` for an org-level platform credential —
+ * there is no acting member behind it. Nullable rather than sentinel-valued so
+ * any handler that needs a member has to say so (and refuse), instead of
+ * silently acting as a user that does not exist. (`email: ""` on the member
+ * api-key path is the pre-existing "member with no resolved email" value and
+ * unrelated to this.)
  */
 export class AuthContext extends Context.Service<
   AuthContext,
   {
     readonly accountId: string | null;
     readonly organizationId: string;
-    readonly email: string;
+    readonly email: string | null;
     readonly name: string | null;
     readonly avatarUrl: string | null;
     readonly roles: readonly string[];
@@ -111,7 +118,7 @@ export const authContextFromPrincipal = (principal: Principal): AuthContext["Ser
 export const authContextFromPlatform = (principal: PlatformPrincipal): AuthContext["Service"] => ({
   accountId: null,
   organizationId: principal.organizationId,
-  email: "",
+  email: null,
   name: null,
   avatarUrl: null,
   roles: [],

--- a/packages/core/api/src/server/identity.ts
+++ b/packages/core/api/src/server/identity.ts
@@ -46,14 +46,49 @@ export interface Principal {
 }
 
 /**
+ * An ORG-level credential (cloud's org-scoped API key), resolved. Deliberately
+ * NOT a `Principal`: a `Principal` names an acting member, and this credential
+ * has none — mirroring the resolution layer's own split (`ApiKeyOwner` keeps
+ * `accountId: string | null` for the same reason). Keeping it a separate shape
+ * means no code path can accidentally bind an org credential to a subject; the
+ * middleware routes it to the subject-less platform executor instead, and
+ * refuses every non-read method before a handler ever runs.
+ *
+ * Self-host and local never produce this: their credentials always name a
+ * member. It exists on the NEUTRAL seam so the shared middleware owns the
+ * platform branch once, instead of each host reinventing it.
+ */
+export interface PlatformPrincipal {
+  readonly kind: "platform";
+  readonly organizationId: string;
+  readonly organizationName: string;
+  /** See {@link Principal.organizationSlug}. */
+  readonly organizationSlug?: string;
+  /** The credential's own id, for audit trails — never an acting member. */
+  readonly keyId: string;
+}
+
+/** What `authenticate` resolves: an acting member, or the org-level platform
+ *  credential. */
+export type ResolvedPrincipal = Principal | PlatformPrincipal;
+
+export const isPlatformPrincipal = (value: ResolvedPrincipal): value is PlatformPrincipal =>
+  "kind" in value && value.kind === "platform";
+
+/**
  * The single `AuthContext` every executor-API handler reads. The roles-bearing
  * tag from self-host is the model; cloud now provides `roles: []` on it, which
  * is forward-compatible (cloud handlers never read roles today).
+ *
+ * `accountId` is `null` for an org-level platform credential — there is no
+ * acting member behind it. Nullable rather than a sentinel so any handler that
+ * needs a member has to say so (and refuse), instead of silently acting as a
+ * user that does not exist.
  */
 export class AuthContext extends Context.Service<
   AuthContext,
   {
-    readonly accountId: string;
+    readonly accountId: string | null;
     readonly organizationId: string;
     readonly email: string;
     readonly name: string | null;
@@ -70,6 +105,16 @@ export const authContextFromPrincipal = (principal: Principal): AuthContext["Ser
   name: principal.name,
   avatarUrl: principal.avatarUrl,
   roles: principal.roles,
+});
+
+/** The platform credential's `AuthContext`: org identity, no member fields. */
+export const authContextFromPlatform = (principal: PlatformPrincipal): AuthContext["Service"] => ({
+  accountId: null,
+  organizationId: principal.organizationId,
+  email: "",
+  name: null,
+  avatarUrl: null,
+  roles: [],
 });
 
 // Optional per-failure render hints. Self-host produces the bare error (these
@@ -111,6 +156,21 @@ export class Unavailable extends Schema.TaggedErrorClass<Unavailable>()(
 ) {}
 
 /**
+ * A valid PLATFORM credential (org-scoped API key) attempted something only an
+ * acting member can do: a write on the product plane, or any request on a host
+ * that serves no platform view (local's fixed executor). Renders 403.
+ *
+ * Its own tag rather than a reuse of `NoOrganization`: the caller DID present a
+ * valid credential of a known org — telling them "no organization" would send
+ * them debugging the wrong thing. The message names the actual constraint.
+ */
+export class ReadOnlyCredential extends Schema.TaggedErrorClass<ReadOnlyCredential>()(
+  "ReadOnlyCredential",
+  renderHints,
+  { httpApiStatus: 403 },
+) {}
+
+/**
  * The swap seam. Resolves an incoming request to a `Principal`. WorkOS (cloud)
  * and Better Auth (self-host) are interchangeable implementations; nothing
  * downstream knows which is wired.
@@ -126,10 +186,10 @@ export class Unavailable extends Schema.TaggedErrorClass<Unavailable>()(
  * Adapter infra defects (cloud's WorkOS / user-store failures) are `Effect.die`d
  * INSIDE the impl so they surface as 500 defects, never as this error channel.
  */
-export type IdentityFailure = Unauthorized | NoOrganization | Unavailable;
+export type IdentityFailure = Unauthorized | NoOrganization | Unavailable | ReadOnlyCredential;
 
 export interface IdentityProviderShape {
-  readonly authenticate: (request: Request) => Effect.Effect<Principal, IdentityFailure>;
+  readonly authenticate: (request: Request) => Effect.Effect<ResolvedPrincipal, IdentityFailure>;
 }
 
 export class IdentityProvider extends Context.Service<IdentityProvider, IdentityProviderShape>()(

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -3585,6 +3585,13 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
     // Best-effort: a failed rebuild leaves the stale-but-working catalog in
     // place and retries on the next read.
     const syncStaleConnectionTools = Effect.gen(function* () {
+      // The platform view can never persist a rebuilt catalog (writes are
+      // denied at the storage boundary), so attempting the sync would only
+      // fire upstream `resolveTools` calls whose results are thrown away —
+      // network side effects on a read-only credential. Skip it entirely:
+      // read-only-ness of the platform read path is a stated invariant here,
+      // not an accident of the best-effort catch below.
+      if (config.platformView === true) return;
       const integrations = yield* core.findMany("integration", {});
       if (integrations.length === 0) return;
       const integrationBySlug = new Map(integrations.map((row) => [row.slug, row] as const));


### PR DESCRIPTION
Reworked per review: instead of a parallel `/api/admin/integrations` endpoint, an org-scoped API key now works on the EXISTING product paths for reads. `GET /api/integrations` — the exact call the customer's backend already makes — plus every other tenant-level GET (integration detail, tools, policies, org-owned connections) accepts the org key with one credential.

How it works:
- The neutral identity seam resolves a credential to `Principal | PlatformPrincipal` — the platform shape has no `accountId`, mirroring the resolution layer's existing `ApiKeyOwner` split, so nothing can bind an org key to a subject by accident.
- The shared execution-stack middleware routes a platform principal to a **subject-less, write-refusing platform executor** (`makePlatformExecutor` — storage policy denies all writes, ordinary surfaces keep bound reach so no member's personal rows resolve, and no `subject` row is minted). Non-GET requests are refused up front with a typed 403 (`read_only_credential`) before any handler runs.
- `AuthContext.accountId` is now honestly `string | null`; the two member-only readers gained explicit guards.
- The fixed-executor host (local) refuses platform credentials — it has no platform view.
- Cloud renders the new refusal as `{ error, code }` JSON like its other identity failures; the shared text strategy covers it too.

What an org key gets vs. doesn't:
- ✅ tenant catalog, tools list/schema, org-owned connection listings, policies — all read-only, tenant-scoped by storage policy
- ❌ any write (403 before dispatch), any member's personal connections (no subject binds), MCP sessions (unchanged rejection), executions (no engine; paused-execution reads answer empty)

Tested: new `platform-credential.test.ts` drives the shared middleware end-to-end over the real router (catalog read succeeds, member rows invisible, writes 403 pre-handler, no phantom subject row); cloud auth unit tests updated for the resolve-not-reject behavior; api/selfhost/cloud suites green (3 pre-existing `org-api-key-revoke` failures reproduce on clean main, flagged separately); cloud e2e admin-users + surface-reachability + connections-credentials green.