### PR TITLE
Stream local MCP responses so native elicitation reaches the client

### DIFF
--- a/.changeset/local-native-elicitation-streaming.md
+++ b/.changeset/local-native-elicitation-streaming.md
@@ -1,0 +1,7 @@
+---
+"executor": patch
+---
+
+**Fix: native MCP elicitation now reaches clients on the local HTTP endpoint instead of timing out**
+
+The local daemon's Streamable HTTP transport ran with `enableJsonResponse: true`, which buffers a `tools/call` into a single JSON body and leaves no open stream for the server to write on. A server-to-client `elicitation/create` raised during that call was therefore never delivered, and approval-gated tools failed with a `-32001` request timeout even though the session had negotiated `elicitation_mode=native` and the client's `elicitation.form` capability. The transport now uses the spec-default SSE streaming, so the reverse request rides the originating tool call's stream — matching the Cloudflare host's behaviour.

--- a/apps/local/src/mcp.ts
+++ b/apps/local/src/mcp.ts
@@ -184,8 +184,16 @@ export const createMcpRequestHandler = (
       let createdSessionId: string | null = null;
       let resourceConfig: LocalMcpServerConfig | null = null;
       const transport = new WebStandardStreamableHTTPServerTransport({
+        // SSE streaming (the spec default), NOT `enableJsonResponse: true`.
+        // JSON mode holds the POST open as a bare Promise and resolves it with
+        // one buffered body once every response is ready, so the transport has
+        // no open stream to write on: a server-to-client `elicitation/create`
+        // issued DURING a `tools/call` is dropped, and native elicitation dies
+        // on the client's request timeout (#1555). Streaming keeps the tool
+        // call's own stream writable in both directions, which is what native
+        // elicitation rides. Clients must already accept `text/event-stream`
+        // (the transport rejects a POST otherwise), so this costs nothing.
         sessionIdGenerator: () => crypto.randomUUID(),
-        enableJsonResponse: true,
         onsessioninitialized: (sid) => {
           createdSessionId = sid;
           transports.set(sid, transport);

--- a/e2e/local/mcp-native-elicitation.test.ts
+++ b/e2e/local/mcp-native-elicitation.test.ts
@@ -1,0 +1,128 @@
+// Repro for #1555: "Local HTTP MCP native elicitation times out before reaching
+// client". The Cloudflare counterpart (cloudflare/mcp-native-elicitation.test.ts,
+// green since #1522) proves the reverse request routes on the originating
+// tools/call stream there. This is the same scenario against the LOCAL daemon's
+// HTTP MCP endpoint, which the report says never delivers `elicitation/create`
+// and fails with McpNativeElicitationTransportError / -32001 request timed out.
+//
+// Same shape as the local browser-approval scenario (a require_approval policy
+// on a built-in read tool), but with `elicitation_mode=native` and a client that
+// advertises `capabilities.elicitation.form` and answers the request in-band —
+// so no browser is needed, only the raw SDK transport with the bearer.
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import { HttpApiClient } from "effect/unstable/httpapi";
+import { FetchHttpClient, HttpClient, HttpClientRequest } from "effect/unstable/http";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { ElicitRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import { composePluginApi } from "@executor-js/api/server";
+
+import { scenario } from "../src/scenario";
+import { Cli, RunDir } from "../src/services";
+import { withLocalServer } from "./local-server";
+
+const coreApi = composePluginApi([] as const);
+
+const GATED_TOOL = "executor.coreTools.policies.list";
+const GATED_CODE = `
+const result = await tools.executor.coreTools.policies.list({});
+return JSON.stringify(result);
+`;
+
+scenario(
+  "Local · native MCP elicitation carries approval decisions on the tool call stream",
+  { timeout: 300_000 },
+  Effect.gen(function* () {
+    const cli = yield* Cli;
+    const runDir = yield* RunDir;
+
+    yield* withLocalServer(cli, runDir, (server) =>
+      Effect.gen(function* () {
+        // Bearer-authed typed API client (local's credential is the printed
+        // token) — used only to plant the gating policy.
+        const api = yield* HttpApiClient.make(coreApi, {
+          baseUrl: new URL("/api", server.origin).toString(),
+          transformClient: HttpClient.mapRequest((request) =>
+            HttpClientRequest.setHeader(request, "authorization", `Bearer ${server.token}`),
+          ),
+        }).pipe(Effect.provide(FetchHttpClient.layer));
+
+        const policy = yield* api.policies.create({
+          payload: { owner: "org", pattern: GATED_TOOL, action: "require_approval" },
+        });
+
+        yield* Effect.gen(function* () {
+          let decision: "accept" | "decline" | "cancel" = "accept";
+          let elicitationCount = 0;
+          const client = yield* Effect.acquireRelease(
+            Effect.promise(async () => {
+              const connectedClient = new Client(
+                { name: "e2e-local-native-elicitation", version: "1.0.0" },
+                { capabilities: { elicitation: { form: {}, url: {} } } },
+              );
+              connectedClient.setRequestHandler(ElicitRequestSchema, async () => {
+                elicitationCount += 1;
+                return decision === "accept"
+                  ? { action: "accept" as const, content: {} }
+                  : { action: decision };
+              });
+              const url = new URL(`${server.origin}/mcp`);
+              url.searchParams.set("elicitation_mode", "native");
+              url.searchParams.set("artifacts", "false");
+              await connectedClient.connect(
+                new StreamableHTTPClientTransport(url, {
+                  requestInit: { headers: { authorization: `Bearer ${server.token}` } },
+                }),
+              );
+              return connectedClient;
+            }),
+            (connectedClient) => Effect.promise(() => connectedClient.close()),
+          );
+
+          const accepted = yield* Effect.promise(() =>
+            client.callTool({ name: "execute", arguments: { code: GATED_CODE } }, undefined, {
+              timeout: 30_000,
+            }),
+          );
+          expect(elicitationCount, "the native elicitation reached the client").toBe(1);
+          expect(accepted.isError, "accepting lets the gated tool complete").toBeFalsy();
+          expect(
+            JSON.stringify(accepted.content),
+            "the gated tool returned its policy listing",
+          ).toContain(policy.id);
+
+          decision = "decline";
+          const declined = yield* Effect.promise(() =>
+            client.callTool({ name: "execute", arguments: { code: GATED_CODE } }, undefined, {
+              timeout: 30_000,
+            }),
+          );
+          expect(elicitationCount, "the second native elicitation also reached the client").toBe(2);
+          expect(declined.isError, "declining blocks the gated tool").toBe(true);
+          expect(
+            JSON.stringify(declined.content),
+            "the engine reports the client's decline decision",
+          ).toContain("declined by the user");
+          expect(
+            JSON.stringify(declined.content),
+            "the declined tool did not return its output",
+          ).not.toContain(policy.id);
+
+          decision = "cancel";
+          const cancelled = yield* Effect.promise(() =>
+            client.callTool({ name: "execute", arguments: { code: GATED_CODE } }, undefined, {
+              timeout: 30_000,
+            }),
+          );
+          expect(elicitationCount, "the cancel elicitation also reached the client").toBe(3);
+          expect(cancelled.isError, "cancelling blocks the gated tool").toBe(true);
+          expect(
+            JSON.stringify(cancelled.content),
+            "the engine reports the client's cancel decision",
+          ).toContain("cancelled by the user");
+        }).pipe(Effect.scoped);
+      }),
+    );
+  }),
+);


### PR DESCRIPTION
Fixes #1555.

Native elicitation over the local daemon's HTTP MCP endpoint never reached the client: `execute` on a policy-gated tool failed with `-32001: Request timed out` while the session had correctly negotiated `elicitation_mode=native` and the client's `elicitation.form` capability.

## Cause

`apps/local/src/mcp.ts` built the Streamable HTTP transport with `enableJsonResponse: true`. In the MCP SDK that mode stores only a `resolveJson` callback for the POST — no stream controller or encoder. `send()` gates every server-to-client write on `!enableJsonResponse && stream?.controller`, so an `elicitation/create` raised during a `tools/call` was dropped on the floor. The buffered response then never resolved, because the tool was blocked waiting on the elicitation that never went out, and the call sat until the client's timeout.

PR #1522 fixed the equivalent routing for Cloudflare; the local host still had the flag.

## Fix

Drop `enableJsonResponse` and use the spec-default SSE streaming, so the reverse request rides the originating tool call's stream. Clients must already accept `text/event-stream` — the transport rejects a POST that does not — so no client compatibility is lost.

## Tests

Adds `e2e/local/mcp-native-elicitation.test.ts`, a local-target mirror of the existing `cloudflare/mcp-native-elicitation.test.ts`, covering accept, decline, and cancel. It fails on the parent commit with the reported `-32001` timeout and passes with the fix.

- `apps/local` unit: 71 passed; `packages/hosts/mcp`: 187 passed
- `typecheck`, `lint`, `format:check` clean
- `local/mcp-browser-approve` and `local/stdio-mcp` still pass (same transport, so they were the regression risk)

## Notes

- `local/toolkits-mcp.test.ts` fails with a 500 on this branch, but fails identically on an unmodified tree — pre-existing, unrelated, not addressed here.
- `packages/hosts/mcp/src/in-memory-session-store.ts:261` still sets `enableJsonResponse: true` for the self-host path, which likely has the same bug. Left alone as out of scope; there is no native-elicitation e2e coverage on self-host to prove it either way.