### PR TITLE
feat(sdk): add provider-neutral authorization seam

### DIFF
--- a/.changeset/provider-neutral-authorization.md
+++ b/.changeset/provider-neutral-authorization.md
@@ -1,0 +1,5 @@
+---
+"executor": patch
+---
+
+Add an optional provider-neutral authorization seam for tool execution. Hosts can supply an `AuthorizationProvider` that receives Executor-bound tenant/subject identity and resolved tool metadata before credentials or plugin invocation; deny and provider failures fail closed, approval reuses the existing elicitation path, and nested tool execution re-enters the same authorization check. Existing hosts that do not configure a provider retain current behavior.

--- a/packages/core/api/src/server/scoped-executor.authorization.test.ts
+++ b/packages/core/api/src/server/scoped-executor.authorization.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Layer, Schema } from "effect";
+
+import {
+  collectTables,
+  definePlugin,
+  tool,
+  ToolAddress,
+  type AuthorizationProvider,
+  type AuthorizationRequest,
+} from "@executor-js/sdk";
+import { createSqliteTestFumaDb } from "@executor-js/sdk/testing";
+
+import { DbProvider } from "./executor-fuma-db";
+import { HostConfig, makeScopedExecutor, PluginsProvider } from "./scoped-executor";
+
+describe("scoped executor authorization composition", () => {
+  it.effect("threads HostConfig authorizationProvider into the real scoped executor", () =>
+    Effect.acquireUseRelease(
+      Effect.promise(() => createSqliteTestFumaDb({ tables: collectTables() })),
+      (db) =>
+        Effect.gen(function* () {
+          const seen: AuthorizationRequest[] = [];
+          const provider: AuthorizationProvider = {
+            authorize: (request) =>
+              Effect.sync(() => {
+                seen.push(request);
+                return {
+                  outcome: "allow" as const,
+                  decisionId: "host-composition-allow",
+                  policyRevision: "host-composition-v1",
+                  reason: "test",
+                };
+              }),
+          };
+          const plugin = definePlugin(() => ({
+            id: "host-authz-fixture" as const,
+            storage: () => ({}),
+            staticIntegrations: () => [
+              {
+                id: "host-authz-fixture.control",
+                kind: "control" as const,
+                name: "Host authz fixture",
+                tools: [
+                  tool({
+                    name: "ping",
+                    description: "ping",
+                    inputSchema: Schema.toStandardSchemaV1(
+                      Schema.toStandardJSONSchemaV1(Schema.Struct({})),
+                    ),
+                    execute: () => Effect.succeed("pong"),
+                  }),
+                ],
+              },
+            ],
+          }))();
+
+          const seams = Layer.mergeAll(
+            Layer.succeed(DbProvider)(db),
+            Layer.succeed(PluginsProvider)({ plugins: () => [plugin] }),
+            Layer.succeed(HostConfig)({
+              allowLocalNetwork: false,
+              oauthCallbackPath: "/api/oauth/callback",
+              authorizationProvider: provider,
+            }),
+          );
+          const executor = yield* makeScopedExecutor("subject-1", "tenant-1", "Tenant One").pipe(
+            Effect.provide(seams),
+          );
+
+          const result = yield* executor
+            .execute(ToolAddress.make("host-authz-fixture.control.ping"), {})
+            .pipe(Effect.ensuring(executor.close().pipe(Effect.ignore)));
+          expect(result).toBe("pong");
+          expect(seen).toHaveLength(1);
+          expect(String(seen[0]!.identity.tenant)).toBe("tenant-1");
+          expect(String(seen[0]!.identity.subject)).toBe("subject-1");
+          expect(seen[0]!.operation).toBe("tool.execute");
+          expect(seen[0]!.tool.address).toBe("host-authz-fixture.control.ping");
+        }),
+      (db) => Effect.promise(() => db.close()),
+    ),
+  );
+});

--- a/packages/core/api/src/server/scoped-executor.ts
+++ b/packages/core/api/src/server/scoped-executor.ts
@@ -6,7 +6,8 @@
 // hosted HTTP client, build the `[userOrgScope, orgScope]` scope stack (P1), and
 // call `createExecutor({...})` with a byte-identical option shape. The ONLY real
 // differences were the DB source/lifetime, the plugin instances, and two host
-// config scalars (`allowLocalNetwork`, `webBaseUrl`).
+// config values (`allowLocalNetwork`, `webBaseUrl`, and optional horizontal
+// authorization provider).
 //
 // `makeScopedExecutor` owns that common body. The per-host knobs are injected
 // through three Effect seams:
@@ -17,8 +18,9 @@
 //     so both lifetimes are preserved by the Layer the host supplies.
 //   - `PluginsProvider` — the plugin array. Cloud injects per-request WorkOS
 //     credentials; self-host returns the plain plugin list.
-//   - `HostConfig` — `allowLocalNetwork` (drives the hosted HTTP client guard)
-//     and `webBaseUrl` (the core-tools elicitation base URL).
+//   - `HostConfig` — `allowLocalNetwork` (drives the hosted HTTP client guard),
+//     `webBaseUrl` (the core-tools elicitation base URL), and an optional
+//     provider-neutral authorization provider threaded to `createExecutor`.
 //
 // This is host-composition machinery: it lives in `@executor-js/api/server`
 // (the host surface), not in `@executor-js/sdk` (the plugin-author contract).
@@ -52,7 +54,7 @@ import {
 import { DbProvider } from "./executor-fuma-db";
 
 // ---------------------------------------------------------------------------
-// HostConfig seam — the two host scalars that vary the `createExecutor` options.
+// HostConfig seam — host values that vary the `createExecutor` options.
 // ---------------------------------------------------------------------------
 
 export interface HostConfigShape {
@@ -97,6 +99,12 @@ export interface HostConfigShape {
    * Hosts that record product analytics supply it; omitted -> no observation.
    */
   readonly onIntegrationChange?: ExecutorConfig["onIntegrationChange"];
+  /**
+   * Optional horizontal authorization PEP provider. The shared host layer only
+   * threads this provider-neutral seam into `createExecutor`; concrete PDP
+   * adapters belong to the host/product composition, not @executor-js/api.
+   */
+  readonly authorizationProvider?: ExecutorConfig["authorizationProvider"];
 }
 
 export class HostConfig extends Context.Service<HostConfig, HostConfigShape>()(
@@ -284,6 +292,7 @@ export const makeScopedExecutor = <
       httpClientLayer,
       fetch: hostedFetch,
       onIntegrationChange: config.onIntegrationChange,
+      authorizationProvider: config.authorizationProvider,
       onElicitation: "accept-all",
       redirectUri,
       oauthCallbackStateOrgSlug: orgSlug,

--- a/packages/core/sdk/src/authorization.test.ts
+++ b/packages/core/sdk/src/authorization.test.ts
@@ -1,0 +1,472 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Data, Effect, Predicate, Result, Schema } from "effect";
+
+import type {
+  AuthorizationDecision,
+  AuthorizationProvider,
+  AuthorizationRequest,
+} from "./authorization";
+import { ElicitationResponse, type ElicitationHandler } from "./elicitation";
+import {
+  AuthTemplateSlug,
+  ConnectionName,
+  IntegrationSlug,
+  ProviderItemId,
+  ProviderKey,
+  ToolAddress,
+  ToolName,
+} from "./ids";
+import { definePlugin, tool } from "./plugin";
+import type { CredentialProvider } from "./provider";
+import { makeTestExecutor } from "./testing";
+
+const VERCEL = IntegrationSlug.make("vercel");
+const TEMPLATE = AuthTemplateSlug.make("apiKey");
+const CONN = ConnectionName.make("main");
+
+const addr = (tool: string): ToolAddress => ToolAddress.make(`tools.${VERCEL}.org.${CONN}.${tool}`);
+
+const decision = (
+  outcome: AuthorizationDecision["outcome"],
+  overrides?: Partial<AuthorizationDecision>,
+): AuthorizationDecision => ({
+  outcome,
+  decisionId: overrides?.decisionId ?? "dec-1",
+  policyRevision: overrides?.policyRevision ?? "rev-1",
+  reason: overrides?.reason ?? `outcome=${outcome}`,
+  obligations: overrides?.obligations,
+});
+
+const recordingProvider = (
+  outcomes:
+    | AuthorizationDecision["outcome"]
+    | ((req: AuthorizationRequest) => AuthorizationDecision),
+  seen: AuthorizationRequest[],
+): AuthorizationProvider => ({
+  authorize: (request) =>
+    Effect.sync(() => {
+      seen.push(request);
+      return typeof outcomes === "function" ? outcomes(request) : decision(outcomes);
+    }),
+});
+
+class FailingAuthorizationProviderError extends Data.TaggedError(
+  "FailingAuthorizationProviderError",
+)<{
+  readonly message: string;
+}> {}
+
+const failingProvider = (message: string): AuthorizationProvider => ({
+  authorize: () => Effect.fail(new FailingAuthorizationProviderError({ message })),
+});
+
+/** Credential get that records whether resolution ran. */
+const gatedCredentialProvider = (resolved: { count: number }): CredentialProvider => {
+  const store = new Map<string, string>([["item", "secret-value"]]);
+  return {
+    key: ProviderKey.make("memory"),
+    writable: true,
+    get: (id) =>
+      Effect.sync(() => {
+        resolved.count++;
+        return store.get(String(id)) ?? null;
+      }),
+    set: (id, value) => Effect.sync(() => void store.set(String(id), value)),
+  };
+};
+
+const memoryProvider = (): CredentialProvider => {
+  const store = new Map<string, string>();
+  return {
+    key: ProviderKey.make("memory"),
+    writable: true,
+    get: (id) => Effect.sync(() => store.get(String(id)) ?? null),
+    set: (id, value) => Effect.sync(() => void store.set(String(id), value)),
+  };
+};
+
+const makeAuthzPlugin = (options?: {
+  readonly credentialProvider?: CredentialProvider;
+  /** When set, only the named outer tool re-enters via `ctx.execute`. */
+  readonly nested?: { readonly outer: string; readonly target: ToolAddress };
+  readonly invokeCount?: { count: number };
+}) => {
+  const credentials = options?.credentialProvider ?? memoryProvider();
+  const invokeCount = options?.invokeCount ?? { count: 0 };
+  return definePlugin(() => ({
+    id: "authz-fixture" as const,
+    storage: () => ({}),
+    credentialProviders: [credentials],
+    resolveTools: () =>
+      Effect.succeed({
+        tools: [
+          { name: ToolName.make("deploy"), description: "deploy" },
+          { name: ToolName.make("delete"), description: "delete" },
+        ],
+      }),
+    invokeTool: ({ toolRow, ctx, args }) =>
+      Effect.gen(function* () {
+        invokeCount.count++;
+        if (options?.nested && toolRow.name === options.nested.outer) {
+          // Nested re-entry through the same core execute seam.
+          const nested = yield* ctx.execute(options.nested.target, args);
+          return { ran: toolRow.name, nested };
+        }
+        return { ran: `${toolRow.integration}.${toolRow.name}` };
+      }),
+    extension: (ctx) => ({
+      seed: () =>
+        ctx.core.integrations.register({
+          slug: VERCEL,
+          description: "Vercel",
+          config: {},
+        }),
+    }),
+  }));
+};
+
+const seedConnection = (
+  executor: {
+    readonly ["authz-fixture"]: { readonly seed: () => Effect.Effect<unknown, unknown> };
+    readonly connections: {
+      readonly create: (input: {
+        readonly owner: "org";
+        readonly name: ConnectionName;
+        readonly integration: IntegrationSlug;
+        readonly template: AuthTemplateSlug;
+        readonly from: { readonly provider: ProviderKey; readonly id: ProviderItemId };
+      }) => Effect.Effect<unknown, unknown>;
+    };
+  },
+  itemId = "item",
+) =>
+  Effect.gen(function* () {
+    yield* executor["authz-fixture"].seed();
+    yield* executor.connections.create({
+      owner: "org",
+      name: CONN,
+      integration: VERCEL,
+      template: TEMPLATE,
+      from: {
+        provider: ProviderKey.make("memory"),
+        id: ProviderItemId.make(itemId),
+      },
+    });
+  });
+
+const recordingHandler = (calls: { count: number }): ElicitationHandler =>
+  (() => {
+    calls.count++;
+    return Effect.succeed(ElicitationResponse.make({ action: "accept" }));
+  }) as ElicitationHandler;
+
+describe("AuthorizationProvider seam", () => {
+  it.effect("absent provider preserves current allow behavior", () =>
+    Effect.gen(function* () {
+      const invokeCount = { count: 0 };
+      const executor = yield* makeTestExecutor({
+        plugins: [makeAuthzPlugin({ invokeCount })()] as const,
+      });
+      yield* seedConnection(executor);
+      const result = yield* executor.execute(addr("deploy"), { x: 1 });
+      expect(result).toEqual({ ran: "vercel.deploy" });
+      expect(invokeCount.count).toBe(1);
+    }),
+  );
+
+  it.effect("identity is executor-bound, not caller-controlled via args", () =>
+    Effect.gen(function* () {
+      const seen: AuthorizationRequest[] = [];
+      const executor = yield* makeTestExecutor({
+        tenant: "bound-tenant",
+        subject: "bound-subject",
+        authorizationProvider: recordingProvider("allow", seen),
+        plugins: [makeAuthzPlugin()()] as const,
+      });
+      yield* seedConnection(executor);
+
+      yield* executor.execute(addr("deploy"), {
+        tenant: "attacker-tenant",
+        subject: "attacker-subject",
+        identity: { tenant: "nope", subject: "nope" },
+      });
+
+      expect(seen).toHaveLength(1);
+      expect(String(seen[0]!.identity.tenant)).toBe("bound-tenant");
+      expect(String(seen[0]!.identity.subject)).toBe("bound-subject");
+      expect(seen[0]!.operation).toBe("tool.execute");
+      expect(seen[0]!.tool.integration).toBe("vercel");
+      expect(seen[0]!.tool.owner).toBe("org");
+      expect(seen[0]!.tool.connection).toBe("main");
+      expect(seen[0]!.tool.plugin).toBe("authz-fixture");
+      expect(seen[0]!.tool.name).toBe("deploy");
+      expect(seen[0]!.args).toEqual({
+        tenant: "attacker-tenant",
+        subject: "attacker-subject",
+        identity: { tenant: "nope", subject: "nope" },
+      });
+    }),
+  );
+
+  it.effect("deny fails closed before credential resolution", () =>
+    Effect.gen(function* () {
+      const resolved = { count: 0 };
+      const invokeCount = { count: 0 };
+      const seen: AuthorizationRequest[] = [];
+      const executor = yield* makeTestExecutor({
+        authorizationProvider: recordingProvider("deny", seen),
+        plugins: [
+          makeAuthzPlugin({
+            credentialProvider: gatedCredentialProvider(resolved),
+            invokeCount,
+          })(),
+        ] as const,
+      });
+      yield* seedConnection(executor);
+
+      // Seed may touch credential storage for connection create; reset after setup.
+      resolved.count = 0;
+      invokeCount.count = 0;
+
+      const result = yield* Effect.result(
+        executor.execute(addr("deploy"), {}, { onElicitation: "accept-all" }),
+      );
+      expect(Result.isFailure(result)).toBe(true);
+      if (!Result.isFailure(result)) return;
+      expect(Predicate.isTagged("AuthorizationDeniedError")(result.failure)).toBe(true);
+      expect(seen).toHaveLength(1);
+      expect(resolved.count).toBe(0);
+      expect(invokeCount.count).toBe(0);
+    }),
+  );
+
+  it.effect("provider allow cannot weaken an existing hard block", () =>
+    Effect.gen(function* () {
+      const resolved = { count: 0 };
+      const invokeCount = { count: 0 };
+      const seen: AuthorizationRequest[] = [];
+      const executor = yield* makeTestExecutor({
+        authorizationProvider: recordingProvider("allow", seen),
+        plugins: [
+          makeAuthzPlugin({
+            credentialProvider: gatedCredentialProvider(resolved),
+            invokeCount,
+          })(),
+        ] as const,
+      });
+      yield* seedConnection(executor);
+      yield* executor.policies.create({
+        owner: "org",
+        pattern: "vercel.org.main.deploy",
+        action: "block",
+      });
+      resolved.count = 0;
+      invokeCount.count = 0;
+
+      const result = yield* Effect.result(
+        executor.execute(addr("deploy"), {}, { onElicitation: "accept-all" }),
+      );
+      expect(Result.isFailure(result)).toBe(true);
+      expect(seen).toHaveLength(0);
+      expect(resolved.count).toBe(0);
+      expect(invokeCount.count).toBe(0);
+    }),
+  );
+
+  it.effect("provider allow cannot weaken an existing approval requirement", () =>
+    Effect.gen(function* () {
+      const seen: AuthorizationRequest[] = [];
+      const calls = { count: 0 };
+      const invokeCount = { count: 0 };
+      const executor = yield* makeTestExecutor({
+        authorizationProvider: recordingProvider("allow", seen),
+        plugins: [makeAuthzPlugin({ invokeCount })()] as const,
+      });
+      yield* seedConnection(executor);
+      yield* executor.policies.create({
+        owner: "org",
+        pattern: "vercel.org.main.deploy",
+        action: "require_approval",
+      });
+
+      const result = yield* executor.execute(
+        addr("deploy"),
+        {},
+        { onElicitation: recordingHandler(calls) },
+      );
+      expect(seen).toHaveLength(1);
+      expect(seen[0]!.policy.action).toBe("require_approval");
+      expect(calls.count).toBe(1);
+      expect(result).toEqual({ ran: "vercel.deploy" });
+      expect(invokeCount.count).toBe(1);
+    }),
+  );
+
+  it.effect("require_approval feeds existing elicitation path", () =>
+    Effect.gen(function* () {
+      const seen: AuthorizationRequest[] = [];
+      const calls = { count: 0 };
+      const invokeCount = { count: 0 };
+      const executor = yield* makeTestExecutor({
+        authorizationProvider: recordingProvider("require_approval", seen),
+        plugins: [makeAuthzPlugin({ invokeCount })()] as const,
+      });
+      yield* seedConnection(executor);
+
+      const result = yield* executor.execute(
+        addr("deploy"),
+        {},
+        { onElicitation: recordingHandler(calls) },
+      );
+      expect(calls.count).toBe(1);
+      expect(result).toEqual({ ran: "vercel.deploy" });
+      expect(invokeCount.count).toBe(1);
+      expect(seen).toHaveLength(1);
+    }),
+  );
+
+  it.effect("require_approval declined does not invoke and cannot bypass deny", () =>
+    Effect.gen(function* () {
+      const invokeCount = { count: 0 };
+      // Deny is absolute: a provider that denies never reaches elicitation.
+      const denyExecutor = yield* makeTestExecutor({
+        authorizationProvider: recordingProvider("deny", []),
+        plugins: [makeAuthzPlugin({ invokeCount })()] as const,
+      });
+      yield* seedConnection(denyExecutor);
+      const denied = yield* Effect.result(
+        denyExecutor.execute(
+          addr("deploy"),
+          {},
+          {
+            onElicitation: () => Effect.succeed(ElicitationResponse.make({ action: "accept" })),
+          },
+        ),
+      );
+      expect(Result.isFailure(denied)).toBe(true);
+      if (!Result.isFailure(denied)) return;
+      expect(Predicate.isTagged("AuthorizationDeniedError")(denied.failure)).toBe(true);
+      expect(invokeCount.count).toBe(0);
+
+      // require_approval + decline still fails closed via elicitation.
+      const approveCalls = { count: 0 };
+      const reqExecutor = yield* makeTestExecutor({
+        authorizationProvider: recordingProvider("require_approval", []),
+        plugins: [makeAuthzPlugin({ invokeCount })()] as const,
+      });
+      yield* seedConnection(reqExecutor);
+      const declined = yield* Effect.result(
+        reqExecutor.execute(
+          addr("deploy"),
+          {},
+          {
+            onElicitation: () => {
+              approveCalls.count++;
+              return Effect.succeed(ElicitationResponse.make({ action: "decline" }));
+            },
+          },
+        ),
+      );
+      expect(Result.isFailure(declined)).toBe(true);
+      if (!Result.isFailure(declined)) return;
+      expect(Predicate.isTagged("ElicitationDeclinedError")(declined.failure)).toBe(true);
+      expect(approveCalls.count).toBe(1);
+      expect(invokeCount.count).toBe(0);
+    }),
+  );
+
+  it.effect("nested ctx.execute re-enters the authorization seam", () =>
+    Effect.gen(function* () {
+      const seen: AuthorizationRequest[] = [];
+      const outer = addr("deploy");
+      const inner = addr("delete");
+      const executor = yield* makeTestExecutor({
+        authorizationProvider: recordingProvider("allow", seen),
+        plugins: [makeAuthzPlugin({ nested: { outer: "deploy", target: inner } })()] as const,
+      });
+      yield* seedConnection(executor);
+
+      const result = yield* executor.execute(outer, { nested: true });
+      expect(result).toEqual({
+        ran: "deploy",
+        nested: { ran: "vercel.delete" },
+      });
+      expect(seen.map((r) => r.tool.name)).toEqual(["deploy", "delete"]);
+      expect(seen.every((r) => r.operation === "tool.execute")).toBe(true);
+    }),
+  );
+
+  it.effect("provider failure fails closed without invoke", () =>
+    Effect.gen(function* () {
+      const invokeCount = { count: 0 };
+      const resolved = { count: 0 };
+      const executor = yield* makeTestExecutor({
+        authorizationProvider: failingProvider("upstream policy unavailable"),
+        plugins: [
+          makeAuthzPlugin({
+            credentialProvider: gatedCredentialProvider(resolved),
+            invokeCount,
+          })(),
+        ] as const,
+      });
+      yield* seedConnection(executor);
+      resolved.count = 0;
+      invokeCount.count = 0;
+
+      const result = yield* Effect.result(executor.execute(addr("deploy"), {}));
+      expect(Result.isFailure(result)).toBe(true);
+      if (!Result.isFailure(result)) return;
+      expect(Predicate.isTagged("AuthorizationProviderError")(result.failure)).toBe(true);
+      expect(resolved.count).toBe(0);
+      expect(invokeCount.count).toBe(0);
+    }),
+  );
+
+  it.effect("static tools also consult the provider", () =>
+    Effect.gen(function* () {
+      const seen: AuthorizationRequest[] = [];
+      const staticPlugin = definePlugin(() => ({
+        id: "static-authz" as const,
+        storage: () => ({}),
+        staticIntegrations: () => [
+          {
+            id: "static-authz.ctl",
+            kind: "control" as const,
+            name: "Static Authz",
+            tools: [
+              tool({
+                name: "ping",
+                description: "ping",
+                inputSchema: Schema.toStandardSchemaV1(
+                  Schema.toStandardJSONSchemaV1(Schema.Struct({})),
+                ),
+                execute: () => Effect.succeed("pong"),
+              }),
+            ],
+          },
+        ],
+      }))();
+
+      const allowExecutor = yield* makeTestExecutor({
+        authorizationProvider: recordingProvider("allow", seen),
+        plugins: [staticPlugin] as const,
+      });
+      const allowed = yield* allowExecutor.execute(ToolAddress.make("static-authz.ctl.ping"), {});
+      expect(allowed).toBe("pong");
+      expect(seen).toHaveLength(1);
+      expect(seen[0]!.tool.plugin).toBe("static-authz");
+      expect(seen[0]!.tool.name).toBe("ping");
+
+      const denyExecutor = yield* makeTestExecutor({
+        authorizationProvider: recordingProvider("deny", []),
+        plugins: [staticPlugin] as const,
+      });
+      const denied = yield* Effect.result(
+        denyExecutor.execute(ToolAddress.make("static-authz.ctl.ping"), {}),
+      );
+      expect(Result.isFailure(denied)).toBe(true);
+      if (!Result.isFailure(denied)) return;
+      expect(Predicate.isTagged("AuthorizationDeniedError")(denied.failure)).toBe(true);
+    }),
+  );
+});

--- a/packages/core/sdk/src/authorization.ts
+++ b/packages/core/sdk/src/authorization.ts
@@ -1,0 +1,69 @@
+// ---------------------------------------------------------------------------
+// AuthorizationProvider — optional universal authorization seam.
+//
+// When absent, execute keeps exact current behavior (coarse tool_policy block /
+// require_approval + annotations). When present, core consults the provider
+// after hard-block resolution and before credential resolution / plugin invoke.
+// Nested `ctx.execute` re-enters the same path.
+//
+// Identity is the executor's bound (tenant, subject) — never caller-supplied
+// args. Domain policy semantics and persistence live outside this contract.
+// ---------------------------------------------------------------------------
+
+import type { Effect } from "effect";
+
+import type { Subject, Tenant, ToolAddress } from "./ids";
+import type { EffectivePolicy } from "./policies";
+
+/** The only operation this seam authorizes today. */
+export type AuthorizationOperation = "tool.execute";
+
+/** Trusted executor identity. Built by core from the bound owner, not from args. */
+export interface AuthorizationIdentity {
+  readonly tenant: Tenant;
+  readonly subject: Subject | null;
+}
+
+/**
+ * Tool address plus routing metadata the provider needs without re-parsing.
+ * Static tools still surface owner/connection as the executor projects them.
+ */
+export interface AuthorizationToolRef {
+  readonly address: ToolAddress;
+  readonly integration: string;
+  readonly owner: string;
+  readonly connection: string;
+  readonly plugin: string;
+  readonly name: string;
+}
+
+export interface AuthorizationRequest {
+  readonly identity: AuthorizationIdentity;
+  readonly operation: AuthorizationOperation;
+  readonly tool: AuthorizationToolRef;
+  /** Raw invoke args. Caller-controlled; never a source of identity. */
+  readonly args: unknown;
+  /** Coarse EffectivePolicy already resolved by core for this call. */
+  readonly policy: EffectivePolicy;
+}
+
+export type AuthorizationOutcome = "allow" | "deny" | "require_approval";
+
+export interface AuthorizationDecision {
+  readonly outcome: AuthorizationOutcome;
+  readonly decisionId: string;
+  readonly policyRevision: string;
+  readonly reason: string;
+  /** Opaque host/provider metadata; core does not interpret obligations. */
+  readonly obligations?: Readonly<Record<string, unknown>>;
+}
+
+/**
+ * Host- or product-supplied authorizer. Failures (Effect failure channel) are
+ * fail-closed by core as `AuthorizationProviderError`.
+ */
+export interface AuthorizationProvider {
+  readonly authorize: (
+    request: AuthorizationRequest,
+  ) => Effect.Effect<AuthorizationDecision, unknown>;
+}

--- a/packages/core/sdk/src/errors.ts
+++ b/packages/core/sdk/src/errors.ts
@@ -80,6 +80,33 @@ export class ToolBlockedError extends Schema.TaggedErrorClass<ToolBlockedError>(
   }
 }
 
+/** Tool invocation was rejected by an `AuthorizationProvider` with outcome
+ *  `deny`. Fail-closed; not bypassable via invoke options. */
+export class AuthorizationDeniedError extends Schema.TaggedErrorClass<AuthorizationDeniedError>()(
+  "AuthorizationDeniedError",
+  {
+    address: ToolAddress,
+    decisionId: Schema.String,
+    policyRevision: Schema.String,
+    reason: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `Authorization denied (${this.decisionId}): ${this.reason}`;
+  }
+}
+
+/** The configured `AuthorizationProvider` failed. Fail-closed: the call does
+ *  not proceed to credentials or plugin invoke. */
+export class AuthorizationProviderError extends Schema.TaggedErrorClass<AuthorizationProviderError>()(
+  "AuthorizationProviderError",
+  {
+    address: ToolAddress,
+    message: Schema.String,
+    cause: Schema.optional(Schema.Unknown),
+  },
+) {}
+
 /** Tool row exists but its owning plugin isn't loaded in this executor config. */
 export class PluginNotLoadedError extends Schema.TaggedErrorClass<PluginNotLoadedError>()(
   "PluginNotLoadedError",
@@ -221,6 +248,8 @@ export type ExecuteError =
   | ToolNotFoundError
   | ToolInvocationError
   | ToolBlockedError
+  | AuthorizationDeniedError
+  | AuthorizationProviderError
   | PluginNotLoadedError
   | NoHandlerError
   | ConnectionNotFoundError

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -63,8 +63,15 @@ import {
   type SaveArtifactInput,
   type SetArtifactPreviewInput,
 } from "./artifact";
+import type {
+  AuthorizationDecision,
+  AuthorizationProvider,
+  AuthorizationToolRef,
+} from "./authorization";
 import {
   ArtifactNotFoundError,
+  AuthorizationDeniedError,
+  AuthorizationProviderError,
   ConnectionNotFoundError,
   CredentialProviderNotRegisteredError,
   CredentialResolutionError,
@@ -609,6 +616,13 @@ export interface ExecutorConfig<TPlugins extends readonly AnyPlugin[] = readonly
    * `"accept-all"` for tests / non-interactive hosts, or a handler.
    */
   readonly onElicitation: OnElicitation;
+  /**
+   * Optional universal authorization seam. When omitted, execute is unchanged
+   * (coarse tool_policy + annotations only). When set, core consults it after
+   * hard-block resolution and before credential resolution / plugin invoke.
+   * Nested `ctx.execute` re-enters the same path. Failures and `deny` fail closed.
+   */
+  readonly authorizationProvider?: AuthorizationProvider;
   readonly httpClientLayer?: Layer.Layer<HttpClient.HttpClient>;
   /**
    * Fetch API implementation for dependencies that cannot consume `httpClientLayer`.
@@ -4213,7 +4227,9 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
     const approvalRequired = (
       annotations: ToolAnnotations | undefined,
       policy: EffectivePolicy,
+      forceApproval = false,
     ): boolean => {
+      if (forceApproval) return true;
       if (policy.action === "approve") return false;
       return policy.action === "require_approval" || annotations?.requiresApproval === true;
     };
@@ -4224,10 +4240,11 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
       args: unknown,
       policy: EffectivePolicy,
       handler: ElicitationHandler,
+      forceApproval = false,
     ) =>
       Effect.gen(function* () {
-        if (!approvalRequired(annotations, policy)) return;
-        const policyForcesApproval = policy.action === "require_approval";
+        if (!approvalRequired(annotations, policy, forceApproval)) return;
+        const policyForcesApproval = policy.action === "require_approval" || forceApproval;
         const message = annotations?.approvalDescription
           ? annotations.approvalDescription
           : policyForcesApproval && policy.pattern
@@ -4245,6 +4262,60 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
           });
         }
       });
+
+    // Optional AuthorizationProvider: after hard block, before credentials /
+    // plugin invoke. Absent provider is a no-op (exact prior behavior).
+    const consultAuthorizationProvider = (
+      address: ToolAddress,
+      tool: AuthorizationToolRef,
+      args: unknown,
+      policy: EffectivePolicy,
+    ): Effect.Effect<
+      { readonly forceApproval: boolean; readonly decision: AuthorizationDecision | null },
+      AuthorizationDeniedError | AuthorizationProviderError
+    > => {
+      const provider = config.authorizationProvider;
+      if (!provider) {
+        return Effect.succeed({ forceApproval: false, decision: null });
+      }
+      return provider
+        .authorize({
+          identity: {
+            tenant: ownerBinding.tenant,
+            subject: ownerBinding.subject,
+          },
+          operation: "tool.execute",
+          tool,
+          args,
+          policy,
+        })
+        .pipe(
+          Effect.mapError(
+            (cause) =>
+              new AuthorizationProviderError({
+                address,
+                message: "Authorization provider failed",
+                cause,
+              }),
+          ),
+          Effect.flatMap((decision) => {
+            if (decision.outcome === "deny") {
+              return Effect.fail(
+                new AuthorizationDeniedError({
+                  address,
+                  decisionId: decision.decisionId,
+                  policyRevision: decision.policyRevision,
+                  reason: decision.reason,
+                }),
+              );
+            }
+            return Effect.succeed({
+              forceApproval: decision.outcome === "require_approval",
+              decision,
+            });
+          }),
+        );
+    };
 
     // ------------------------------------------------------------------
     // execute — the invoke path.
@@ -4341,7 +4412,27 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
               pattern: policy.pattern ?? "*",
             });
           }
-          yield* enforceApproval(staticEntry.tool.annotations, address, args, policy, handler);
+          const authz = yield* consultAuthorizationProvider(
+            address,
+            {
+              address,
+              integration: staticEntry.integration.id,
+              owner: staticToolOwner(),
+              connection: String(staticToolConnection(staticEntry.integration)),
+              plugin: staticEntry.pluginId,
+              name: staticEntry.tool.name,
+            },
+            args,
+            policy,
+          );
+          yield* enforceApproval(
+            staticEntry.tool.annotations,
+            address,
+            args,
+            policy,
+            handler,
+            authz.forceApproval,
+          );
           return yield* wrapInvocationError(
             staticEntry.tool.handler({
               ctx: staticEntry.ctx,
@@ -4395,6 +4486,20 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
           });
         }
 
+        const authz = yield* consultAuthorizationProvider(
+          address,
+          {
+            address,
+            integration: String(parsed.integration),
+            owner: String(parsed.owner),
+            connection: String(parsed.connection),
+            plugin: row.plugin_id,
+            name: String(parsed.tool),
+          },
+          args,
+          policy,
+        );
+
         const runtime = runtimes.get(row.plugin_id);
         if (!runtime) {
           return yield* new PluginNotLoadedError({
@@ -4441,12 +4546,22 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
         // body) must be rejected here, not after the user grants an approval
         // that then goes to waste. Non-pausing calls skip this — invokeTool
         // raises the identical failure moments later without the extra pass.
-        if (approvalRequired(resolvedAnnotations, policy) && runtime.plugin.validateToolArgs) {
+        if (
+          approvalRequired(resolvedAnnotations, policy, authz.forceApproval) &&
+          runtime.plugin.validateToolArgs
+        ) {
           yield* runtime.plugin
             .validateToolArgs({ ctx: runtime.ctx, toolRow: row, args })
             .pipe(wrapInvocationError);
         }
-        yield* enforceApproval(resolvedAnnotations, address, args, policy, handler);
+        yield* enforceApproval(
+          resolvedAnnotations,
+          address,
+          args,
+          policy,
+          handler,
+          authz.forceApproval,
+        );
 
         // Resolve every named credential input (`variable → value`); `value` is
         // the primary `token` for single-input + OAuth callers.

--- a/packages/core/sdk/src/index.ts
+++ b/packages/core/sdk/src/index.ts
@@ -64,6 +64,8 @@ export {
   ToolNotFoundError,
   ToolInvocationError,
   ToolBlockedError,
+  AuthorizationDeniedError,
+  AuthorizationProviderError,
   NoHandlerError,
   PluginNotLoadedError,
   IntegrationNotFoundError,
@@ -78,6 +80,17 @@ export {
   type ExecutorError,
   type UserActionableError,
 } from "./errors";
+
+// Universal authorization seam (optional provider; absent = prior behavior).
+export type {
+  AuthorizationOperation,
+  AuthorizationIdentity,
+  AuthorizationToolRef,
+  AuthorizationRequest,
+  AuthorizationOutcome,
+  AuthorizationDecision,
+  AuthorizationProvider,
+} from "./authorization";
 
 // Integration / connection / tool domain contracts.
 export type {

--- a/packages/core/sdk/src/promise-executor.ts
+++ b/packages/core/sdk/src/promise-executor.ts
@@ -25,6 +25,7 @@ import type { ElicitationContext, ElicitationResponse } from "./elicitation";
 import type { FumaDb, FumaTables } from "./fuma-runtime";
 import { Subject, Tenant } from "./ids";
 import type { AnyPlugin } from "./plugin";
+import type { AuthorizationProvider } from "./authorization";
 import type { CredentialProvider } from "./provider";
 
 // ---------------------------------------------------------------------------
@@ -127,6 +128,11 @@ export interface ExecutorConfig<TPlugins extends readonly AnyPlugin[] = readonly
    * an options arg.
    */
   readonly onElicitation: PromiseOnElicitation;
+  /**
+   * Optional universal authorization seam. Effect-native; bring from
+   * `@executor-js/sdk/core`. Absent = exact prior execute behavior.
+   */
+  readonly authorizationProvider?: AuthorizationProvider;
 }
 
 // ---------------------------------------------------------------------------
@@ -213,6 +219,9 @@ export const createExecutor = async <const TPlugins extends readonly AnyPlugin[]
     plugins,
     ...(config.providers ? { providers: config.providers } : {}),
     onElicitation: toEffectOnElicitation(config.onElicitation),
+    ...(config.authorizationProvider
+      ? { authorizationProvider: config.authorizationProvider }
+      : {}),
     ...(db ? { db } : {}),
   };
 

--- a/packages/core/sdk/src/promise.ts
+++ b/packages/core/sdk/src/promise.ts
@@ -73,6 +73,8 @@ export {
   ToolNotFoundError,
   ToolInvocationError,
   ToolBlockedError,
+  AuthorizationDeniedError,
+  AuthorizationProviderError,
   NoHandlerError,
   PluginNotLoadedError,
   ConnectionNotFoundError,
@@ -82,3 +84,13 @@ export {
   IntegrationRemovalNotAllowedError,
   type ExecutorError,
 } from "./errors";
+
+export type {
+  AuthorizationOperation,
+  AuthorizationIdentity,
+  AuthorizationToolRef,
+  AuthorizationRequest,
+  AuthorizationOutcome,
+  AuthorizationDecision,
+  AuthorizationProvider,
+} from "./authorization";

--- a/packages/core/sdk/src/shared.ts
+++ b/packages/core/sdk/src/shared.ts
@@ -54,6 +54,8 @@ export {
   ToolNotFoundError,
   ToolInvocationError,
   ToolBlockedError,
+  AuthorizationDeniedError,
+  AuthorizationProviderError,
   PluginNotLoadedError,
   NoHandlerError,
   IntegrationNotFoundError,
@@ -69,6 +71,16 @@ export {
   type ExecutorError,
   type UserActionableError,
 } from "./errors";
+
+export type {
+  AuthorizationOperation,
+  AuthorizationIdentity,
+  AuthorizationToolRef,
+  AuthorizationRequest,
+  AuthorizationOutcome,
+  AuthorizationDecision,
+  AuthorizationProvider,
+} from "./authorization";
 
 // Elicitation wire schemas.
 export {

--- a/packages/core/sdk/src/test-config.ts
+++ b/packages/core/sdk/src/test-config.ts
@@ -123,6 +123,7 @@ export type TestConfigOptions<TPlugins extends readonly AnyPlugin[] = readonly [
   readonly redirectUri?: string | null;
   readonly oauthCallbackStateOrgSlug?: string;
   readonly onIntegrationChange?: ExecutorConfig<TPlugins>["onIntegrationChange"];
+  readonly authorizationProvider?: ExecutorConfig<TPlugins>["authorizationProvider"];
 };
 
 export const makeTestConfig = <const TPlugins extends readonly AnyPlugin[] = readonly []>(
@@ -161,6 +162,7 @@ export const makeTestConfig = <const TPlugins extends readonly AnyPlugin[] = rea
     // Tests default to auto-accepting elicitation prompts.
     onElicitation: "accept-all",
     onIntegrationChange: options?.onIntegrationChange,
+    authorizationProvider: options?.authorizationProvider,
     ...(redirectUri != null ? { redirectUri } : {}),
     oauthCallbackStateOrgSlug: options?.oauthCallbackStateOrgSlug,
   };


### PR DESCRIPTION
## Summary

Adds an optional provider-neutral `AuthorizationProvider` seam to Executor tool execution so hosts can enforce a horizontal PDP without coupling Executor core to Cerbos, OPA, or another policy engine.

The provider receives Executor-bound tenant/subject identity plus resolved tool metadata and arguments. It is consulted after Executor's existing hard block checks and before credential resolution or plugin invocation.

Behavior:

- no provider configured: existing behavior is preserved;
- `allow`: execution continues normally;
- `deny`: fails closed before credentials or plugin invocation;
- provider failure: fails closed;
- `require_approval`: reuses Executor's existing elicitation flow;
- nested `ctx.execute(...)`: re-enters the same authorization seam;
- caller arguments cannot mint tenant/subject identity;
- the real scoped host threads the optional provider through `HostConfig` to `createExecutor`.

No concrete PDP dependency is added. Product/host code owns the provider implementation.

## Validation

Validated against current upstream `main` with the branch 0 commits behind before publication:

- `packages/core/sdk/src/authorization.test.ts`: 10/10 passing
- `packages/core/api/src/server/scoped-executor.authorization.test.ts`: 1/1 passing
- `@executor-js/sdk` typecheck: passing
- `@executor-js/api` typecheck: passing
- repository `bun run lint`: 0 warnings, 0 errors
- changeset included for the public release surface

The seam is also exercised by an external integration acceptance using a provider implementation outside Executor core, confirming the intended host-owned composition model.
