### PR TITLE
Slash shortcut no longer fires while typing in editable fields

### DIFF
--- a/packages/react/src/components/tool-tree.tsx
+++ b/packages/react/src/components/tool-tree.tsx
@@ -352,8 +352,20 @@ export function ToolTree(props: {
 
   // Keyboard shortcuts — `/` focuses search, Escape clears
   useEffect(() => {
+    const isEditing = (el: Element | null) =>
+      el instanceof HTMLElement &&
+      (el.isContentEditable ||
+        el.tagName === "INPUT" ||
+        el.tagName === "TEXTAREA" ||
+        el.tagName === "SELECT");
     const handler = (e: KeyboardEvent) => {
-      if (e.key === "/" && document.activeElement?.tagName !== "INPUT") {
+      if (
+        e.key === "/" &&
+        !e.metaKey &&
+        !e.ctrlKey &&
+        !e.altKey &&
+        !isEditing(document.activeElement)
+      ) {
         e.preventDefault();
         searchRef.current?.focus();
       }


### PR DESCRIPTION
The tool tree binds a document-level `/` keydown that focuses the tool filter. The guard only excluded `INPUT`, so typing `/` in a textarea, contenteditable, or select on any page with the tool tree stole focus mid-word (e.g. a URL died at `https:`).

The handler now ignores the shortcut when the active element is any editable target (input, textarea, select, contenteditable) or when a modifier is held, so browser shortcuts like Cmd+/ pass through. Plain `/` with nothing focused still focuses the filter.

Both clips type `Try https://example.com/path` into a textarea (added to the tools page for the repro) with real key events.

### Before

Typing dies at `Try https:` — the first `/` steals focus into the tool filter and the rest of the URL lands there instead.

![before: slash steals focus mid-URL](https://raw.githubusercontent.com/UsefulSoftwareCo/executor/e2e-media/slash-search-hijack-before-5ab29af2.gif)

### After

The full URL lands in the textarea; pressing `/` with nothing focused still jumps to the filter and types `probe`.

![after: URL types cleanly, slash shortcut still works](https://raw.githubusercontent.com/UsefulSoftwareCo/executor/e2e-media/slash-search-fixed-after-52cbf235.gif)
