### PR TITLE
Add integrations.remove to core tools

### DIFF
--- a/.changeset/core-tools-integrations-remove.md
+++ b/.changeset/core-tools-integrations-remove.md
@@ -1,0 +1,9 @@
+---
+"executor": patch
+---
+
+**Add `integrations.remove` to the core tools so an agent can drop a catalog integration**
+
+`integrations.list` advertises `canRemove` per integration, but nothing on the agent surface could act on it: removal existed only on the HTTP API and the web console, so an agent that could add an integration could never take one back out. Cleaning up a catalog meant clicking through the UI once per integration.
+
+The core-tools plugin now contributes `integrations.remove`, taking the `slug` reported by `integrations.list` and cascading to every connection under the integration and the tools those produced. It is approval-gated, being strictly more destructive than `connections.remove`. The `removed` flag is honest rather than always-true: `false` means no catalog row matched, so an already-absent slug and a built-in namespace like `executor` are distinguishable from a real removal, and an integration pinned with `canRemove: false` is refused with `IntegrationRemovalNotAllowedError` instead of silently surviving.

--- a/packages/core/sdk/src/core-tools.ts
+++ b/packages/core/sdk/src/core-tools.ts
@@ -51,6 +51,8 @@ const IntegrationsListOutput = Schema.Struct({
   integrations: Schema.Array(IntegrationOutput),
 });
 
+const IntegrationRemoveInput = Schema.Struct({ slug: Schema.String });
+
 const DetectInput = Schema.Struct({ url: Schema.String });
 const DetectOutput = Schema.Struct({
   results: Schema.Array(
@@ -331,6 +333,7 @@ const OAuthCancelInput = Schema.Struct({
 
 // Standard-schema versions for the tool() builder.
 const IntegrationsListOutputStd = schemaToStandard(IntegrationsListOutput);
+const IntegrationRemoveInputStd = schemaToStandard(IntegrationRemoveInput);
 const DetectInputStd = schemaToStandard(DetectInput);
 const DetectOutputStd = schemaToStandard(DetectOutput);
 const ConnectionsListInputStd = schemaToStandard(ConnectionsListInput);
@@ -558,6 +561,30 @@ export const coreToolsPlugin = definePlugin((options: CoreToolsPluginOptions = {
                 slug: r.slug,
               })),
             })),
+        }),
+        tool({
+          name: "integrations.remove",
+          description:
+            "Remove an integration from the workspace catalog by slug, dropping every connection under it and every tool those produced. `removed: false` means no catalog row matched: the slug was already gone, or it names a built-in namespace that is not catalog-backed. Integrations whose `canRemove` is false are refused.",
+          inputSchema: IntegrationRemoveInputStd,
+          outputSchema: RemovedOutputStd,
+          // Strictly more destructive than `connections.remove`, which is
+          // already approval-gated: this cascades to every connection under the
+          // integration and takes the catalog row with it, so re-adding means
+          // re-importing the definition, not just reconnecting an account.
+          annotations: { requiresApproval: true },
+          execute: (input: typeof IntegrationRemoveInput.Type, { ctx }) =>
+            Effect.gen(function* () {
+              const slug = IntegrationSlug.make(input.slug);
+              // `core.integrations.get` reads catalog ROWS only, so a built-in
+              // static namespace reports absent here. Checking first is what
+              // keeps `removed` honest — the underlying remove is a silent
+              // no-op for a slug it can't find.
+              const existing = yield* ctx.core.integrations.get(slug);
+              if (existing === null) return { removed: false };
+              yield* ctx.core.integrations.remove(slug);
+              return { removed: true };
+            }),
         }),
         tool({
           name: "connections.list",

--- a/packages/core/sdk/src/executor.test.ts
+++ b/packages/core/sdk/src/executor.test.ts
@@ -38,6 +38,7 @@ const memoryProvider = (): CredentialProvider => {
 };
 
 const INTEG = IntegrationSlug.make("demo");
+const PINNED = IntegrationSlug.make("demo-pinned");
 const TEMPLATE = AuthTemplateSlug.make("apiKey");
 const CONN = ConnectionName.make("main");
 
@@ -93,6 +94,15 @@ const demoPlugin = definePlugin(() => ({
         slug: INTEG,
         description: "Demo",
         config: {},
+      }),
+    /** A catalog row the host pins in place (`canRemove: false`), the shape
+     *  `integrations.remove` has to refuse rather than drop. */
+    seedPinned: () =>
+      ctx.core.integrations.register({
+        slug: PINNED,
+        description: "Demo (pinned)",
+        config: {},
+        canRemove: false,
       }),
     storagePut: (owner: "org" | "user", key: string, value: string) =>
       ctx.storage.put(owner, key, value),
@@ -344,6 +354,66 @@ describe("createExecutor", () => {
 
       const out = yield* executor.execute(addr("run"), {});
       expect(out).toEqual({ ran: "run" });
+    }),
+  );
+
+  it.effect("removes catalog integrations through the built-in Executor tools", () =>
+    Effect.gen(function* () {
+      const executor = yield* makeTestExecutor({
+        plugins: [demoPlugin] as const,
+        coreTools: {},
+      });
+      yield* executor.demo.seed();
+      yield* executor.demo.seedPinned();
+      yield* executor.execute(
+        ToolAddress.make("executor.coreTools.connections.create"),
+        {
+          owner: "org",
+          name: String(CONN),
+          integration: String(INTEG),
+          template: String(TEMPLATE),
+          from: { provider: "memory", id: "secret-token" },
+        },
+        { onElicitation: "accept-all" },
+      );
+
+      const remove = ToolAddress.make("executor.coreTools.integrations.remove");
+
+      // Removing the integration cascades to the connections under it.
+      const removed = yield* executor.execute(
+        remove,
+        { slug: String(INTEG) },
+        { onElicitation: "accept-all" },
+      );
+      expect(removed).toEqual({ removed: true });
+      const listed = yield* executor.integrations.list();
+      expect(listed.map((integration) => String(integration.slug))).not.toContain(String(INTEG));
+      expect(yield* executor.connections.list()).toHaveLength(0);
+
+      // An already-absent slug and a built-in namespace both report honestly
+      // instead of claiming a removal that never happened.
+      expect(
+        yield* executor.execute(remove, { slug: String(INTEG) }, { onElicitation: "accept-all" }),
+      ).toEqual({ removed: false });
+      expect(
+        yield* executor.execute(remove, { slug: "executor" }, { onElicitation: "accept-all" }),
+      ).toEqual({ removed: false });
+
+      // A pinned integration is refused, and survives the attempt.
+      const refused = yield* Effect.result(
+        executor.execute(remove, { slug: String(PINNED) }, { onElicitation: "accept-all" }),
+      );
+      expect(Result.isFailure(refused)).toBe(true);
+      if (!Result.isFailure(refused)) return;
+      expect(Predicate.isTagged(refused.failure, "ToolInvocationError")).toBe(true);
+      expect(
+        Predicate.isTagged(
+          (refused.failure as { readonly cause?: unknown }).cause,
+          "IntegrationRemovalNotAllowedError",
+        ),
+      ).toBe(true);
+      const afterRefusal = yield* executor.integrations.list();
+      expect(afterRefusal.map((integration) => String(integration.slug))).toContain(String(PINNED));
     }),
   );
 


### PR DESCRIPTION
`integrations.list` reports `canRemove` per integration, but nothing on the agent surface could act on it. Removal lived only on the HTTP API and the web console, so an agent that could add an integration could never take one back out — cleaning up a catalog meant clicking through the UI once per integration.

The core-tools plugin now contributes `integrations.remove`. It takes the `slug` that `integrations.list` already returns and delegates to the existing `executor.integrations.remove`, which cascades to every connection under the integration and the tools those produced.

Two details worth reviewing:

- **Approval-gated.** Strictly more destructive than `connections.remove` (already gated): this drops the catalog row too, so re-adding means re-importing the definition, not just reconnecting an account.
- **`removed` is honest, not always-true.** The underlying remove silently no-ops on a slug it can't find, and built-in static namespaces like `executor` have no catalog row at all. The tool checks `core.integrations.get` first and returns `removed: false` in those cases, so "nothing matched" is distinguishable from a real removal. An integration pinned with `canRemove: false` still fails with `IntegrationRemovalNotAllowedError` rather than quietly surviving.

## Verification

- New unit test covers all four paths through the real `executor.execute` address: cascade removal, absent slug, built-in namespace, pinned refusal (asserting the `ToolInvocationError` → `IntegrationRemovalNotAllowedError` cause chain).
- `format:check`, `lint`, repo-wide `typecheck` clean; `packages/core/sdk` suite 595/595.
- No e2e scenario added or run — this adds no UI and no new HTTP surface, and the unit test drives the same tool address MCP resolves. Live confirmation on the deployed workspace after merge.