### PR TITLE
Add changeset for MCP 2026-07-28 support

### DIFF
--- a/.changeset/mcp-spec-2026-07-28.md
+++ b/.changeset/mcp-spec-2026-07-28.md
@@ -1,0 +1,5 @@
+---
+"@executor-js/plugin-mcp": patch
+---
+
+Support MCP spec 2026-07-28 end to end. The MCP client negotiates the protocol era automatically (`server/discover` probe with legacy fallback), so integrations hosted on modern-only MCP servers connect without the server enabling legacy compatibility. Executor-hosted MCP endpoints serve both eras, and the `executor mcp` stdio bridge passes either era through to the daemon.


### PR DESCRIPTION
Queues the MCP spec 2026-07-28 work (merged in #1591 / #1611) into the next patch release.