### PR TITLE
Isolate the legacy GHCR mirror in its own release job

### DIFF
--- a/.github/workflows/publish-selfhost-docker.yml
+++ b/.github/workflows/publish-selfhost-docker.yml
@@ -281,9 +281,6 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       packages: write
-    env:
-      HAS_LEGACY_TOKEN: ${{ secrets.GHCR_LEGACY_TOKEN != '' }}
-
     steps:
       - name: Download image digests
         uses: actions/download-artifact@v4
@@ -330,9 +327,27 @@ jobs:
 
           docker buildx imagetools create "${tag_args[@]}" "${sources[@]}"
 
+  # Mirrors each release to the pre-org-move namespace
+  # (ghcr.io/rhyssullivan/executor-selfhost), which GHCR cannot redirect.
+  # Deliberately a separate job: the canonical publish above never depends on
+  # it, and a failure here (an expired GHCR_LEGACY_TOKEN, historically) shows
+  # as one red job pointing at exactly what to fix.
+  mirror-legacy:
+    needs:
+      - metadata
+      - merge
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    env:
+      HAS_LEGACY_TOKEN: ${{ secrets.GHCR_LEGACY_TOKEN != '' }}
+
+    steps:
       - name: Skip legacy GHCR mirror (GHCR_LEGACY_TOKEN not configured)
         if: env.HAS_LEGACY_TOKEN != 'true'
         run: echo "GHCR_LEGACY_TOKEN is not configured; skipping legacy GHCR mirror."
+
+      - name: Set up Docker Buildx
+        if: env.HAS_LEGACY_TOKEN == 'true'
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to legacy GHCR namespace
         if: env.HAS_LEGACY_TOKEN == 'true'
@@ -342,7 +357,7 @@ jobs:
           username: rhyssullivan
           password: ${{ secrets.GHCR_LEGACY_TOKEN }}
 
-      - name: Mirror self-host image to legacy GHCR namespace
+      - name: Mirror release tags to the legacy namespace
         if: env.HAS_LEGACY_TOKEN == 'true'
         shell: bash
         env:


### PR DESCRIPTION
The mirror to the pre-org namespace (ghcr.io/rhyssullivan/executor-selfhost, ~130 pulls/day) stays — but moves out of the `merge` job into a dedicated `mirror-legacy` job so:

- the canonical publish can never be blocked or marked failed by mirror trouble, and
- a mirror failure (an expired `GHCR_LEGACY_TOKEN`, which is how it silently froze at v1.5.37 for 18 days) shows as one red job pointing at exactly what to fix.

The token secret has been replaced with a durable one, and the legacy tags were re-pointed at the canonical v1.5.41 digest, so both namespaces are current and identical again. No behavior change for the canonical image.