### PR TITLE
Answer dead-session standalone GETs with 405 to stop reconnect loops

### DIFF
--- a/apps/cloud/src/mcp/agent-handler.ts
+++ b/apps/cloud/src/mcp/agent-handler.ts
@@ -45,6 +45,25 @@ const jsonRpcResponse = (
     ? jsonRpcErrorBody(status, code, message)
     : jsonRpcErrorBody(status, code, message, { challenge });
 
+/**
+ * A dead session id answers by request method. POST/DELETE keep the 404 that
+ * tells a compliant client to re-initialize. A standalone GET gets 405: the
+ * v1 SDK treats that as "no SSE stream offered" and stops retrying quietly,
+ * which breaks the reconnect loops of pre-cutover always-on deployments —
+ * their GET-404 path never re-initialized, it just retried forever.
+ */
+const deadSessionResponse = (method: string, message: string): Response =>
+  method === "GET"
+    ? new Response(JSON.stringify({ jsonrpc: "2.0", error: { code: -32001, message }, id: null }), {
+        status: 405,
+        headers: {
+          "content-type": "application/json",
+          allow: "POST, DELETE",
+          "access-control-allow-origin": "*",
+        },
+      })
+    : jsonRpcResponse(404, -32001, message);
+
 const renderAuthError = (
   auth: McpAuthProvider["Service"],
   request: Request,
@@ -217,7 +236,7 @@ export const makeCloudMcpAgentHandler = () => {
 
     const existingSession = sessionId ? mcpSessionStub(env.MCP_SESSION, sessionId) : null;
     if (sessionId && !existingSession) {
-      return jsonRpcResponse(404, -32001, "Session not found");
+      return deadSessionResponse(request.method, "Session not found");
     }
     if (existingSession) {
       const owner = await existingSession.validateMcpSessionOwner({
@@ -225,13 +244,13 @@ export const makeCloudMcpAgentHandler = () => {
         organizationId: outcome.principal.organizationId,
       });
       if (owner === "not_found") {
-        return jsonRpcResponse(404, -32001, "Session not found");
+        return deadSessionResponse(request.method, "Session not found");
       }
       if (owner === "terminated") {
         // DELETE-condemned but the deferred destroy alarm hasn't wiped storage
         // yet. Same envelope as the post-destroy race below: the client must
         // treat the id as dead and reconnect.
-        return jsonRpcResponse(404, -32001, "Session timed out, please reconnect");
+        return deadSessionResponse(request.method, "Session timed out, please reconnect");
       }
       if (owner === "forbidden") {
         return jsonRpcResponse(403, -32003, "MCP session does not belong to the current bearer");
@@ -267,7 +286,7 @@ export const makeCloudMcpAgentHandler = () => {
       // client to be told to reconnect, matching a timed-out session).
       // oxlint-disable-next-line executor/no-unknown-error-message -- adapter boundary: the abort reason is a plain runtime Error whose message IS the signal
       if (Predicate.isError(error) && error.message === "destroyed") {
-        return jsonRpcResponse(404, -32001, "Session timed out, please reconnect");
+        return deadSessionResponse(request.method, "Session timed out, please reconnect");
       }
       // oxlint-disable-next-line executor/no-try-catch-or-throw -- adapter boundary: rethrow anything that isn't the condemned-DO abort to the Workers runtime unchanged
       throw error;

--- a/apps/host-cloudflare/src/mcp/agent-handler.ts
+++ b/apps/host-cloudflare/src/mcp/agent-handler.ts
@@ -41,6 +41,25 @@ const jsonRpcResponse = (
     ? jsonRpcErrorBody(status, code, message)
     : jsonRpcErrorBody(status, code, message, { challenge });
 
+/**
+ * A dead session id answers by request method. POST/DELETE keep the 404 that
+ * tells a compliant client to re-initialize. A standalone GET gets 405: the
+ * v1 SDK treats that as "no SSE stream offered" and stops retrying quietly,
+ * which breaks the reconnect loops of pre-cutover always-on deployments —
+ * their GET-404 path never re-initialized, it just retried forever.
+ */
+const deadSessionResponse = (method: string, message: string): Response =>
+  method === "GET"
+    ? new Response(JSON.stringify({ jsonrpc: "2.0", error: { code: -32001, message }, id: null }), {
+        status: 405,
+        headers: {
+          "content-type": "application/json",
+          allow: "POST, DELETE",
+          "access-control-allow-origin": "*",
+        },
+      })
+    : jsonRpcResponse(404, -32001, message);
+
 const renderAuthError = (
   auth: McpAuthProvider["Service"],
   request: Request,
@@ -145,7 +164,7 @@ export const makeCloudflareMcpAgentHandler = (config: CloudflareConfig) => {
 
     const existingSession = sessionId ? mcpSessionStub(env.MCP_SESSION, sessionId) : null;
     if (sessionId && !existingSession) {
-      return jsonRpcResponse(404, -32001, "Session not found");
+      return deadSessionResponse(request.method, "Session not found");
     }
     if (existingSession) {
       const owner = await existingSession.validateMcpSessionOwner({
@@ -153,12 +172,12 @@ export const makeCloudflareMcpAgentHandler = (config: CloudflareConfig) => {
         organizationId: outcome.principal.organizationId,
       });
       if (owner === "not_found") {
-        return jsonRpcResponse(404, -32001, "Session not found");
+        return deadSessionResponse(request.method, "Session not found");
       }
       if (owner === "terminated") {
         // DELETE-condemned but the deferred destroy alarm hasn't wiped storage
         // yet; the terminated id must read as dead immediately.
-        return jsonRpcResponse(404, -32001, "Session timed out, please reconnect");
+        return deadSessionResponse(request.method, "Session timed out, please reconnect");
       }
       if (owner === "forbidden") {
         return jsonRpcResponse(403, -32003, "MCP session does not belong to the current bearer");

--- a/packages/hosts/cloudflare/src/mcp/agent-session-durable-object.test.ts
+++ b/packages/hosts/cloudflare/src/mcp/agent-session-durable-object.test.ts
@@ -576,4 +576,32 @@ describe("McpAgentSessionDOBase session serving", () => {
       error: { code: -32001, message: "Session not found" },
     });
   });
+
+  it("answers a dead-session standalone GET with 405 so old clients stop retrying", async () => {
+    const state = new MemoryDurableObjectState();
+    await state.storage.put("session-meta", {
+      organizationId: ORGANIZATION_ID,
+      organizationName: "Old Agent Org",
+      userId: ACCOUNT_ID,
+      resource: defaultMcpResource,
+    } satisfies SessionMeta);
+    const session = new HarnessSession(state, {} as Cloudflare.Env);
+    const request = verifiedRequest(
+      new Request("https://executor.test/mcp", {
+        method: "GET",
+        headers: {
+          accept: "text/event-stream",
+          "mcp-session-id": SESSION_ID,
+        },
+      }),
+    );
+
+    const response = await session.fetch(request);
+
+    expect(response.status).toBe(405);
+    expect(response.headers.get("allow")).toBe("POST, DELETE");
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: -32001, message: "Session not found" },
+    });
+  });
 });

--- a/packages/hosts/cloudflare/src/mcp/agent-session-durable-object.ts
+++ b/packages/hosts/cloudflare/src/mcp/agent-session-durable-object.ts
@@ -285,6 +285,24 @@ type QueuedTransportMessage = {
   readonly extra?: MessageExtraInfo;
 };
 
+/**
+ * Dead-session answer by method: POST/DELETE keep the 404 that drives client
+ * re-initialization; a standalone GET gets 405, which the v1 SDK reads as
+ * "no SSE stream offered" and stops retrying — breaking the reconnect loops
+ * of pre-cutover deployments whose GET-404 path never re-initialized.
+ */
+const deadSessionDoResponse = (method: string): Response =>
+  method === "GET"
+    ? new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          error: { code: -32001, message: "Session not found" },
+          id: null,
+        }),
+        { status: 405, headers: { "content-type": "application/json", allow: "POST, DELETE" } },
+      )
+    : jsonRpcErrorBody(404, -32001, "Session not found", { cors: false });
+
 export abstract class McpAgentSessionDOBase<
   Env extends Cloudflare.Env = Cloudflare.Env,
   TDbHandle extends SessionDbHandle = SessionDbHandle,
@@ -1117,7 +1135,7 @@ export abstract class McpAgentSessionDOBase<
     return this.serializedTransportRequest(async () => {
       const transport = this.transport;
       if (!transport) {
-        return jsonRpcErrorBody(404, -32001, "Session not found", { cors: false });
+        return deadSessionDoResponse(request.method);
       }
       if (request.method === "GET") {
         const lastEventId = request.headers.get("last-event-id");
@@ -1212,7 +1230,7 @@ export abstract class McpAgentSessionDOBase<
     if (!stored) {
       if (!isInitializeBody(parsedBody)) {
         return request.headers.has("mcp-session-id")
-          ? jsonRpcErrorBody(404, -32001, "Session not found", { cors: false })
+          ? deadSessionDoResponse(request.method)
           : jsonRpcErrorBody(400, -32000, "Bad Request: Server not initialized", {
               cors: false,
             });

--- a/packages/hosts/mcp/src/envelope.test.ts
+++ b/packages/hosts/mcp/src/envelope.test.ts
@@ -252,6 +252,43 @@ describe("McpServingRoutes envelope", () => {
     });
   });
 
+  it("answers a dead-session standalone GET with 405 so old clients stop retrying", async () => {
+    const NotFoundStoreLive = Layer.succeed(McpSessionStore)({
+      dispatch: (): Effect.Effect<McpDispatchResult> => Effect.succeed("not-found"),
+      dispose: () => Effect.void,
+    });
+    const handler = buildHandler(NotFoundStoreLive, McpErrorReporterNoop);
+
+    const get = await handler(
+      new Request("https://host.test/mcp", {
+        method: "GET",
+        headers: {
+          authorization: "Bearer x",
+          accept: "text/event-stream",
+          "mcp-session-id": "dead-session",
+          "mcp-protocol-version": "2025-06-18",
+        },
+      }),
+    );
+    expect(get.status).toBe(405);
+    expect(get.headers.get("allow")).toBe("POST, DELETE");
+    expect(await get.json()).toMatchObject({ error: { code: -32001 } });
+
+    const post = await handler(
+      new Request("https://host.test/mcp", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer x",
+          "content-type": "application/json",
+          "mcp-session-id": "dead-session",
+          "mcp-protocol-version": "2025-06-18",
+        },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+      }),
+    );
+    expect(post.status).toBe(404);
+  });
+
   it("404s a modern request whose toolkit route is not served", async () => {
     const handler = buildHandler(OkStoreLive, McpErrorReporterNoop);
     const response = await handler(modernRequest("https://host.test/mcp/toolkits/unknown/extra"));

--- a/packages/hosts/mcp/src/envelope.ts
+++ b/packages/hosts/mcp/src/envelope.ts
@@ -238,11 +238,29 @@ const renderAuthError = (
     Match.exhaustive,
   );
 
-/** Render a non-`Response` {@link McpDispatchResult} discriminant. */
-const renderDispatchError = (lookup: "not-found" | "forbidden"): Response =>
-  lookup === "not-found"
-    ? jsonRpcResponse(404, -32001, "Session not found")
-    : jsonRpcResponse(403, -32003, "MCP session does not belong to the current bearer");
+/**
+ * Render a non-`Response` {@link McpDispatchResult} discriminant. A dead
+ * session answers by method: POST/DELETE keep the 404 that drives client
+ * re-initialization; a standalone GET gets 405, which the v1 SDK reads as
+ * "no SSE stream offered" and stops retrying — breaking pre-cutover
+ * reconnect loops whose GET-404 path never re-initialized.
+ */
+const renderDispatchError = (lookup: "not-found" | "forbidden", method: string): Response => {
+  if (lookup === "forbidden") {
+    return jsonRpcResponse(403, -32003, "MCP session does not belong to the current bearer");
+  }
+  if (method === "GET") {
+    return new Response(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        error: { code: -32001, message: "Session not found" },
+        id: null,
+      }),
+      { status: 405, headers: { "content-type": "application/json", allow: "POST, DELETE" } },
+    );
+  }
+  return jsonRpcResponse(404, -32001, "Session not found");
+};
 
 const withModernMcpCors = (response: Response): Response => {
   const headers = new Headers(response.headers);
@@ -398,7 +416,9 @@ const mcpDispatch = (resource: McpResource, modern: ModernMcpRouter) =>
       sessionId,
       method: request.method,
     });
-    return fromWebResponse(result instanceof Response ? result : renderDispatchError(result));
+    return fromWebResponse(
+      result instanceof Response ? result : renderDispatchError(result, request.method),
+    );
   });
 
 /**


### PR DESCRIPTION
Pre-cutover always-on deployments hold session ids that died at the migration reset. Their standalone SSE GET path retries a 404 forever without re-initializing (only a POST triggers re-init in that client generation) — 145 accounts were looping by Monday morning, ~99% of MCP request volume, growing as deployments wake up.

The v1 SDK treats a 405 on the standalone GET as \"server offers no SSE stream\" and stops retrying quietly — no error raised, so harness-level reconnect loops also settle. So: a request bearing a dead session id now answers by method — GET gets 405 (+ \"Allow: POST, DELETE\"), POST/DELETE keep the 404 that drives proper re-initialization on next real use. Compliant clients lose nothing (the v1 SDK never re-initialized from a GET 404).

Applied uniformly: cloud worker, standalone Cloudflare worker, the session DO fallbacks, and the neutral envelope. New tests assert the GET/POST split at the envelope and DO levels; existing POST-404 assertions unchanged.

Expected effect on merge: the ~18 req/sec loop volume decays to zero as each looper receives its first 405.