### PR TITLE
Improve trace quality: redact headers, fix DO span parenting, cut noise

### DIFF
--- a/apps/cloud/src/account/org-api-key-revoke.node.test.ts
+++ b/apps/cloud/src/account/org-api-key-revoke.node.test.ts
@@ -77,7 +77,7 @@ const stubWorkOS = Layer.succeed(
 );
 
 const stubUsers = Layer.succeed(UserStoreService)({
-  use: (fn) =>
+  use: (_op, fn) =>
     Effect.promise(() =>
       fn({
         ensureAccount: async (id: string) => ({ id, createdAt }),

--- a/apps/cloud/src/account/workos-account-service.ts
+++ b/apps/cloud/src/account/workos-account-service.ts
@@ -386,7 +386,9 @@ export const workosAccountProvider: Layer.Layer<
             .updateOrganization(org.id, name)
             .pipe(Effect.catchTag("WorkOSError", toAccountError));
           yield* users
-            .use((s) => s.upsertOrganization({ id: updated.id, name: updated.name }))
+            .use("upsertOrganization", (s) =>
+              s.upsertOrganization({ id: updated.id, name: updated.name }),
+            )
             .pipe(Effect.catchTag("UserStoreError", toAccountError));
           return { name: updated.name };
         }),

--- a/apps/cloud/src/api/protected-api-key-auth.node.test.ts
+++ b/apps/cloud/src/api/protected-api-key-auth.node.test.ts
@@ -47,7 +47,7 @@ const stubWorkOS = Layer.succeed(
 );
 
 const stubUsers = Layer.succeed(UserStoreService)({
-  use: (fn) =>
+  use: (_op, fn) =>
     Effect.promise(() =>
       fn({
         ensureAccount: async (id: string) => ({ id, createdAt }),

--- a/apps/cloud/src/api/protected-jwt-auth.node.test.ts
+++ b/apps/cloud/src/api/protected-jwt-auth.node.test.ts
@@ -64,7 +64,7 @@ const stubWorkOS = Layer.succeed(
 );
 
 const stubUsers = Layer.succeed(UserStoreService)({
-  use: (fn) =>
+  use: (_op, fn) =>
     Effect.promise(() =>
       fn({
         ensureAccount: async (id: string) => ({ id, createdAt }),

--- a/apps/cloud/src/auth/context.ts
+++ b/apps/cloud/src/auth/context.ts
@@ -9,10 +9,13 @@ import { UserStoreError, tryPromiseService, withServiceLogging } from "./errors"
 
 type RawStore = ReturnType<typeof makeUserStore>;
 
+// `op` names the store call so every span reads `user_store.<operation>`
+// instead of one undifferentiated "user_store" bucket, and failures log which
+// query actually failed.
 const makeService = (store: RawStore) => ({
-  use: <A>(fn: (s: RawStore) => Promise<A>) =>
+  use: <A>(op: string, fn: (s: RawStore) => Promise<A>) =>
     withServiceLogging(
-      "user_store",
+      `user_store.${op}`,
       () => new UserStoreError(),
       tryPromiseService(() => fn(store)),
     ),

--- a/apps/cloud/src/auth/handlers.ts
+++ b/apps/cloud/src/auth/handlers.ts
@@ -202,7 +202,7 @@ export const CloudAuthPublicHandlers = HttpApiBuilder.group(
           const result = yield* workos.authenticateWithCode(query.code);
 
           // Mirror the account locally
-          yield* users.use((s) => s.ensureAccount(result.user.id));
+          yield* users.use("ensureAccount", (s) => s.ensureAccount(result.user.id));
 
           let sealedSession = result.sealedSession;
 
@@ -420,7 +420,7 @@ export const CloudSessionAuthHandlers = HttpApiBuilder.group(
           const org = yield* workos.createOrganization(name);
           yield* workos.createMembership(org.id, session.accountId, "admin");
           // `upsertOrganization` mints the slug at insert — no separate heal step.
-          const mirrored = yield* users.use((s) =>
+          const mirrored = yield* users.use("upsertOrganization", (s) =>
             s.upsertOrganization({ id: org.id, name: org.name }),
           );
 
@@ -474,7 +474,7 @@ export const CloudSessionAuthHandlers = HttpApiBuilder.group(
 
           // The typed confirmation must match the org's current name — the same
           // label the settings page shows. Trimmed on both sides.
-          const org = yield* users.use((s) => s.getOrganization(organizationId));
+          const org = yield* users.use("getOrganization", (s) => s.getOrganization(organizationId));
           if (!org || payload.confirmName.trim() !== org.name.trim()) {
             return yield* new OrganizationDeletionForbidden();
           }
@@ -492,7 +492,7 @@ export const CloudSessionAuthHandlers = HttpApiBuilder.group(
           // everyone (unreachable) but its secrets/tenant rows linger orphaned —
           // alert loudly so that window gets swept, then surface the failure.
           yield* users
-            .use((s) => s.deleteOrganizationCascade(organizationId))
+            .use("deleteOrganizationCascade", (s) => s.deleteOrganizationCascade(organizationId))
             .pipe(
               Effect.tapError((error) =>
                 Effect.logError(
@@ -593,7 +593,7 @@ export const CloudSessionAuthHandlers = HttpApiBuilder.group(
           // Mirror the org locally so domain tables can FK against it; the
           // upsert mints the slug at insert — no separate heal step.
           const org = yield* workos.getOrganization(invitation.organizationId);
-          const mirrored = yield* users.use((s) =>
+          const mirrored = yield* users.use("upsertOrganization", (s) =>
             s.upsertOrganization({ id: org.id, name: org.name }),
           );
 

--- a/apps/cloud/src/auth/org-api-key-auth.node.test.ts
+++ b/apps/cloud/src/auth/org-api-key-auth.node.test.ts
@@ -62,7 +62,7 @@ const stubWorkOS = Layer.succeed(
 );
 
 const stubUsers = Layer.succeed(UserStoreService)({
-  use: (fn) =>
+  use: (_op, fn) =>
     Effect.promise(() =>
       fn({
         ensureAccount: async (id: string) => ({ id, createdAt }),

--- a/apps/cloud/src/auth/org-selector-auth.node.test.ts
+++ b/apps/cloud/src/auth/org-selector-auth.node.test.ts
@@ -64,7 +64,7 @@ const stubWorkOS = Layer.succeed(
 );
 
 const stubUsers = Layer.succeed(UserStoreService)({
-  use: (fn) =>
+  use: (_op, fn) =>
     Effect.promise(() =>
       fn({
         ensureAccount: async (id: string) => ({ id, createdAt }),

--- a/apps/cloud/src/auth/organization.ts
+++ b/apps/cloud/src/auth/organization.ts
@@ -38,12 +38,14 @@ import { WorkOSClient } from "./workos";
 export const resolveOrganization = (organizationId: string) =>
   Effect.gen(function* () {
     const users = yield* UserStoreService;
-    const existing = yield* users.use((s) => s.getOrganization(organizationId));
+    const existing = yield* users.use("getOrganization", (s) => s.getOrganization(organizationId));
     if (existing) return existing;
 
     const workos = yield* WorkOSClient;
     const fresh = yield* workos.getOrganization(organizationId);
-    return yield* users.use((s) => s.upsertOrganization({ id: fresh.id, name: fresh.name }));
+    return yield* users.use("upsertOrganization", (s) =>
+      s.upsertOrganization({ id: fresh.id, name: fresh.name }),
+    );
   });
 
 // ---------------------------------------------------------------------------
@@ -125,7 +127,7 @@ export const authorizeOrganizationSelector = (userId: string, selector: string) 
       return yield* authorizeOrganization(userId, selector);
     }
     const users = yield* UserStoreService;
-    const org = yield* users.use((s) => s.getOrganizationBySlug(selector));
+    const org = yield* users.use("getOrganizationBySlug", (s) => s.getOrganizationBySlug(selector));
     if (!org) return null;
     return yield* authorizeOrganization(userId, org.id);
   });

--- a/apps/cloud/src/auth/ssr-gate.ts
+++ b/apps/cloud/src/auth/ssr-gate.ts
@@ -153,7 +153,7 @@ const organizationDisplay = async (
 ): Promise<{ name: string; slug: string }> => {
   const exit = await getRuntime().runPromiseExit(
     Effect.flatMap(UserStoreService.asEffect(), (users) =>
-      users.use((store) => store.getOrganization(organizationId)),
+      users.use("getOrganization", (store) => store.getOrganization(organizationId)),
     ).pipe(Effect.provide(Layer.provide(makeUserStoreLayer(), makeDbLayer()))),
   );
   return Exit.isSuccess(exit)

--- a/apps/cloud/src/auth/workos.ts
+++ b/apps/cloud/src/auth/workos.ts
@@ -338,9 +338,12 @@ const make = Effect.gen(function* () {
   // exception had one (all its typed exceptions do), so consumers can tell a
   // definitive WorkOS denial (401/403/404 — fail closed) from a transient
   // failure (429/5xx/network — retryable).
-  const use = <A>(fn: (wos: WorkOS) => Promise<A>) =>
+  // `op` names the SDK call (mirroring its `namespace.method` path) so every
+  // span reads `workos.<operation>` instead of one undifferentiated "workos"
+  // bucket, and failures log which call actually failed.
+  const use = <A>(op: string, fn: (wos: WorkOS) => Promise<A>) =>
     withServiceLogging(
-      "workos",
+      `workos.${op}`,
       workosErrorFromFailure,
       tryPromiseService(() => fn(workos)),
     );
@@ -376,7 +379,7 @@ const make = Effect.gen(function* () {
       if (isLocalSessionInvalidCookie(local)) return null;
 
       // Try refreshing
-      const refreshed = yield* use(() => session.refresh()).pipe(
+      const refreshed = yield* use("session.refresh", () => session.refresh()).pipe(
         Effect.orElseSucceed(() => ({ authenticated: false as const })),
       );
 
@@ -405,7 +408,7 @@ const make = Effect.gen(function* () {
       }),
 
     authenticateWithCode: (code: string) =>
-      use((wos) =>
+      use("userManagement.authenticateWithCode", (wos) =>
         wos.userManagement.authenticateWithCode({
           code,
           clientId,
@@ -415,11 +418,13 @@ const make = Effect.gen(function* () {
 
     /** Create a new organization in WorkOS. */
     createOrganization: (name: string) =>
-      use((wos) => wos.organizations.createOrganization({ name })),
+      use("organizations.createOrganization", (wos) =>
+        wos.organizations.createOrganization({ name }),
+      ),
 
     /** Add a user to an organization. */
     createMembership: (organizationId: string, userId: string, roleSlug?: string) =>
-      use((wos) =>
+      use("userManagement.createOrganizationMembership", (wos) =>
         wos.userManagement.createOrganizationMembership({
           organizationId,
           userId,
@@ -429,7 +434,7 @@ const make = Effect.gen(function* () {
 
     /** List organization memberships for a user. */
     listUserMemberships: (userId: string) =>
-      use(async (wos) =>
+      use("userManagement.listOrganizationMemberships", async (wos) =>
         collectWorkOSList(
           await wos.userManagement.listOrganizationMemberships({
             userId,
@@ -448,7 +453,7 @@ const make = Effect.gen(function* () {
           sessionData,
           cookiePassword,
         });
-        const refreshed = yield* use(() =>
+        const refreshed = yield* use("session.refresh", () =>
           session.refresh(organizationId ? { organizationId } : undefined),
         );
         if (!refreshed.authenticated || !("sealedSession" in refreshed)) return null;
@@ -517,10 +522,13 @@ const make = Effect.gen(function* () {
      * auth/api-keys.ts.
      */
     validateApiKey: (value: string) =>
-      use((wos) => wos.apiKeys.validateApiKey({ value }) as Promise<unknown>),
+      use(
+        "apiKeys.validateApiKey",
+        (wos) => wos.apiKeys.validateApiKey({ value }) as Promise<unknown>,
+      ),
 
     listUserApiKeys: (userId: string, organizationId: string) =>
-      use(async (wos) => {
+      use("userManagement.listUserApiKeys", async (wos) => {
         const raw = wos as RawWorkOS;
         return collectRawWorkOSList(async (after) => {
           const response = await raw.get(`/user_management/users/${userId}/api_keys`, {
@@ -535,7 +543,7 @@ const make = Effect.gen(function* () {
       }),
 
     createUserApiKey: (params: { userId: string; organizationId: string; name: string }) =>
-      use(async (wos) => {
+      use("userManagement.createUserApiKey", async (wos) => {
         const raw = wos as RawWorkOS;
         const response = await raw.post(`/user_management/users/${params.userId}/api_keys`, {
           name: params.name,
@@ -552,7 +560,7 @@ const make = Effect.gen(function* () {
      * other key response.
      */
     listOrgApiKeys: (organizationId: string) =>
-      use(async (wos) =>
+      use("organizations.listOrganizationApiKeys", async (wos) =>
         collectWorkOSList(await wos.organizations.listOrganizationApiKeys({ organizationId })),
       ),
 
@@ -564,6 +572,7 @@ const make = Effect.gen(function* () {
      */
     createOrgApiKey: (params: { organizationId: string; name: string }) =>
       use(
+        "organizations.createOrganizationApiKey",
         (wos) =>
           wos.organizations.createOrganizationApiKey({
             organizationId: params.organizationId,
@@ -571,11 +580,12 @@ const make = Effect.gen(function* () {
           }) as Promise<unknown>,
       ),
 
-    deleteApiKey: (id: string) => use((wos) => wos.apiKeys.deleteApiKey(id)),
+    deleteApiKey: (id: string) =>
+      use("apiKeys.deleteApiKey", (wos) => wos.apiKeys.deleteApiKey(id)),
 
     /** List organization memberships with user details. */
     listOrgMembers: (organizationId: string) =>
-      use(async (wos) =>
+      use("userManagement.listOrganizationMemberships", async (wos) =>
         collectWorkOSList(
           await wos.userManagement.listOrganizationMemberships({
             organizationId,
@@ -586,7 +596,7 @@ const make = Effect.gen(function* () {
 
     /** Get a user's membership in an organization. */
     getUserOrgMembership: (organizationId: string, userId: string) =>
-      use(async (wos) => {
+      use("userManagement.listOrganizationMemberships", async (wos) => {
         const response = await wos.userManagement.listOrganizationMemberships({
           organizationId,
           userId,
@@ -596,11 +606,12 @@ const make = Effect.gen(function* () {
       }),
 
     /** Get a user by ID. */
-    getUser: (userId: string) => use((wos) => wos.userManagement.getUser(userId)),
+    getUser: (userId: string) =>
+      use("userManagement.getUser", (wos) => wos.userManagement.getUser(userId)),
 
     /** List users matching an email within one organization. */
     listUsers: (params: { email: string; organizationId: string }) =>
-      use(async (wos) =>
+      use("userManagement.listUsers", async (wos) =>
         collectWorkOSList(
           await wos.userManagement.listUsers({
             email: params.email,
@@ -611,7 +622,7 @@ const make = Effect.gen(function* () {
 
     /** Send an organization invitation. */
     sendInvitation: (params: { email: string; organizationId: string; roleSlug?: string }) =>
-      use((wos) =>
+      use("userManagement.sendInvitation", (wos) =>
         wos.userManagement.sendInvitation({
           email: params.email,
           organizationId: params.organizationId,
@@ -625,7 +636,7 @@ const make = Effect.gen(function* () {
      * API level, so we filter after.
      */
     listPendingInvitations: (organizationId: string) =>
-      use(async (wos) =>
+      use("userManagement.listInvitations", async (wos) =>
         collectWorkOSList(
           await wos.userManagement.listInvitations({
             organizationId,
@@ -640,7 +651,7 @@ const make = Effect.gen(function* () {
 
     /** List invitations for an email address (across all orgs). */
     listInvitationsByEmail: (email: string) =>
-      use(async (wos) =>
+      use("userManagement.listInvitations", async (wos) =>
         collectWorkOSList(
           await wos.userManagement.listInvitations({
             email,
@@ -650,19 +661,25 @@ const make = Effect.gen(function* () {
 
     /** Accept an invitation; returns the (now accepted) invitation. */
     acceptInvitation: (invitationId: string) =>
-      use((wos) => wos.userManagement.acceptInvitation(invitationId)),
+      use("userManagement.acceptInvitation", (wos) =>
+        wos.userManagement.acceptInvitation(invitationId),
+      ),
 
     /** Remove an organization membership. */
     deleteOrgMembership: (membershipId: string) =>
-      use((wos) => wos.userManagement.deleteOrganizationMembership(membershipId)),
+      use("userManagement.deleteOrganizationMembership", (wos) =>
+        wos.userManagement.deleteOrganizationMembership(membershipId),
+      ),
 
     /** Get the role for a membership. */
     getOrgMembership: (membershipId: string) =>
-      use((wos) => wos.userManagement.getOrganizationMembership(membershipId)),
+      use("userManagement.getOrganizationMembership", (wos) =>
+        wos.userManagement.getOrganizationMembership(membershipId),
+      ),
 
     /** Update a membership's role. */
     updateOrgMembershipRole: (membershipId: string, roleSlug: string) =>
-      use((wos) =>
+      use("userManagement.updateOrganizationMembership", (wos) =>
         wos.userManagement.updateOrganizationMembership(membershipId, {
           roleSlug,
         }),
@@ -670,15 +687,19 @@ const make = Effect.gen(function* () {
 
     /** List available roles for an organization. */
     listOrgRoles: (organizationId: string) =>
-      use((wos) => wos.organizations.listOrganizationRoles({ organizationId })),
+      use("organizations.listOrganizationRoles", (wos) =>
+        wos.organizations.listOrganizationRoles({ organizationId }),
+      ),
 
     /** Get an organization (includes domains). */
     getOrganization: (organizationId: string) =>
-      use((wos) => wos.organizations.getOrganization(organizationId)),
+      use("organizations.getOrganization", (wos) =>
+        wos.organizations.getOrganization(organizationId),
+      ),
 
     /** Update an organization. */
     updateOrganization: (organizationId: string, name: string) =>
-      use((wos) =>
+      use("organizations.updateOrganization", (wos) =>
         wos.organizations.updateOrganization({
           organization: organizationId,
           name,
@@ -690,11 +711,13 @@ const make = Effect.gen(function* () {
      * invitations, and domains go with it, so every member loses access.
      */
     deleteOrganization: (organizationId: string) =>
-      use((wos) => wos.organizations.deleteOrganization(organizationId)),
+      use("organizations.deleteOrganization", (wos) =>
+        wos.organizations.deleteOrganization(organizationId),
+      ),
 
     /** Generate an Admin Portal link for domain verification. */
     generateDomainVerificationPortalLink: (organizationId: string, returnUrl: string) =>
-      use((wos) =>
+      use("portal.generateLink", (wos) =>
         wos.portal.generateLink({
           organization: organizationId,
           intent: GeneratePortalLinkIntent.DomainVerification,
@@ -704,11 +727,11 @@ const make = Effect.gen(function* () {
 
     /** Get a domain by ID. */
     getOrganizationDomain: (domainId: string) =>
-      use((wos) => wos.organizationDomains.get(domainId)),
+      use("organizationDomains.get", (wos) => wos.organizationDomains.get(domainId)),
 
     /** Delete a domain claim. */
     deleteOrganizationDomain: (domainId: string) =>
-      use((wos) => wos.organizationDomains.delete(domainId)),
+      use("organizationDomains.delete", (wos) => wos.organizationDomains.delete(domainId)),
   };
 });
 
@@ -717,9 +740,10 @@ export type WorkOSClientService = Effect.Success<typeof make>;
 export class WorkOSClient extends Context.Service<WorkOSClient, WorkOSClientService>()(
   "@executor-js/cloud/WorkOSClient",
 ) {
-  static Default = Layer.effect(this)(make).pipe(
-    Layer.withSpan("WorkOSClient", { attributes: { module: "WorkOSClient" } }),
-  );
+  // Deliberately unspanned: client construction is synchronous and ran per
+  // layer build, which produced one of the highest-volume zero-duration span
+  // names in the whole trace corpus while telling us nothing.
+  static Default = Layer.effect(this)(make);
 }
 
 // The boot-scoped WorkOS client root — the one neutral service the stateless

--- a/apps/cloud/src/extensions/billing/route.node.test.ts
+++ b/apps/cloud/src/extensions/billing/route.node.test.ts
@@ -34,7 +34,7 @@ const stubWorkOS = Layer.succeed(
 );
 
 const stubUsers = Layer.succeed(UserStoreService)({
-  use: (fn) =>
+  use: (_op, fn) =>
     Effect.promise(() =>
       fn({
         ensureAccount: async (id: string) => ({ id, createdAt }),

--- a/apps/cloud/src/mcp/auth-provider.ts
+++ b/apps/cloud/src/mcp/auth-provider.ts
@@ -21,8 +21,9 @@
 //       clearExistingSession.
 //   - verified + org allowed -> Authenticated(principal)
 //
-// The rich `mcp.request.annotate` client-fingerprint span (cloud-specific, no
-// envelope seam) is emitted from here so telemetry parity is preserved.
+// The rich client-fingerprint annotations (cloud-specific, no envelope seam)
+// are stamped onto the `mcp.request` span from here so telemetry parity is
+// preserved.
 //
 // The OAuth endpoints (/authorize, /token, /register) are NOT cloud's — they
 // live at WorkOS/AuthKit (external); only the two discovery docs are mounted.

--- a/apps/cloud/src/mcp/auth.ts
+++ b/apps/cloud/src/mcp/auth.ts
@@ -204,7 +204,9 @@ const resolveOrgSelector = (selector: string) =>
     ? Effect.succeed(selector)
     : Effect.gen(function* () {
         const users = yield* UserStoreService;
-        const org = yield* users.use((s) => s.getOrganizationBySlug(selector));
+        const org = yield* users.use("getOrganizationBySlug", (s) =>
+          s.getOrganizationBySlug(selector),
+        );
         return org?.id ?? null;
       });
 

--- a/apps/cloud/src/mcp/telemetry.ts
+++ b/apps/cloud/src/mcp/telemetry.ts
@@ -254,5 +254,4 @@ export const annotateMcpRequest = (
     };
 
     yield* Effect.annotateCurrentSpan(attrs);
-    yield* Effect.annotateCurrentSpan(attrs).pipe(Effect.withSpan("mcp.request.annotate"));
   });

--- a/apps/cloud/src/mcp/traceparent.ts
+++ b/apps/cloud/src/mcp/traceparent.ts
@@ -1,13 +1,13 @@
 // ---------------------------------------------------------------------------
 // W3C traceparent parsing shared by the worker edge (server.ts), the MCP agent
-// handler, and the session DO. Single-sourced so the producer (the worker span
-// stamping traceparent onto the forwarded request) and the consumers (the
-// Effect programs joining that span) cannot drift on the header grammar.
+// handler, and the session DO. The header grammar itself is single-sourced in
+// `@executor-js/cloudflare/mcp/do-headers` beside the producer that stamps the
+// header; this module only layers the OTel `tracestate` carrier on top for the
+// consumers that join the span via the OTel API.
 // ---------------------------------------------------------------------------
 
 import { createTraceState } from "@opentelemetry/api";
-
-const TRACEPARENT_PATTERN = /^([0-9a-f]{2})-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})$/;
+import { parseTraceparentHeader } from "@executor-js/cloudflare/mcp/do-headers";
 
 export type IncomingSpanContext = {
   readonly traceId: string;
@@ -20,13 +20,10 @@ export const parseTraceparent = (
   traceparent: string | null | undefined,
   tracestate: string | null | undefined,
 ): IncomingSpanContext | null => {
-  if (!traceparent) return null;
-  const match = TRACEPARENT_PATTERN.exec(traceparent);
-  if (!match) return null;
+  const parsed = parseTraceparentHeader(traceparent);
+  if (!parsed) return null;
   return {
-    traceId: match[2]!,
-    spanId: match[3]!,
-    traceFlags: parseInt(match[4]!, 16),
+    ...parsed,
     ...(tracestate ? { traceState: createTraceState(tracestate) } : {}),
   };
 };

--- a/apps/cloud/src/observability/header-redaction.ts
+++ b/apps/cloud/src/observability/header-redaction.ts
@@ -54,9 +54,9 @@ const SAFE_HEADER_NAMES = [
   "x-request-id",
 ] as const;
 
-// `Headers.redact` lowercases stored names and, for a RegExp entry, redacts
-// every name the pattern matches. One negative lookahead turns the allowlist
-// into "redact everything else".
+// Header names are lowercased at `Headers` construction, and `Headers.redact`
+// masks every name a RegExp entry matches. One negative lookahead turns the
+// allowlist into "redact everything else".
 const redactAllButSafe = new RegExp(`^(?!(?:${SAFE_HEADER_NAMES.join("|")})$)`);
 
 export const SpanHeaderRedactionLive: Layer.Layer<never> = Layer.succeed(

--- a/apps/cloud/src/observability/header-redaction.ts
+++ b/apps/cloud/src/observability/header-redaction.ts
@@ -1,0 +1,65 @@
+// ---------------------------------------------------------------------------
+// Span header redaction.
+//
+// Effect's HttpClient/HttpServer tracer records every request and response
+// header as a span attribute, masking only the names in
+// `Headers.CurrentRedactedNames` (default: authorization, cookie, set-cookie,
+// x-api-key). That blocklist can never be right here: executor's whole job is
+// calling arbitrary upstream APIs whose credentials ride in provider-specific
+// headers (x-goog-api-key, api-key, x-auth-token, ...), and any name missing
+// from the list ships a live secret to the trace backend verbatim.
+//
+// So the override inverts the model: every header is redacted unless its name
+// is on the allowlist of structurally safe, diagnostically useful headers.
+// The alternative of enumerating known secret-bearing names was rejected: new
+// integrations add new credential headers faster than a blocklist can learn
+// them, and one miss is a leaked customer credential.
+// ---------------------------------------------------------------------------
+
+import { Layer } from "effect";
+import { Headers } from "effect/unstable/http";
+
+// Names that never carry credentials and are worth reading on a span while
+// debugging: negotiation, caching, routing, and the tracing headers
+// themselves. Everything else renders as `<redacted>`.
+const SAFE_HEADER_NAMES = [
+  "accept",
+  "accept-encoding",
+  "accept-language",
+  "age",
+  "cache-control",
+  "connection",
+  "content-encoding",
+  "content-length",
+  "content-type",
+  "date",
+  "etag",
+  "expires",
+  "host",
+  "if-modified-since",
+  "if-none-match",
+  "last-modified",
+  "location",
+  "mcp-protocol-version",
+  "mcp-session-id",
+  "origin",
+  "referer",
+  "retry-after",
+  "traceparent",
+  "tracestate",
+  "transfer-encoding",
+  "user-agent",
+  "vary",
+  "via",
+  "x-request-id",
+] as const;
+
+// `Headers.redact` lowercases stored names and, for a RegExp entry, redacts
+// every name the pattern matches. One negative lookahead turns the allowlist
+// into "redact everything else".
+const redactAllButSafe = new RegExp(`^(?!(?:${SAFE_HEADER_NAMES.join("|")})$)`);
+
+export const SpanHeaderRedactionLive: Layer.Layer<never> = Layer.succeed(
+  Headers.CurrentRedactedNames,
+  [redactAllButSafe],
+);

--- a/apps/cloud/src/observability/telemetry.ts
+++ b/apps/cloud/src/observability/telemetry.ts
@@ -45,6 +45,7 @@ import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from "@opentelemetry/semantic
 import { env } from "cloudflare:workers";
 import { Effect, Layer } from "effect";
 
+import { SpanHeaderRedactionLive } from "./header-redaction";
 import {
   CountingSpanExporter,
   CountingSpanProcessor,
@@ -124,15 +125,21 @@ export const flushTracerProvider = async (): Promise<void> => {
 };
 
 const makeTelemetryLive = (): Layer.Layer<never> =>
-  Layer.unwrap(
-    Effect.sync(() =>
-      ensureGlobalTracerProvider()
-        ? OtelTracer.layerGlobal.pipe(
-            Layer.provide(
-              Resource.layer({ serviceName: SERVICE_NAME, serviceVersion: SERVICE_VERSION }),
-            ),
-          )
-        : Layer.empty,
+  Layer.mergeAll(
+    // Redaction applies even when the exporter is not installed: Effect still
+    // builds spans (and their header attributes) in-memory, and any future
+    // consumer of those spans must never observe an unredacted credential.
+    SpanHeaderRedactionLive,
+    Layer.unwrap(
+      Effect.sync(() =>
+        ensureGlobalTracerProvider()
+          ? OtelTracer.layerGlobal.pipe(
+              Layer.provide(
+                Resource.layer({ serviceName: SERVICE_NAME, serviceVersion: SERVICE_VERSION }),
+              ),
+            )
+          : Layer.empty,
+      ),
     ),
   );
 

--- a/apps/cloud/src/server.ts
+++ b/apps/cloud/src/server.ts
@@ -172,11 +172,18 @@ const cloudflareHandler: ExportedHandler<Env> = {
             const response = await mcpAgentHandler(new Request(forwarded, { headers }), env, ctx);
             span.setAttribute(ATTR_HTTP_RESPONSE_STATUS_CODE, response.status);
             if (response.status >= 500) {
-              span.setStatus({ code: SpanStatusCode.ERROR });
+              span.setStatus({ code: SpanStatusCode.ERROR, message: `HTTP ${response.status}` });
             }
             return response;
           } catch (err) {
-            span.setStatus({ code: SpanStatusCode.ERROR });
+            // Record the exception itself, not just the status bit: without it
+            // these spans are ERROR with zero diagnostic content.
+            // oxlint-disable-next-line executor/no-instanceof-error, executor/no-unknown-error-message -- adapter boundary: Cloudflare's fetch callback throws untyped; normalized only for the OTel span record, the original error is rethrown below
+            const cause = err instanceof Error ? err : String(err);
+            span.recordException(cause);
+            // oxlint-disable-next-line executor/no-unknown-error-message -- adapter boundary: same normalization as the recordException line above
+            const message = typeof cause === "string" ? cause : cause.message;
+            span.setStatus({ code: SpanStatusCode.ERROR, message });
             // oxlint-disable-next-line executor/no-try-catch-or-throw -- adapter boundary; preserve original error to Cloudflare runtime
             throw err;
           } finally {
@@ -237,11 +244,18 @@ const cloudflareHandler: ExportedHandler<Env> = {
           const response = await fetchHandler(request, env, ctx);
           span.setAttribute(ATTR_HTTP_RESPONSE_STATUS_CODE, response.status);
           if (response.status >= 500) {
-            span.setStatus({ code: SpanStatusCode.ERROR });
+            span.setStatus({ code: SpanStatusCode.ERROR, message: `HTTP ${response.status}` });
           }
           return response;
         } catch (err) {
-          span.setStatus({ code: SpanStatusCode.ERROR });
+          // Record the exception itself, not just the status bit: without it
+          // these spans are ERROR with zero diagnostic content.
+          // oxlint-disable-next-line executor/no-instanceof-error, executor/no-unknown-error-message -- adapter boundary: Cloudflare's fetch callback throws untyped; normalized only for the OTel span record, the original error is rethrown below
+          const cause = err instanceof Error ? err : String(err);
+          span.recordException(cause);
+          // oxlint-disable-next-line executor/no-unknown-error-message -- adapter boundary: same normalization as the recordException line above
+          const message = typeof cause === "string" ? cause : cause.message;
+          span.setStatus({ code: SpanStatusCode.ERROR, message });
           // oxlint-disable-next-line executor/no-try-catch-or-throw -- adapter boundary; preserve original error to Cloudflare runtime
           throw err;
         } finally {

--- a/packages/core/api/src/server/execution-stack.ts
+++ b/packages/core/api/src/server/execution-stack.ts
@@ -124,13 +124,9 @@ export const makeExecutionStack = <
       organizationId,
       organizationName,
       { plugins: { mcpResource: options?.mcpResource } },
-    ).pipe(Effect.withSpan("executor.stack.scoped_executor"));
-    const codeExecutor = yield* CodeExecutorProvider.asEffect().pipe(
-      Effect.withSpan("executor.stack.code_executor"),
     );
-    const { decorate } = yield* EngineDecorator.asEffect().pipe(
-      Effect.withSpan("executor.stack.decorator"),
-    );
+    const codeExecutor = yield* CodeExecutorProvider.asEffect();
+    const { decorate } = yield* EngineDecorator.asEffect();
     const engine = yield* Effect.sync(() =>
       decorate(
         createExecutionEngine({ executor, codeExecutor }),
@@ -141,7 +137,7 @@ export const makeExecutionStack = <
         },
         { mcpResource: options?.mcpResource },
       ),
-    ).pipe(Effect.withSpan("executor.stack.engine.init"));
+    );
     return { executor, engine };
   }).pipe(Effect.withSpan("executor.stack.build"));
 

--- a/packages/core/api/src/server/scoped-executor.ts
+++ b/packages/core/api/src/server/scoped-executor.ts
@@ -221,13 +221,9 @@ export const makeScopedExecutor = <
   options?: { readonly plugins?: PluginsProviderContext },
 ): Effect.Effect<Executor<TPlugins>, StorageFailure, DbProvider | PluginsProvider | HostConfig> =>
   Effect.gen(function* () {
-    const { db, blobs } = yield* DbProvider.asEffect().pipe(
-      Effect.withSpan("executor.stack.db_provider"),
-    );
-    const { plugins: pluginsFactory } = yield* PluginsProvider.asEffect().pipe(
-      Effect.withSpan("executor.stack.plugins_provider"),
-    );
-    const config = yield* HostConfig.asEffect().pipe(Effect.withSpan("executor.stack.host_config"));
+    const { db, blobs } = yield* DbProvider.asEffect();
+    const { plugins: pluginsFactory } = yield* PluginsProvider.asEffect();
+    const config = yield* HostConfig.asEffect();
     // Explicit config wins; otherwise fall back to the request origin if a host
     // provided one (HTTP middleware / MCP session DO). Stays `undefined` for
     // non-request callers — `coreTools.webBaseUrl` is optional and only the
@@ -263,9 +259,7 @@ export const makeScopedExecutor = <
       oauthCallbackPath: config.oauthCallbackPath,
     });
 
-    const plugins = yield* Effect.sync(() => pluginsFactory(options?.plugins)).pipe(
-      Effect.withSpan("executor.plugins.init"),
-    );
+    const plugins = yield* Effect.sync(() => pluginsFactory(options?.plugins));
     const hostedHttpOptions = {
       allowLocalNetwork: config.allowLocalNetwork,
     };
@@ -292,7 +286,7 @@ export const makeScopedExecutor = <
         orgSlug,
         includeProviders: config.exposeCredentialProviders ?? true,
       },
-    }).pipe(Effect.withSpan("executor.stack.create_executor"));
+    });
     // Record the sighting. THIS is the seam every HTTP request and MCP session
     // on every host passes through, so it is where the `subject` table gets
     // populated: a principal earns a row the first time it authenticates,

--- a/packages/hosts/cloudflare/src/mcp/agent-session-durable-object.ts
+++ b/packages/hosts/cloudflare/src/mcp/agent-session-durable-object.ts
@@ -1,6 +1,6 @@
 import { DurableObject } from "cloudflare:workers";
 import { Cause, Data, Deferred, Effect, Option, Schema } from "effect";
-import type * as Tracer from "effect/Tracer";
+import * as Tracer from "effect/Tracer";
 import {
   createMcpHandler,
   DEFAULT_NEGOTIATED_PROTOCOL_VERSION,
@@ -39,6 +39,7 @@ import {
   type McpResource,
 } from "@executor-js/host-mcp";
 import {
+  parseTraceparentHeader,
   readArtifactsEnabled,
   readElicitationMode,
   verifiedMcpRequestHeaders,
@@ -301,6 +302,15 @@ export abstract class McpAgentSessionDOBase<
   private modernRunningRequestCount = 0;
   private modernRequestBodies = new WeakMap<Request, unknown>();
   private modernRequestPropagation = new WeakMap<Request, IncomingTraceHeaders | undefined>();
+  // Trace context of the most recently entered MCP request, kept for
+  // `currentParentSpan`. Deliberately not cleared when the request settles:
+  // deferred SDK callbacks fire after the response resolves, and parenting
+  // them under the latest request is right far more often than falling back
+  // to the session's construction-time span. Concurrent requests on one DO
+  // can mis-parent to each other's trace (last writer wins); threading a
+  // per-request context through the MCP SDK's callback surface is the
+  // rejected-for-now alternative.
+  private lastIncomingTrace: IncomingTraceHeaders | undefined;
   private legacyRunningRequestCount = 0;
   private activeLegacyStreamCount = 0;
   private keepAliveCount = 0;
@@ -369,8 +379,20 @@ export abstract class McpAgentSessionDOBase<
     return this.ctx.id.toString();
   }
 
+  // Parent for spans opened by deferred MCP SDK callbacks (tool handlers run
+  // through `runToolEffect`, which otherwise inherits the Effect context
+  // captured when the server was BUILT). The legacy sessionful runtime builds
+  // its server once per session and reuses it across every request, so
+  // without this the whole tool execution tree parents under the long-closed
+  // session-construction span instead of the request that triggered it.
   protected currentParentSpan(): Tracer.AnySpan | undefined {
-    return undefined;
+    const parsed = parseTraceparentHeader(this.lastIncomingTrace?.traceparent);
+    if (!parsed) return undefined;
+    return Tracer.externalSpan({
+      traceId: parsed.traceId,
+      spanId: parsed.spanId,
+      sampled: (parsed.traceFlags & 1) === 1,
+    });
   }
 
   protected sessionTimeoutMs(): number {
@@ -1201,6 +1223,11 @@ export abstract class McpAgentSessionDOBase<
         cors: false,
       });
     }
+    this.lastIncomingTrace = {
+      traceparent: request.headers.get("traceparent") ?? undefined,
+      tracestate: request.headers.get("tracestate") ?? undefined,
+      baggage: request.headers.get("baggage") ?? undefined,
+    };
     if ((await this.ctx.storage.get<boolean>(DESTROY_PENDING_KEY)) === true) {
       return jsonRpcErrorBody(404, -32001, "Session timed out, please reconnect", {
         cors: false,
@@ -1284,6 +1311,7 @@ export abstract class McpAgentSessionDOBase<
 
     this.modernRequestBodies.set(request, parsedBody);
     this.modernRequestPropagation.set(request, props.propagation);
+    this.lastIncomingTrace = props.propagation;
     this.modernRunningRequestCount += 1;
     // oxlint-disable-next-line executor/no-try-catch-or-throw -- adapter boundary: the RPC must decrement its in-memory running lease on both handler resolution and rejection
     try {

--- a/packages/hosts/cloudflare/src/mcp/do-headers.ts
+++ b/packages/hosts/cloudflare/src/mcp/do-headers.ts
@@ -52,6 +52,33 @@ export type IncomingPropagationHeaders = {
   readonly baggage?: string;
 };
 
+// W3C traceparent grammar, owned here beside the producer that stamps the
+// header (`currentPropagationHeaders`) so producer and consumers cannot
+// drift. The worker edge's richer parser (apps/cloud, which also carries
+// tracestate into the OTel API) delegates its grammar to this one.
+const TRACEPARENT_PATTERN = /^([0-9a-f]{2})-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})$/;
+
+export type ParsedTraceparent = {
+  readonly traceId: string;
+  readonly spanId: string;
+  readonly traceFlags: number;
+};
+
+export const parseTraceparentHeader = (
+  traceparent: string | null | undefined,
+): ParsedTraceparent | null => {
+  if (!traceparent) return null;
+  const match = TRACEPARENT_PATTERN.exec(traceparent);
+  if (!match) return null;
+  // SAFETY: the pattern has exactly four capture groups, so a match always
+  // fills indices 1-4.
+  return {
+    traceId: match[2]!,
+    spanId: match[3]!,
+    traceFlags: parseInt(match[4]!, 16),
+  };
+};
+
 // `currentParentSpan`, not `currentSpan`: the worker's MCP handler joins the
 // edge `http.server` span via `OtelTracer.withSpanContext`, which provides an
 // ExternalSpan as the fiber's ParentSpan without opening an Effect-local span.

--- a/packages/hosts/mcp/src/tool-server-core.ts
+++ b/packages/hosts/mcp/src/tool-server-core.ts
@@ -1105,9 +1105,7 @@ export const buildExecutorMcpTools = <
         ),
       );
 
-    const assembly = yield* Effect.sync(createAssembly).pipe(
-      Effect.withSpan("mcp.host.create_server"),
-    );
+    const assembly = yield* Effect.sync(createAssembly);
     const server = assembly.server;
 
     const executeWithNativeElicitation = (
@@ -1433,10 +1431,6 @@ export const buildExecutorMcpTools = <
         },
         ({ code }, extra) => runToolEffect(executeCode(code, extra)),
       ),
-    ).pipe(
-      Effect.withSpan("mcp.host.register_tool", {
-        attributes: { "mcp.tool.name": "execute" },
-      }),
     );
 
     yield* Effect.sync(() =>
@@ -1458,10 +1452,6 @@ export const buildExecutorMcpTools = <
         ({ name }) =>
           runToolEffect(Effect.succeed(skillsResult(name, executeInventory, skillCatalog))),
       ),
-    ).pipe(
-      Effect.withSpan("mcp.host.register_tool", {
-        attributes: { "mcp.tool.name": "skills" },
-      }),
     );
 
     yield* Effect.sync(() => {
@@ -1509,11 +1499,7 @@ export const buildExecutorMcpTools = <
         },
         ({ executionId }, extra) => runToolEffect(resumeAfterBrowserApproval(executionId, extra)),
       );
-    }).pipe(
-      Effect.withSpan("mcp.host.register_tool", {
-        attributes: { "mcp.tool.name": "resume" },
-      }),
-    );
+    });
 
     // --- artifacts / MCP Apps ---
     //
@@ -1892,11 +1878,7 @@ export const buildExecutorMcpTools = <
             ],
           }),
         );
-      }).pipe(
-        Effect.withSpan("mcp.host.register_resource", {
-          attributes: { "mcp.resource.uri": MCP_APPS_SHELL_RESOURCE_URI },
-        }),
-      );
+      });
 
       yield* Effect.sync(() =>
         assembly.registerAppTool(
@@ -1952,10 +1934,6 @@ export const buildExecutorMcpTools = <
           ({ code, title, description, connections, artifactId }) =>
             runToolEffect(createArtifact({ code, title, description, connections, artifactId })),
         ),
-      ).pipe(
-        Effect.withSpan("mcp.host.register_tool", {
-          attributes: { "mcp.tool.name": "create-artifact" },
-        }),
       );
 
       yield* Effect.sync(() =>
@@ -2017,10 +1995,6 @@ export const buildExecutorMcpTools = <
           ({ artifactId, edits, connections, title, description }) =>
             runToolEffect(editArtifact({ artifactId, edits, connections, title, description })),
         ),
-      ).pipe(
-        Effect.withSpan("mcp.host.register_tool", {
-          attributes: { "mcp.tool.name": "edit-artifact" },
-        }),
       );
 
       yield* Effect.sync(() =>
@@ -2035,10 +2009,6 @@ export const buildExecutorMcpTools = <
           },
           () => runToolEffect(listArtifacts()),
         ),
-      ).pipe(
-        Effect.withSpan("mcp.host.register_tool", {
-          attributes: { "mcp.tool.name": "list-artifacts" },
-        }),
       );
 
       yield* Effect.sync(() =>
@@ -2059,10 +2029,6 @@ export const buildExecutorMcpTools = <
           },
           ({ id }) => runToolEffect(showArtifact(id)),
         ),
-      ).pipe(
-        Effect.withSpan("mcp.host.register_tool", {
-          attributes: { "mcp.tool.name": "show-artifact" },
-        }),
       );
 
       yield* Effect.sync(() => {
@@ -2113,11 +2079,7 @@ export const buildExecutorMcpTools = <
               resumeExecution(executionId, action, parseJsonContent(rawContent), extra),
             ),
         );
-      }).pipe(
-        Effect.withSpan("mcp.host.register_tool", {
-          attributes: { "mcp.tool.name": "execute-action" },
-        }),
-      );
+      });
     }
 
     // Client capabilities only exist after `initialize`, and `tools/list` is


### PR DESCRIPTION
Trace-quality fixes driven by an audit of a week of executor-cloud data in Axiom.

- **Redact all non-allowlisted headers on spans.** The HTTP client tracer records every header, masking only a four-name default blocklist; upstream integrations carry credentials in provider-specific headers, so anything outside that list shipped verbatim to the trace backend. Redaction is now allowlist-inverted (safe negotiation/caching/tracing headers stay readable, everything else renders `<redacted>`), provided with both telemetry layers.
- **Parent DO tool spans under the live request.** `currentParentSpan()` was an unimplemented stub, so every tool execution in a legacy session parented under the long-closed session-construction span (`mcp.host.tool.execute` under a 0ms `mcp.host.create_executor_server`, up to 42 minutes stale). The DO now tracks the most recent request's traceparent and resolves it to an external parent span.
- **Drop zero-duration span noise.** `mcp.host.register_tool` / `register_resource` / `create_server`, `mcp.request.annotate`, the `executor.stack.*` sub-spans, and the `WorkOSClient` layer-construction span wrapped synchronous work: roughly a fifth of weekly span ingest at exactly 0ms with zero recorded errors. `mcp.request` keeps the fingerprint attributes the annotate wrapper was duplicating onto itself; `executor.stack.build` remains as the umbrella.
- **Name workos and user_store spans by operation.** The two highest-volume span names were bare `workos` / `user_store` wrappers with no attributes (5.3M spans/week, indistinguishable). `use()` now takes the operation, so spans read `workos.userManagement.getUser` / `user_store.getOrganization`.
- **Record exceptions on worker http.server error spans.** The worker-boundary catch set ERROR with no message and no exception event; 75% of `http.server GET` ERROR spans had zero diagnostic content.

Verification: `format:check`, `lint`, `typecheck` green; tests green for `hosts/cloudflare`, `hosts/mcp`, `core/api`; `apps/cloud` green except `org-api-key-revoke.node.test.ts` (3 failures, reproduced on main before this branch). After deploy, the audit queries can be re-run to confirm: no unredacted credential headers on new `http.client` spans, `mcp.host.tool.execute` parented inside its request trace, and span ingest down roughly 20%.

Known issues out of scope here: the `cf-workers-logs` logpush dataset has been empty since early July (no crash/OOM cross-check), previously recorded header values remain in the trace backend until retention or manual purge, `http.route` is templated on only ~10% of http.server spans, and the workerd/deno subprocess runtimes have no code-execution spans.