### PR TITLE
Sign out browsers whose session has already ended

### DIFF
--- a/apps/cloud/src/auth/api.ts
+++ b/apps/cloud/src/auth/api.ts
@@ -181,6 +181,15 @@ const McpApprovalErrors = [
 /** Public auth endpoints — no authentication required */
 export class CloudAuthPublicApi extends HttpApiGroup.make("cloudAuthPublic")
   .add(HttpApiEndpoint.get("login", "/auth/login", { query: AuthLoginSearch }))
+  // Sign-out is PUBLIC on purpose. The console posts it as a top-level form
+  // navigation (the WorkOS hop is cross-origin, so it can't be a fetch), which
+  // means an error response is rendered as the page — and a browser whose
+  // session has already ended is exactly the browser most likely to click it
+  // (a second tab, a re-submit from history, an expired or revoked session).
+  // Behind SessionAuth all of those got a raw `{"_tag":"Unauthorized"}` screen
+  // instead of being signed out. There is nothing to authorize here anyway:
+  // the request can only end the session whose cookie it presents.
+  .add(HttpApiEndpoint.post("logout", "/auth/logout"))
   .add(
     HttpApiEndpoint.get("callback", "/auth/callback", {
       query: AuthCallbackSearch,
@@ -201,7 +210,6 @@ export class CloudAuthApi extends HttpApiGroup.make("cloudAuth")
       error: AuthErrors,
     }),
   )
-  .add(HttpApiEndpoint.post("logout", "/auth/logout"))
   .add(
     HttpApiEndpoint.get("organizations", "/auth/organizations", {
       success: AuthOrganizationsResponse,

--- a/apps/cloud/src/auth/handlers.ts
+++ b/apps/cloud/src/auth/handlers.ts
@@ -144,8 +144,8 @@ const deleteResponseCookie = (response: HttpServerResponse.HttpServerResponse, n
   HttpServerResponse.setCookieUnsafe(response, name, "", DELETE_COOKIE_OPTIONS);
 
 // ---------------------------------------------------------------------------
-// Single non-protected API surface — public (login/callback) + session
-// (me/logout/organizations/switch-organization). The session group has SessionAuth on it.
+// Single non-protected API surface — public (login/callback/logout) + session
+// (me/organizations/switch-organization). The session group has SessionAuth on it.
 // ---------------------------------------------------------------------------
 
 export const NonProtectedApi = HttpApi.make("cloudWeb").add(CloudAuthPublicApi).add(CloudAuthApi);
@@ -274,6 +274,42 @@ export const CloudAuthPublicHandlers = HttpApiBuilder.group(
           );
         }),
       )
+      .handleRaw("logout", ({ request }) =>
+        Effect.gen(function* () {
+          const workos = yield* WorkOSClient;
+          // The session this browser presents, NOT one the middleware vouched
+          // for — signing out of a session that has already ended must still
+          // sign the browser out (see the group declaration in ./api.ts).
+          const sealedSession = request.cookies["wos-session"] ?? "";
+
+          // WorkOS's documented sign-out: send the browser through the WorkOS
+          // logout endpoint, which ends the AuthKit session upstream and then
+          // redirects to the registered sign-out URL. Without this hop, the
+          // hosted session survives and the next "Sign in" silently
+          // re-authenticates (issue #1445). Fail-open when the cookie won't
+          // unseal — there is then nothing to end upstream, and local sign-out
+          // must still complete, so fall back to "/".
+          const origin = env.VITE_PUBLIC_SITE_URL ?? "";
+          const logoutUrl = sealedSession
+            ? yield* workos.logoutUrl(sealedSession, origin ? `${origin}/` : undefined)
+            : null;
+
+          const response = HttpServerResponse.redirect(logoutUrl ?? "/", { status: 302 });
+
+          // Drop only what this browser actually presented. Both cookies are
+          // SameSite=Lax, so a cross-site form POST carries neither — it gets
+          // the bare redirect and cannot be used to sign anyone out.
+          if (!sealedSession && request.cookies[AUTH_HINT_COOKIE] === undefined) return response;
+
+          // The auth-hint travels with the session: leaving it behind would
+          // make the next page load optimistically paint the app shell for a
+          // signed-out browser.
+          return deleteResponseCookie(
+            deleteResponseCookie(response, "wos-session"),
+            AUTH_HINT_COOKIE,
+          );
+        }),
+      )
       // CLI device-login discovery. The WorkOS device endpoints live on the
       // WorkOS API host (`WORKOS_API_URL`, or api.workos.com in production,
       // the SAME base the SDK uses, so e2e points the CLI at the emulator with
@@ -317,35 +353,6 @@ export const CloudSessionAuthHandlers = HttpApiBuilder.group(
             },
             organization: org ? { id: org.id, name: org.name, slug: org.slug } : null,
           };
-        }),
-      )
-      .handleRaw("logout", () =>
-        Effect.gen(function* () {
-          const workos = yield* WorkOSClient;
-          const session = yield* SessionContext;
-
-          // WorkOS's documented sign-out: send the browser through the WorkOS
-          // logout endpoint, which ends the AuthKit session upstream and then
-          // redirects to the registered sign-out URL. Without this hop, the
-          // hosted session survives and the next "Sign in" silently
-          // re-authenticates (issue #1445). Fail-open when the cookie won't
-          // unseal: local sign-out must still complete, so fall back to "/".
-          const origin = env.VITE_PUBLIC_SITE_URL ?? "";
-          const logoutUrl = yield* workos.logoutUrl(
-            session.sealedSession,
-            origin ? `${origin}/` : undefined,
-          );
-
-          // The auth-hint travels with the session: leaving it behind would
-          // make the next page load optimistically paint the app shell for a
-          // signed-out browser.
-          return deleteResponseCookie(
-            deleteResponseCookie(
-              HttpServerResponse.redirect(logoutUrl ?? "/", { status: 302 }),
-              "wos-session",
-            ),
-            AUTH_HINT_COOKIE,
-          );
         }),
       )
       .handle("organizations", () =>

--- a/e2e/cloud/logout-stale-session.test.ts
+++ b/e2e/cloud/logout-stale-session.test.ts
@@ -1,0 +1,148 @@
+// Cloud-only: signing out must ALWAYS sign the browser out. The shell's
+// sign-out is a top-level form POST (the WorkOS hop is cross-origin, so it
+// can't be a fetch), which means whatever `/api/auth/logout` answers is
+// rendered AS THE PAGE. An error response is therefore not a silent failure —
+// it is a screenful of raw API JSON where the homepage should be. Reported
+// from the field as `{"_tag":"Unauthorized"}`.
+//
+// The endpoint sits behind SessionAuth, so a browser whose sealed session no
+// longer authenticates AT THE MOMENT OF THE CLICK gets the middleware's 401
+// instead of being signed out. Reaching that state needs nothing exotic: a
+// second open tab does it (sign out in one, the other's shell is still painted
+// but its cookie is gone), and an expired or upstream-revoked session lands on
+// the same branch. Signing out of a session that is already over is the one
+// request that must never fail — the user is asking for the state they are
+// already in.
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import type { Page } from "playwright";
+
+import { scenario } from "../src/scenario";
+import { Api, Browser, Target } from "../src/services";
+
+/** First `Set-Cookie` header for `name`, as the raw header string. */
+const setCookieFor = (response: Response, name: string): string => {
+  for (const header of response.headers.getSetCookie()) {
+    if (header.startsWith(`${name}=`)) return header;
+  }
+  return "";
+};
+
+// Open the account dropdown and sign out. Bounded retry: a click can land
+// while the shell is still hydrating and the radix menu never opens (same
+// idiom as auth-hint / org-switcher).
+const clickSignOut = async (page: Page) => {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      await page.keyboard.press("Escape");
+      await page.getByRole("button", { name: /Test User/ }).click();
+      await page.getByRole("menuitem", { name: "Sign out" }).click({ timeout: 5_000 });
+      return;
+    } catch (error) {
+      if (attempt >= 3) throw error;
+    }
+  }
+};
+
+scenario(
+  "Sign-out · a browser whose session is already over is signed out, not handed an API error page",
+  {},
+  Effect.gen(function* () {
+    // Gate: the REST API plane is mounted on this target.
+    yield* Api;
+    const target = yield* Target;
+
+    // Two ways a real browser arrives here holding no live session: it never
+    // had one (the cookie was cleared, or sign-out is re-submitted from
+    // history), and it holds one that no longer authenticates (expired, or
+    // revoked upstream). Both POST the same form the shell posts.
+    const signOut = (cookie?: string) =>
+      Effect.promise(() =>
+        fetch(new URL("/api/auth/logout", target.baseUrl), {
+          method: "POST",
+          redirect: "manual",
+          ...(cookie ? { headers: { cookie } } : {}),
+        }),
+      );
+
+    for (const [label, cookie] of [
+      ["no session cookie at all", undefined],
+      ["a session cookie that no longer authenticates", "wos-session=stale-sealed-session"],
+    ] as const) {
+      const response = yield* signOut(cookie);
+      const body = yield* Effect.promise(() => response.text());
+
+      // The response IS the page the user reads. This is the reported symptom.
+      expect(body, `sign-out with ${label} never renders an API error envelope`).not.toContain(
+        "_tag",
+      );
+      expect(response.status, `sign-out with ${label} sends the browser onward`).toBe(302);
+      expect(
+        new URL(response.headers.get("location") ?? "", target.baseUrl).pathname,
+        `sign-out with ${label} lands the browser home`,
+      ).toBe("/");
+      // Nothing to end upstream without a session, but the browser must still
+      // leave with its cookies dropped — a stale session cookie left in place
+      // keeps routing / into the app instead of marketing.
+      expect(
+        setCookieFor(response, "wos-session"),
+        `sign-out with ${label} still clears the session cookie`,
+      ).toContain("Max-Age=0");
+    }
+  }),
+);
+
+scenario(
+  "Sign-out · a second open tab signs out too instead of showing raw JSON",
+  {},
+  Effect.gen(function* () {
+    const browser = yield* Browser;
+    const target = yield* Target;
+    const identity = yield* target.newIdentity();
+
+    // `page` is the tab the user is LOOKING at when it breaks — the run's
+    // video and screenshots follow it, so the artifacts show the reported
+    // symptom rather than the tab that already signed out cleanly.
+    yield* browser.session(identity, async ({ page, step }) => {
+      const otherTab = await page.context().newPage();
+
+      await step("The user has the app open in two tabs", async () => {
+        await page.goto("/", { waitUntil: "commit" });
+        await page.getByRole("link", { name: "Policies" }).waitFor();
+        await otherTab.goto("/", { waitUntil: "commit" });
+        await otherTab.getByRole("link", { name: "Policies" }).waitFor();
+      });
+
+      await step("Sign out in the other tab", async () => {
+        await clickSignOut(otherTab);
+        await otherTab.waitForURL((url) => url.pathname === "/" || url.pathname === "/login", {
+          timeout: 15_000,
+        });
+      });
+
+      // This tab was never told: its shell is still painted, and its sign-out
+      // button still works the only way it knows how.
+      const before = page.url();
+      await step("Sign out in this tab, which still shows the app", async () => {
+        await clickSignOut(page);
+        await page.waitForURL((url) => url.toString() !== before, {
+          timeout: 15_000,
+        });
+        await page.waitForLoadState("networkidle");
+      });
+
+      const shown = (await page.locator("body").innerText()).trim();
+      expect(shown, "sign-out never renders the API's error envelope as a page").not.toContain(
+        "_tag",
+      );
+      expect(
+        new URL(page.url()).pathname,
+        "this tab lands on a signed-out page like the other one",
+      ).toMatch(/^\/(login)?$/);
+      expect(
+        (await page.context().cookies()).map((cookie) => cookie.name),
+        "the browser is left with no session either way",
+      ).not.toContain("wos-session");
+    });
+  }),
+);

--- a/e2e/cloud/logout-stale-session.test.ts
+++ b/e2e/cloud/logout-stale-session.test.ts
@@ -5,20 +5,23 @@
 // it is a screenful of raw API JSON where the homepage should be. Reported
 // from the field as `{"_tag":"Unauthorized"}`.
 //
-// The endpoint sits behind SessionAuth, so a browser whose sealed session no
-// longer authenticates AT THE MOMENT OF THE CLICK gets the middleware's 401
-// instead of being signed out. Reaching that state needs nothing exotic: a
-// second open tab does it (sign out in one, the other's shell is still painted
-// but its cookie is gone), and an expired or upstream-revoked session lands on
-// the same branch. Signing out of a session that is already over is the one
-// request that must never fail — the user is asking for the state they are
-// already in.
+// The endpoint used to sit behind SessionAuth, so a browser whose sealed
+// session no longer authenticated AT THE MOMENT OF THE CLICK got the
+// middleware's 401 instead of being signed out. Reaching that state needs
+// nothing exotic: a second open tab does it (sign out in one, the other's
+// shell is still painted but its cookie is gone), and an expired or
+// upstream-revoked session lands on the same branch. Signing out of a session
+// that is already over is the one request that must never fail — the user is
+// asking for the state they are already in.
 import { expect } from "@effect/vitest";
 import { Effect } from "effect";
 import type { Page } from "playwright";
 
 import { scenario } from "../src/scenario";
 import { Api, Browser, Target } from "../src/services";
+
+/** The display-only identity cookie the SSR gate mints (non-HttpOnly). */
+const HINT_COOKIE = "executor-auth-hint";
 
 /** First `Set-Cookie` header for `name`, as the raw header string. */
 const setCookieFor = (response: Response, name: string): string => {
@@ -52,10 +55,6 @@ scenario(
     yield* Api;
     const target = yield* Target;
 
-    // Two ways a real browser arrives here holding no live session: it never
-    // had one (the cookie was cleared, or sign-out is re-submitted from
-    // history), and it holds one that no longer authenticates (expired, or
-    // revoked upstream). Both POST the same form the shell posts.
     const signOut = (cookie?: string) =>
       Effect.promise(() =>
         fetch(new URL("/api/auth/logout", target.baseUrl), {
@@ -65,30 +64,48 @@ scenario(
         }),
       );
 
-    for (const [label, cookie] of [
-      ["no session cookie at all", undefined],
-      ["a session cookie that no longer authenticates", "wos-session=stale-sealed-session"],
-    ] as const) {
-      const response = yield* signOut(cookie);
-      const body = yield* Effect.promise(() => response.text());
+    // A session cookie that no longer authenticates — expired, or revoked
+    // upstream while the tab sat open. There is nothing to end at WorkOS, but
+    // this browser must still leave signed out: a stale session cookie left in
+    // place keeps routing / into the app instead of marketing.
+    const stale = yield* signOut("wos-session=stale-sealed-session");
+    const staleBody = yield* Effect.promise(() => stale.text());
 
-      // The response IS the page the user reads. This is the reported symptom.
-      expect(body, `sign-out with ${label} never renders an API error envelope`).not.toContain(
-        "_tag",
-      );
-      expect(response.status, `sign-out with ${label} sends the browser onward`).toBe(302);
-      expect(
-        new URL(response.headers.get("location") ?? "", target.baseUrl).pathname,
-        `sign-out with ${label} lands the browser home`,
-      ).toBe("/");
-      // Nothing to end upstream without a session, but the browser must still
-      // leave with its cookies dropped — a stale session cookie left in place
-      // keeps routing / into the app instead of marketing.
-      expect(
-        setCookieFor(response, "wos-session"),
-        `sign-out with ${label} still clears the session cookie`,
-      ).toContain("Max-Age=0");
-    }
+    // The response IS the page the user reads. This is the reported symptom.
+    expect(staleBody, "sign-out never renders an API error envelope").not.toContain("_tag");
+    expect(stale.status, "sign-out sends the browser onward").toBe(302);
+    expect(
+      new URL(stale.headers.get("location") ?? "", target.baseUrl).pathname,
+      "sign-out lands the browser home",
+    ).toBe("/");
+    expect(setCookieFor(stale, "wos-session"), "the dead session cookie is dropped").toContain(
+      "Max-Age=0",
+    );
+    expect(
+      setCookieFor(stale, HINT_COOKIE),
+      "the auth hint never outlives the session it describes",
+    ).toContain("Max-Age=0");
+
+    // A POST carrying no cookies at all is what a CROSS-SITE form reaching
+    // this endpoint looks like: both cookies are SameSite=Lax, so another
+    // origin's POST arrives bare. Signing out is public, so it must answer
+    // such a request without touching this browser's session — otherwise any
+    // site could sign our users out.
+    const bare = yield* signOut();
+    const bareBody = yield* Effect.promise(() => bare.text());
+
+    expect(bareBody, "a session-less sign-out renders no error envelope either").not.toContain(
+      "_tag",
+    );
+    expect(bare.status, "it is sent home like any other sign-out").toBe(302);
+    expect(
+      new URL(bare.headers.get("location") ?? "", target.baseUrl).pathname,
+      "it lands home",
+    ).toBe("/");
+    expect(
+      bare.headers.getSetCookie(),
+      "a request that presented no session cannot expire anyone else's",
+    ).toEqual([]);
   }),
 );
 


### PR DESCRIPTION
Signing out could answer with a raw `{"_tag":"Unauthorized"}` page instead of signing the browser out. Reported from the field.

## Cause

`logout` was declared on `CloudAuthApi`, which carries `.middleware(SessionAuth)`. A browser whose sealed session no longer authenticated at click time got the middleware's 401 before the handler ran. The console posts sign-out as a top-level form navigation (the WorkOS hop is cross-origin, so it can't be a fetch), so that error body was rendered as the page.

Nothing exotic is needed to reach it: a second open tab, a re-submit from history, or a session that expired or was revoked upstream while the tab sat open.

## Change

Move the endpoint to `CloudAuthPublicApi` and read the sealed session off the request cookie. There is nothing to authorize — the request can only end the session whose cookie it presents — and the handler already fell back to `/` when the cookie wouldn't unseal.

Cookies are dropped only when the request actually presented one. Both are `SameSite=Lax`, so a cross-site form POST arrives bare, gets the redirect, and cannot be used to sign a user out.

Self-host is unaffected; it signs out through Better Auth.

## Tests

`e2e/cloud/logout-stale-session.test.ts` — both scenarios fail on `main` with the reported body and pass here:

- wire level: a stale session cookie is dropped and the browser is sent home; a cookie-less POST expires nothing
- browser: two tabs open, sign out in one, then the other lands on the sign-in page instead of raw JSON

`vitest run --project cloud cloud/logout-stale-session.test.ts cloud/auth-session.test.ts cloud/auth-hint.test.ts` — 8 passed, including the existing "logout ends the AuthKit session upstream" and "logout clears the hint with the session" contracts. `typecheck` clean; `vitest run src/auth` in apps/cloud 73 passed.