### PR TITLE
Pin worker logpush in wrangler config

### DIFF
--- a/apps/cloud/wrangler.jsonc
+++ b/apps/cloud/wrangler.jsonc
@@ -21,6 +21,12 @@
   "observability": {
     "enabled": true,
   },
+  // Script-level logpush feeds the account's workers_trace_events Logpush job
+  // (invocation logs, outcomes like exceededMemory, console output) into
+  // Axiom. Pinned here because the setting lives on the script: a deploy that
+  // omits it can reset it to false, which is how the export silently died in
+  // the July deploy-tooling migration.
+  "logpush": true,
   "durable_objects": {
     "bindings": [
       {


### PR DESCRIPTION
The account-level Logpush job (workers_trace_events to Axiom) has been idle since July 4: the deploy-tooling migration recreated the executor-cloud script without the script-level logpush flag, so Cloudflare stopped producing trace events while the job itself stayed enabled with no error. The flag is re-enabled via API as of today; this pins it in wrangler.jsonc so a future deploy cannot silently reset it again.