### PR TITLE
Bind span header redaction to the hosted HTTP client

### DIFF
--- a/.changeset/hosted-client-span-header-redaction.md
+++ b/.changeset/hosted-client-span-header-redaction.md
@@ -1,0 +1,5 @@
+---
+"@executor-js/sdk": patch
+---
+
+Redact every span header attribute outside a safe allowlist on the hosted HTTP client. The tracer's default four-name blocklist let provider-specific credential headers reach the trace backend verbatim; the hosted client now inverts the model and masks everything except structurally safe negotiation, caching, and tracing headers.

--- a/apps/cloud/src/observability/header-redaction.ts
+++ b/apps/cloud/src/observability/header-redaction.ts
@@ -1,65 +1,19 @@
 // ---------------------------------------------------------------------------
-// Span header redaction.
-//
-// Effect's HttpClient/HttpServer tracer records every request and response
-// header as a span attribute, masking only the names in
-// `Headers.CurrentRedactedNames` (default: authorization, cookie, set-cookie,
-// x-api-key). That blocklist can never be right here: executor's whole job is
-// calling arbitrary upstream APIs whose credentials ride in provider-specific
-// headers (x-goog-api-key, api-key, x-auth-token, ...), and any name missing
-// from the list ships a live secret to the trace backend verbatim.
-//
-// So the override inverts the model: every header is redacted unless its name
-// is on the allowlist of structurally safe, diagnostically useful headers.
-// The alternative of enumerating known secret-bearing names was rejected: new
-// integrations add new credential headers faster than a blocklist can learn
-// them, and one miss is a leaked customer credential.
+// Span header redaction for fibers composed under the cloud telemetry layers
+// (the Effect HTTP server tracer and any request-scoped client use). The
+// allowlist itself lives beside the hosted HTTP client in
+// `@executor-js/sdk/host-internal`, which also binds it directly to that
+// client: consumers capture the client value at construction, so a context
+// layer alone cannot reach their request fibers. This layer is the
+// server-side/defense-in-depth half of the same decision; see
+// hosted-http-client.ts for the rationale and the allowlist.
 // ---------------------------------------------------------------------------
 
 import { Layer } from "effect";
 import { Headers } from "effect/unstable/http";
-
-// Names that never carry credentials and are worth reading on a span while
-// debugging: negotiation, caching, routing, and the tracing headers
-// themselves. Everything else renders as `<redacted>`.
-const SAFE_HEADER_NAMES = [
-  "accept",
-  "accept-encoding",
-  "accept-language",
-  "age",
-  "cache-control",
-  "connection",
-  "content-encoding",
-  "content-length",
-  "content-type",
-  "date",
-  "etag",
-  "expires",
-  "host",
-  "if-modified-since",
-  "if-none-match",
-  "last-modified",
-  "location",
-  "mcp-protocol-version",
-  "mcp-session-id",
-  "origin",
-  "referer",
-  "retry-after",
-  "traceparent",
-  "tracestate",
-  "transfer-encoding",
-  "user-agent",
-  "vary",
-  "via",
-  "x-request-id",
-] as const;
-
-// Header names are lowercased at `Headers` construction, and `Headers.redact`
-// masks every name a RegExp entry matches. One negative lookahead turns the
-// allowlist into "redact everything else".
-const redactAllButSafe = new RegExp(`^(?!(?:${SAFE_HEADER_NAMES.join("|")})$)`);
+import { spanRedactedHeaderNames } from "@executor-js/sdk/host-internal";
 
 export const SpanHeaderRedactionLive: Layer.Layer<never> = Layer.succeed(
   Headers.CurrentRedactedNames,
-  [redactAllButSafe],
+  spanRedactedHeaderNames,
 );

--- a/packages/core/sdk/src/host-internal.ts
+++ b/packages/core/sdk/src/host-internal.ts
@@ -33,6 +33,7 @@ export {
   HostedOutboundRequestBlocked,
   makeHostedFetch,
   makeHostedHttpClientLayer,
+  spanRedactedHeaderNames,
   type HostedHttpClientOptions,
 } from "./hosted-http-client";
 

--- a/packages/core/sdk/src/hosted-http-client.test.ts
+++ b/packages/core/sdk/src/hosted-http-client.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "@effect/vitest";
 import { Effect, Predicate, Result } from "effect";
+import type * as Tracer from "effect/Tracer";
 import { HttpClient, HttpClientRequest } from "effect/unstable/http";
 
 import {
@@ -264,6 +265,73 @@ describe("hosted outbound HTTP client", () => {
 
       expect(Result.isFailure(result)).toBe(true);
       expect(calls).toBe(1);
+    }),
+  );
+
+  it.effect("redacts every span header attribute outside the safe allowlist", () =>
+    Effect.gen(function* () {
+      const spanAttributes = new Map<string, unknown>();
+      const recordingTracer: Tracer.Tracer = {
+        span: (options) => {
+          let status: Tracer.SpanStatus = { _tag: "Started", startTime: options.startTime };
+          return {
+            _tag: "Span",
+            name: options.name,
+            spanId: "0000000000000001",
+            traceId: "00000000000000000000000000000001",
+            parent: options.parent,
+            annotations: options.annotations,
+            get status() {
+              return status;
+            },
+            attributes: spanAttributes,
+            links: options.links,
+            sampled: options.sampled,
+            kind: options.kind,
+            end: (endTime, exit) => {
+              status = { _tag: "Ended", startTime: options.startTime, endTime, exit };
+            },
+            attribute: (key, value) => {
+              spanAttributes.set(key, value);
+            },
+            event: () => undefined,
+            addLinks: () => undefined,
+          };
+        },
+      };
+
+      const fakeFetch: typeof globalThis.fetch = (async () =>
+        new Response("{}", {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+            "cf-ray": "a2ca5b47bb7f3550",
+          },
+        })) as typeof globalThis.fetch;
+
+      yield* Effect.gen(function* () {
+        const client = yield* HttpClient.HttpClient;
+        return yield* client.execute(
+          HttpClientRequest.get("https://api.example/data").pipe(
+            HttpClientRequest.setHeaders({
+              accept: "application/json",
+              "x-goog-api-key": "live-credential",
+            }),
+          ),
+        );
+      }).pipe(
+        Effect.provide(
+          makeHostedHttpClientLayer({ fetch: fakeFetch, resolveHostname: publicResolver }),
+        ),
+        Effect.withTracer(recordingTracer),
+      );
+
+      expect(String(spanAttributes.get("http.request.header.accept"))).toBe("application/json");
+      expect(String(spanAttributes.get("http.request.header.x-goog-api-key"))).toBe("<redacted>");
+      expect(String(spanAttributes.get("http.response.header.content-type"))).toBe(
+        "application/json",
+      );
+      expect(String(spanAttributes.get("http.response.header.cf-ray"))).toBe("<redacted>");
     }),
   );
 });

--- a/packages/core/sdk/src/hosted-http-client.ts
+++ b/packages/core/sdk/src/hosted-http-client.ts
@@ -1,5 +1,5 @@
 import { Effect, Layer, Schema } from "effect";
-import { FetchHttpClient, HttpClient } from "effect/unstable/http";
+import { FetchHttpClient, Headers as HttpHeaders, HttpClient } from "effect/unstable/http";
 
 export class HostedOutboundRequestBlocked extends Schema.TaggedErrorClass<HostedOutboundRequestBlocked>()(
   "HostedOutboundRequestBlocked",
@@ -250,10 +250,79 @@ export const makeHostedFetch = (options: HostedHttpClientOptions = {}): typeof g
   // oxlint-disable-next-line executor/no-raw-fetch -- boundary: exposes a guarded Fetch API adapter for libraries that require fetch
   guardFetch(options.fetch ?? globalThis.fetch, options);
 
+// ---------------------------------------------------------------------------
+// Span header redaction.
+//
+// The HttpClient tracer records every request and response header as a span
+// attribute, masking only the names in `Headers.CurrentRedactedNames`
+// (default: authorization, cookie, set-cookie, x-api-key). That blocklist can
+// never be right for a hosted client whose whole job is calling arbitrary
+// upstream APIs: credentials ride in provider-specific headers
+// (x-goog-api-key, api-key, x-auth-token, ...), and any name missing from the
+// list ships a live secret to the trace backend verbatim. So the model is
+// inverted: every header is redacted unless its name is on the allowlist of
+// structurally safe, diagnostically useful headers. Enumerating known
+// secret-bearing names was rejected: new integrations add credential headers
+// faster than a blocklist can learn them, and one miss is a leaked customer
+// credential.
+//
+// Bound to the client itself (not a host telemetry layer): consumers capture
+// the client value at construction and execute requests on fibers whose
+// context a host layer never sees, so the reference must travel with every
+// request effect.
+// ---------------------------------------------------------------------------
+
+const SPAN_SAFE_HEADER_NAMES = [
+  "accept",
+  "accept-encoding",
+  "accept-language",
+  "age",
+  "cache-control",
+  "connection",
+  "content-encoding",
+  "content-length",
+  "content-type",
+  "date",
+  "etag",
+  "expires",
+  "host",
+  "if-modified-since",
+  "if-none-match",
+  "last-modified",
+  "location",
+  "mcp-protocol-version",
+  "mcp-session-id",
+  "origin",
+  "referer",
+  "retry-after",
+  "traceparent",
+  "tracestate",
+  "transfer-encoding",
+  "user-agent",
+  "vary",
+  "via",
+  "x-request-id",
+] as const;
+
+// Header names are lowercased at `Headers` construction, and `Headers.redact`
+// masks every name a RegExp entry matches. One negative lookahead turns the
+// allowlist into "redact everything else".
+export const spanRedactedHeaderNames: readonly (string | RegExp)[] = [
+  new RegExp(`^(?!(?:${SPAN_SAFE_HEADER_NAMES.join("|")})$)`),
+];
+
+const withSpanHeaderRedaction = (client: HttpClient.HttpClient): HttpClient.HttpClient =>
+  HttpClient.transformResponse(client, (effect) =>
+    Effect.provideService(effect, HttpHeaders.CurrentRedactedNames, spanRedactedHeaderNames),
+  );
+
 export const makeHostedHttpClientLayer = (
   options: HostedHttpClientOptions = {},
 ): Layer.Layer<HttpClient.HttpClient> =>
-  FetchHttpClient.layer.pipe(
+  Layer.effect(HttpClient.HttpClient)(
+    Effect.map(Effect.service(HttpClient.HttpClient), withSpanHeaderRedaction),
+  ).pipe(
+    Layer.provide(FetchHttpClient.layer),
     Layer.provide(
       options.fetch
         ? Layer.succeed(FetchHttpClient.Fetch)(guardFetch(options.fetch, options))

--- a/packages/plugins/mcp/tsconfig.json
+++ b/packages/plugins/mcp/tsconfig.json
@@ -5,7 +5,7 @@
     "moduleResolution": "Bundler",
     "strict": true,
     "skipLibCheck": true,
-    "lib": ["ES2022", "DOM"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "types": ["bun-types", "node"],
     "noUnusedLocals": true,
     "noImplicitOverride": true,


### PR DESCRIPTION
Follow-up to #1623. Live verification showed post-deploy http.client spans still recording non-allowlisted headers: consumers capture the client at construction and run requests on fibers the host telemetry layers never reach, so the Context.Reference provided by layer did not make it to the tracer's getRef. The redaction now travels with the client itself (HttpClient.transformResponse wrapping each request effect in provideService), with the allowlist single-sourced in the sdk and the cloud telemetry layer reusing it for the server-side tracer. Includes a regression test that drives a request through the real hosted client and asserts redaction on the recorded span attributes.