### PR TITLE
Negative-cache dead MCP session ids in the workers

### DIFF
--- a/apps/cloud/src/mcp/agent-handler.test.ts
+++ b/apps/cloud/src/mcp/agent-handler.test.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it, vi } from "@effect/vitest";
+import { Effect, Layer } from "effect";
+
+import {
+  authenticated,
+  McpAuthProvider,
+  unauthorized,
+  type Principal,
+} from "@executor-js/host-mcp";
+
+import { cloudDeadSessionCacheForTest, makeCloudMcpAgentHandler } from "./agent-handler";
+
+const principal: Principal = {
+  accountId: "acct_test",
+  organizationId: "org_test",
+  organizationName: "Test Org",
+  email: "test@example.com",
+  name: "Test",
+  avatarUrl: null,
+  roles: ["member"],
+};
+
+const AuthProviderLive = Layer.succeed(McpAuthProvider)({
+  discoveryRoutes: [],
+  resourceMetadataUrl: (request) => new URL("/.well-known/mcp", request.url).toString(),
+  authenticate: (request) =>
+    Effect.succeed(
+      request.headers.has("authorization") ? authenticated(principal) : unauthorized(),
+    ),
+});
+
+const requestFor = (method: "GET" | "POST", sessionId: string, authenticated = true): Request =>
+  new Request("https://executor.test/mcp", {
+    method,
+    headers: {
+      ...(authenticated ? { authorization: "Bearer test" } : {}),
+      "mcp-session-id": sessionId,
+      ...(method === "POST" ? { "content-type": "application/json" } : {}),
+    },
+    ...(method === "POST"
+      ? {
+          body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list", params: {} }),
+        }
+      : {}),
+  });
+
+const makeHarness = (owner: "not_found" | "terminated" = "not_found") => {
+  const ownerChecks = { count: 0 };
+  const traces = { count: 0 };
+  const stub = {
+    validateMcpSessionOwner: async () => {
+      ownerChecks.count += 1;
+      return owner;
+    },
+  };
+  const namespace = {
+    idFromString: (sessionId: string) => sessionId,
+    get: () => stub,
+  };
+  // oxlint-disable-next-line executor/no-double-cast -- test boundary: the handler only reads the MCP_SESSION namespace in these legacy dead-session cases
+  const env = { MCP_SESSION: namespace } as unknown as Env;
+  // oxlint-disable-next-line executor/no-double-cast -- test boundary: no ExecutionContext capability is used before the dead-session response
+  const ctx = {} as unknown as ExecutionContext;
+  const handler = makeCloudMcpAgentHandler({
+    authProvider: AuthProviderLive,
+    makeModernServerBuilder: () => ({ build: () => Effect.die("unused modern builder") }),
+    traceRequest: async (request, _env, _ctx, handle) => {
+      traces.count += 1;
+      return handle(request);
+    },
+  });
+  return { ctx, env, handler, ownerChecks, traces };
+};
+
+describe("cloud MCP dead-session negative cache", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    cloudDeadSessionCacheForTest.clear();
+  });
+
+  it.each([
+    { method: "GET" as const, status: 405 },
+    { method: "POST" as const, status: 404 },
+  ])("serves a repeated $method without another DO lookup", async ({ method, status }) => {
+    const { ctx, env, handler, ownerChecks, traces } = makeHarness();
+    const sessionId = `dead-${method.toLowerCase()}`;
+
+    const first = await handler(requestFor(method, sessionId), env, ctx);
+    const second = await handler(requestFor(method, sessionId), env, ctx);
+
+    expect(first.status).toBe(status);
+    expect(second.status).toBe(status);
+    expect(ownerChecks.count).toBe(1);
+    expect(traces.count).toBe(1);
+  });
+
+  it("keeps authentication ahead of cached session existence", async () => {
+    const { ctx, env, handler, ownerChecks, traces } = makeHarness();
+    const sessionId = "dead-auth";
+
+    expect((await handler(requestFor("GET", sessionId), env, ctx)).status).toBe(405);
+    const unauthenticated = await handler(requestFor("GET", sessionId, false), env, ctx);
+
+    expect(unauthenticated.status).toBe(401);
+    expect(ownerChecks.count).toBe(1);
+    expect(traces.count).toBe(1);
+  });
+
+  it("preserves the terminated-session response on a cached hit", async () => {
+    const { ctx, env, handler, ownerChecks, traces } = makeHarness("terminated");
+    const sessionId = "dead-terminated";
+
+    const first = await handler(requestFor("POST", sessionId), env, ctx);
+    const second = await handler(requestFor("POST", sessionId), env, ctx);
+
+    expect(first.status).toBe(404);
+    expect(second.status).toBe(404);
+    expect(await second.text()).toBe(await first.text());
+    expect(ownerChecks.count).toBe(1);
+    expect(traces.count).toBe(1);
+  });
+
+  it("consults the DO again after five minutes", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const { ctx, env, handler, ownerChecks } = makeHarness();
+    const sessionId = "dead-expiry";
+
+    expect((await handler(requestFor("GET", sessionId), env, ctx)).status).toBe(405);
+    vi.advanceTimersByTime(5 * 60 * 1_000 + 1);
+    expect((await handler(requestFor("GET", sessionId), env, ctx)).status).toBe(405);
+
+    expect(ownerChecks.count).toBe(2);
+  });
+
+  it("evicts the oldest entry without exceeding 4,096 sessions", () => {
+    for (let index = 0; index <= 4_096; index += 1) {
+      cloudDeadSessionCacheForTest.remember(`dead-${index}`, 0);
+    }
+
+    expect(cloudDeadSessionCacheForTest.size()).toBe(4_096);
+    expect(cloudDeadSessionCacheForTest.has("dead-0", 1)).toBe(false);
+    expect(cloudDeadSessionCacheForTest.has("dead-1", 1)).toBe(true);
+    expect(cloudDeadSessionCacheForTest.has("dead-4096", 1)).toBe(true);
+  });
+});

--- a/apps/cloud/src/mcp/agent-handler.ts
+++ b/apps/cloud/src/mcp/agent-handler.ts
@@ -1,5 +1,5 @@
 import * as OtelTracer from "@effect/opentelemetry/Tracer";
-import { Effect, Predicate } from "effect";
+import { Effect, Layer, Predicate } from "effect";
 
 import {
   McpAuthProvider,
@@ -8,6 +8,7 @@ import {
   defaultMcpResource,
   UNAVAILABLE_RETRY_AFTER_SECONDS,
   type AuthOutcome,
+  type McpModernServerBuilder,
   type McpResource,
 } from "@executor-js/host-mcp";
 import { requestBodyFromRequest } from "@executor-js/host-mcp/tool-server";
@@ -32,8 +33,52 @@ import { createMcpSessionStub, mcpSessionStub } from "@executor-js/cloudflare/mc
 import { wrapMcpSseResponse } from "../observability/memory-metrics";
 import { WorkerTelemetryLive } from "../observability/telemetry";
 import { cloudMcpAuth } from "./auth-provider";
-import { makeCloudModernMcpServerBuilder } from "./session-durable-object";
 import { parseTraceparent } from "./traceparent";
+
+const DEAD_SESSION_CACHE_TTL_MS = 5 * 60 * 1_000;
+const DEAD_SESSION_CACHE_MAX_ENTRIES = 4_096;
+const deadSessionExpiries = new Map<string, number>();
+const timedOutSessionIds = new Set<string>();
+
+type DeadSessionReason = "not_found" | "timed_out";
+
+const isDeadSessionCached = (sessionId: string, now = Date.now()): boolean => {
+  const expiry = deadSessionExpiries.get(sessionId);
+  if (expiry === undefined) return false;
+  if (expiry > now) return true;
+  deadSessionExpiries.delete(sessionId);
+  timedOutSessionIds.delete(sessionId);
+  return false;
+};
+
+const cacheDeadSession = (sessionId: string, reason: DeadSessionReason, now = Date.now()): void => {
+  deadSessionExpiries.delete(sessionId);
+  if (deadSessionExpiries.size >= DEAD_SESSION_CACHE_MAX_ENTRIES) {
+    const oldestSessionId = deadSessionExpiries.keys().next().value;
+    if (oldestSessionId !== undefined) {
+      deadSessionExpiries.delete(oldestSessionId);
+      timedOutSessionIds.delete(oldestSessionId);
+    }
+  }
+  deadSessionExpiries.set(sessionId, now + DEAD_SESSION_CACHE_TTL_MS);
+  if (reason === "timed_out") timedOutSessionIds.add(sessionId);
+  else timedOutSessionIds.delete(sessionId);
+};
+
+const cachedDeadSessionMessage = (sessionId: string): string =>
+  timedOutSessionIds.has(sessionId) ? "Session timed out, please reconnect" : "Session not found";
+
+/** Test-only access to reset and verify the isolate-local dead-session cache. */
+export const cloudDeadSessionCacheForTest = {
+  clear: (): void => {
+    deadSessionExpiries.clear();
+    timedOutSessionIds.clear();
+  },
+  remember: (sessionId: string, now?: number): void =>
+    cacheDeadSession(sessionId, "not_found", now),
+  has: isDeadSessionCached,
+  size: (): number => deadSessionExpiries.size,
+};
 
 const jsonRpcResponse = (
   status: number,
@@ -97,12 +142,12 @@ const renderAuthError = (
   });
 };
 
-const authenticate = (request: Request) =>
+const authenticate = (request: Request, authProvider: Layer.Layer<McpAuthProvider>) =>
   Effect.gen(function* () {
     const auth = yield* McpAuthProvider;
     const outcome = yield* auth.authenticate(request);
     return { auth, outcome };
-  }).pipe(Effect.provide(cloudMcpAuth));
+  }).pipe(Effect.provide(authProvider));
 
 // The earlier shared envelope ran the MCP auth path inside the Effect app, whose
 // HttpMiddleware provided the OTEL tracer — that is where the `mcp.request`
@@ -125,6 +170,21 @@ const runTraced = <A>(request: Request, program: Effect.Effect<A>): Promise<A> =
     ),
   );
 };
+
+type TraceCloudMcpRequest = (
+  request: Request,
+  env: Env,
+  ctx: ExecutionContext,
+  handle: (tracedRequest: Request) => Promise<Response>,
+) => Promise<Response>;
+
+interface CloudMcpAgentHandlerOptions {
+  readonly makeModernServerBuilder: (
+    session: McpSessionProps["session"],
+  ) => McpModernServerBuilder["Service"];
+  readonly authProvider?: Layer.Layer<McpAuthProvider>;
+  readonly traceRequest?: TraceCloudMcpRequest;
+}
 
 // The MCP resource the request targets. `server.ts` routes both the bare `/mcp`
 // and `/mcp/toolkits/<slug>` to this handler (`prepareMcpOrgScope` strips the org
@@ -158,11 +218,14 @@ const propsForPrincipal = (
     };
   });
 
-export const makeCloudMcpAgentHandler = () => {
+/** Build the cloud worker's authenticated legacy/modern MCP request handler. */
+export const makeCloudMcpAgentHandler = (options: CloudMcpAgentHandlerOptions) => {
+  const authProvider = options.authProvider ?? cloudMcpAuth;
+  const traceRequest = options.traceRequest ?? ((request, _env, _ctx, handle) => handle(request));
   const modern = makeMcpModernRequestRouter();
   const ALLOWED_METHODS = new Set(["GET", "POST", "DELETE", "OPTIONS"]);
 
-  return async (request: Request, env: Env, ctx: ExecutionContext): Promise<Response> => {
+  const handle = async (request: Request, env: Env, ctx: ExecutionContext): Promise<Response> => {
     if (request.method === "OPTIONS") {
       return mcpCorsPreflightResponse(request.headers.get("access-control-request-headers"));
     }
@@ -173,7 +236,7 @@ export const makeCloudMcpAgentHandler = () => {
     }
     const sessionId = request.headers.get("mcp-session-id");
 
-    const { auth, outcome } = await runTraced(request, authenticate(request));
+    const { auth, outcome } = await runTraced(request, authenticate(request, authProvider));
     if (!Predicate.isTagged(outcome, "Authenticated")) {
       // Destroying a live session on auth grounds requires a POSITIVE
       // determination that access is genuinely gone — only `Forbidden` carries
@@ -218,7 +281,7 @@ export const makeCloudMcpAgentHandler = () => {
         resource,
         props,
         requestStateSigningKey: requireMcpRequestStateKey(env.MCP_REQUEST_STATE_KEY),
-        builder: makeCloudModernMcpServerBuilder(props.session),
+        builder: options.makeModernServerBuilder(props.session),
         sessions: env.MCP_SESSION,
         executionOwners: mcpExecutionOwnerDirectoryFromNamespace(env.MCP_EXECUTION_OWNER),
       });
@@ -238,18 +301,20 @@ export const makeCloudMcpAgentHandler = () => {
     if (sessionId && !existingSession) {
       return deadSessionResponse(request.method, "Session not found");
     }
-    if (existingSession) {
+    if (existingSession && sessionId) {
       const owner = await existingSession.validateMcpSessionOwner({
         accountId: outcome.principal.accountId,
         organizationId: outcome.principal.organizationId,
       });
       if (owner === "not_found") {
+        cacheDeadSession(sessionId, "not_found");
         return deadSessionResponse(request.method, "Session not found");
       }
       if (owner === "terminated") {
         // DELETE-condemned but the deferred destroy alarm hasn't wiped storage
         // yet. Same envelope as the post-destroy race below: the client must
         // treat the id as dead and reconnect.
+        cacheDeadSession(sessionId, "timed_out");
         return deadSessionResponse(request.method, "Session timed out, please reconnect");
       }
       if (owner === "forbidden") {
@@ -286,11 +351,28 @@ export const makeCloudMcpAgentHandler = () => {
       // client to be told to reconnect, matching a timed-out session).
       // oxlint-disable-next-line executor/no-unknown-error-message -- adapter boundary: the abort reason is a plain runtime Error whose message IS the signal
       if (Predicate.isError(error) && error.message === "destroyed") {
+        if (sessionId) cacheDeadSession(sessionId, "timed_out");
         return deadSessionResponse(request.method, "Session timed out, please reconnect");
       }
       // oxlint-disable-next-line executor/no-try-catch-or-throw -- adapter boundary: rethrow anything that isn't the condemned-DO abort to the Workers runtime unchanged
       throw error;
     }
     return withMcpResponseHeaders(wrapMcpSseResponse(request, env, response));
+  };
+
+  return async (request: Request, env: Env, ctx: ExecutionContext): Promise<Response> => {
+    const sessionId = request.headers.get("mcp-session-id");
+    const cacheEligible = request.method !== "OPTIONS" && ALLOWED_METHODS.has(request.method);
+    if (cacheEligible && sessionId && isDeadSessionCached(sessionId)) {
+      return Effect.runPromise(
+        Effect.gen(function* () {
+          const { auth, outcome } = yield* authenticate(request, authProvider);
+          return Predicate.isTagged(outcome, "Authenticated")
+            ? deadSessionResponse(request.method, cachedDeadSessionMessage(sessionId))
+            : renderAuthError(auth, request, outcome);
+        }).pipe(Effect.withTracerEnabled(false)),
+      );
+    }
+    return traceRequest(request, env, ctx, (tracedRequest) => handle(tracedRequest, env, ctx));
   };
 };

--- a/apps/cloud/src/server.ts
+++ b/apps/cloud/src/server.ts
@@ -15,7 +15,10 @@ import { isAppOwnedPath } from "./app-paths";
 import { makeCloudMcpAgentHandler } from "./mcp/agent-handler";
 import { classifyMcpPath, prepareMcpOrgScope } from "./mcp/mount";
 import { parseTraceparent } from "./mcp/traceparent";
-import { McpSessionDOSqlite as McpSessionDOBase } from "./mcp/session-durable-object";
+import {
+  makeCloudModernMcpServerBuilder,
+  McpSessionDOSqlite as McpSessionDOBase,
+} from "./mcp/session-durable-object";
 import {
   beforeSendWithOtelCorrelation,
   captureCause,
@@ -85,15 +88,12 @@ export { McpExecutionOwnerDirectoryDO } from "@executor-js/cloudflare/mcp/execut
 // migration — without the OTel-SDK version-conflict that package would now
 // drag in (it pins `@opentelemetry/otlp-* ^0.200.0`, we ship ^0.214.0).
 //
-// ONLY for paths the Effect app does not own. App-owned paths (/api/*, /mcp,
-// /.well-known/* — see app-paths.ts) get their `http.server` span from
-// Effect's own HttpMiddleware.tracer, which parses `traceparent` itself and
-// parents the workos/store/db child spans. Wrapping those here too produced
-// two identical sibling `http.server` spans per request (scope
-// `executor-cloud-worker` next to scope `executor-cloud`) — double ingest,
-// and the waterfall showed a childless twin. The worker span remains for
-// everything Effect never sees: Start SSR, the marketing proxy, /_astro
-// assets.
+// App-owned paths (/api/* and /.well-known/* — see app-paths.ts) get their
+// `http.server` span from Effect's HttpMiddleware tracer. `/mcp` is dispatched
+// directly and uses `traceCloudMcpRequest` below so the agent handler can skip
+// the entire span envelope for negative-cache hits. Other paths keep this
+// worker span. Wrapping Effect-owned paths here too produced duplicate sibling
+// spans per request.
 //
 // SimpleSpanProcessor exports synchronously at span end but the underlying
 // `fetch()` to Axiom is fire-and-forget; the Worker may terminate before it
@@ -108,7 +108,70 @@ const fetchHandler = handler.fetch as (
 ) => Response | Promise<Response>;
 
 const tracer = trace.getTracer("executor-cloud-worker");
-const mcpAgentHandler = makeCloudMcpAgentHandler();
+
+const traceCloudMcpRequest = async (
+  request: Request,
+  _env: Env,
+  ctx: ExecutionContext,
+  handle: (tracedRequest: Request) => Promise<Response>,
+): Promise<Response> => {
+  if (!installTracerProvider()) return handle(request);
+
+  const url = new URL(request.url);
+  const inbound = parseTraceparent(request.headers.get("traceparent"), null);
+  const parentContext = inbound
+    ? trace.setSpanContext(context.active(), {
+        traceId: inbound.traceId,
+        spanId: inbound.spanId,
+        traceFlags: inbound.traceFlags,
+        isRemote: true,
+      })
+    : context.active();
+
+  return tracer.startActiveSpan(
+    `http.server ${request.method}`,
+    { kind: SpanKind.SERVER },
+    parentContext,
+    async (span) => {
+      span.setAttribute(ATTR_HTTP_REQUEST_METHOD, request.method);
+      span.setAttribute(ATTR_URL_FULL, request.url);
+      span.setAttribute(ATTR_URL_PATH, url.pathname);
+      span.setAttribute(ATTR_URL_SCHEME, url.protocol.replace(/:$/, ""));
+      const spanContext = span.spanContext();
+      const headers = new Headers(request.headers);
+      headers.set(
+        "traceparent",
+        `00-${spanContext.traceId}-${spanContext.spanId}-${(spanContext.traceFlags & 0xff).toString(16).padStart(2, "0")}`,
+      );
+      // oxlint-disable-next-line executor/no-try-catch-or-throw -- adapter boundary; observe response/error for span status, keep trace export alive after the Agents bridge resolves or rejects
+      try {
+        const response = await handle(new Request(request, { headers }));
+        span.setAttribute(ATTR_HTTP_RESPONSE_STATUS_CODE, response.status);
+        if (response.status >= 500) {
+          span.setStatus({ code: SpanStatusCode.ERROR, message: `HTTP ${response.status}` });
+        }
+        return response;
+      } catch (err) {
+        // oxlint-disable-next-line executor/no-instanceof-error, executor/no-unknown-error-message -- adapter boundary: Cloudflare's fetch callback throws untyped; normalized only for the OTel span record, the original error is rethrown below
+        const cause = err instanceof Error ? err : String(err);
+        span.recordException(cause);
+        // oxlint-disable-next-line executor/no-unknown-error-message -- adapter boundary: same normalization as the recordException line above
+        const message = typeof cause === "string" ? cause : cause.message;
+        span.setStatus({ code: SpanStatusCode.ERROR, message });
+        // oxlint-disable-next-line executor/no-try-catch-or-throw -- adapter boundary; preserve original error to Cloudflare runtime
+        throw err;
+      } finally {
+        span.end();
+        ctx.waitUntil(flushTracerProvider());
+      }
+    },
+  );
+};
+
+const mcpAgentHandler = makeCloudMcpAgentHandler({
+  makeModernServerBuilder: makeCloudModernMcpServerBuilder,
+  traceRequest: traceCloudMcpRequest,
+});
 
 const cloudflareHandler: ExportedHandler<Env> = {
   fetch: async (request, env, ctx) => {
@@ -120,10 +183,17 @@ const cloudflareHandler: ExportedHandler<Env> = {
     // The MCP dispatch is classified up front, independent of whether
     // telemetry installs — an unset `AXIOM_TOKEN` (tracer not installed) must
     // never take /mcp requests down with it. See `installTracerProvider`'s
-    // early return below: it only governs the tracing envelope for
-    // non-MCP paths.
+    // early return below: the handler invokes it for uncached MCP traffic, and
+    // this entry invokes it for non-MCP paths.
     const url = new URL(request.url);
     const mcpRoute = classifyMcpPath(url.pathname);
+    if (mcpRoute?.kind === "mcp") {
+      // The Cloudflare Agents MCP bridge needs the platform ExecutionContext
+      // to pass authenticated session props into the hibernatable DO.
+      // Discovery docs still flow through the app-level MCP envelope.
+      const forwarded = prepareMcpOrgScope(request);
+      return mcpAgentHandler(forwarded, env, ctx);
+    }
     const tracingInstalled = installTracerProvider();
     // Join the caller's W3C trace when the request carries one — the web UI
     // sends traceparent on every API fetch, so the browser's spans and this
@@ -138,61 +208,6 @@ const cloudflareHandler: ExportedHandler<Env> = {
           isRemote: true,
         })
       : context.active();
-    if (mcpRoute?.kind === "mcp") {
-      // The Cloudflare Agents MCP bridge needs the platform ExecutionContext
-      // to pass authenticated session props into the hibernatable DO.
-      // Discovery docs still flow through the app-level MCP envelope.
-      const forwarded = prepareMcpOrgScope(request);
-      if (!tracingInstalled) {
-        return mcpAgentHandler(forwarded, env, ctx);
-      }
-      // /mcp left the Effect app in the Agents-bridge migration, so no
-      // downstream HttpMiddleware.tracer opens the request envelope anymore —
-      // this worker span is now THE `http.server` span for MCP traffic. Its
-      // context is stamped onto the forwarded request's traceparent so the
-      // agent handler's Effect programs (mcp.request and children) and the
-      // session DO parent under it instead of exporting orphaned roots.
-      return tracer.startActiveSpan(
-        `http.server ${request.method}`,
-        { kind: SpanKind.SERVER },
-        parentContext,
-        async (span) => {
-          span.setAttribute(ATTR_HTTP_REQUEST_METHOD, request.method);
-          span.setAttribute(ATTR_URL_FULL, request.url);
-          span.setAttribute(ATTR_URL_PATH, url.pathname);
-          span.setAttribute(ATTR_URL_SCHEME, url.protocol.replace(/:$/, ""));
-          const spanContext = span.spanContext();
-          const headers = new Headers(forwarded.headers);
-          headers.set(
-            "traceparent",
-            `00-${spanContext.traceId}-${spanContext.spanId}-${(spanContext.traceFlags & 0xff).toString(16).padStart(2, "0")}`,
-          );
-          // oxlint-disable-next-line executor/no-try-catch-or-throw -- adapter boundary; observe response/error for span status, keep trace export alive after the Agents bridge resolves or rejects
-          try {
-            const response = await mcpAgentHandler(new Request(forwarded, { headers }), env, ctx);
-            span.setAttribute(ATTR_HTTP_RESPONSE_STATUS_CODE, response.status);
-            if (response.status >= 500) {
-              span.setStatus({ code: SpanStatusCode.ERROR, message: `HTTP ${response.status}` });
-            }
-            return response;
-          } catch (err) {
-            // Record the exception itself, not just the status bit: without it
-            // these spans are ERROR with zero diagnostic content.
-            // oxlint-disable-next-line executor/no-instanceof-error, executor/no-unknown-error-message -- adapter boundary: Cloudflare's fetch callback throws untyped; normalized only for the OTel span record, the original error is rethrown below
-            const cause = err instanceof Error ? err : String(err);
-            span.recordException(cause);
-            // oxlint-disable-next-line executor/no-unknown-error-message -- adapter boundary: same normalization as the recordException line above
-            const message = typeof cause === "string" ? cause : cause.message;
-            span.setStatus({ code: SpanStatusCode.ERROR, message });
-            // oxlint-disable-next-line executor/no-try-catch-or-throw -- adapter boundary; preserve original error to Cloudflare runtime
-            throw err;
-          } finally {
-            span.end();
-            ctx.waitUntil(flushTracerProvider());
-          }
-        },
-      );
-    }
     if (!tracingInstalled) {
       return fetchHandler(request, env, ctx);
     }

--- a/apps/host-cloudflare/src/app.ts
+++ b/apps/host-cloudflare/src/app.ts
@@ -16,6 +16,7 @@ import { ErrorCaptureLive } from "./observability";
 import { cloudflareAccountMiddleware } from "./account/account-provider";
 import { makeCloudflareApprovalHandler } from "./mcp";
 import { makeCloudflareMcpAgentHandler } from "./mcp/agent-handler";
+import { makeCloudflareModernMcpServerBuilder } from "./mcp/session-durable-object";
 import { preloadQuickJs } from "./quickjs";
 
 // ===========================================================================
@@ -45,7 +46,9 @@ export const makeCloudflareApp = async (env: CloudflareEnv) => {
   // handle the per-request scoped executor reads through the DbProvider seam.
   const dbHandle = await createD1ExecutorDb(env.DB, env.BLOBS);
   const identityLayer = cloudflareAccessIdentityLayer(config);
-  const mcpAgentHandler = makeCloudflareMcpAgentHandler(config);
+  const mcpAgentHandler = makeCloudflareMcpAgentHandler(config, {
+    makeModernServerBuilder: makeCloudflareModernMcpServerBuilder,
+  });
   const approvalHandler = makeCloudflareApprovalHandler(config, env);
 
   const { appLayer, toWebHandler } = ExecutorApp.make({

--- a/apps/host-cloudflare/src/mcp/agent-handler.test.ts
+++ b/apps/host-cloudflare/src/mcp/agent-handler.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from "@effect/vitest";
+import { Effect, Layer } from "effect";
+
+import {
+  authenticated,
+  McpAuthProvider,
+  unauthorized,
+  type Principal,
+} from "@executor-js/host-mcp";
+
+import type { CloudflareConfig, CloudflareEnv } from "../config";
+import { cloudflareDeadSessionCacheForTest, makeCloudflareMcpAgentHandler } from "./agent-handler";
+
+const principal: Principal = {
+  accountId: "acct_test",
+  organizationId: "org_test",
+  organizationName: "Test Org",
+  email: "test@example.com",
+  name: "Test",
+  avatarUrl: null,
+  roles: ["member"],
+};
+
+const config = {
+  accessTeamDomain: "test.cloudflareaccess.com",
+  accessAud: "aud_test",
+  accessNameClaim: "name",
+  accessGroupsClaim: "groups",
+  adminEmails: [],
+  organizationId: "org_test",
+  organizationName: "Test Org",
+  organizationSlug: "test-org",
+  secretKey: "test-secret-key-0123456789",
+  allowLocalNetwork: false,
+  enableDevAuth: false,
+} satisfies CloudflareConfig;
+
+const AuthProviderLive = Layer.succeed(McpAuthProvider)({
+  discoveryRoutes: [],
+  resourceMetadataUrl: (request) => new URL("/.well-known/mcp", request.url).toString(),
+  authenticate: (request) =>
+    Effect.succeed(
+      request.headers.has("authorization") ? authenticated(principal) : unauthorized(),
+    ),
+});
+
+const requestFor = (method: "GET" | "POST", sessionId: string, authenticated = true): Request =>
+  new Request("https://executor.test/mcp", {
+    method,
+    headers: {
+      ...(authenticated ? { authorization: "Bearer test" } : {}),
+      "mcp-session-id": sessionId,
+      ...(method === "POST" ? { "content-type": "application/json" } : {}),
+    },
+    ...(method === "POST"
+      ? {
+          body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list", params: {} }),
+        }
+      : {}),
+  });
+
+const makeHarness = (owner: "not_found" | "terminated" = "not_found") => {
+  const ownerChecks = { count: 0 };
+  const stub = {
+    validateMcpSessionOwner: async () => {
+      ownerChecks.count += 1;
+      return owner;
+    },
+  };
+  const namespace = {
+    idFromString: (sessionId: string) => sessionId,
+    get: () => stub,
+  };
+  // oxlint-disable-next-line executor/no-double-cast -- test boundary: the handler only reads the MCP_SESSION namespace in these legacy dead-session cases
+  const env = { MCP_SESSION: namespace } as unknown as CloudflareEnv;
+  // oxlint-disable-next-line executor/no-double-cast -- test boundary: no ExecutionContext capability is used before the dead-session response
+  const ctx = {} as unknown as ExecutionContext;
+  const handler = makeCloudflareMcpAgentHandler(config, {
+    authProvider: AuthProviderLive,
+    makeModernServerBuilder: () => ({ build: () => Effect.die("unused modern builder") }),
+  });
+  return { ctx, env, handler, ownerChecks };
+};
+
+describe("standalone Cloudflare MCP dead-session negative cache", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    cloudflareDeadSessionCacheForTest.clear();
+  });
+
+  it.each([
+    { method: "GET" as const, status: 405 },
+    { method: "POST" as const, status: 404 },
+  ])("serves a repeated $method without another DO lookup", async ({ method, status }) => {
+    const { ctx, env, handler, ownerChecks } = makeHarness();
+    const sessionId = `dead-${method.toLowerCase()}`;
+
+    const first = await handler(requestFor(method, sessionId), env, ctx);
+    const second = await handler(requestFor(method, sessionId), env, ctx);
+
+    expect(first.status).toBe(status);
+    expect(second.status).toBe(status);
+    expect(ownerChecks.count).toBe(1);
+  });
+
+  it("keeps authentication ahead of cached session existence", async () => {
+    const { ctx, env, handler, ownerChecks } = makeHarness();
+    const sessionId = "dead-auth";
+
+    expect((await handler(requestFor("GET", sessionId), env, ctx)).status).toBe(405);
+    const unauthenticated = await handler(requestFor("GET", sessionId, false), env, ctx);
+
+    expect(unauthenticated.status).toBe(401);
+    expect(ownerChecks.count).toBe(1);
+  });
+
+  it("preserves the terminated-session response on a cached hit", async () => {
+    const { ctx, env, handler, ownerChecks } = makeHarness("terminated");
+    const sessionId = "dead-terminated";
+
+    const first = await handler(requestFor("POST", sessionId), env, ctx);
+    const second = await handler(requestFor("POST", sessionId), env, ctx);
+
+    expect(first.status).toBe(404);
+    expect(second.status).toBe(404);
+    expect(await second.text()).toBe(await first.text());
+    expect(ownerChecks.count).toBe(1);
+  });
+
+  it("consults the DO again after five minutes", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const { ctx, env, handler, ownerChecks } = makeHarness();
+    const sessionId = "dead-expiry";
+
+    expect((await handler(requestFor("GET", sessionId), env, ctx)).status).toBe(405);
+    vi.advanceTimersByTime(5 * 60 * 1_000 + 1);
+    expect((await handler(requestFor("GET", sessionId), env, ctx)).status).toBe(405);
+
+    expect(ownerChecks.count).toBe(2);
+  });
+
+  it("evicts the oldest entry without exceeding 4,096 sessions", () => {
+    for (let index = 0; index <= 4_096; index += 1) {
+      cloudflareDeadSessionCacheForTest.remember(`dead-${index}`, 0);
+    }
+
+    expect(cloudflareDeadSessionCacheForTest.size()).toBe(4_096);
+    expect(cloudflareDeadSessionCacheForTest.has("dead-0", 1)).toBe(false);
+    expect(cloudflareDeadSessionCacheForTest.has("dead-1", 1)).toBe(true);
+    expect(cloudflareDeadSessionCacheForTest.has("dead-4096", 1)).toBe(true);
+  });
+});

--- a/apps/host-cloudflare/src/mcp/agent-handler.ts
+++ b/apps/host-cloudflare/src/mcp/agent-handler.ts
@@ -1,4 +1,4 @@
-import { Effect, Predicate } from "effect";
+import { Effect, Layer, Predicate } from "effect";
 
 import {
   McpAuthProvider,
@@ -6,6 +6,7 @@ import {
   mcpModernDisabledResponse,
   defaultMcpResource,
   type AuthOutcome,
+  type McpModernServerBuilder,
   type Principal,
 } from "@executor-js/host-mcp";
 import { requestBodyFromRequest } from "@executor-js/host-mcp/tool-server";
@@ -29,7 +30,51 @@ import { createMcpSessionStub, mcpSessionStub } from "@executor-js/cloudflare/mc
 
 import type { CloudflareConfig, CloudflareEnv } from "../config";
 import { cloudflareAccessMcpAuth } from "./auth";
-import { makeCloudflareModernMcpServerBuilder } from "./session-durable-object";
+
+const DEAD_SESSION_CACHE_TTL_MS = 5 * 60 * 1_000;
+const DEAD_SESSION_CACHE_MAX_ENTRIES = 4_096;
+const deadSessionExpiries = new Map<string, number>();
+const timedOutSessionIds = new Set<string>();
+
+type DeadSessionReason = "not_found" | "timed_out";
+
+const isDeadSessionCached = (sessionId: string, now = Date.now()): boolean => {
+  const expiry = deadSessionExpiries.get(sessionId);
+  if (expiry === undefined) return false;
+  if (expiry > now) return true;
+  deadSessionExpiries.delete(sessionId);
+  timedOutSessionIds.delete(sessionId);
+  return false;
+};
+
+const cacheDeadSession = (sessionId: string, reason: DeadSessionReason, now = Date.now()): void => {
+  deadSessionExpiries.delete(sessionId);
+  if (deadSessionExpiries.size >= DEAD_SESSION_CACHE_MAX_ENTRIES) {
+    const oldestSessionId = deadSessionExpiries.keys().next().value;
+    if (oldestSessionId !== undefined) {
+      deadSessionExpiries.delete(oldestSessionId);
+      timedOutSessionIds.delete(oldestSessionId);
+    }
+  }
+  deadSessionExpiries.set(sessionId, now + DEAD_SESSION_CACHE_TTL_MS);
+  if (reason === "timed_out") timedOutSessionIds.add(sessionId);
+  else timedOutSessionIds.delete(sessionId);
+};
+
+const cachedDeadSessionMessage = (sessionId: string): string =>
+  timedOutSessionIds.has(sessionId) ? "Session timed out, please reconnect" : "Session not found";
+
+/** Test-only access to reset and verify the isolate-local dead-session cache. */
+export const cloudflareDeadSessionCacheForTest = {
+  clear: (): void => {
+    deadSessionExpiries.clear();
+    timedOutSessionIds.clear();
+  },
+  remember: (sessionId: string, now?: number): void =>
+    cacheDeadSession(sessionId, "not_found", now),
+  has: isDeadSessionCached,
+  size: (): number => deadSessionExpiries.size,
+};
 
 const jsonRpcResponse = (
   status: number,
@@ -79,12 +124,12 @@ const renderAuthError = (
   return jsonRpcResponse(503, -32001, outcome.message);
 };
 
-const authenticate = (request: Request, config: CloudflareConfig) =>
+const authenticate = (request: Request, authProvider: Layer.Layer<McpAuthProvider>) =>
   Effect.gen(function* () {
     const auth = yield* McpAuthProvider;
     const outcome = yield* auth.authenticate(request);
     return { auth, outcome };
-  }).pipe(Effect.provide(cloudflareAccessMcpAuth(config)));
+  }).pipe(Effect.provide(authProvider));
 
 const propsForPrincipal = (
   request: Request,
@@ -108,7 +153,21 @@ const propsForPrincipal = (
     };
   });
 
-export const makeCloudflareMcpAgentHandler = (config: CloudflareConfig) => {
+interface CloudflareMcpAgentHandlerOptions {
+  readonly makeModernServerBuilder: (
+    env: CloudflareEnv,
+    config: CloudflareConfig,
+    session: McpSessionProps["session"],
+  ) => McpModernServerBuilder["Service"];
+  readonly authProvider?: Layer.Layer<McpAuthProvider>;
+}
+
+/** Build the standalone Cloudflare worker's authenticated MCP request handler. */
+export const makeCloudflareMcpAgentHandler = (
+  config: CloudflareConfig,
+  options: CloudflareMcpAgentHandlerOptions,
+) => {
+  const authProvider = options.authProvider ?? cloudflareAccessMcpAuth(config);
   const modern = makeMcpModernRequestRouter();
   return async (request: Request, env: CloudflareEnv, ctx: ExecutionContext): Promise<Response> => {
     if (request.method === "OPTIONS") {
@@ -116,7 +175,18 @@ export const makeCloudflareMcpAgentHandler = (config: CloudflareConfig) => {
     }
     const sessionId = request.headers.get("mcp-session-id");
 
-    const { auth, outcome } = await Effect.runPromise(authenticate(request, config));
+    if (sessionId && isDeadSessionCached(sessionId)) {
+      return Effect.runPromise(
+        Effect.gen(function* () {
+          const { auth, outcome } = yield* authenticate(request, authProvider);
+          return Predicate.isTagged(outcome, "Authenticated")
+            ? deadSessionResponse(request.method, cachedDeadSessionMessage(sessionId))
+            : renderAuthError(auth, request, outcome);
+        }).pipe(Effect.withTracerEnabled(false)),
+      );
+    }
+
+    const { auth, outcome } = await Effect.runPromise(authenticate(request, authProvider));
     if (!Predicate.isTagged(outcome, "Authenticated")) {
       if (Predicate.isTagged(outcome, "Forbidden") && sessionId) {
         const session = mcpSessionStub(env.MCP_SESSION, sessionId);
@@ -152,7 +222,7 @@ export const makeCloudflareMcpAgentHandler = (config: CloudflareConfig) => {
         resource: defaultMcpResource,
         props,
         requestStateSigningKey: requireMcpRequestStateKey(env.MCP_REQUEST_STATE_KEY),
-        builder: makeCloudflareModernMcpServerBuilder(env, config, props.session),
+        builder: options.makeModernServerBuilder(env, config, props.session),
         sessions: env.MCP_SESSION,
         executionOwners: mcpExecutionOwnerDirectoryFromNamespace(env.MCP_EXECUTION_OWNER),
       });
@@ -166,17 +236,19 @@ export const makeCloudflareMcpAgentHandler = (config: CloudflareConfig) => {
     if (sessionId && !existingSession) {
       return deadSessionResponse(request.method, "Session not found");
     }
-    if (existingSession) {
+    if (existingSession && sessionId) {
       const owner = await existingSession.validateMcpSessionOwner({
         accountId: outcome.principal.accountId,
         organizationId: outcome.principal.organizationId,
       });
       if (owner === "not_found") {
+        cacheDeadSession(sessionId, "not_found");
         return deadSessionResponse(request.method, "Session not found");
       }
       if (owner === "terminated") {
         // DELETE-condemned but the deferred destroy alarm hasn't wiped storage
         // yet; the terminated id must read as dead immediately.
+        cacheDeadSession(sessionId, "timed_out");
         return deadSessionResponse(request.method, "Session timed out, please reconnect");
       }
       if (owner === "forbidden") {

--- a/apps/host-cloudflare/test-stubs/cloudflare-workers.ts
+++ b/apps/host-cloudflare/test-stubs/cloudflare-workers.ts
@@ -1,0 +1,7 @@
+/** Node-test stand-ins for Cloudflare module exports reached during handler imports. */
+export const env: Record<string, unknown> = {};
+export class WorkerEntrypoint {}
+export class DurableObject {}
+export class WorkflowEntrypoint {}
+export class RpcTarget {}
+export const exports: Record<string, unknown> = {};

--- a/apps/host-cloudflare/vitest.config.ts
+++ b/apps/host-cloudflare/vitest.config.ts
@@ -1,6 +1,13 @@
+import { resolve } from "node:path";
+
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "cloudflare:workers": resolve(__dirname, "./test-stubs/cloudflare-workers.ts"),
+    },
+  },
   test: {
     include: ["src/**/*.test.ts"],
     passWithNoTests: true,


### PR DESCRIPTION
Follow-up to the dead-session 405 change: repeats from harness-level reconnect loops now skip the DO ownership RPC and emit zero spans (per-isolate cache, 5 min TTL, 4096 cap). Auth still runs first — unauthenticated requests keep getting 401. First-time dead hits stay fully observable. Tests cover DO-stub call counts, 401 preservation, TTL expiry, and cap eviction.