### PR TITLE
Warm the Start server graph on isolate first-fetch

### DIFF
--- a/apps/cloud/src/server.ts
+++ b/apps/cloud/src/server.ts
@@ -110,8 +110,51 @@ const fetchHandler = handler.fetch as (
 const tracer = trace.getTracer("executor-cloud-worker");
 const mcpAgentHandler = makeCloudMcpAgentHandler();
 
+// ---------------------------------------------------------------------------
+// Start server-graph warmup
+//
+// TanStack Start's server entry loads the router and start instance behind a
+// dynamic import on the first Start-handled request per isolate
+// (start-server-core's `loadEntries`). That graph is the whole app bundle
+// (React SSR + the Effect app), so the request that pays the load stalls for
+// seconds on production metal. Under heavy MCP traffic the worker spreads
+// across enough isolates that nearly every page/asset request IS such a first
+// request — the 2026-08-16 session-reset reconnect storm took the homepage
+// p50 from ~15ms to ~2.6s exactly this way.
+//
+// So: on each isolate's first fetch, kick the same imports off in the
+// background. MCP traffic then pre-warms an isolate long before a page
+// request reaches it. The specifiers are the virtual module ids the Start
+// vite plugin registers for `loadEntries`' own imports, so both resolve to
+// the same chunk and `loadEntries`' cache finds it already evaluated.
+//
+// Deliberately NOT at module scope: a full warmup there trips workerd's
+// global-scope I/O restriction, and DO-only isolates should not carry the
+// SSR graph in memory.
+// ---------------------------------------------------------------------------
+let startGraphWarm = false;
+let startGraphWarmupStarted = false;
+const warmStartGraph = () => {
+  if (startGraphWarmupStarted) return;
+  startGraphWarmupStarted = true;
+  // oxlint-disable-next-line executor/no-promise-catch -- adapter boundary; fire-and-forget warmup outside any Effect runtime
+  void Promise.all([import("#tanstack-router-entry"), import("#tanstack-start-entry")])
+    .then(() => {
+      startGraphWarm = true;
+    })
+    .catch(() => {
+      // Advisory only — the request path still loads the graph lazily.
+      startGraphWarmupStarted = false;
+    });
+};
+
 const cloudflareHandler: ExportedHandler<Env> = {
   fetch: async (request, env, ctx) => {
+    warmStartGraph();
+    // Captured before any await: whether the Start graph was already
+    // evaluated when this request arrived (stamped on the page span below —
+    // a cold graph is the known multi-second page-latency mode).
+    const startGraphWasWarm = startGraphWarm;
     // Browser OTLP ingress — before the server span opens: exporter traffic
     // must never trace itself (the browser already excludes /v1/traces from
     // its own tracing for the same reason).
@@ -212,6 +255,7 @@ const cloudflareHandler: ExportedHandler<Env> = {
         span.setAttribute(ATTR_URL_FULL, request.url);
         span.setAttribute(ATTR_URL_PATH, url.pathname);
         span.setAttribute(ATTR_URL_SCHEME, url.protocol.replace(/:$/, ""));
+        span.setAttribute("executor.start_graph.warm", startGraphWasWarm);
         // Adapter boundary: Cloudflare's fetch handler is a Promise-based
         // callback and the OTel span lifecycle needs to observe both the
         // resolved response and any thrown error before `span.end()`. Sentry's

--- a/apps/cloud/src/start-virtual-entries.d.ts
+++ b/apps/cloud/src/start-virtual-entries.d.ts
@@ -1,0 +1,8 @@
+// TanStack Start's internal virtual server-entry modules (registered by the
+// Start vite plugin; the same ids `start-server-core`'s `loadEntries`
+// imports). server.ts imports them for the isolate warmup — only the
+// module-evaluation side effect matters there, so the value shape is left
+// untyped. Kept in a standalone declaration file: shorthand ambient modules
+// only register from a non-module file (env-augment.d.ts is a module).
+declare module "#tanstack-router-entry";
+declare module "#tanstack-start-entry";


### PR DESCRIPTION
## Problem

Homepage/app/asset TTFB went from ~15ms p50 to ~2.6s p50 at the 2026-08-16 21:20 UTC deploy and has stayed there (worst bins >3s). MCP serving was unaffected.

TanStack Start loads the router + start instance behind a dynamic import on the first Start-handled request per isolate (`start-server-core` `loadEntries`); that graph is the whole app bundle. The v2 session migration reset every live MCP session, the resulting reconnect storm multiplied request volume ~15x, and the worker spread across enough isolates that nearly every page request became a first request — each paying multi-second module load on production metal.

## Fix

On each isolate's first fetch, kick off the same virtual-module imports (`#tanstack-router-entry`, `#tanstack-start-entry`) in the background. MCP traffic then pre-warms isolates before page requests reach them. Also stamps `executor.start_graph.warm` on the worker page span so warm/cold is visible in traces.

Not module scope: a full warmup there trips workerd's global-scope I/O restriction, and DO-only isolates should not carry the SSR graph.

## Evidence

- Production build under local workerd: cold page request 167ms, then 3–8ms once any prior request warmed the isolate; first-request-is-page path unchanged; no workerd errors.
- Built bundle emits the warmup and `loadEntries` pointing at the same chunk files, so the entries cache hits the warm module.

Typecheck, lint, format pass. `apps/cloud` vitest: 243 passed; `src/account/org-api-key-revoke.node.test.ts` (3 tests) fails identically with and without this change.
