### PR TITLE
Keep the standalone MCP SSE listener open after undelivered replay

### DIFF
--- a/packages/hosts/cloudflare/src/mcp/agent-session-durable-object.test.ts
+++ b/packages/hosts/cloudflare/src/mcp/agent-session-durable-object.test.ts
@@ -418,9 +418,21 @@ describe("McpAgentSessionDOBase session serving", () => {
         }),
       ),
     );
-    const standaloneReplayBody = await standaloneReplay.text();
+    // The standalone listener replays undelivered responses as its opening
+    // frames and then STAYS OPEN (a close-after-replay here put every active
+    // client into a permanent reconnect loop), so read incrementally instead
+    // of draining to EOF.
+    const standaloneReader = standaloneReplay.body?.getReader();
+    const decoder = new TextDecoder();
+    let standaloneReplayBody = "";
+    while (!standaloneReplayBody.includes("slow result")) {
+      const next = await standaloneReader?.read();
+      if (!next || next.done) break;
+      standaloneReplayBody += decoder.decode(next.value, { stream: true });
+    }
     expect(standaloneReplayBody).toContain("slow result");
     expect(standaloneReplayBody).toContain("event: message");
+    await standaloneReader?.cancel("test complete");
     await state.flushWaitUntil();
   });
 

--- a/packages/hosts/cloudflare/src/mcp/agent-session-durable-object.ts
+++ b/packages/hosts/cloudflare/src/mcp/agent-session-durable-object.ts
@@ -1148,14 +1148,36 @@ export abstract class McpAgentSessionDOBase<
       },
       onClose: (reason) => {
         this.activeLegacyStreamCount = Math.max(0, this.activeLegacyStreamCount - 1);
-        if (reason === "complete" && options.acknowledge && options.acknowledge.length > 0) {
+        // "complete": the source body drained to its natural end. "rotate":
+        // the client stayed attached for the whole max-age window, so the
+        // initial replay frames were drained long before. Both count as
+        // delivered. "cancel"/"error" leave the streams replayable for the
+        // client's reconnect GET.
+        if (
+          (reason === "complete" || reason === "rotate") &&
+          options.acknowledge &&
+          options.acknowledge.length > 0
+        ) {
           this.ctx.waitUntil(this.eventStore.acknowledgeUndeliveredStreams(options.acknowledge));
         }
       },
     });
 
-  private async replayUndeliveredOnStandaloneGet(request: Request): Promise<Response | null> {
-    if (request.method !== "GET" || request.headers.has("last-event-id")) return null;
+  /**
+   * Collect every undelivered stream's events as one SSE frame block, for
+   * prepending onto the standalone GET stream. Returning a FINITE response
+   * here instead (the pre-2026-08-17 behavior) was catastrophic: the client's
+   * standalone listener closed the moment the replay flushed, and because
+   * every POST marks its stream undelivered until acknowledged, an active
+   * session ALWAYS had something to replay — so every listener GET became a
+   * ~3s reconnect short-poll. Fleet-wide, that reconnect storm multiplied
+   * /mcp volume ~15x, drove the worker into memory-limit kills, and (by
+   * recycling isolates) pushed homepage TTFB from ~15ms to ~3s.
+   */
+  private async collectUndeliveredReplay(): Promise<{
+    readonly frame: Uint8Array;
+    readonly streamIds: readonly string[];
+  } | null> {
     const frames: Uint8Array[] = [];
     const streamIds = await this.eventStore.replayUndeliveredStreams({
       send: (eventId, message) => {
@@ -1164,18 +1186,7 @@ export abstract class McpAgentSessionDOBase<
       },
     });
     if (frames.length === 0) return null;
-    return this.trackedLegacyResponse(
-      new Response(combineFrames(frames), {
-        headers: {
-          "content-type": "text/event-stream",
-          "cache-control": "no-cache, no-transform",
-          connection: "keep-alive",
-          "x-accel-buffering": "no",
-          "mcp-session-id": this.sessionId,
-        },
-      }),
-      { acknowledge: streamIds },
-    );
+    return { frame: new Uint8Array(combineFrames(frames)), streamIds };
   }
 
   private async serializedTransportRequest<A>(run: () => Promise<A>): Promise<A> {
@@ -1211,8 +1222,19 @@ export abstract class McpAgentSessionDOBase<
           // through every workerd/Vite streaming hop, so explicitly retire a
           // stale standalone mapping before opening its replacement.
           transport.closeStandaloneSSEStream();
-          const replay = await this.replayUndeliveredOnStandaloneGet(request);
-          if (replay) return replay;
+          const replay = await this.collectUndeliveredReplay();
+          if (replay) {
+            // Prepend the replay onto the transport's own long-lived
+            // standalone stream — the stream MUST stay open afterwards (see
+            // collectUndeliveredReplay). Acknowledgement moves to stream end:
+            // "complete"/"rotate" imply the client stayed attached long
+            // enough to have drained the prepended frames.
+            const response = await transport.handleRequest(request);
+            return this.trackedLegacyResponse(response, {
+              initialFrame: replay.frame,
+              acknowledge: replay.streamIds,
+            });
+          }
         }
       }
       const toolCallIds = legacyToolCallRequestIds(parsedBody);


### PR DESCRIPTION
## Problem

Since the v2 session deploy (2026-08-16 21:20 UTC), every active MCP session has been stuck in a ~3s standalone-GET reconnect loop. `replayUndeliveredOnStandaloneGet` answered the listener GET with a FINITE body whenever any stream was undelivered, and every `tools/call` marks its stream undelivered until acknowledged — so an active client's listener always closed the moment its replay flushed (prod: 12k+ stream closes per 30min, p90 age 0ms), and the client immediately reconnected.

Fleet-wide effects: /mcp volume grew ~15x (sessions observed at 270+ GETs per 15min), the worker went into escalating memory-limit kills (9k+/hour and climbing), and the resulting isolate churn is what pushed homepage/app TTFB from ~15ms to ~3s (#1628 attacked that symptom; this is the cause).

## Fix

Replay undelivered responses as the OPENING frames of the transport's own long-lived standalone stream (`trackedLegacyResponse` `initialFrame`), instead of returning a finite response. The listener stays open afterwards.

Acknowledgement moves to stream end: `complete` or `rotate` (the client stayed attached through the max-age window, so the prepended frames drained long before). `cancel`/`error` leave streams replayable for the next reconnect, preserving the at-least-once delivery contract.

## Evidence

- Local repro against the dev cloud instance (stock `agents@0.20.1`, same as prod): initialize → `tools/call execute` → standalone GET. Before: GET returns the replay and closes in ~50ms. After: GET delivers the replayed response (priming + result frames) and holds open past a 15s cap.
- `packages/hosts/cloudflare` vitest: 64/64 (the replay test now reads frames incrementally and asserts the stream stays open).
- e2e `mcp-sse-replay`, `mcp-priming-reconnect`, `mcp-protocol`: 15 passed, 2 skipped.
- Typecheck, lint, format pass.

After deploy, expect: /mcp GET volume collapse toward the ~1.5/s baseline, memory-limit kills stop, `sse_close` ages move from 0ms to rotation-scale, and homepage p50 back to ~15ms as isolates stop churning (with #1628 covering the residual cold tail).
