### PR TITLE
Hold MCP listener streams open: keepalives + drained Last-Event-ID routing

### DIFF
--- a/packages/hosts/cloudflare/src/mcp/agent-session-durable-object.ts
+++ b/packages/hosts/cloudflare/src/mcp/agent-session-durable-object.ts
@@ -1115,6 +1115,27 @@ export abstract class McpAgentSessionDOBase<
     return typeof streamId === "string" ? streamId : null;
   }
 
+  /**
+   * Whether the stream named by `lastEventId` still has a request awaiting
+   * its response. SAFETY: reads the transport's pinned
+   * `_requestToStreamMapping` for the same reason `requestStreamId` and
+   * `supersedeReplayStream` do — the SDK exposes no public pending-request
+   * probe.
+   */
+  private async lastEventIdStreamHasPendingRequest(
+    transport: WebStandardStreamableHTTPServerTransport,
+    lastEventId: string,
+  ): Promise<boolean> {
+    const streamId = await this.eventStore.getStreamIdForEventId(lastEventId);
+    if (!streamId) return false;
+    const mapping: unknown = Reflect.get(transport, "_requestToStreamMapping");
+    if (!(mapping instanceof Map)) return false;
+    for (const mappedStreamId of mapping.values()) {
+      if (mappedStreamId === streamId) return true;
+    }
+    return false;
+  }
+
   private async supersedeReplayStream(
     transport: WebStandardStreamableHTTPServerTransport,
     lastEventId: string,
@@ -1215,9 +1236,16 @@ export abstract class McpAgentSessionDOBase<
       }
       if (request.method === "GET") {
         const lastEventId = request.headers.get("last-event-id");
-        const resumeHasPendingEvents =
-          lastEventId !== null && (await this.eventStore.hasEventsAfter(lastEventId));
-        if (lastEventId && resumeHasPendingEvents) {
+        // A reconnect id is only "drained" when the stream has no stored
+        // events after it AND no request still in flight on it. An in-flight
+        // tool call has produced no events past the priming frame yet, but
+        // its POST stream must still be resumed so the eventual result lands
+        // on this connection (the severed-POST recovery contract).
+        const resumable =
+          lastEventId !== null &&
+          ((await this.eventStore.hasEventsAfter(lastEventId)) ||
+            (await this.lastEventIdStreamHasPendingRequest(transport, lastEventId)));
+        if (lastEventId && resumable) {
           await this.supersedeReplayStream(transport, lastEventId);
         } else {
           // Standalone listener path — taken for a bare GET AND for a GET

--- a/packages/hosts/cloudflare/src/mcp/agent-session-durable-object.ts
+++ b/packages/hosts/cloudflare/src/mcp/agent-session-durable-object.ts
@@ -1215,26 +1215,37 @@ export abstract class McpAgentSessionDOBase<
       }
       if (request.method === "GET") {
         const lastEventId = request.headers.get("last-event-id");
-        if (lastEventId) {
+        const resumeHasPendingEvents =
+          lastEventId !== null && (await this.eventStore.hasEventsAfter(lastEventId));
+        if (lastEventId && resumeHasPendingEvents) {
           await this.supersedeReplayStream(transport, lastEventId);
         } else {
+          // Standalone listener path — taken for a bare GET AND for a GET
+          // whose Last-Event-ID stream is fully drained. EventSource clients
+          // echo their last id on every reconnect, so a drained id must not
+          // enter the transport's resume (it closes a completed stream's
+          // resume immediately, turning the echo into a reconnect loop).
+          let serveRequest = request;
+          if (lastEventId) {
+            const headers = new Headers(request.headers);
+            headers.delete("last-event-id");
+            serveRequest = new Request(request, { headers });
+          }
           // Latest-listener-wins. Client cancellation is not reliably relayed
           // through every workerd/Vite streaming hop, so explicitly retire a
           // stale standalone mapping before opening its replacement.
           transport.closeStandaloneSSEStream();
           const replay = await this.collectUndeliveredReplay();
-          if (replay) {
-            // Prepend the replay onto the transport's own long-lived
-            // standalone stream — the stream MUST stay open afterwards (see
-            // collectUndeliveredReplay). Acknowledgement moves to stream end:
-            // "complete"/"rotate" imply the client stayed attached long
-            // enough to have drained the prepended frames.
-            const response = await transport.handleRequest(request);
-            return this.trackedLegacyResponse(response, {
-              initialFrame: replay.frame,
-              acknowledge: replay.streamIds,
-            });
-          }
+          // Replayed responses ride as the opening frames of the transport's
+          // own long-lived standalone stream — the stream MUST stay open
+          // afterwards (see collectUndeliveredReplay). Acknowledgement moves
+          // to stream end: "complete"/"rotate" imply the client stayed
+          // attached long enough to have drained the prepended frames.
+          const response = await transport.handleRequest(serveRequest);
+          return this.trackedLegacyResponse(
+            response,
+            replay ? { initialFrame: replay.frame, acknowledge: replay.streamIds } : {},
+          );
         }
       }
       const toolCallIds = legacyToolCallRequestIds(parsedBody);

--- a/packages/hosts/cloudflare/src/mcp/do-event-store.ts
+++ b/packages/hosts/cloudflare/src/mcp/do-event-store.ts
@@ -245,6 +245,35 @@ export class DurableObjectMcpEventStore implements EventStore {
   }
 
   /** Replay persisted events after the supplied ID, in storage-key order. */
+  /**
+   * Whether the stream named by `lastEventId` still has stored events after
+   * it — i.e. whether a reconnect GET carrying this id has anything left to
+   * resume. EventSource clients echo the last id they saw on EVERY
+   * reconnect, so a drained id must route the connection to the standalone
+   * listener path instead of a resume (the transport closes a completed
+   * stream's resume immediately, which turns the echo into a reconnect
+   * loop).
+   */
+  async hasEventsAfter(lastEventId: EventId): Promise<boolean> {
+    const streamId = streamIdFromEventId(lastEventId);
+    if (!streamId) return false;
+    // oxlint-disable-next-line executor/no-try-catch-or-throw -- storage boundary: on probe failure fall back to resume semantics
+    try {
+      const rows = await this.storage.list<JSONRPCMessage>({
+        prefix: eventPrefix(streamId),
+        startAfter: `${EVENT_KEY_PREFIX}${lastEventId}`,
+        limit: 1,
+      });
+      return rows.size > 0;
+    } catch {
+      logStoreWarning("mcp_event_store_list_failed", {
+        operation: "has_events_after",
+        streamId,
+      });
+      return true;
+    }
+  }
+
   async replayEventsAfter(
     lastEventId: EventId,
     { send }: { readonly send: (eventId: EventId, message: JSONRPCMessage) => Promise<void> },

--- a/packages/hosts/cloudflare/src/mcp/sse-response-rotation.ts
+++ b/packages/hosts/cloudflare/src/mcp/sse-response-rotation.ts
@@ -5,8 +5,19 @@ export const SSE_MAX_AGE_RECONNECT_FRAME = ": max-age rotation, reconnect\n\n";
 
 export type SseResponseCloseReason = "cancel" | "complete" | "error" | "rotate";
 
+/**
+ * Comment frame emitted while the source is quiet so intermediaries and
+ * client idle timers see a live stream. The pre-v2 worker bridge sent one
+ * every 25s; without it, held-open standalone GET listeners die to ~30s
+ * client/proxy idle timeouts and every session reconnect-cycles at that
+ * cadence.
+ */
+export const SSE_KEEPALIVE_FRAME = ": keepalive\n\n";
+export const SSE_KEEPALIVE_INTERVAL_MS = 20_000;
+
 export interface SseResponseRotationOptions {
   readonly maxAgeMs?: number;
+  readonly keepaliveMs?: number;
   readonly initialFrame?: Uint8Array;
   readonly onOpen?: () => void;
   readonly onClose?: (reason: SseResponseCloseReason) => void;
@@ -29,16 +40,21 @@ export const rotateSseResponse = (
   if (!isSseResponse(response) || !response.body) return response;
 
   const reader = response.body.getReader();
-  const reconnectFrame = new TextEncoder().encode(SSE_MAX_AGE_RECONNECT_FRAME);
+  const encoder = new TextEncoder();
+  const reconnectFrame = encoder.encode(SSE_MAX_AGE_RECONNECT_FRAME);
+  const keepaliveFrame = encoder.encode(SSE_KEEPALIVE_FRAME);
   const maxAgeMs = options.maxAgeMs ?? SSE_MAX_AGE_MS;
+  const keepaliveMs = options.keepaliveMs ?? SSE_KEEPALIVE_INTERVAL_MS;
   let controller: ReadableStreamDefaultController<Uint8Array>;
   let closed = false;
   let timer: ReturnType<typeof setTimeout> | undefined;
+  let keepaliveTimer: ReturnType<typeof setInterval> | undefined;
 
   const finish = (reason: SseResponseCloseReason): void => {
     if (closed) return;
     closed = true;
     if (timer !== undefined) clearTimeout(timer);
+    if (keepaliveTimer !== undefined) clearInterval(keepaliveTimer);
     if (reason === "rotate") {
       controller.enqueue(reconnectFrame);
       controller.close();
@@ -58,6 +74,10 @@ export const rotateSseResponse = (
       options.onOpen?.();
       if (options.initialFrame) controller.enqueue(options.initialFrame);
       timer = setTimeout(() => finish("rotate"), maxAgeMs);
+      keepaliveTimer = setInterval(() => {
+        if (closed) return;
+        controller.enqueue(keepaliveFrame);
+      }, keepaliveMs);
     },
     async pull() {
       // oxlint-disable-next-line executor/no-try-catch-or-throw -- stream boundary: propagate the source body's rejected read to the response consumer
@@ -73,6 +93,7 @@ export const rotateSseResponse = (
         if (closed) return;
         closed = true;
         if (timer !== undefined) clearTimeout(timer);
+        if (keepaliveTimer !== undefined) clearInterval(keepaliveTimer);
         options.onClose?.("error");
         controller.error(cause);
       }
@@ -81,6 +102,7 @@ export const rotateSseResponse = (
       if (!closed) {
         closed = true;
         if (timer !== undefined) clearTimeout(timer);
+        if (keepaliveTimer !== undefined) clearInterval(keepaliveTimer);
         options.onClose?.("cancel");
       }
       await reader.cancel(reason);


### PR DESCRIPTION
## Problem

After #1629, standalone MCP listener streams stay open — but nothing on them emits while a session is quiet, so ~30s client/proxy idle timeouts kill them and every session still reconnect-cycles at ~35s (observed in prod post-#1629: GET volume plateaued at ~15/s instead of collapsing). The pre-v2 worker bridge sent a keepalive comment every 25s; the v2 direct-DO path lost that.

## Fix

`rotateSseResponse` now enqueues a `: keepalive` SSE comment every 20s alongside its existing max-age rotation timer, cleared on every close path. This covers every rotated legacy SSE response (standalone listeners and POST streams).

## Evidence

- Dev cloud instance: initialize → tools/call → standalone GET replayed the result, held open for a 47s cap, and carried the keepalive comments.
- `packages/hosts/cloudflare` vitest: 64/64. Typecheck, lint, format pass.

Expected in prod: reconnect cadence stretches from ~35s to the 30min rotation window, /mcp GET volume drops toward baseline (~1.5/s), memory-limit kills subside, and homepage requests start landing on warm isolates (`executor.start_graph.warm=true`, ~15ms).

## Second commit: drained Last-Event-ID routing

Post-#1629 prod showed the storm cohort still closing instantly: EventSource clients echo their last event id on every reconnect, and the transport resume path closes a completed stream's resume immediately. A GET whose Last-Event-ID stream has no stored events after it now routes to the standalone listener path (header stripped, undelivered replay prepended, stream held open with keepalives).

Verified live on the dev instance: a reconnect carrying a drained Last-Event-ID previously closed at ~50ms; it now delivers the replay and holds past a 30s cap with keepalives.