### PR TITLE
Route Google OAuth page to marketing

### DIFF
--- a/apps/cloud/src/edge/marketing.test.ts
+++ b/apps/cloud/src/edge/marketing.test.ts
@@ -12,6 +12,7 @@ describe("isMarketingPath", () => {
     "/home",
     "/privacy",
     "/terms",
+    "/google-oauth",
     "/blog",
     "/blog/",
     "/blog/some-post",

--- a/apps/cloud/src/edge/marketing.ts
+++ b/apps/cloud/src/edge/marketing.ts
@@ -18,6 +18,7 @@ const MARKETING_PATHS = [
   "/setup",
   "/privacy",
   "/terms",
+  "/google-oauth",
   "/blog",
   "/llms.txt",
   "/api/detect",


### PR DESCRIPTION
## What changed

- Route `/google-oauth` through the production marketing-worker allowlist.
- Cover the route with the existing marketing-edge regression test.

## Why

The page was deployed by the marketing worker, but production requests reached the cloud app shell because the path was not in the edge proxy allowlist.

## Validation

- `bun run --cwd apps/cloud test src/edge/marketing.test.ts`
- `bun run --cwd apps/cloud typecheck`
- Scoped Oxlint and Oxfmt checks
