### PR TITLE
Bypass Start for marketing requests

### DIFF
--- a/apps/cloud/src/edge/index.ts
+++ b/apps/cloud/src/edge/index.ts
@@ -1,11 +1,10 @@
 // ---------------------------------------------------------------------------
-// Edge concerns — the analytics/marketing/docs request middlewares that run at
-// the worker edge BEFORE the app's own mcp + api dispatch. None of these touch
-// the Effect app layer; they proxy or tunnel to external services (the
-// marketing worker, Sentry, PostHog, Mintlify docs).
+// Edge concerns — request middleware that runs before the app's own mcp + api
+// dispatch. These proxy or tunnel to external services without touching the
+// Effect app layer. Marketing is dispatched even earlier, from server.ts, so a
+// public page never loads the TanStack Start graph.
 // ---------------------------------------------------------------------------
 
-export { marketingMiddleware } from "./marketing";
 export { sentryTunnelMiddleware } from "./sentry-tunnel";
 export { posthogProxyMiddleware } from "./posthog";
 export { docsProxyMiddleware } from "./docs";

--- a/apps/cloud/src/edge/marketing.test.ts
+++ b/apps/cloud/src/edge/marketing.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "@effect/vitest";
 
-import { isMarketingPath } from "./marketing";
+import { isMarketingPath, marketingProxyRequest } from "./marketing";
 
 // On executor.sh the marketing middleware proxies an allow-list of paths to the
 // `executor-marketing` worker; everything else falls through to the auth-gated
@@ -36,4 +36,55 @@ describe("isMarketingPath", () => {
       expect(isMarketingPath(pathname)).toBe(false);
     });
   }
+});
+
+describe("marketingProxyRequest", () => {
+  it("routes a signed-out homepage request", () => {
+    const request = new Request("https://executor.sh/?source=test");
+
+    const proxied = marketingProxyRequest(request);
+
+    expect(proxied?.url).toBe("https://executor.sh/?source=test");
+  });
+
+  it("leaves the signed-in homepage with the cloud application", () => {
+    const request = new Request("https://executor.sh/", {
+      headers: { cookie: "other=value; wos-session=sealed" },
+    });
+
+    expect(marketingProxyRequest(request)).toBeNull();
+  });
+
+  it("routes public content even when a session cookie is present", () => {
+    const request = new Request("https://executor.sh/blog/post", {
+      headers: { cookie: "wos-session=sealed" },
+    });
+
+    expect(marketingProxyRequest(request)?.url).toBe("https://executor.sh/blog/post");
+  });
+
+  it("rewrites the public home alias to the marketing root", () => {
+    const request = new Request("https://executor.sh/home?source=test");
+
+    expect(marketingProxyRequest(request)?.url).toBe("https://executor.sh/?source=test");
+  });
+
+  it("preserves the request method, headers, and body", async () => {
+    const request = new Request("https://executor.sh/_astro/_ph/capture", {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-request-id": "request-1" },
+      body: JSON.stringify({ event: "test" }),
+    });
+
+    const proxied = marketingProxyRequest(request);
+
+    expect(proxied?.method).toBe("POST");
+    expect(proxied?.headers.get("x-request-id")).toBe("request-1");
+    await expect(proxied?.json()).resolves.toEqual({ event: "test" });
+  });
+
+  it("does not proxy non-production hosts or app-owned paths", () => {
+    expect(marketingProxyRequest(new Request("http://executor-cloud.localhost/"))).toBeNull();
+    expect(marketingProxyRequest(new Request("https://executor.sh/login"))).toBeNull();
+  });
 });

--- a/apps/cloud/src/edge/marketing.ts
+++ b/apps/cloud/src/edge/marketing.ts
@@ -3,13 +3,9 @@
 //
 // On the production domain (`executor.sh`), marketing paths and the
 // unauthenticated landing page are served by the separate `executor-marketing`
-// worker (bound as `env.MARKETING`). In local dev that worker isn't running, so
-// unauthenticated visits fall through to the cloud app's routes (the sign-in
-// page).
+// worker. This module deliberately has no TanStack Start or cloud application
+// imports: the Worker entry calls it before loading the Start server graph.
 // ---------------------------------------------------------------------------
-
-import { env } from "cloudflare:workers";
-import { createMiddleware } from "@tanstack/react-start";
 
 import { parseCookie } from "../auth/cookies";
 
@@ -27,33 +23,25 @@ const MARKETING_PATHS = [
   "/pattern-graph-paper.svg",
 ];
 
-export const isMarketingPath = (pathname: string) =>
+const SESSION_COOKIE = "wos-session";
+
+/** Whether an exact pathname belongs to the public marketing worker. */
+export const isMarketingPath = (pathname: string): boolean =>
   MARKETING_PATHS.some((p) => pathname === p || pathname.startsWith(`${p}/`));
 
-const getMarketingWorker = () => env.MARKETING as { fetch: typeof fetch } | undefined;
+/**
+ * Project a production request onto the marketing service-binding request.
+ * Returns `null` when the cloud application owns the request instead.
+ */
+export const marketingProxyRequest = (request: Request): Request | null => {
+  const url = new URL(request.url);
+  if (url.hostname !== "executor.sh") return null;
 
-export const marketingMiddleware = createMiddleware({ type: "request" }).server(
-  async ({ pathname, request, next }) => {
-    // Only proxy to the marketing worker on the production domain. In local
-    // dev we don't run `executor-marketing`, so unauthenticated visits fall
-    // through to the cloud app's routes (which show the sign-in page).
-    const host = new URL(request.url).hostname;
-    if (host !== "executor.sh") return next();
+  const shouldProxy =
+    isMarketingPath(url.pathname) ||
+    (url.pathname === "/" && !parseCookie(request.headers.get("cookie"), SESSION_COOKIE));
+  if (!shouldProxy) return null;
 
-    const shouldProxyToMarketing =
-      isMarketingPath(pathname) ||
-      (pathname === "/" && !parseCookie(request.headers.get("cookie"), "wos-session"));
-
-    if (!shouldProxyToMarketing) return next();
-
-    const marketing = getMarketingWorker();
-    if (!marketing) return next();
-
-    const url = new URL(request.url);
-    // Rewrite /home to / so marketing worker serves its homepage
-    if (pathname === "/home") {
-      url.pathname = "/";
-    }
-    return marketing.fetch(new Request(url, request));
-  },
-);
+  if (url.pathname === "/home") url.pathname = "/";
+  return new Request(url, request);
+};

--- a/apps/cloud/src/server.ts
+++ b/apps/cloud/src/server.ts
@@ -12,6 +12,7 @@ import * as Sentry from "@sentry/cloudflare";
 import handler from "@tanstack/react-start/server-entry";
 
 import { isAppOwnedPath } from "./app-paths";
+import { marketingProxyRequest } from "./edge/marketing";
 import { makeCloudMcpAgentHandler } from "./mcp/agent-handler";
 import { classifyMcpPath, prepareMcpOrgScope } from "./mcp/mount";
 import { parseTraceparent } from "./mcp/traceparent";
@@ -175,6 +176,14 @@ const mcpAgentHandler = makeCloudMcpAgentHandler({
 
 const cloudflareHandler: ExportedHandler<Env> = {
   fetch: async (request, env, ctx) => {
+    // Public pages must not enter TanStack Start: its first-request dynamic
+    // import loads the entire React + Effect server graph and can take seconds
+    // on a cold isolate. Classify and service-bind marketing at the Worker
+    // entry, before telemetry or fetchHandler touches that graph.
+    const marketingRequest = marketingProxyRequest(request);
+    const marketing: Fetcher | undefined = env.MARKETING;
+    if (marketingRequest && marketing) return marketing.fetch(marketingRequest);
+
     // Browser OTLP ingress — before the server span opens: exporter traffic
     // must never trace itself (the browser already excludes /v1/traces from
     // its own tracing for the same reason).

--- a/apps/cloud/src/start.ts
+++ b/apps/cloud/src/start.ts
@@ -10,7 +10,6 @@ import { loginPath } from "./auth/return-to";
 import { prepareMcpOrgScope } from "./mcp/mount";
 import {
   docsProxyMiddleware,
-  marketingMiddleware,
   openAiAppsChallengeMiddleware,
   posthogProxyMiddleware,
   sentryTunnelMiddleware,
@@ -89,20 +88,19 @@ const appRequestMiddleware = createMiddleware({ type: "request" }).server(
   },
 );
 
-// The edge concerns (marketing proxy, docs proxy, sentry tunnel, posthog proxy)
-// live in `./edge`; they run before the app's own dispatch. Ordering is
-// load-bearing: marketing first (production landing/page proxy), then the docs
-// proxy and analytics tunnels, then the unified app plane (api + mcp), and last
-// the SSR auth gate — it only sees document requests nothing above claimed, so
-// signed-out visitors are redirected to /login before the SPA (and its
-// app-shell skeleton) is served. The docs proxy sits among the edges (not after
-// the auth gate) because `/docs` is public and must skip the sign-in redirect;
-// its path is disjoint from every other matcher, so its slot is not otherwise
-// load-bearing.
+// The remaining edge concerns (docs proxy, sentry tunnel, posthog proxy) live
+// in `./edge`; they run before the app's own dispatch. Marketing is handled in
+// server.ts before this module is loaded. Ordering here is load-bearing: public
+// challenges and docs, then analytics tunnels, then the unified app plane (api
+// + mcp), and last the SSR auth gate — it only sees document requests nothing
+// above claimed, so signed-out visitors are redirected to /login before the SPA
+// (and its app-shell skeleton) is served. The docs proxy sits among the edges
+// (not after the auth gate) because `/docs` is public and must skip the sign-in
+// redirect; its path is disjoint from every other matcher, so its slot is not
+// otherwise load-bearing.
 export const startInstance = createStart(() => ({
   requestMiddleware: [
     openAiAppsChallengeMiddleware,
-    marketingMiddleware,
     docsProxyMiddleware,
     sentryTunnelMiddleware,
     posthogProxyMiddleware,


### PR DESCRIPTION
## What changed

- classify production marketing requests at the Worker entry
- dispatch them through the existing `MARKETING` service binding before TanStack Start
- preserve signed-in homepage routing, public path behavior, and the `/home` rewrite
- add request-level regression coverage for cookies, hosts, queries, headers, methods, and bodies

## Why

The marketing proxy lived inside TanStack Start middleware. On a cold isolate, a homepage request therefore loaded the 2.56 MB lazy Start server graph before forwarding to the fast marketing Worker. This moves the routing decision ahead of that import, so public pages only pay the small Worker-entry path.

## Validation

- `bun run typecheck`
- `bun run lint`
- `bun run --cwd apps/cloud build`
- `bun run --cwd apps/cloud test -- src/edge/marketing.test.ts` (22 passed)
- production bundle exercised in Miniflare with a real service binding
