### PR TITLE
Add Slack first-party OAuth

### DIFF
--- a/apps/cloud/src/engine/execution-stack.ts
+++ b/apps/cloud/src/engine/execution-stack.ts
@@ -43,8 +43,13 @@ import {
   collectTables,
 } from "@executor-js/api/server";
 import { googleCatalogOAuthScopesForPreset } from "@executor-js/plugin-openapi/providers/google";
+import { slackMcpUserScopes } from "@executor-js/react/lib/slack-mcp-oauth";
 import { makeDynamicWorkerExecutor } from "@executor-js/runtime-dynamic-worker";
-import type { AnyPlugin, FirstPartyOAuthClientConfig } from "@executor-js/sdk";
+import {
+  IntegrationSlug,
+  type AnyPlugin,
+  type FirstPartyOAuthClientConfig,
+} from "@executor-js/sdk";
 
 import executorConfig from "../../executor.config";
 import { DbService } from "../db/db";
@@ -133,6 +138,20 @@ const cloudFirstPartyOAuthClients = (): readonly FirstPartyOAuthClientConfig[] =
           clientId: env.FIRST_PARTY_GOOGLE_CLIENT_ID,
           clientSecret: env.FIRST_PARTY_GOOGLE_CLIENT_SECRET,
           allowedScopes: GOOGLE_FIRST_PARTY_ALLOWED_SCOPES,
+        },
+      ]
+    : []),
+  ...(env.FIRST_PARTY_SLACK_CLIENT_ID && env.FIRST_PARTY_SLACK_CLIENT_SECRET
+    ? [
+        {
+          name: "slack",
+          authorizationUrl: "https://slack.com/oauth/v2_user/authorize",
+          tokenUrl: "https://slack.com/api/oauth.v2.user.access",
+          resource: "https://mcp.slack.com",
+          clientId: env.FIRST_PARTY_SLACK_CLIENT_ID,
+          clientSecret: env.FIRST_PARTY_SLACK_CLIENT_SECRET,
+          integrations: [IntegrationSlug.make("slack")],
+          allowedScopes: slackMcpUserScopes,
         },
       ]
     : []),

--- a/apps/cloud/src/env-augment.d.ts
+++ b/apps/cloud/src/env-augment.d.ts
@@ -67,6 +67,8 @@ declare global {
       FIRST_PARTY_GITHUB_TOKEN_URL?: string;
       FIRST_PARTY_GOOGLE_CLIENT_ID?: string;
       FIRST_PARTY_GOOGLE_CLIENT_SECRET?: string;
+      FIRST_PARTY_SLACK_CLIENT_ID?: string;
+      FIRST_PARTY_SLACK_CLIENT_SECRET?: string;
 
       // Billing
       AUTUMN_SECRET_KEY?: string;

--- a/packages/core/sdk/src/oauth-client.ts
+++ b/packages/core/sdk/src/oauth-client.ts
@@ -122,13 +122,19 @@ export interface FirstPartyOAuthClientConfig {
   readonly clientId: string;
   /** Literal secret from host env. Empty string for a public/PKCE client. */
   readonly clientSecret: string;
+  /** RFC 8707 protected resource for MCP-style providers. Required when the
+   *  integration discovers its OAuth scopes from resource metadata. */
+  readonly resource?: string | null;
   /** Integrations this app is intended for, used by pickers to rank it as the
    *  exact-match default for those integrations. Endpoint-host matching still
    *  applies when omitted. */
   readonly integrations?: readonly IntegrationSlug[];
   /** OAuth scopes this deployment permits the app to request. Omit to allow
-   *  every scope declared by a matching integration. When present, OAuth start
-   *  and completion fail unless every requested scope belongs to this set. */
+   *  every scope declared by a matching integration. For declared scopes,
+   *  start and completion fail unless every requested scope belongs to this
+   *  set. For MCP-style discovery, the provider's advertised scope catalog is
+   *  capped to this set because it may include capabilities the registered app
+   *  was not approved for. */
   readonly allowedScopes?: readonly string[];
 }
 

--- a/packages/core/sdk/src/oauth-first-party.test.ts
+++ b/packages/core/sdk/src/oauth-first-party.test.ts
@@ -220,7 +220,11 @@ describe("first-party oauth clients", () => {
         const { executor } = yield* makeTestWorkspaceHarness({
           plugins,
           firstPartyOAuthClients: [
-            { ...firstPartyClientFor(server), allowedScopes: ["openid", "read"] },
+            {
+              ...firstPartyClientFor(server),
+              resource: server.resourceUrl,
+              allowedScopes: ["openid", "read"],
+            },
           ],
         });
         yield* executor.acme.seed();
@@ -244,6 +248,7 @@ describe("first-party oauth clients", () => {
           allowedScopes: ["openid", "read"],
         });
         expect(firstParty.clientId).toBe("test-client");
+        expect(firstParty.resource).toBe(server.resourceUrl);
         expect("clientSecret" in firstParty).toBe(false);
       }),
     ),

--- a/packages/core/sdk/src/oauth-scope-union.test.ts
+++ b/packages/core/sdk/src/oauth-scope-union.test.ts
@@ -11,6 +11,7 @@ import {
   ToolName,
 } from "./ids";
 import type { AuthMethodDescriptor } from "./integration";
+import { firstPartyOAuthClientSlug } from "./oauth-client";
 import { definePlugin, type IntegrationRecord } from "./plugin";
 import { makeTestWorkspaceHarness, memoryCredentialsPlugin } from "./test-config";
 import { serveTestHttpApp } from "./testing";
@@ -528,6 +529,51 @@ describe("oauth.start integration-driven scopes", () => {
             }),
           );
           expect(Exit.isFailure(exit)).toBe(true);
+        }),
+      ),
+  );
+
+  it.effect(
+    "(i) a scope-limited first-party MCP app caps the provider's advertised scope catalog",
+    () =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          const server = yield* serveMetadataServer({
+            prm: { scopesSupported: ["read", "write", "admin"] },
+          });
+          const plugins = [
+            memoryCredentialsPlugin(),
+            makeMcpScopePlugin({ scopes: null }),
+          ] as const;
+          const { executor } = yield* makeTestWorkspaceHarness({
+            plugins,
+            firstPartyOAuthClients: [
+              {
+                name: "acme",
+                authorizationUrl: server.authorizationEndpoint,
+                tokenUrl: server.tokenEndpoint,
+                resource: server.mcpResourceUrl,
+                clientId: "test-client",
+                clientSecret: "test-secret",
+                integrations: [INTEG],
+                allowedScopes: ["read", "write"],
+              },
+            ],
+          });
+          yield* executor.mcp.seed();
+
+          const started = yield* executor.oauth.start({
+            owner: "org",
+            client: firstPartyOAuthClientSlug("acme"),
+            clientOwner: "org",
+            name: ConnectionName.make("main"),
+            integration: INTEG,
+            template: TEMPLATE,
+          });
+          expect(started.status).toBe("redirect");
+          if (started.status !== "redirect") return;
+
+          expect(scopesFromAuthorizeUrl(started.authorizationUrl)).toEqual(["read", "write"]);
         }),
       ),
   );

--- a/packages/core/sdk/src/oauth-service.ts
+++ b/packages/core/sdk/src/oauth-service.ts
@@ -513,7 +513,7 @@ export const loadedFirstPartyClient = (
   readonly grant: OAuthGrant;
   readonly clientId: string;
   readonly clientSecret: string;
-  readonly resource: null;
+  readonly resource: string | null;
 } => ({
   slug: String(firstPartyOAuthClientSlug(config.name)),
   authorizationUrl: config.authorizationUrl,
@@ -521,7 +521,7 @@ export const loadedFirstPartyClient = (
   grant: "authorization_code",
   clientId: config.clientId,
   clientSecret: config.clientSecret,
-  resource: null,
+  resource: config.resource ?? null,
 });
 
 export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
@@ -1026,7 +1026,7 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
         grant: "authorization_code",
         authorizationUrl: config.authorizationUrl,
         tokenUrl: config.tokenUrl,
-        resource: null,
+        resource: config.resource ?? null,
         clientId: config.clientId,
         origin: {
           kind: "first_party",
@@ -1213,25 +1213,32 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
               }),
           ),
         );
+      const firstParty = firstPartyFlow ? firstPartyBySlug.get(String(input.client)) : undefined;
       const requestedScopes =
         scopePolicy.kind === "discover"
-          ? yield* discoverScopesForResource(client.resource).pipe(
-              Effect.mapError(
-                (cause) =>
-                  new OAuthStartError({
-                    // oxlint-disable-next-line executor/no-unknown-error-message -- boundary: OAuthDiscoveryError carries a typed `message` field
-                    message: `Failed to discover OAuth scopes: ${cause.message}`,
-                  }),
-              ),
-            )
+          ? yield* (() => {
+              const discovered = discoverScopesForResource(client.resource).pipe(
+                Effect.mapError(
+                  (cause) =>
+                    new OAuthStartError({
+                      // oxlint-disable-next-line executor/no-unknown-error-message -- boundary: OAuthDiscoveryError carries a typed `message` field
+                      message: `Failed to discover OAuth scopes: ${cause.message}`,
+                    }),
+                ),
+              );
+              if (firstParty?.allowedScopes === undefined) return discovered;
+              const allowed = new Set(firstParty.allowedScopes);
+              return discovered.pipe(
+                Effect.map((scopes) => scopes.filter((scope) => allowed.has(scope))),
+              );
+            })()
           : dedupeScopes(scopePolicy.scopes);
 
       // An explicitly scope-limited first-party app is an authorization
-      // boundary, not picker decoration. Endpoint matching can associate one
-      // Google client with every Google API, so enforce the complete requested
-      // set here before persisting an OAuth session or redirecting the browser.
+      // boundary, not picker decoration. Endpoint matching and provider
+      // discovery can surface capabilities outside the registered app, so
+      // enforce the complete requested set before persisting or redirecting.
       if (firstPartyFlow) {
-        const firstParty = firstPartyBySlug.get(String(input.client));
         if (
           firstParty !== undefined &&
           !firstPartyOAuthClientAllowsScopes(firstParty, requestedScopes)

--- a/packages/react/src/components/oauth-app-setup.ts
+++ b/packages/react/src/components/oauth-app-setup.ts
@@ -1,3 +1,7 @@
+import { slackMcpUserScopes } from "../lib/slack-mcp-oauth";
+
+export { slackMcpUserScopes } from "../lib/slack-mcp-oauth";
+
 export interface OAuthAppSetup {
   readonly id: string;
   readonly title: string;
@@ -28,35 +32,6 @@ interface SlackManifest {
     readonly is_mcp_enabled: boolean;
   };
 }
-
-export const slackMcpUserScopes = [
-  "search:read.public",
-  "search:read.private",
-  "search:read.mpim",
-  "search:read.im",
-  "search:read.files",
-  "search:read.users",
-  "chat:write",
-  "channels:history",
-  "groups:history",
-  "mpim:history",
-  "im:history",
-  "canvases:read",
-  "canvases:write",
-  "users:read",
-  "users:read.email",
-  "reactions:write",
-  "reactions:read",
-  "emoji:read",
-  "files:read",
-  "channels:write",
-  "groups:write",
-  "im:write",
-  "mpim:write",
-  "channels:read",
-  "groups:read",
-  "mpim:read",
-] as const;
 
 const slackManifest = (callbackUrl: string): SlackManifest => ({
   display_information: { name: "Executor" },

--- a/packages/react/src/lib/slack-mcp-oauth.ts
+++ b/packages/react/src/lib/slack-mcp-oauth.ts
@@ -1,0 +1,32 @@
+/** User scopes approved on Executor's Slack MCP OAuth app and embedded in the
+ *  BYO-app creation manifest. Cloud uses the same list as its first-party
+ *  discovery cap so Slack metadata cannot expand the requested grant beyond
+ *  the provider-side registration. */
+export const slackMcpUserScopes = [
+  "search:read.public",
+  "search:read.private",
+  "search:read.mpim",
+  "search:read.im",
+  "search:read.files",
+  "search:read.users",
+  "chat:write",
+  "channels:history",
+  "groups:history",
+  "mpim:history",
+  "im:history",
+  "canvases:read",
+  "canvases:write",
+  "users:read",
+  "users:read.email",
+  "reactions:write",
+  "reactions:read",
+  "emoji:read",
+  "files:read",
+  "channels:write",
+  "groups:write",
+  "im:write",
+  "mpim:write",
+  "channels:read",
+  "groups:read",
+  "mpim:read",
+] as const;


### PR DESCRIPTION
## What changed

- add the hosted Slack OAuth client to Cloud configuration
- preserve protected-resource metadata for first-party OAuth clients
- cap discovered MCP scopes to the provider-approved scope set
- share the Slack MCP scope list between the app manifest and Cloud runtime

## Why

Slack connections currently require customers to register their own OAuth app. This adds a built-in production client while ensuring provider metadata cannot expand the requested grant beyond the scopes approved on that app.

## Validation

- full test suite
- full typecheck
- full lint
- Cloud production build
- focused OAuth and React tests
