### PR TITLE
Show first-party OAuth for MCP discovery

### DIFF
--- a/packages/react/src/components/add-account-modal.tsx
+++ b/packages/react/src/components/add-account-modal.tsx
@@ -1517,6 +1517,9 @@ function AddAccountModalView(props: AddAccountModalProps) {
     tokenUrl: method?.oauth?.tokenUrl ?? oauthFallbackProbe?.tokenUrl,
     authorizationUrl: method?.oauth?.authorizationUrl ?? oauthFallbackProbe?.authorizationUrl,
     scopes: method?.oauth?.scopes,
+    // MCP OAuth scopes are discovered by the server at connect time, where a
+    // first-party app's configured allow-list caps the provider's catalog.
+    discoversScopes: isDcr,
     // Recorded intent: a manual app registered from THIS integration's dialog is
     // a tier-1 match regardless of host.
     integration,

--- a/packages/react/src/plugins/use-effective-oauth-client.test.ts
+++ b/packages/react/src/plugins/use-effective-oauth-client.test.ts
@@ -316,6 +316,38 @@ describe("selectClientsForEndpoints", () => {
     expect(result.unmatched).toEqual([]);
   });
 
+  it("only allows unknown first-party scopes on the provider-discovery path", () => {
+    const integration = IntegrationSlug.make("slack_mcp");
+    const firstParty = app("first-party:slack", {
+      owner: "org",
+      authorizationUrl: "https://slack.com/oauth/v2_user/authorize",
+      tokenUrl: "https://slack.com/api/oauth.v2.user.access",
+      origin: {
+        kind: "first_party",
+        allowedScopes: ["search:read.public", "chat:write"],
+      },
+    });
+    const endpoints = {
+      authorizationUrl: "https://slack.com/oauth/v2_user/authorize",
+      tokenUrl: "https://slack.com/api/oauth.v2.user.access",
+      integration,
+      requireEndpointMatch: true,
+    } as const;
+
+    const staticUnknown = selectClientsForEndpoints([firstParty], endpoints);
+    expect(staticUnknown.endpointMatched).toBe(false);
+    expect(staticUnknown.matched).toEqual([]);
+
+    const discovered = selectClientsForEndpoints([firstParty], {
+      ...endpoints,
+      discoversScopes: true,
+    });
+    expect(discovered.endpointMatched).toBe(true);
+    expect(discovered.matched.map((a: OAuthClientOption) => String(a.slug))).toEqual([
+      "first-party:slack",
+    ]);
+  });
+
   it("intent-matches a first-party app to its declared integrations even without endpoints", () => {
     const integration = IntegrationSlug.make("github_rest");
     const firstParty = app("first-party:github", {

--- a/packages/react/src/plugins/use-effective-oauth-client.tsx
+++ b/packages/react/src/plugins/use-effective-oauth-client.tsx
@@ -59,9 +59,13 @@ export const isFirstPartyClient = (app: OAuthClientOption): boolean =>
 const firstPartyClientAllowsScopes = (
   app: OAuthClientOption,
   requestedScopes: readonly string[] | undefined,
+  discoversScopes: boolean,
 ): boolean => {
   if (app.origin.kind !== "first_party" || app.origin.allowedScopes === undefined) return true;
-  if (requestedScopes === undefined) return false;
+  // MCP providers discover their scopes at OAuth start. The server intersects
+  // that catalog with this same allow-list before redirecting, so an absent
+  // static scope list is safe only on the explicit discovery path.
+  if (requestedScopes === undefined) return discoversScopes;
   const allowed = new Set(app.origin.allowedScopes);
   return requestedScopes.every((scope) => allowed.has(scope));
 };
@@ -178,6 +182,9 @@ export function selectClientsForEndpoints(
     /** Complete scope set declared by the selected OAuth auth method. Used to
      *  hide scope-limited first-party apps that the host will reject. */
     readonly scopes?: readonly string[];
+    /** The OAuth service discovers provider scopes at connect time and caps a
+     *  first-party app's result to its configured allow-list. */
+    readonly discoversScopes?: boolean;
     /** When set, an integration that targets a SPECIFIC server (MCP, whose
      *  endpoints are discovered at connect) must match by endpoint — absent
      *  endpoints mean NO match (show the register CTA), never "every app
@@ -192,7 +199,9 @@ export function selectClientsForEndpoints(
 } {
   // DCR clients are plumbing, never picker options.
   const manual = all.filter(
-    (app) => !isDcrClient(app) && firstPartyClientAllowsScopes(app, endpoints.scopes),
+    (app) =>
+      !isDcrClient(app) &&
+      firstPartyClientAllowsScopes(app, endpoints.scopes, endpoints.discoversScopes === true),
   );
 
   const intent = endpoints.integration;
@@ -281,6 +290,7 @@ export function useOAuthClientsForIntegration(opts: {
   readonly authorizationUrl?: string;
   readonly integration?: IntegrationSlug;
   readonly scopes?: readonly string[];
+  readonly discoversScopes?: boolean;
   readonly requireEndpointMatch?: boolean;
 }): UseOAuthClientsResult {
   // Read the optimistic list so a just-registered/edited/removed app paints
@@ -303,6 +313,7 @@ export function useOAuthClientsForIntegration(opts: {
         authorizationUrl: opts.authorizationUrl,
         integration: opts.integration,
         scopes: opts.scopes,
+        discoversScopes: opts.discoversScopes,
         requireEndpointMatch: opts.requireEndpointMatch,
       }),
     [
@@ -311,6 +322,7 @@ export function useOAuthClientsForIntegration(opts: {
       opts.authorizationUrl,
       opts.integration,
       opts.scopes,
+      opts.discoversScopes,
       opts.requireEndpointMatch,
     ],
   );


### PR DESCRIPTION
## What changed

- allow scope-limited first-party apps in MCP OAuth pickers when scopes are discovered at connect time
- retain the fail-closed behavior for integrations with unknown static scopes
- add a regression test for the Slack MCP case

## Why

The server now caps discovered provider scopes to the first-party app's allow-list, but the picker still hid that app whenever an MCP integration had no static scope list. This left the older workspace-owned app as the only visible choice.

## Validation

- 325 React tests
- React build and typecheck
- targeted lint and formatting
