### PR TITLE
Handle Slack user OAuth scopes

### DIFF
--- a/packages/core/sdk/src/oauth-helpers.test.ts
+++ b/packages/core/sdk/src/oauth-helpers.test.ts
@@ -487,6 +487,82 @@ describe("exchangeAuthorizationCode", () => {
     ),
   );
 
+  it.effect("uses nested granted scopes for Slack-style user token responses", () =>
+    withTokenEndpoint(
+      tokenResponse({
+        access_token: "xoxp-user-token",
+        token_type: "Bearer",
+        scope: "",
+        authed_user: {
+          id: "U12345",
+          scope: "channels:read,chat:write",
+        },
+      }),
+      ({ tokenUrl }) =>
+        Effect.gen(function* () {
+          const result = yield* exchangeAuthorizationCode({
+            tokenUrl,
+            clientId: "cid",
+            clientSecret: "csecret",
+            redirectUrl: "https://app.example.com/cb",
+            codeVerifier: "verifier",
+            code: "abc",
+          });
+          expect(result.access_token).toBe("xoxp-user-token");
+          expect(result.scope).toBe("channels:read chat:write");
+        }),
+    ),
+  );
+
+  it.effect("does not assign nested user scopes to a distinct top-level bot token", () =>
+    withTokenEndpoint(
+      tokenResponse({
+        access_token: "xoxb-bot-token",
+        token_type: "Bearer",
+        scope: "",
+        authed_user: {
+          scope: "channels:read,chat:write",
+          access_token: "xoxp-user-token",
+        },
+      }),
+      ({ tokenUrl }) =>
+        Effect.gen(function* () {
+          const result = yield* exchangeAuthorizationCode({
+            tokenUrl,
+            clientId: "cid",
+            clientSecret: "csecret",
+            redirectUrl: "https://app.example.com/cb",
+            codeVerifier: "verifier",
+            code: "abc",
+          });
+          expect(result.scope).toBe("");
+        }),
+    ),
+  );
+
+  it.effect("keeps a standard top-level scope ahead of nested provider metadata", () =>
+    withTokenEndpoint(
+      tokenResponse({
+        access_token: "user-token",
+        token_type: "Bearer",
+        scope: "standard.scope",
+        authed_user: { scope: "provider.scope" },
+      }),
+      ({ tokenUrl }) =>
+        Effect.gen(function* () {
+          const result = yield* exchangeAuthorizationCode({
+            tokenUrl,
+            clientId: "cid",
+            clientSecret: "csecret",
+            redirectUrl: "https://app.example.com/cb",
+            codeVerifier: "verifier",
+            code: "abc",
+          });
+          expect(result.scope).toBe("standard.scope");
+        }),
+    ),
+  );
+
   it.effect("still surfaces RFC 6749 §5.2 error envelopes after the id_token strip", () =>
     withTokenEndpoint(
       () =>

--- a/packages/core/sdk/src/oauth-helpers.ts
+++ b/packages/core/sdk/src/oauth-helpers.ts
@@ -604,6 +604,48 @@ type StrippedTokenResponse = {
   readonly idTokenIdentityLabel?: string;
 };
 
+const NestedAuthedUserScope = Schema.Struct({
+  authed_user: Schema.Struct({
+    scope: Schema.String,
+    access_token: Schema.optional(Schema.String),
+  }),
+});
+const decodeNestedAuthedUserScope = Schema.decodeUnknownOption(NestedAuthedUserScope);
+
+type NestedAuthedUserGrant = {
+  readonly scope: string;
+  readonly accessToken?: string;
+};
+
+/** Slack's MCP-oriented `oauth.v2.user.access` endpoint returns its granted
+ * user scopes under `authed_user.scope` instead of the RFC 6749 top-level
+ * `scope`. Preserve that provider extension only when the standard field is
+ * absent or empty, and normalize Slack's comma separator back to RFC space-delimited
+ * scope syntax at this boundary. */
+const nestedAuthedUserGrant = async (
+  response: Response,
+): Promise<NestedAuthedUserGrant | undefined> => {
+  const body = await response
+    .clone()
+    .json()
+    .then(
+      (value: unknown) => value,
+      () => null,
+    );
+  const decoded = decodeNestedAuthedUserScope(body);
+  if (Option.isNone(decoded)) return undefined;
+  const normalized = decoded.value.authed_user.scope
+    .split(/[\s,]+/)
+    .filter(Boolean)
+    .join(" ");
+  if (normalized.length === 0) return undefined;
+  const nestedAccessToken = decoded.value.authed_user.access_token;
+  return {
+    scope: normalized,
+    ...(nestedAccessToken === undefined ? {} : { accessToken: nestedAccessToken }),
+  };
+};
+
 // MCP source connections are pure OAuth 2.0. Some providers (PostHog, etc.)
 // front an OIDC backend and emit an `id_token` anyway; oauth4webapi then
 // strict-validates its claims against the AS metadata and rejects mismatches we
@@ -638,9 +680,18 @@ const processTokenEndpointResponse = async (
   response: Response,
 ): Promise<OAuth2TokenResponse> => {
   const stripped = await stripIdToken(response);
-  const token = tokenResponseFrom(
+  const providerUserGrant = await nestedAuthedUserGrant(stripped.response);
+  const parsed = tokenResponseFrom(
     await oauth.processGenericTokenEndpointResponse(as, client, stripped.response),
   );
+  const topLevelScopeIsEmpty = parsed.scope === undefined || parsed.scope.trim().length === 0;
+  const nestedGrantMatchesAccessToken =
+    providerUserGrant?.accessToken === undefined ||
+    providerUserGrant.accessToken === parsed.access_token;
+  const token =
+    topLevelScopeIsEmpty && providerUserGrant !== undefined && nestedGrantMatchesAccessToken
+      ? { ...parsed, scope: providerUserGrant.scope }
+      : parsed;
   return stripped.idTokenIdentityLabel
     ? { ...token, idTokenIdentityLabel: stripped.idTokenIdentityLabel }
     : token;


### PR DESCRIPTION
Slack's MCP-oriented OAuth token endpoint returns an empty top-level `scope`
and the actual user grants under `authed_user.scope`. Executor treated that as
a zero-scope grant and marked every requested Slack scope missing.

This parses the nested user grant at the token-response boundary, normalizes
Slack's comma-separated scopes, and only applies it when it belongs to the same
access token so a separate bot token is not conflated with user scopes.

Checks:

- Core SDK: 611 tests passed
- Core SDK typecheck
- Targeted oxlint
- Targeted oxfmt check
