### PR TITLE
Select Slack user token grants

### DIFF
--- a/packages/core/sdk/src/oauth-helpers.test.ts
+++ b/packages/core/sdk/src/oauth-helpers.test.ts
@@ -514,15 +514,21 @@ describe("exchangeAuthorizationCode", () => {
     ),
   );
 
-  it.effect("does not assign nested user scopes to a distinct top-level bot token", () =>
+  it.effect("selects the nested user grant when an empty top-level grant has a bot token", () =>
     withTokenEndpoint(
       tokenResponse({
         access_token: "xoxb-bot-token",
         token_type: "Bearer",
         scope: "",
+        refresh_token: "bot-refresh-token",
+        expires_in: 600,
+        id_token: unsignedJwt({ email: "alice@example.com" }),
         authed_user: {
           scope: "channels:read,chat:write",
           access_token: "xoxp-user-token",
+          token_type: "user",
+          refresh_token: "user-refresh-token",
+          expires_in: 3600,
         },
       }),
       ({ tokenUrl }) =>
@@ -535,7 +541,36 @@ describe("exchangeAuthorizationCode", () => {
             codeVerifier: "verifier",
             code: "abc",
           });
-          expect(result.scope).toBe("");
+          expect(result).toMatchObject({
+            access_token: "xoxp-user-token",
+            token_type: "user",
+            refresh_token: "user-refresh-token",
+            expires_in: 3600,
+            scope: "channels:read chat:write",
+            idTokenIdentityLabel: "alice@example.com",
+          });
+        }),
+    ),
+  );
+
+  it.effect("treats an empty standard scope as omitted", () =>
+    withTokenEndpoint(
+      tokenResponse({
+        access_token: "user-token",
+        token_type: "Bearer",
+        scope: "   ",
+      }),
+      ({ tokenUrl }) =>
+        Effect.gen(function* () {
+          const result = yield* exchangeAuthorizationCode({
+            tokenUrl,
+            clientId: "cid",
+            clientSecret: "csecret",
+            redirectUrl: "https://app.example.com/cb",
+            codeVerifier: "verifier",
+            code: "abc",
+          });
+          expect(result.scope).toBeUndefined();
         }),
     ),
   );

--- a/packages/core/sdk/src/oauth-helpers.ts
+++ b/packages/core/sdk/src/oauth-helpers.ts
@@ -557,7 +557,7 @@ const tokenResponseFrom = (r: oauth.TokenEndpointResponse): OAuth2TokenResponse 
   token_type: r.token_type,
   refresh_token: r.refresh_token,
   expires_in: typeof r.expires_in === "number" ? r.expires_in : undefined,
-  scope: r.scope,
+  scope: typeof r.scope === "string" && r.scope.trim().length > 0 ? r.scope : undefined,
 });
 
 const JwtClaims = Schema.Record(Schema.String, Schema.Unknown);
@@ -608,6 +608,9 @@ const NestedAuthedUserScope = Schema.Struct({
   authed_user: Schema.Struct({
     scope: Schema.String,
     access_token: Schema.optional(Schema.String),
+    token_type: Schema.optional(Schema.String),
+    refresh_token: Schema.optional(Schema.String),
+    expires_in: Schema.optional(Schema.Number),
   }),
 });
 const decodeNestedAuthedUserScope = Schema.decodeUnknownOption(NestedAuthedUserScope);
@@ -615,6 +618,9 @@ const decodeNestedAuthedUserScope = Schema.decodeUnknownOption(NestedAuthedUserS
 type NestedAuthedUserGrant = {
   readonly scope: string;
   readonly accessToken?: string;
+  readonly tokenType?: string;
+  readonly refreshToken?: string;
+  readonly expiresIn?: number;
 };
 
 /** Slack's MCP-oriented `oauth.v2.user.access` endpoint returns its granted
@@ -640,9 +646,15 @@ const nestedAuthedUserGrant = async (
     .join(" ");
   if (normalized.length === 0) return undefined;
   const nestedAccessToken = decoded.value.authed_user.access_token;
+  const nestedTokenType = decoded.value.authed_user.token_type;
+  const nestedRefreshToken = decoded.value.authed_user.refresh_token;
+  const nestedExpiresIn = decoded.value.authed_user.expires_in;
   return {
     scope: normalized,
     ...(nestedAccessToken === undefined ? {} : { accessToken: nestedAccessToken }),
+    ...(nestedTokenType === undefined ? {} : { tokenType: nestedTokenType }),
+    ...(nestedRefreshToken === undefined ? {} : { refreshToken: nestedRefreshToken }),
+    ...(nestedExpiresIn === undefined ? {} : { expiresIn: nestedExpiresIn }),
   };
 };
 
@@ -684,13 +696,17 @@ const processTokenEndpointResponse = async (
   const parsed = tokenResponseFrom(
     await oauth.processGenericTokenEndpointResponse(as, client, stripped.response),
   );
-  const topLevelScopeIsEmpty = parsed.scope === undefined || parsed.scope.trim().length === 0;
-  const nestedGrantMatchesAccessToken =
-    providerUserGrant?.accessToken === undefined ||
-    providerUserGrant.accessToken === parsed.access_token;
   const token =
-    topLevelScopeIsEmpty && providerUserGrant !== undefined && nestedGrantMatchesAccessToken
-      ? { ...parsed, scope: providerUserGrant.scope }
+    parsed.scope === undefined && providerUserGrant !== undefined
+      ? providerUserGrant.accessToken === undefined
+        ? { ...parsed, scope: providerUserGrant.scope }
+        : {
+            access_token: providerUserGrant.accessToken,
+            token_type: providerUserGrant.tokenType,
+            refresh_token: providerUserGrant.refreshToken,
+            expires_in: providerUserGrant.expiresIn,
+            scope: providerUserGrant.scope,
+          }
       : parsed;
   return stripped.idTokenIdentityLabel
     ? { ...token, idTokenIdentityLabel: stripped.idTokenIdentityLabel }


### PR DESCRIPTION
Slack can return an empty top-level OAuth grant while placing the usable user token, scopes, refresh token, and expiry under `authed_user`. Executor kept the top-level token and therefore recorded every requested Slack scope as missing.

This selects the complete nested user grant when the standard top-level scope is empty, while preserving a non-empty standard grant. Empty scope strings are normalized as omitted.

Live production reproduction:
- workspace Slack client: healthy connection, all scopes recorded missing
- built-in Slack client: healthy connection, all 26 scopes recorded missing

Checks:
- Core SDK: 45 files, 612 tests passed
- Core SDK typecheck
- Targeted oxlint
- Targeted oxfmt check
- `git diff --check`
