### PR TITLE
Serve toolkit-scoped MCP sessions on the Cloudflare host

### DIFF
--- a/apps/host-cloudflare/src/mcp/agent-handler.ts
+++ b/apps/host-cloudflare/src/mcp/agent-handler.ts
@@ -7,6 +7,7 @@ import {
   defaultMcpResource,
   type AuthOutcome,
   type McpModernServerBuilder,
+  type McpResource,
   type Principal,
 } from "@executor-js/host-mcp";
 import { requestBodyFromRequest } from "@executor-js/host-mcp/tool-server";
@@ -131,9 +132,23 @@ const authenticate = (request: Request, authProvider: Layer.Layer<McpAuthProvide
     return { auth, outcome };
   }).pipe(Effect.provide(authProvider));
 
+// The MCP resource the request targets. The worker entry routes both the bare
+// `/mcp` endpoint and `/mcp/toolkits/<slug>` here; everything downstream keys
+// off the resource this returns — the modern router caches one server per
+// resource, and a session Durable Object pins the resource it was opened with
+// for its entire lifetime (it rejects a later request carrying a different one).
+const resourceFromPath = (request: Request): McpResource => {
+  const segments = new URL(request.url).pathname.split("/").filter((segment) => segment.length > 0);
+  if (segments.length === 3 && segments[0] === "mcp" && segments[1] === "toolkits" && segments[2]) {
+    return { kind: "toolkit", slug: segments[2] };
+  }
+  return defaultMcpResource;
+};
+
 const propsForPrincipal = (
   request: Request,
   principal: Principal,
+  resource: McpResource,
 ): Effect.Effect<McpSessionProps> =>
   Effect.gen(function* () {
     const propagation = yield* currentPropagationHeaders(request);
@@ -143,10 +158,7 @@ const propsForPrincipal = (
         userId: principal.accountId,
         elicitationMode: readElicitationMode(request),
         artifactsEnabled: readArtifactsEnabled(request),
-        // host-cloudflare only routes the bare `/mcp` endpoint to the session
-        // Durable Object (see worker.ts), so it always serves the default
-        // resource.
-        resource: defaultMcpResource,
+        resource,
         webOrigin: new URL(request.url).origin,
       },
       propagation,
@@ -199,13 +211,19 @@ export const makeCloudflareMcpAgentHandler = (
       return renderAuthError(auth, request, outcome);
     }
 
+    // Both eras carry the resource the same way — stamped into the internal
+    // identity header the session DO verifies — so it is resolved once here,
+    // before the era split.
+    const resource = resourceFromPath(request);
     const parsedBody = await Effect.runPromise(requestBodyFromRequest(request));
     const era = await classifyMcpProtocolEra(request, parsedBody);
     if (era === "modern") {
       if (env.MCP_2026_07_28_ENABLED === "false") {
         return mcpModernDisabledResponse();
       }
-      const props = await Effect.runPromise(propsForPrincipal(request, outcome.principal));
+      const props = await Effect.runPromise(
+        propsForPrincipal(request, outcome.principal, resource),
+      );
       (ctx as ExecutionContext & { props?: McpSessionProps }).props = props;
       const forwarded = withVerifiedIdentityHeaders(
         request,
@@ -213,13 +231,13 @@ export const makeCloudflareMcpAgentHandler = (
           accountId: outcome.principal.accountId,
           organizationId: outcome.principal.organizationId,
         },
-        defaultMcpResource,
+        resource,
       );
       return modern.fetch({
         request: forwarded,
         parsedBody,
         principal: outcome.principal,
-        resource: defaultMcpResource,
+        resource,
         props,
         requestStateSigningKey: requireMcpRequestStateKey(env.MCP_REQUEST_STATE_KEY),
         builder: options.makeModernServerBuilder(env, config, props.session),
@@ -264,7 +282,7 @@ export const makeCloudflareMcpAgentHandler = (
           accountId: outcome.principal.accountId,
           organizationId: outcome.principal.organizationId,
         },
-        defaultMcpResource,
+        resource,
       ),
       propagation,
     );

--- a/apps/host-cloudflare/src/worker.e2e.node.test.ts
+++ b/apps/host-cloudflare/src/worker.e2e.node.test.ts
@@ -303,6 +303,74 @@ describe("cloudflare host e2e (workerd/miniflare)", () => {
     expect(toolNames).toContain("execute");
   }, 60_000);
 
+  it("serves a toolkit-scoped MCP session", async () => {
+    const created = await worker.fetch("/api/toolkits", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ owner: "org", name: "Test Kit", slug: "test-kit" }),
+    });
+    expect(created.status).toBe(200);
+
+    const path = "/mcp/toolkits/test-kit";
+    const accept = "application/json, text/event-stream";
+    const rpc = (sessionId: string | null, body: unknown) =>
+      worker.fetch(path, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          accept,
+          ...(sessionId ? { "mcp-session-id": sessionId } : {}),
+        },
+        body: JSON.stringify(body),
+      });
+
+    const init = await rpc(null, {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-03-26",
+        capabilities: {},
+        clientInfo: { name: "test", version: "1" },
+      },
+    });
+    expect(init.status).toBe(200);
+    const sessionId = init.headers.get("mcp-session-id");
+    expect(sessionId).toBeTruthy();
+
+    await rpc(sessionId, {
+      jsonrpc: "2.0",
+      method: "notifications/initialized",
+    });
+
+    const list = await rpc(sessionId, {
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/list",
+    });
+    expect(list.status).toBe(200);
+    const listed = await readMcpJson<{
+      result?: { tools?: ReadonlyArray<{ name: string }> };
+    }>(list);
+    expect(listed.result?.tools?.map((tool) => tool.name)).toContain("execute");
+
+    // The session is pinned to `toolkit:test-kit`, not merely reachable at that
+    // path: replaying its id against the bare `/mcp` endpoint carries the
+    // default resource key, which the session DO refuses. Were the resource
+    // still defaulted at the edge, the two paths would agree and this would
+    // succeed — so this is the assertion that fails if the scoping regresses.
+    const crossResource = await worker.fetch("/mcp", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept,
+        ...(sessionId ? { "mcp-session-id": sessionId } : {}),
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 3, method: "tools/list" }),
+    });
+    expect(crossResource.status).toBe(403);
+  }, 60_000);
+
   it("serves streamable HTTP GET only for initialized sessions", async () => {
     const missing = await worker.fetch("/mcp", {
       method: "GET",

--- a/apps/host-cloudflare/src/worker.ts
+++ b/apps/host-cloudflare/src/worker.ts
@@ -11,8 +11,9 @@ export { McpExecutionOwnerDirectoryDO, McpSessionDO } from "./mcp";
 
 // ---------------------------------------------------------------------------
 // The Worker fetch entry. Most requests go to `ExecutorApp.make`'s Effect web
-// handler. `/mcp` stays at this edge boundary so the Worker authenticates and
-// binds ownership before forwarding the request to its session Durable Object.
+// handler. `/mcp` and `/mcp/toolkits/<slug>` stay at this edge boundary so the
+// Worker authenticates and binds ownership before forwarding the request to its
+// session Durable Object.
 // ---------------------------------------------------------------------------
 
 let handlerPromise: Promise<{
@@ -47,7 +48,8 @@ export default {
     }
 
     const serve = await resolveHandler(env);
-    if (new URL(request.url).pathname === "/mcp") {
+    const pathname = new URL(request.url).pathname;
+    if (pathname === "/mcp" || /^\/mcp\/toolkits\/[^/]+$/.test(pathname)) {
       return serve.mcp(request, env, ctx);
     }
     return serve.app(request);


### PR DESCRIPTION
The shared MCP envelope defines `/mcp/toolkits/:toolkitSlug` and both the cloud and self-host surfaces serve it. The Cloudflare host routed only the bare `/mcp` endpoint, so a toolkit URL fell through to the SPA, and its MCP handler pinned every session to `defaultMcpResource`.

Everything downstream was already resource-aware — `makeMcpModernRequestRouter` caches one server per resource, and the session Durable Object rebuilds its resource from the verified identity header (`mcpResourceFromKey`) and refuses a later request carrying a different one. Only the edge was missing.

- `worker.ts` routes `/mcp/toolkits/<slug>` to the MCP handler alongside `/mcp`.
- `agent-handler.ts` resolves the resource from the path once, before the protocol-era split, so the modern and legacy paths both stamp the resource the request actually targets.

## Testing

`src/worker.e2e.node.test.ts` gains a scenario that creates a toolkit, opens a session at `/mcp/toolkits/test-kit`, and lists tools. It then asserts the session is *scoped* rather than merely reachable: replaying its id against bare `/mcp` is rejected with 403, since that path carries the default resource key. Reverting the resource to `defaultMcpResource` turns that assertion into `expected 200 to be 403`, so it fails if the scoping ever regresses.

Full `apps/host-cloudflare` suite passes (31 tests), plus typecheck and lint.