### PR TITLE
Keep installation config out of the tracked Wrangler template

### DIFF
--- a/apps/docs/hosted/cloudflare.mdx
+++ b/apps/docs/hosted/cloudflare.mdx
@@ -27,9 +27,12 @@ bunx wrangler login
 bun run deploy:setup
 ```
 
-`deploy:setup` is idempotent: it creates or reuses the `executor` D1 database,
-writes its id into `wrangler.jsonc`, generates and uploads the `EXECUTOR_SECRET_KEY`
-secret, and deploys the Worker. It then prints the one remaining manual step.
+`deploy:setup` is idempotent: it creates or reuses the `executor` D1 database, records
+its id in `wrangler.local.jsonc` (this installation's gitignored settings — the tracked
+`wrangler.jsonc` template is never written, which is what keeps
+[upgrading](#upgrading) a plain `git pull`), generates and uploads the
+`EXECUTOR_SECRET_KEY` secret, and deploys the Worker. It then prints the one remaining
+manual step.
 
 ## Put it behind Cloudflare Access
 
@@ -42,13 +45,16 @@ Until the Worker is behind an Access application, every API and MCP route return
 4. Copy the application **Audience (AUD)** tag, then redeploy with your Access settings:
 
    ```bash
-   bunx wrangler deploy \
+   bunx wrangler deploy --config wrangler.deploy.json \
      --var ACCESS_AUD:<aud> \
      --var ACCESS_TEAM_DOMAIN:<your-team>.cloudflareaccess.com
    ```
 
-   You can also set `ACCESS_AUD` and `ACCESS_TEAM_DOMAIN` in `wrangler.jsonc` and
-   redeploy.
+   These become live Worker variables, and `keep_vars` preserves them through every
+   later deploy — so you set them once, and an upgrade cannot drop them. To change
+   them, run the command again. If you would rather keep them in a file, put them
+   under `vars` in `wrangler.local.jsonc` (never in the tracked `wrangler.jsonc`,
+   which each release updates).
 
 Now visiting the Worker prompts a Cloudflare Access login, and the Worker validates
 the issued JWT on every request.
@@ -149,3 +155,83 @@ authenticate machine-to-machine with an Access service token instead.
 
 Once connected, see [MCP Proxy](/mcp-proxy) for how the endpoint exposes your
 integrations.
+
+## Upgrading
+
+The console's sidebar shows an **Update available** card when the running Worker is
+behind the published release, and links here. A Cloudflare install upgrades by
+redeploying the Worker from a newer checkout:
+
+```bash
+git pull            # from a fork: git fetch upstream && git merge --ff-only upstream/main
+bun install
+cd apps/host-cloudflare
+bun run deploy
+```
+
+`bun run deploy` rebuilds the SPA, regenerates the deploy config, and ships a new
+Worker version. Database migrations run on demand at boot, so there is no separate
+migrate step.
+
+### What a redeploy keeps
+
+Nothing installation-specific lives in the code you just pulled, so an upgrade
+carries none of it away:
+
+| State                                                     | Where it lives                     |
+| --------------------------------------------------------- | ---------------------------------- |
+| Integrations, connections, secrets, policies              | your D1 database                   |
+| `EXECUTOR_SECRET_KEY` and any other `wrangler secret`     | Worker secrets                     |
+| `ACCESS_AUD`, `ACCESS_TEAM_DOMAIN`, `ADMIN_EMAILS`        | live Worker vars (`keep_vars`)     |
+| Your Access application, its policies, and service tokens | Cloudflare Access                  |
+| Your D1 database id and org name                          | `wrangler.local.jsonc` (see below) |
+
+The one thing to check before deploying is whether the release added a _new_
+deployment prerequisite — usually a `wrangler secret` the Worker now requires. The
+Worker fails closed when one is missing rather than serving in a degraded state, so
+read the release notes for the versions you are jumping across and set anything new
+first:
+
+```bash
+bunx wrangler secret put <NAME> --config wrangler.deploy.json
+```
+
+### Keeping local modifications
+
+Two kinds of local change need different homes, and only one of them belongs in a
+file you edit.
+
+**Configuration** — your D1 database id, the org name in the console, a custom Worker
+name or route — goes in `apps/host-cloudflare/wrangler.local.jsonc`, a gitignored
+overlay merged over the tracked `wrangler.jsonc` template at deploy time:
+
+```jsonc
+{
+  "d1_databases": [{ "binding": "DB", "database_id": "<your database id>" }],
+  "vars": { "SELF_HOSTED_ORG_NAME": "Acme" },
+}
+```
+
+`deploy:setup` writes your provisioned database id there for you. Because the tracked
+template is never modified, `git pull` on a new release can never conflict with your
+deployment's settings.
+
+**Code changes** belong on a branch you rebase onto each release, not in an
+uncommitted working tree — an upgrade pull will otherwise ask you to reconcile your
+edits against a moving codebase with no record of what you changed or why. If the
+change is a fix or a missing capability rather than something specific to your
+install, [send it upstream](https://github.com/UsefulSoftwareCo/executor) and carry
+nothing.
+
+### Rolling back
+
+Worker versions are retained, so a bad upgrade reverts in one command:
+
+```bash
+bunx wrangler rollback --config wrangler.deploy.json
+```
+
+Two caveats. Cloudflare refuses a rollback across a Durable Object class migration, so
+a release that adds one (the `migrations` array in `wrangler.jsonc`) can only be
+reverted by redeploying the older checkout. And rollback restores code, not data: any
+database migration the newer version applied at boot stays applied.

--- a/apps/host-cloudflare/.gitignore
+++ b/apps/host-cloudflare/.gitignore
@@ -2,3 +2,7 @@ dist/
 .dev.vars
 .wrangler/
 wrangler.preview.jsonc
+# This installation's Wrangler deltas + the generated merge wrangler actually
+# reads (scripts/deploy-config.ts). Deployment state, never the repo's.
+wrangler.local.jsonc
+wrangler.deploy.json

--- a/apps/host-cloudflare/README.md
+++ b/apps/host-cloudflare/README.md
@@ -37,8 +37,18 @@ bun run deploy:setup    # apps/host-cloudflare — provisions D1 + secret + depl
 ```
 
 `deploy:setup` (scripts/deploy.sh) is idempotent. It creates or reuses the
-`executor` D1 database, writes its id into `wrangler.jsonc`, generates and
+`executor` D1 database, records its id in `wrangler.local.jsonc`, generates and
 uploads `EXECUTOR_SECRET_KEY`, then deploys. It then prints the one manual step.
+
+### Config: template, overlay, generated
+
+`wrangler.jsonc` is the tracked template — bindings, migrations, routing, owned
+by the release. Values that belong to one installation (the D1 id created in
+your account, the org name, a custom worker name) go in `wrangler.local.jsonc`,
+a gitignored overlay. `scripts/deploy-config.ts` merges the two into
+`wrangler.deploy.json`, which every deploying command reads via `--config`; the
+template is never written. That is what keeps an upgrade a plain `git pull` —
+see [Upgrading](https://executor.sh/docs/hosted/cloudflare#upgrading).
 
 ### The one manual step — Cloudflare Access
 
@@ -72,7 +82,7 @@ EXECUTOR_SECRET_KEY=dev-secret-key-0123456789abcdef
 ENABLE_DEV_AUTH=true     # bypass Access; every request is a fixed dev admin
 
 bun run build            # vite build -> dist/ (the SPA)
-bunx wrangler dev --local   # serves the SPA + Worker API together
+bun run dev              # merges the config, then serves the SPA + Worker API
 ```
 
 `bun run dev:web` runs the Vite dev server (HMR) for UI work; point its API at a

--- a/apps/host-cloudflare/package.json
+++ b/apps/host-cloudflare/package.json
@@ -4,8 +4,9 @@
   "type": "module",
   "scripts": {
     "build": "vite build && node scripts/assert-shell-asset.mjs",
-    "deploy": "vite build && node scripts/assert-shell-asset.mjs && wrangler deploy",
-    "dev": "wrangler dev",
+    "config": "bun scripts/deploy-config.ts",
+    "deploy": "vite build && node scripts/assert-shell-asset.mjs && bun scripts/deploy-config.ts && wrangler deploy --config wrangler.deploy.json",
+    "dev": "bun scripts/deploy-config.ts && wrangler dev --config wrangler.deploy.json",
     "dev:web": "vite dev",
     "typecheck": "tsgo --noEmit",
     "cf-typegen": "wrangler types",

--- a/apps/host-cloudflare/scripts/deploy-config.ts
+++ b/apps/host-cloudflare/scripts/deploy-config.ts
@@ -1,0 +1,164 @@
+// The deploy-time Wrangler config for this installation.
+//
+// `wrangler.jsonc` is the shared template: the bindings, migrations, and
+// routing every Executor deployment needs, tracked in git and updated by every
+// new release. A handful of values in it belong to ONE installation, not to the
+// repo — the D1 database id created in your account, the org name your console
+// shows. Writing those into the tracked file (as `deploy.sh` used to) leaves the
+// working tree permanently dirty, so every upgrade pull lands on a modified
+// config and the operator has to hand-merge deployment state against release
+// changes.
+//
+// So the two are kept apart:
+//
+//   wrangler.jsonc         tracked template   — upstream owns it, never written
+//   wrangler.local.jsonc   this installation  — gitignored, only your deltas
+//   wrangler.deploy.json   generated merge    — gitignored, what wrangler reads
+//
+// Every wrangler command that deploys or serves this app passes
+// `--config wrangler.deploy.json` (see package.json + deploy.sh), so upgrading
+// is `git pull` + redeploy with no config to reconcile.
+//
+//   bun scripts/deploy-config.ts              # write the merged config
+//   bun scripts/deploy-config.ts --set-d1 ID  # record a provisioned D1 id
+//
+// The overlay is a partial config in the same shape as the template:
+//
+//   {
+//     "d1_databases": [{ "binding": "DB", "database_id": "<your id>" }],
+//     "vars": { "SELF_HOSTED_ORG_NAME": "Acme" }
+//   }
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { applyEdits, modify, parse as parseJsonc, type ParseError } from "jsonc-parser";
+
+const APP_DIR = resolve(import.meta.dirname, "..");
+const TEMPLATE_PATH = resolve(APP_DIR, "wrangler.jsonc");
+const OVERLAY_PATH = resolve(APP_DIR, "wrangler.local.jsonc");
+const GENERATED_PATH = resolve(APP_DIR, "wrangler.deploy.json");
+
+type JsonRecord = Record<string, unknown>;
+
+const fail = (message: string): never => {
+  process.stderr.write(`${message}\n`);
+  process.exit(1);
+};
+
+const readConfig = (path: string): JsonRecord => {
+  const errors: ParseError[] = [];
+  const parsed = parseJsonc(readFileSync(path, "utf8"), errors, {
+    allowTrailingComma: true,
+  }) as unknown;
+  if (errors.length > 0) fail(`${path} is not valid JSONC (offset ${errors[0]?.offset})`);
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    fail(`${path} must contain a JSON object`);
+  }
+  return parsed as JsonRecord;
+};
+
+const isRecord = (value: unknown): value is JsonRecord =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+/** A binding entry's identity: `binding` for resource bindings (D1, R2, KV),
+ *  `name` for Durable Object bindings. Entries without one are positional. */
+const identity = (entry: unknown): string | null => {
+  if (!isRecord(entry)) return null;
+  const key = entry.binding ?? entry.name;
+  return typeof key === "string" ? key : null;
+};
+
+/**
+ * Merge an overlay array over a base array by binding identity: an overlay
+ * entry patches the base entry it names (so an overlay can supply just a
+ * `database_id`) and any unmatched entry is appended. Arrays of non-bindings
+ * (`compatibility_flags`, `migrations`, `run_worker_first`) are release-owned
+ * lists, so an overlay entry replaces the base wholesale rather than
+ * accumulating stale values across upgrades.
+ */
+const mergeArray = (base: readonly unknown[], overlay: readonly unknown[]): unknown[] => {
+  if (!overlay.every((entry) => identity(entry) !== null)) return [...overlay];
+  const merged = base.map((entry) => {
+    const match = overlay.find((candidate) => identity(candidate) === identity(entry));
+    return match && isRecord(entry) && isRecord(match) ? mergeRecords(entry, match) : entry;
+  });
+  const added = overlay.filter(
+    (entry) => !base.some((candidate) => identity(candidate) === identity(entry)),
+  );
+  return [...merged, ...added];
+};
+
+const mergeRecords = (base: JsonRecord, overlay: JsonRecord): JsonRecord => {
+  const merged: JsonRecord = { ...base };
+  for (const [key, value] of Object.entries(overlay)) {
+    const current = merged[key];
+    if (isRecord(current) && isRecord(value)) {
+      merged[key] = mergeRecords(current, value);
+    } else if (Array.isArray(current) && Array.isArray(value)) {
+      merged[key] = mergeArray(current, value);
+    } else {
+      merged[key] = value;
+    }
+  }
+  return merged;
+};
+
+const readOverlay = (): JsonRecord => (existsSync(OVERLAY_PATH) ? readConfig(OVERLAY_PATH) : {});
+
+const NEW_OVERLAY_HEADER = `// This installation's Wrangler deltas — gitignored, merged over the tracked
+// wrangler.jsonc template into wrangler.deploy.json at deploy time (see
+// scripts/deploy-config.ts). Hand-edit it freely: only the keys set here
+// override the template, and comments survive \`deploy:setup\` re-runs.
+`;
+
+/**
+ * Record a provisioned D1 database id in the overlay. `deploy.sh` calls this
+ * after creating or finding the database, so the tracked template keeps
+ * whatever id it shipped with. The write is a surgical JSONC edit rather than a
+ * reserialize — an operator's comments and formatting in a file they maintain
+ * survive every re-run.
+ */
+const setD1DatabaseId = (databaseId: string): void => {
+  const template = readConfig(TEMPLATE_PATH);
+  const templateDatabases = Array.isArray(template.d1_databases) ? template.d1_databases : [];
+  const binding = identity(templateDatabases[0]) ?? "DB";
+  if (!existsSync(OVERLAY_PATH)) {
+    const seed = { d1_databases: [{ binding, database_id: databaseId }] };
+    writeFileSync(OVERLAY_PATH, `${NEW_OVERLAY_HEADER}${JSON.stringify(seed, null, 2)}\n`);
+    return;
+  }
+  const text = readFileSync(OVERLAY_PATH, "utf8");
+  const databases = readOverlay().d1_databases;
+  const entries = Array.isArray(databases) ? databases : [];
+  const index = entries.findIndex((entry) => identity(entry) === binding);
+  const options = { formattingOptions: { tabSize: 2, insertSpaces: true } };
+  const edits =
+    index === -1
+      ? modify(
+          text,
+          ["d1_databases", entries.length],
+          { binding, database_id: databaseId },
+          options,
+        )
+      : modify(text, ["d1_databases", index, "database_id"], databaseId, options);
+  writeFileSync(OVERLAY_PATH, applyEdits(text, edits));
+};
+
+const writeGeneratedConfig = (): string => {
+  const merged = mergeRecords(readConfig(TEMPLATE_PATH), readOverlay());
+  // A generated file: JSON, no comments, never hand-edited. Wrangler resolves
+  // `main` and `assets.directory` relative to the config file, so this must
+  // stay beside the template it was derived from.
+  writeFileSync(GENERATED_PATH, `${JSON.stringify(merged, null, 2)}\n`);
+  return GENERATED_PATH;
+};
+
+const args = process.argv.slice(2);
+const setD1Index = args.indexOf("--set-d1");
+if (setD1Index !== -1) {
+  const databaseId = args[setD1Index + 1];
+  if (!databaseId) fail("--set-d1 needs a database id");
+  setD1DatabaseId(databaseId);
+}
+process.stdout.write(`${writeGeneratedConfig()}\n`);

--- a/apps/host-cloudflare/scripts/deploy.sh
+++ b/apps/host-cloudflare/scripts/deploy.sh
@@ -3,19 +3,21 @@
 #
 # Provisions everything a fresh account needs and deploys the Worker:
 #   1. verifies wrangler is logged in
-#   2. creates (or reuses) the `executor` D1 database and writes its id into
-#      wrangler.jsonc
+#   2. creates (or reuses) the `executor` D1 database and records its id in
+#      wrangler.local.jsonc (this installation's gitignored overlay — the
+#      tracked wrangler.jsonc template is never written, so upgrading is a
+#      clean `git pull`; see scripts/deploy-config.ts)
 #   3. generates + uploads EXECUTOR_SECRET_KEY (the at-rest secret key) if unset
 #   4. deploys the Worker
 #   5. prints the single manual step: configure the Cloudflare Access application
 #
-# Idempotent — safe to re-run. Run from anywhere:
+# Idempotent — safe to re-run, and re-running it after an upgrade is the whole
+# upgrade procedure. Run from anywhere:
 #   bash apps/host-cloudflare/scripts/deploy.sh
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 APP_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-CONFIG="$APP_DIR/wrangler.jsonc"
 cd "$APP_DIR"
 
 step() { printf '\n\033[1;36m==> %s\033[0m\n' "$1"; }
@@ -42,22 +44,20 @@ else
 fi
 [ -n "$DB_ID" ] || { echo "Failed to resolve D1 database id" >&2; exit 1; }
 
-step "Writing D1 id into wrangler.jsonc"
-# Replace whatever database_id is present (placeholder or a prior id).
-node -e '
-  const fs=require("fs"),p=process.argv[1],id=process.argv[2];
-  let t=fs.readFileSync(p,"utf8");
-  t=t.replace(/("database_id":\s*")[^"]*(")/, `$1${id}$2`);
-  fs.writeFileSync(p,t);
-' "$CONFIG" "$DB_ID"
-info "wrangler.jsonc -> $DB_ID"
+step "Recording D1 id in wrangler.local.jsonc"
+# The id belongs to this account, not to the repo, so it goes in the gitignored
+# overlay; deploy-config.ts merges it over the tracked template and prints the
+# generated config every wrangler command below deploys with.
+CONFIG="$(bun scripts/deploy-config.ts --set-d1 "$DB_ID")"
+info "wrangler.local.jsonc -> $DB_ID"
+info "deploying with $(basename "$CONFIG")"
 
 step "Ensuring EXECUTOR_SECRET_KEY secret"
-if bunx wrangler secret list 2>/dev/null | grep -q EXECUTOR_SECRET_KEY; then
+if bunx wrangler secret list --config "$CONFIG" 2>/dev/null | grep -q EXECUTOR_SECRET_KEY; then
   info "Secret already set — leaving it."
 else
   SECRET="$(node -e 'console.log(require("node:crypto").randomBytes(32).toString("hex"))')"
-  printf '%s' "$SECRET" | bunx wrangler secret put EXECUTOR_SECRET_KEY >/dev/null
+  printf '%s' "$SECRET" | bunx wrangler secret put EXECUTOR_SECRET_KEY --config "$CONFIG" >/dev/null
   info "Generated + uploaded a fresh 32-byte key."
 fi
 
@@ -65,7 +65,7 @@ step "Building the web SPA"
 bunx vite build
 
 step "Deploying Worker"
-bunx wrangler deploy
+bunx wrangler deploy --config "$CONFIG"
 
 cat <<'NEXT'
 

--- a/packages/react/src/components/update-card.tsx
+++ b/packages/react/src/components/update-card.tsx
@@ -42,7 +42,7 @@ const UPGRADE_HINT = appEnv?.VITE_UPGRADE_HINT as UpgradeHint | undefined;
 // wrong upgrade step.
 const UPGRADE_DOCS_URL: Partial<Record<UpgradeHint, string>> = {
   selfhost: `${DOCS_BASE_URL}/hosted/docker`,
-  cloudflare: `${DOCS_BASE_URL}/hosted/cloudflare`,
+  cloudflare: `${DOCS_BASE_URL}/hosted/cloudflare#upgrading`,
 };
 
 // ── useLatestVersion ────────────────────────────────────────────────────


### PR DESCRIPTION
`deploy:setup` wrote the provisioned D1 id straight into `wrangler.jsonc`, and `SELF_HOSTED_ORG_NAME` lives there too, so every Cloudflare deployment permanently modifies a tracked file. Pulling a release then lands on a dirty config, and the operator has to hand-merge their deployment state against the release's changes — the one thing an upgrade should never ask. There is also no upgrade documentation at all today, though the console's update card links to `/docs/hosted/cloudflare` for exactly that.

## Config

Split three ways:

| File | Owner | Tracked |
|---|---|---|
| `wrangler.jsonc` | the release | yes — no longer written by anything |
| `wrangler.local.jsonc` | one installation | no |
| `wrangler.deploy.json` | generated merge, read via `--config` | no |

`scripts/deploy-config.ts` does the merge. Binding arrays merge by binding name, so an overlay supplies a `database_id` without restating `database_name`. `--set-d1` (called by `deploy.sh`) edits the overlay through `jsonc-parser`'s `modify`/`applyEdits` rather than reserializing, so an operator's comments and formatting survive every `deploy:setup` re-run. `deploy`, `dev`, and `deploy.sh` all go through the generated config.

With no overlay present the generated config is semantically identical to the template, so this is a no-op for anyone who has not created one.

## Docs

Adds an `## Upgrading` section to the Cloudflare hosting page: the redeploy steps, a table of what an upgrade preserves (D1 data, secrets, `keep_vars` live vars, the Access application), how to check a release for new secret prerequisites, where local modifications belong, and rollback — including that Cloudflare refuses a rollback across a Durable Object class migration, and that rollback restores code but not data. Corrects the two earlier sections that described the old `wrangler.jsonc`-writing behavior, and points the update card at the new anchor.

## Testing

Verified by hand against `apps/host-cloudflare`: no overlay produces a config semantically identical to the template; `--set-d1` bootstraps a missing overlay, patches an existing one in place while preserving comments and unrelated keys, and appends `d1_databases` when the overlay lacks it. `wrangler deploy --dry-run` against the generated config resolves every binding and asset path. Format, lint, and typecheck pass.