### PR TITLE
Drop ignored package from mixed changeset

### DIFF
--- a/.changeset/mcp-client-span-attribution.md
+++ b/.changeset/mcp-client-span-attribution.md
@@ -1,5 +1,4 @@
 ---
-"@executor-js/host-mcp": patch
 "@executor-js/cloudflare": patch
 ---
 


### PR DESCRIPTION
changeset version has been failing on main since this changeset landed: it names both @executor-js/host-mcp (in the changesets ignore list) and @executor-js/cloudflare (not ignored), and mixed changesets are rejected, so no Version Packages PR could be created. Keep only the non-ignored package; the changelog entry still ships on @executor-js/cloudflare. Ignored packages get no changelog either way.

Follow-up worth considering separately: @executor-js/cloudflare is private but not in the ignore list, which is the inconsistency that made this easy to hit.