### PR TITLE
Normalize Slack OAuth scopes

### DIFF
--- a/packages/core/sdk/src/oauth-helpers.test.ts
+++ b/packages/core/sdk/src/oauth-helpers.test.ts
@@ -99,6 +99,14 @@ const tokenResponse =
   () =>
     json(200, body);
 
+const tokenResponseFetch =
+  (body: unknown): typeof globalThis.fetch =>
+  async () =>
+    new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+
 // ---------------------------------------------------------------------------
 // PKCE
 // ---------------------------------------------------------------------------
@@ -575,6 +583,46 @@ describe("exchangeAuthorizationCode", () => {
     ),
   );
 
+  it.effect("normalizes Slack's comma-delimited top-level scopes", () =>
+    Effect.gen(function* () {
+      const result = yield* exchangeAuthorizationCode({
+        tokenUrl: "https://slack.com/api/oauth.v2.user.access",
+        clientId: "cid",
+        clientSecret: "csecret",
+        redirectUrl: "https://app.example.com/cb",
+        codeVerifier: "verifier",
+        code: "abc",
+        fetch: tokenResponseFetch({
+          access_token: "xoxp-user-token",
+          token_type: "Bearer",
+          scope: "channels:read,chat:write,reactions:read",
+        }),
+      });
+
+      expect(result.scope).toBe("channels:read chat:write reactions:read");
+    }),
+  );
+
+  it.effect("preserves commas in scope tokens from non-Slack providers", () =>
+    Effect.gen(function* () {
+      const result = yield* exchangeAuthorizationCode({
+        tokenUrl: "https://oauth.example.com/token",
+        clientId: "cid",
+        clientSecret: "csecret",
+        redirectUrl: "https://app.example.com/cb",
+        codeVerifier: "verifier",
+        code: "abc",
+        fetch: tokenResponseFetch({
+          access_token: "provider-token",
+          token_type: "Bearer",
+          scope: "scope,with-comma other.scope",
+        }),
+      });
+
+      expect(result.scope).toBe("scope,with-comma other.scope");
+    }),
+  );
+
   it.effect("keeps a standard top-level scope ahead of nested provider metadata", () =>
     withTokenEndpoint(
       tokenResponse({
@@ -856,6 +904,24 @@ describe("exchangeClientCredentials", () => {
 });
 
 describe("refreshAccessToken", () => {
+  it.effect("normalizes Slack's comma-delimited scopes on refresh", () =>
+    Effect.gen(function* () {
+      const result = yield* refreshAccessToken({
+        tokenUrl: "https://slack.com/api/oauth.v2.user.access",
+        clientId: "cid",
+        clientSecret: "csecret",
+        refreshToken: "refresh-token",
+        fetch: tokenResponseFetch({
+          access_token: "xoxp-refreshed-token",
+          token_type: "Bearer",
+          scope: "channels:read,chat:write,reactions:read",
+        }),
+      });
+
+      expect(result.scope).toBe("channels:read chat:write reactions:read");
+    }),
+  );
+
   it.effect("posts grant_type=refresh_token with the refresh token", () =>
     withTokenEndpoint(tokenResponse(validRefreshBody), ({ tokenUrl, calls }) =>
       Effect.gen(function* () {

--- a/packages/core/sdk/src/oauth-helpers.ts
+++ b/packages/core/sdk/src/oauth-helpers.ts
@@ -552,12 +552,34 @@ const pickClientAuth = (
     : oauth.ClientSecretPost(clientSecret);
 };
 
-const tokenResponseFrom = (r: oauth.TokenEndpointResponse): OAuth2TokenResponse => ({
+const normalizedTokenScope = (
+  as: oauth.AuthorizationServer,
+  scope: string | undefined,
+): string | undefined => {
+  if (scope === undefined || scope.trim().length === 0) return undefined;
+  const tokenEndpoint = typeof as.token_endpoint === "string" ? URL.parse(as.token_endpoint) : null;
+  const isSlackTokenEndpoint =
+    tokenEndpoint?.hostname.toLowerCase() === "slack.com" &&
+    (tokenEndpoint.pathname === "/api/oauth.v2.access" ||
+      tokenEndpoint.pathname === "/api/oauth.v2.user.access");
+  if (!isSlackTokenEndpoint) return scope;
+
+  const normalized = scope
+    .split(/[\s,]+/)
+    .filter(Boolean)
+    .join(" ");
+  return normalized.length > 0 ? normalized : undefined;
+};
+
+const tokenResponseFrom = (
+  as: oauth.AuthorizationServer,
+  r: oauth.TokenEndpointResponse,
+): OAuth2TokenResponse => ({
   access_token: r.access_token,
   token_type: r.token_type,
   refresh_token: r.refresh_token,
   expires_in: typeof r.expires_in === "number" ? r.expires_in : undefined,
-  scope: typeof r.scope === "string" && r.scope.trim().length > 0 ? r.scope : undefined,
+  scope: normalizedTokenScope(as, typeof r.scope === "string" ? r.scope : undefined),
 });
 
 const JwtClaims = Schema.Record(Schema.String, Schema.Unknown);
@@ -694,6 +716,7 @@ const processTokenEndpointResponse = async (
   const stripped = await stripIdToken(response);
   const providerUserGrant = await nestedAuthedUserGrant(stripped.response);
   const parsed = tokenResponseFrom(
+    as,
     await oauth.processGenericTokenEndpointResponse(as, client, stripped.response),
   );
   const token =
@@ -839,7 +862,7 @@ export const exchangeClientCredentials = (
         ),
       );
       const result = await oauth.processClientCredentialsResponse(as, client, response);
-      return tokenResponseFrom(result);
+      return tokenResponseFrom(as, result);
     },
     catch: (cause) => cause,
   }).pipe(
@@ -918,7 +941,7 @@ export const refreshAccessToken = (
         client,
         (await stripIdToken(response)).response,
       );
-      return tokenResponseFrom(result);
+      return tokenResponseFrom(as, result);
     },
     catch: (cause) => cause,
   }).pipe(


### PR DESCRIPTION
Slack returns granted OAuth scopes as a comma-separated string, while Executor persists and compares OAuth scopes as RFC space-delimited tokens. The live `personalSlackMcp4` connection stored all granted scopes in one comma-separated value, so every requested scope appeared missing.

Normalize top-level token scopes from Slack's `oauth.v2.access` and `oauth.v2.user.access` endpoints at the provider boundary. Apply the same normalization to initial exchange and refresh responses, while preserving comma-containing scope tokens from all other providers.

Checks:
- Core SDK: 45 files, 615 tests passed
- Core SDK typecheck
- Targeted oxlint
- Targeted oxfmt check
- `git diff --check`
