### PR TITLE
Capture pageviews on the marketing site

### DIFF
--- a/apps/marketing/src/layouts/Layout.astro
+++ b/apps/marketing/src/layouts/Layout.astro
@@ -50,9 +50,16 @@ const canonical = new URL(Astro.url.pathname, Astro.site ?? Astro.url).toString(
       // deploy env, so it's a no-op in dev / unconfigured builds (and the SDK
       // isn't even shipped, thanks to the dynamic import). Events are proxied
       // first-party through src/middleware.ts to survive adblockers.
-      // autocapture and pageviews are off on purpose: we only send the explicit
-      // events the page fires (e.g. the "Set up with your agent" copy). Flip
-      // capture_pageview on if you want a denominator for conversion.
+      // autocapture stays off on purpose: beyond $pageview we only send the
+      // explicit events the page fires (e.g. the "Set up with your agent" copy).
+      //
+      // capture_pageview is ON because this is the campaign landing surface.
+      // With it off, a visit to executor.sh/?utm_source=... produced no
+      // $pageview at all, so every UTM-tagged campaign read as zero traffic in
+      // PostHog — the params only ever reached $web_vitals, which no funnel or
+      // web-analytics view is built on. Astro serves a full page load per
+      // navigation, so plain `true` (capture once on init) is right here;
+      // `history_change` is for SPAs like apps/cloud.
       const phKey = import.meta.env.PUBLIC_POSTHOG_KEY;
       if (phKey) {
         // api_host rides the `/_astro` prefix that the cloud edge forwards to
@@ -62,7 +69,7 @@ const canonical = new URL(Astro.url.pathname, Astro.site ?? Astro.url).toString(
             api_host: `${window.location.origin}/_astro/_ph`,
             ui_host: import.meta.env.PUBLIC_POSTHOG_HOST ?? "https://us.posthog.com",
             autocapture: false,
-            capture_pageview: false,
+            capture_pageview: true,
             persistence: "localStorage",
           });
           return posthog;


### PR DESCRIPTION
## Problem

`apps/marketing` initialized PostHog with `capture_pageview: false`, so landing on
`executor.sh/?utm_source=...` produced **no `$pageview` event at all**. The UTM
params only ever reached `$web_vitals`, which no funnel or web-analytics view is
built on — so every UTM-tagged campaign read as zero traffic.

Measured over the last 30 days:

| event | carries `utm_source` | total |
| --- | --- | --- |
| `$web_vitals` | 76 | 31,538 |
| `$pageview` | 2 | 22,506 |

The `$pageview` events that do exist come from `apps/cloud`, which inits with
`defaults: "2025-05-24"` (pageview capture on). The marketing site contributed none.

## Change

Flip `capture_pageview` to `true` in `apps/marketing/src/layouts/Layout.astro`.
Astro serves a full page load per navigation, so plain `true` is correct here;
`history_change` is for SPAs like `apps/cloud`.

`autocapture` stays `false` — unchanged on purpose.

## Verification

- `typecheck` and `build` pass for `apps/marketing`; repo `lint` passes.
- Compiled production bundle contains `autocapture:!1,capture_pageview:!0`.
- Served the production build under wrangler and loaded a UTM-tagged URL in
  Chromium. Importing the same module chunk yields the live SDK singleton, which
  reports `capture_pageview: true`, `autocapture: false`, and a `$current_url`
  retaining the full query string.

Not verified end-to-end: that an ingested `$pageview` lands in PostHog carrying
`utm_source`. Doing so would have written test events into the production PostHog
project, so event ingest was blocked throughout. That UTM params attach to events
under this exact init is already evidenced by production data — `$web_vitals`
carries `utm_source`/`utm_medium`/`utm_campaign` correctly today. The only thing
missing was the `$pageview` event itself.

Confirm after deploy by querying for `$pageview` with a non-null `utm_source`.

## Note

Repo `format:check` currently fails on `plans/kill-plugin-system.md`, and
`@executor-js/plugin-mcp` typecheck fails on `stdio-negotiation-test-server.ts`.
Both reproduce on clean `origin/main` and are untouched by this branch.