### PR TITLE
Support GitHub App OAuth permissions

### DIFF
--- a/apps/cloud/src/engine/execution-stack.ts
+++ b/apps/cloud/src/engine/execution-stack.ts
@@ -126,6 +126,10 @@ const cloudFirstPartyOAuthClients = (): readonly FirstPartyOAuthClientConfig[] =
             env.FIRST_PARTY_GITHUB_TOKEN_URL ?? "https://github.com/login/oauth/access_token",
           clientId: env.FIRST_PARTY_GITHUB_CLIENT_ID,
           clientSecret: env.FIRST_PARTY_GITHUB_CLIENT_SECRET,
+          integrations: [IntegrationSlug.make("github_rest")],
+          // GitHub App user access tokens do not use classic OAuth scopes;
+          // their capabilities come from the app's registered permissions.
+          authorizationScopes: [],
         },
       ]
     : []),

--- a/packages/core/sdk/src/oauth-client.ts
+++ b/packages/core/sdk/src/oauth-client.ts
@@ -129,6 +129,11 @@ export interface FirstPartyOAuthClientConfig {
    *  exact-match default for those integrations. Endpoint-host matching still
    *  applies when omitted. */
   readonly integrations?: readonly IntegrationSlug[];
+  /** Scopes sent on the provider authorization request instead of the
+   *  integration-declared set. Use an empty array for providers such as
+   *  GitHub Apps, whose capabilities are configured on the app and whose OAuth
+   *  user-token flow does not use scopes. Omit for normal OAuth clients. */
+  readonly authorizationScopes?: readonly string[];
   /** OAuth scopes this deployment permits the app to request. Omit to allow
    *  every scope declared by a matching integration. For declared scopes,
    *  start and completion fail unless every requested scope belongs to this

--- a/packages/core/sdk/src/oauth-first-party.test.ts
+++ b/packages/core/sdk/src/oauth-first-party.test.ts
@@ -17,7 +17,7 @@ import {
 } from "./oauth-client";
 import { definePlugin } from "./plugin";
 import { makeTestWorkspaceHarness, memoryCredentialsPlugin } from "./test-config";
-import { serveOAuthTestServer } from "./testing/oauth-test-server";
+import { scopesFromAuthorizeUrl, serveOAuthTestServer } from "./testing/oauth-test-server";
 
 // First-party OAuth clients: host-operated apps declared in executor config
 // (`firstPartyOAuthClients`), addressed as `first-party:<name>`. Resolved from
@@ -163,6 +163,40 @@ describe("first-party oauth clients", () => {
         Effect.withTracer(makeRecordingTracer(spans)),
       );
     },
+  );
+
+  it.effect("an authorization scope override supports scope-less provider app tokens", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const server = yield* serveOAuthTestServer({ scopes: ["repo"] });
+        const { executor } = yield* makeTestWorkspaceHarness({
+          plugins,
+          firstPartyOAuthClients: [{ ...firstPartyClientFor(server), authorizationScopes: [] }],
+        });
+        yield* executor.acme.seed(["repo"]);
+
+        const started = yield* executor.oauth.start({
+          owner: "org",
+          client: FIRST_PARTY,
+          clientOwner: "org",
+          name: ConnectionName.make("github-app"),
+          integration: INTEG,
+          template: TEMPLATE,
+        });
+        expect(started.status).toBe("redirect");
+        if (started.status !== "redirect") return;
+        expect(scopesFromAuthorizeUrl(started.authorizationUrl)).toEqual([]);
+
+        const callback = yield* server.completeAuthorizationCodeFlow({
+          authorizationUrl: started.authorizationUrl,
+        });
+        const connection = yield* executor.oauth.complete({
+          state: started.state,
+          code: callback.code,
+        });
+        expect(connection.oauthScope).toBeNull();
+      }),
+    ),
   );
 
   it.effect("refresh resolves the config-declared client (no oauth_client row exists)", () =>

--- a/packages/core/sdk/src/oauth-service.ts
+++ b/packages/core/sdk/src/oauth-service.ts
@@ -1302,9 +1302,11 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
       // list is already authoritative (§7.2) and must not be re-narrowed by a
       // divergent authorization server.
       const authorizationRequestedScopes =
-        scopePolicy.kind === "discover"
-          ? requestedScopes
-          : yield* filterAuthorizationCodeScopes(client, requestedScopes);
+        firstParty?.authorizationScopes !== undefined
+          ? dedupeScopes(firstParty.authorizationScopes)
+          : scopePolicy.kind === "discover"
+            ? requestedScopes
+            : yield* filterAuthorizationCodeScopes(client, requestedScopes);
 
       // authorization_code: persist a session + build the authorize URL.
       const verifier = createPkceCodeVerifier();


### PR DESCRIPTION
Use the built-in GitHub App without classic OAuth scopes, while preserving integration permission matching. Adds a focused scope-less authorization lifecycle test.