### PR TITLE
Recognize vite strictPort exits as port collisions in claimAndBoot

### DIFF
--- a/e2e/src/ports.ts
+++ b/e2e/src/ports.ts
@@ -234,8 +234,14 @@ export const isAddrInUse = (error: unknown): boolean => {
   for (let cursor: unknown = error; cursor instanceof Error; cursor = cursor.cause) {
     if ((cursor as NodeJS.ErrnoException).code === "EADDRINUSE") return true;
     // The emulate/vite boot glue wraps the OS error in a plain Error whose
-    // message carries the code, so match the text too.
-    if (/EADDRINUSE/.test(cursor.message)) return true;
+    // message carries the code, so match the text too. Vite's --strictPort
+    // exit never says EADDRINUSE at all — the CLI catches the bind failure
+    // and dies with "Port N is already in use", which reaches us only as
+    // BootProcessExitError's log tail — so match that phrasing as well, or
+    // the claimAndBoot re-claim retry never engages for the most common
+    // collision (a Linux ephemeral outbound socket grabbing the claimed
+    // port between probe release and vite's bind).
+    if (/EADDRINUSE|is already in use/.test(cursor.message)) return true;
   }
   return false;
 };


### PR DESCRIPTION
Sixth CI e2e flake from PR #1648's runs: a cloud shard died at boot with `BootProcessExitError` — vite `--strictPort` exited with "Port 44550 is already in use".

The boot glue already handles exactly this: `claimAndBoot` bind-probes a port block and, on a collision between probe release and the service's bind (a Linux ephemeral outbound socket can grab the port in that window), re-claims the next block and retries. But the retry only engages when `isAddrInUse` recognizes the failure, and vite's strictPort exit never says `EADDRINUSE` — the CLI catches the bind error and dies with "Port N is already in use", which reaches the setup only inside the boot log tail. So the retry never fired and the shard failed on attempt 1.

`isAddrInUse` now also matches that phrasing (verified against the exact error shape from the failed run: detected, and unrelated boot failures still are not).