### PR TITLE
Expand first-party Google Workspace support

### DIFF
--- a/apps/cloud/src/engine/execution-stack.ts
+++ b/apps/cloud/src/engine/execution-stack.ts
@@ -94,15 +94,34 @@ export const CloudPluginsProvider: Layer.Layer<PluginsProvider> = Layer.succeed(
  */
 export const CLOUD_MOUNT_PREFIX = "/api" as const;
 
-// Initial Google launch boundary. Gmail uses gmail.modify for read, send, and
-// trash operations while immediate permanent deletion remains absent until the
-// broader mail.google.com scope is approved. Account-wide Drive remains absent.
-// The same scope source builds the catalog auth templates, preventing drift.
+// Consumer Google launch boundary. Keep this list aligned with the scopes
+// submitted for the Executor-owned production app: ordinary Workspace services
+// plus Photos, Meet, and Search Console. Admin, Classroom, YouTube, Apps Script,
+// BigQuery, and Cloud Resource Manager have materially different audiences or
+// provider requirements and remain BYO OAuth. The same scope source builds each
+// catalog auth template, preventing picker/start drift.
+const GOOGLE_FIRST_PARTY_PRESET_IDS = [
+  "google-calendar",
+  "google-meet",
+  "google-gmail",
+  "google-sheets",
+  "google-drive",
+  "google-docs",
+  "google-slides",
+  "google-forms",
+  "google-tasks",
+  "google-people",
+  "google-photos-library",
+  "google-photos-picker",
+  "google-search-console",
+] as const;
+
 const GOOGLE_FIRST_PARTY_ALLOWED_SCOPES: readonly string[] = [
   ...new Set([
-    ...googleCatalogOAuthScopesForPreset("google-calendar"),
-    ...googleCatalogOAuthScopesForPreset("google-gmail"),
-    ...googleCatalogOAuthScopesForPreset("google-sheets"),
+    ...GOOGLE_FIRST_PARTY_PRESET_IDS.flatMap(googleCatalogOAuthScopesForPreset),
+    // Connections created before the full-Gmail review retain this declared
+    // scope on reconnect. New Gmail presets request `mail.google.com`.
+    "https://www.googleapis.com/auth/gmail.modify",
   ]),
 ];
 

--- a/apps/marketing/src/pages/about-executor.astro
+++ b/apps/marketing/src/pages/about-executor.astro
@@ -1,7 +1,7 @@
 ---
 const pageTitle = "Executor";
 const pageDescription =
-  "Executor is a web application that lets people connect AI assistants to Google Calendar, Gmail, Google Sheets, and other software, then control the actions those assistants can take.";
+  "Executor is a web application that lets people connect AI assistants to Google Workspace, related Google services, and other software, then control the actions those assistants can take.";
 ---
 
 <!doctype html>
@@ -106,9 +106,9 @@ const pageDescription =
       <section aria-labelledby="what-heading">
         <h2 id="what-heading">What Executor does</h2>
         <p>
-          A person can use Executor to connect an AI assistant to services such as Google
-          Calendar, Gmail, and Google Sheets. The person can then ask the assistant to manage a
-          schedule, organize email, or update a spreadsheet through Executor.
+          A person can use Executor to connect an AI assistant to Google Workspace and related
+          Google services. The person can then ask the assistant to manage schedules, email,
+          files, documents, contacts, tasks, meetings, photos, or website data through Executor.
         </p>
         <p>
           Executor performs only the actions the person requests and permits. It does not give an
@@ -125,8 +125,13 @@ const pageDescription =
         </p>
         <ul>
           <li><strong>Google Calendar:</strong> read calendars and events, or create, update, and remove events.</li>
-          <li><strong>Gmail:</strong> read and search messages, compose and send mail, manage labels, archive messages, or move messages to trash.</li>
+          <li><strong>Gmail:</strong> read and search messages, compose and send mail, manage labels, archive or trash messages, or permanently delete messages only when explicitly requested.</li>
           <li><strong>Google Sheets:</strong> read spreadsheet data and update cells, ranges, and worksheets.</li>
+          <li><strong>Google Drive, Docs, Slides, and Forms:</strong> find and manage files and folders, edit documents and presentations, and create or read forms and responses.</li>
+          <li><strong>Google Contacts and Tasks:</strong> read or update contacts and contact groups, read other contacts or an available Workspace directory, and manage task lists and tasks.</li>
+          <li><strong>Google Meet:</strong> create and configure meeting spaces or read meeting records, participants, recordings, and transcripts.</li>
+          <li><strong>Google Photos:</strong> upload and manage app-created media or read media explicitly selected through Google Photos Picker.</li>
+          <li><strong>Google Search Console:</strong> inspect verified sites, sitemaps, indexed URLs, and search-performance data.</li>
         </ul>
       </section>
 

--- a/apps/marketing/src/pages/google-oauth.astro
+++ b/apps/marketing/src/pages/google-oauth.astro
@@ -13,8 +13,8 @@ const googleServices = [
     index: "02",
     name: "Gmail",
     purpose:
-      "Executor can read, search, compose, send, label, archive, and move messages to trash when you instruct an agent to work with your email.",
-    scope: "googleapis.com/auth/gmail.modify",
+      "Executor can read, search, compose, send, organize, trash, and permanently delete messages only when you explicitly instruct an agent to work with your email.",
+    scope: "mail.google.com",
   },
   {
     index: "03",
@@ -23,12 +23,54 @@ const googleServices = [
       "Executor can read spreadsheet data and update cells, ranges, and worksheets when you ask an agent to work with a spreadsheet.",
     scope: "googleapis.com/auth/spreadsheets",
   },
+  {
+    index: "04",
+    name: "Google Drive",
+    purpose:
+      "Executor can find, create, download, organize, share, or delete files and folders when you ask an agent to manage your Drive.",
+    scope: "googleapis.com/auth/drive",
+  },
+  {
+    index: "05",
+    name: "Google Docs, Slides, and Forms",
+    purpose:
+      "Executor can read and edit documents and presentations, and create or read forms and responses, when you ask an agent to work with that content.",
+    scope: "documents · presentations · forms.body · forms.responses.readonly",
+  },
+  {
+    index: "06",
+    name: "Google Contacts and Tasks",
+    purpose:
+      "Executor can read or update contacts and contact groups, read other contacts or an available Workspace directory, and manage task lists and tasks when you ask an agent to organize people or work.",
+    scope: "contacts · contacts.other.readonly · directory.readonly · tasks",
+  },
+  {
+    index: "07",
+    name: "Google Meet",
+    purpose:
+      "Executor can create and configure meeting spaces or read meeting records, participants, recordings, and transcripts when you request meeting-related work.",
+    scope: "meetings.space.created · readonly · settings",
+  },
+  {
+    index: "08",
+    name: "Google Photos",
+    purpose:
+      "Executor can upload and manage app-created media or read media that you explicitly select through Google Photos Picker.",
+    scope: "photoslibrary.app-created read/write · photospicker.readonly",
+  },
+  {
+    index: "09",
+    name: "Google Search Console",
+    purpose:
+      "Executor can inspect verified sites, sitemaps, indexed URLs, and search-performance data when you request website analysis.",
+    scope: "googleapis.com/auth/webmasters",
+  },
 ] as const;
 ---
 
 <Layout
   title="Executor"
-  description="How Executor connects AI agents to Google Calendar, Gmail, and Google Sheets with your permission."
+  description="How Executor connects AI agents to Google Workspace and related Google services with your permission."
 >
   <main class="google-page">
     <div class="grid-field" aria-hidden="true"></div>
@@ -57,7 +99,7 @@ const googleServices = [
       <h1>Executor</h1>
       <p class="hero-copy">
         Executor is an integration platform and MCP gateway for AI agents. It lets you
-        securely connect Google Calendar, Gmail, and Google Sheets so an agent can read
+        securely connect Google Workspace and related Google services so an agent can read
         data and take the actions <em>you request</em>.
       </p>
       <div class="hero-rule">

--- a/apps/marketing/src/pages/google-workspace.astro
+++ b/apps/marketing/src/pages/google-workspace.astro
@@ -8,12 +8,37 @@ const services = [
   {
     name: "Gmail",
     description:
-      "Read, search, compose, send, label, archive, or move messages to trash when you ask an agent to work with your email.",
+      "Read, search, compose, send, label, archive, trash, or permanently delete messages when you explicitly ask an agent to work with your email.",
   },
   {
     name: "Google Sheets",
     description:
       "Read spreadsheet data and update cells, ranges, or worksheets when you ask an agent to work with a spreadsheet.",
+  },
+  {
+    name: "Google Drive, Docs, Slides, and Forms",
+    description:
+      "Find and manage files and folders, edit documents and presentations, and create or read forms and responses when you ask an agent to work with them.",
+  },
+  {
+    name: "Google Contacts and Tasks",
+    description:
+      "Read or update contacts and contact groups, read other contacts or an available Workspace directory, and manage task lists and tasks when you ask an agent to organize people or work.",
+  },
+  {
+    name: "Google Meet",
+    description:
+      "Create and configure meeting spaces or read meeting records, participants, recordings, and transcripts when you request meeting-related work.",
+  },
+  {
+    name: "Google Photos",
+    description:
+      "Upload and manage app-created photos or read media you explicitly select through Google Photos Picker.",
+  },
+  {
+    name: "Google Search Console",
+    description:
+      "Read and manage verified sites, sitemaps, URL inspection results, and search-performance data when you request website analysis.",
   },
 ] as const;
 ---
@@ -26,7 +51,7 @@ const services = [
     <meta name="robots" content="index, follow" />
     <meta
       name="description"
-      content="Executor connects AI agents to Google Calendar, Gmail, and Google Sheets with your permission."
+      content="Executor connects AI agents to Google Workspace and related Google services with your permission."
     />
     <link rel="canonical" href="https://executor.sh/google-workspace" />
     <title>Executor</title>
@@ -134,7 +159,7 @@ const services = [
       <h1>Executor</h1>
       <p class="purpose">
         Executor is an integration platform and MCP gateway for AI agents. Executor lets you
-        securely connect Google Calendar, Gmail, and Google Sheets so an agent can read your
+        securely connect Google Workspace and related Google services so an agent can read your
         Google data and take only the actions you request.
       </p>
     </header>

--- a/apps/marketing/src/pages/privacy.astro
+++ b/apps/marketing/src/pages/privacy.astro
@@ -57,9 +57,12 @@ import LegalLayout from "../components/LegalLayout.astro";
   <p>
     If you connect a Google Workspace service, Executor uses the permissions you grant to perform the actions you
     request through that integration. Depending on the service and permissions you choose, this may include accessing
-    or modifying Google Calendar events, Google Sheets spreadsheets, Gmail messages, drafts, threads, attachments,
-    labels, or other Google Workspace content. For Gmail, this can include reading and searching email, composing and
-    sending messages, and organizing or moving messages to Trash when you request those actions.
+    or modifying Google Calendar events; Gmail messages, drafts, threads, attachments, labels, and settings; Google
+    Drive files and folders; Docs documents; Sheets spreadsheets; Slides presentations; Forms and responses; Contacts,
+    other contacts, and an available Workspace directory; Tasks; Meet spaces, participants, recordings, and transcripts; app-created or user-selected Photos media; Search
+    Console sites, sitemaps, indexed URLs, and performance data; or other Google content made available by the service
+    you connect. For Gmail, this can include permanently deleting messages or threads only when you explicitly request
+    that irreversible action.
   </p>
   <p>
     Executor stores OAuth credentials and connection metadata so the integration can continue working. It processes

--- a/e2e/scenarios/first-party-oauth.test.ts
+++ b/e2e/scenarios/first-party-oauth.test.ts
@@ -25,7 +25,8 @@ import {
 } from "@executor-js/sdk/shared";
 
 import { scenario } from "../src/scenario";
-import { Api, Target } from "../src/services";
+import { Api, Browser, Target } from "../src/services";
+import { clickToReveal } from "../src/surfaces/browser";
 
 const api = composePluginApi([openApiHttpPlugin()] as const);
 
@@ -168,15 +169,48 @@ scenario(
 );
 
 scenario(
-  "First-party OAuth · Google offers Gmail modify but refuses full Gmail and Drive scopes",
+  "First-party OAuth · Google offers the reviewed consumer bundle and refuses admin scopes",
   {},
   Effect.scoped(
     Effect.gen(function* () {
       const target = yield* Target;
       if (target.name !== "cloud") return;
+      const browser = yield* Browser;
       const { client: makeApiClient } = yield* Api;
       const identity = yield* target.newIdentity();
       const client = yield* makeApiClient(api, identity);
+
+      yield* browser.session(identity, async ({ page, step }) => {
+        await step("Open the Google integration catalog", async () => {
+          await page.goto("/integrations", { waitUntil: "networkidle" });
+          const dialog = page.getByRole("dialog", { name: "Connect an integration" });
+          await clickToReveal(page.getByRole("button", { name: /Connect/ }).first(), dialog);
+        });
+
+        const services = [
+          "Google Calendar",
+          "Google Meet",
+          "Gmail",
+          "Google Sheets",
+          "Google Drive",
+          "Google Docs",
+          "Google Slides",
+          "Google Forms",
+          "Google Tasks",
+          "Google People",
+          "Google Photos Library",
+          "Google Photos Picker",
+          "Google Search Console",
+        ] as const;
+        const dialog = page.getByRole("dialog", { name: "Connect an integration" });
+        const search = dialog.getByPlaceholder(/Search or paste a URL/);
+        for (const service of services) {
+          await step(`${service} is available to connect`, async () => {
+            await search.fill(service);
+            await dialog.getByRole("link", { name: new RegExp(`^${service}\\b`) }).waitFor();
+          });
+        }
+      });
 
       const clients = yield* client.oauth.listClients();
       const google = clients.find((candidate) => String(candidate.slug) === "first-party:google");
@@ -184,10 +218,46 @@ scenario(
       expect(google?.origin.kind).toBe("first_party");
       if (google?.origin.kind !== "first_party") return;
       expect(google.origin.allowedScopes).toContain("https://www.googleapis.com/auth/calendar");
+      expect(google.origin.allowedScopes).toContain(
+        "https://www.googleapis.com/auth/meetings.space.readonly",
+      );
       expect(google.origin.allowedScopes).toContain("https://www.googleapis.com/auth/gmail.modify");
+      expect(google.origin.allowedScopes).toContain("https://mail.google.com/");
       expect(google.origin.allowedScopes).toContain("https://www.googleapis.com/auth/spreadsheets");
-      expect(google.origin.allowedScopes).not.toContain("https://mail.google.com/");
-      expect(google.origin.allowedScopes).not.toContain("https://www.googleapis.com/auth/drive");
+      expect(google.origin.allowedScopes).toContain("https://www.googleapis.com/auth/drive");
+      expect(google.origin.allowedScopes).toContain("https://www.googleapis.com/auth/documents");
+      expect(google.origin.allowedScopes).toContain(
+        "https://www.googleapis.com/auth/presentations",
+      );
+      expect(google.origin.allowedScopes).toContain("https://www.googleapis.com/auth/forms.body");
+      expect(google.origin.allowedScopes).toContain(
+        "https://www.googleapis.com/auth/forms.responses.readonly",
+      );
+      expect(google.origin.allowedScopes).toContain("https://www.googleapis.com/auth/tasks");
+      expect(google.origin.allowedScopes).toContain("https://www.googleapis.com/auth/contacts");
+      expect(google.origin.allowedScopes).toContain(
+        "https://www.googleapis.com/auth/contacts.other.readonly",
+      );
+      expect(google.origin.allowedScopes).toContain(
+        "https://www.googleapis.com/auth/directory.readonly",
+      );
+      expect(google.origin.allowedScopes).toContain(
+        "https://www.googleapis.com/auth/photoslibrary.appendonly",
+      );
+      expect(google.origin.allowedScopes).toContain(
+        "https://www.googleapis.com/auth/photoslibrary.edit.appcreateddata",
+      );
+      expect(google.origin.allowedScopes).toContain(
+        "https://www.googleapis.com/auth/photospicker.mediaitems.readonly",
+      );
+      expect(google.origin.allowedScopes).toContain("https://www.googleapis.com/auth/webmasters");
+      expect(google.origin.allowedScopes).not.toContain(
+        "https://www.googleapis.com/auth/admin.directory.user",
+      );
+      expect(google.origin.allowedScopes).not.toContain("https://www.googleapis.com/auth/youtube");
+      expect(google.origin.allowedScopes).not.toContain(
+        "https://www.googleapis.com/auth/cloud-platform",
+      );
 
       const calendar = IntegrationSlug.make(unique("google_calendar"));
       yield* client.openapi.addSpec({
@@ -266,14 +336,67 @@ scenario(
           slug: fullGmail,
         },
       });
+      const fullGmailStarted = yield* client.oauth.start({
+        payload: {
+          client: OAuthClientSlug.make("first-party:google"),
+          clientOwner: "org",
+          owner: "org",
+          name: ConnectionName.make("gmail-full"),
+          integration: fullGmail,
+          template: AuthTemplateSlug.make("oauth"),
+        },
+      });
+      expect(fullGmailStarted.status).toBe("redirect");
+      const fullGmailAuthorizationUrl =
+        fullGmailStarted.status === "redirect" ? fullGmailStarted.authorizationUrl : "";
+      expect(
+        new Set(new URL(fullGmailAuthorizationUrl).searchParams.get("scope")?.split(" ") ?? []),
+      ).toEqual(new Set(["openid", "email", "profile", "https://mail.google.com/"]));
+
+      const drive = IntegrationSlug.make(unique("google_drive"));
+      yield* client.openapi.addSpec({
+        payload: {
+          ...googleShapedIntegrationSpec([
+            "openid",
+            "email",
+            "profile",
+            "https://www.googleapis.com/auth/drive",
+          ]),
+          slug: drive,
+        },
+      });
+      const driveStarted = yield* client.oauth.start({
+        payload: {
+          client: OAuthClientSlug.make("first-party:google"),
+          clientOwner: "org",
+          owner: "org",
+          name: ConnectionName.make("drive"),
+          integration: drive,
+          template: AuthTemplateSlug.make("oauth"),
+        },
+      });
+      expect(driveStarted.status).toBe("redirect");
+
+      const admin = IntegrationSlug.make(unique("google_admin"));
+      yield* client.openapi.addSpec({
+        payload: {
+          ...googleShapedIntegrationSpec([
+            "openid",
+            "email",
+            "profile",
+            "https://www.googleapis.com/auth/admin.directory.user",
+          ]),
+          slug: admin,
+        },
+      });
       const blocked = yield* client.oauth
         .start({
           payload: {
             client: OAuthClientSlug.make("first-party:google"),
             clientOwner: "org",
             owner: "org",
-            name: ConnectionName.make("gmail-full"),
-            integration: fullGmail,
+            name: ConnectionName.make("admin"),
+            integration: admin,
             template: AuthTemplateSlug.make("oauth"),
           },
         })

--- a/packages/plugins/openapi/src/providers/google/__snapshots__/presets.test.ts.snap
+++ b/packages/plugins/openapi/src/providers/google/__snapshots__/presets.test.ts.snap
@@ -7,6 +7,10 @@ exports[`classifies every Google service for bundle OAuth UX 1`] = `
     "oauthAudience": "standard-user",
   },
   {
+    "id": "google-meet",
+    "oauthAudience": "standard-user",
+  },
+  {
     "id": "google-gmail",
     "oauthAudience": "standard-user",
   },

--- a/packages/plugins/openapi/src/providers/google/presets.test.ts
+++ b/packages/plugins/openapi/src/providers/google/presets.test.ts
@@ -174,6 +174,7 @@ const googleHealthCheckDiscoveryFixtures = {
 
 const FROZEN_GOOGLE_SLUGS = [
   "google_calendar",
+  "google_meet",
   "google_gmail",
   "google_sheets",
   "google_drive",
@@ -200,6 +201,7 @@ it("keeps Select all limited to Google services that can use normal user OAuth",
   const standardIds = new Set(googleStandardUserOAuthPresets.map((preset) => preset.id));
 
   expect(standardIds).toContain("google-calendar");
+  expect(standardIds).toContain("google-meet");
   expect(standardIds).toContain("google-gmail");
   expect(standardIds).toContain("google-tasks");
   expect(standardIds).toContain("google-people");
@@ -211,6 +213,52 @@ it("keeps Select all limited to Google services that can use normal user OAuth",
   expect(standardIds).not.toContain("google-keep");
   expect(standardIds).not.toContain("google-admin-directory");
   expect(standardIds).not.toContain("google-admin-reports");
+});
+
+it("requests full Gmail and the complete user-facing Meet surface", () => {
+  const gmail = googleCatalog.find((preset) => preset.id === "google-gmail");
+  const meet = googleCatalog.find((preset) => preset.id === "google-meet");
+  const gmailOAuth = gmail?.authTemplate?.find((template) => template.kind === "oauth2");
+  const meetOAuth = meet?.authTemplate?.find((template) => template.kind === "oauth2");
+
+  expect(gmailOAuth?.scopes).toContain("https://mail.google.com/");
+  expect(gmailOAuth?.scopes).not.toContain("https://www.googleapis.com/auth/gmail.modify");
+  expect(meetOAuth?.scopes).toEqual(
+    expect.arrayContaining([
+      "https://www.googleapis.com/auth/meetings.space.created",
+      "https://www.googleapis.com/auth/meetings.space.readonly",
+      "https://www.googleapis.com/auth/meetings.space.settings",
+    ]),
+  );
+});
+
+it("requests every scope needed by Forms, People, and app-created Photos", () => {
+  const oauthScopes = (presetId: string) => {
+    const preset = googleCatalog.find((candidate) => candidate.id === presetId);
+    const oauth = preset?.authTemplate?.find((template) => template.kind === "oauth2");
+    return oauth?.scopes ?? [];
+  };
+
+  expect(oauthScopes("google-forms")).toEqual(
+    expect.arrayContaining([
+      "https://www.googleapis.com/auth/forms.body",
+      "https://www.googleapis.com/auth/forms.responses.readonly",
+    ]),
+  );
+  expect(oauthScopes("google-photos-library")).toEqual(
+    expect.arrayContaining([
+      "https://www.googleapis.com/auth/photoslibrary.appendonly",
+      "https://www.googleapis.com/auth/photoslibrary.edit.appcreateddata",
+      "https://www.googleapis.com/auth/photoslibrary.readonly.appcreateddata",
+    ]),
+  );
+  expect(oauthScopes("google-people")).toEqual(
+    expect.arrayContaining([
+      "https://www.googleapis.com/auth/contacts",
+      "https://www.googleapis.com/auth/contacts.other.readonly",
+      "https://www.googleapis.com/auth/directory.readonly",
+    ]),
+  );
 });
 
 it("classifies every Google service for bundle OAuth UX", () => {

--- a/packages/plugins/openapi/src/providers/google/presets.ts
+++ b/packages/plugins/openapi/src/providers/google/presets.ts
@@ -57,6 +57,15 @@ export const googleOpenApiPresets: readonly GoogleOpenApiPreset[] = [
     oauthAudience: "standard-user",
   },
   {
+    id: "google-meet",
+    name: "Google Meet",
+    summary: "Meeting spaces, conference records, participants, recordings, and transcripts.",
+    url: "https://meet.googleapis.com/$discovery/rest?version=v2",
+    icon: "https://fonts.gstatic.com/s/i/productlogos/meet_2020q4/v8/192px.svg",
+    featured: true,
+    oauthAudience: "standard-user",
+  },
+  {
     id: "google-gmail",
     name: "Gmail",
     summary: "Messages, threads, labels, and drafts.",
@@ -250,16 +259,29 @@ export const googlePhotosOpenApiPresets: readonly GoogleOpenApiPreset[] =
 
 export const googleOAuthConsentScopes: Readonly<Record<string, readonly string[]>> = {
   "google-calendar": ["https://www.googleapis.com/auth/calendar"],
-  "google-gmail": ["https://www.googleapis.com/auth/gmail.modify"],
+  "google-meet": [
+    "https://www.googleapis.com/auth/meetings.space.created",
+    "https://www.googleapis.com/auth/meetings.space.readonly",
+    "https://www.googleapis.com/auth/meetings.space.settings",
+  ],
+  "google-gmail": ["https://mail.google.com/"],
   "google-sheets": ["https://www.googleapis.com/auth/spreadsheets"],
   "google-drive": ["https://www.googleapis.com/auth/drive"],
   "google-docs": ["https://www.googleapis.com/auth/documents"],
   "google-slides": ["https://www.googleapis.com/auth/presentations"],
-  "google-forms": ["https://www.googleapis.com/auth/forms.body"],
+  "google-forms": [
+    "https://www.googleapis.com/auth/forms.body",
+    "https://www.googleapis.com/auth/forms.responses.readonly",
+  ],
   "google-tasks": ["https://www.googleapis.com/auth/tasks"],
-  "google-people": ["https://www.googleapis.com/auth/contacts"],
+  "google-people": [
+    "https://www.googleapis.com/auth/contacts",
+    "https://www.googleapis.com/auth/contacts.other.readonly",
+    "https://www.googleapis.com/auth/directory.readonly",
+  ],
   "google-photos-library": [
     "https://www.googleapis.com/auth/photoslibrary.appendonly",
+    "https://www.googleapis.com/auth/photoslibrary.edit.appcreateddata",
     "https://www.googleapis.com/auth/photoslibrary.readonly.appcreateddata",
   ],
   "google-photos-picker": ["https://www.googleapis.com/auth/photospicker.mediaitems.readonly"],

--- a/packages/plugins/provider-service-split/src/planner.test.ts
+++ b/packages/plugins/provider-service-split/src/planner.test.ts
@@ -140,6 +140,7 @@ const youtubeDiscoveryUrl = "https://www.googleapis.com/discovery/v1/apis/youtub
 
 const googleCatalogMethodPrefixFixtures: ReadonlyMap<string, readonly string[]> = new Map([
   ["google-calendar", ["calendar.events.list"]],
+  ["google-meet", ["meet.spaces.get", "meet.conferenceRecords.list"]],
   ["google-gmail", ["gmail.users.messages.list"]],
   ["google-sheets", ["sheets.spreadsheets.get"]],
   ["google-drive", ["drive.files.list"]],

--- a/packages/plugins/provider-service-split/src/planner.ts
+++ b/packages/plugins/provider-service-split/src/planner.ts
@@ -264,6 +264,7 @@ const GOOGLE_IDENTITY_DISCOVERY_URL = "https://www.googleapis.com/discovery/v1/a
 
 const GOOGLE_TOOL_PREFIX_TO_PRESET_ID: ReadonlyMap<string, string> = new Map([
   ["calendar", "google-calendar"],
+  ["meet", "google-meet"],
   ["gmail", "google-gmail"],
   ["sheets", "google-sheets"],
   ["drive", "google-drive"],


### PR DESCRIPTION
Adds the broad consumer Google bundle to first-party OAuth, including full Gmail, Drive/Docs/Sheets/Slides/Forms, Calendar, Meet, People, Tasks, Photos, and Search Console. Adds Meet catalog routing, scope coverage, disclosures, and a recorded cloud browser scenario.

Checks:
- openapi Google tests
- provider service split tests
- touched package typechecks
- marketing production build
- cloud first-party OAuth browser E2E

Repository-wide typecheck remains blocked by the existing missing `@modelcontextprotocol/server` dependency in the MCP package.