### PR TITLE
Make latency regressions attributable: version stamps, deploy markers, JWKS and dispatch spans

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,11 +77,29 @@ jobs:
           VITE_PUBLIC_SENTRY_DSN: ${{ secrets.VITE_PUBLIC_SENTRY_DSN }}
 
       - name: Deploy cloud
-        run: bun run wrangler deploy -c dist/server/wrangler.json
+        run: bun run wrangler deploy -c dist/server/wrangler.json --var GIT_COMMIT_SHA:${{ github.sha }}
         working-directory: apps/cloud
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      # Deploy marker: one event per deploy into the same Axiom dataset the
+      # worker traces land in, so a latency step-change lines up with its
+      # deploy in one query. Skipped (not failed) when the secret is absent,
+      # and never blocks the deploy.
+      - name: Record deploy marker in Axiom
+        env:
+          AXIOM_INGEST_TOKEN: ${{ secrets.AXIOM_INGEST_TOKEN }}
+        run: |
+          if [ -z "$AXIOM_INGEST_TOKEN" ]; then
+            echo "AXIOM_INGEST_TOKEN not configured; skipping deploy marker"
+            exit 0
+          fi
+          curl -sf -X POST "https://api.axiom.co/v1/datasets/executor-cloud/ingest" \
+            -H "Authorization: Bearer $AXIOM_INGEST_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "[{\"event\":\"deploy\",\"service\":\"executor-cloud\",\"commit_sha\":\"${{ github.sha }}\",\"actor\":\"${{ github.actor }}\",\"run_id\":\"${{ github.run_id }}\"}]" \
+            || echo "deploy marker ingest failed (non-blocking)"
 
   deploy-marketing:
     name: Deploy marketing

--- a/apps/cloud/src/auth/jwks-cache.ts
+++ b/apps/cloud/src/auth/jwks-cache.ts
@@ -48,8 +48,20 @@ export interface CachedRemoteJWKSetOptions {
 export interface CachedRemoteJWKSet extends JWTVerifyGetKey {
   /** Drop the cached JWKS so the next call refetches. */
   readonly forceRefresh: () => void;
-  /** Inspect the current cache state (testing/diagnostics). */
-  readonly inspect: () => { fetchedAt: number | null; hasJwks: boolean };
+  /**
+   * Inspect the current cache state (testing/diagnostics/span annotation).
+   * `fetchCount`/`fetchFailureCount` are lifetime counters for this resolver
+   * instance; callers snapshot them around a verify to tell a cache hit from
+   * a live upstream fetch (the Aug 2026 latency regression was exactly this
+   * cache silently missing on ~92% of verifies, invisible in traces).
+   */
+  readonly inspect: () => {
+    fetchedAt: number | null;
+    hasJwks: boolean;
+    fetchCount: number;
+    fetchFailureCount: number;
+    lastFetchDurationMs: number | null;
+  };
 }
 
 const DEFAULT_TTL_MS = 60 * 60 * 1000;
@@ -125,9 +137,14 @@ export const createCachedRemoteJWKSet = (
 
   let entry: CacheEntry | null = null;
   let inflight: Promise<CacheEntry> | null = null;
+  let fetchCount = 0;
+  let fetchFailureCount = 0;
+  let lastFetchDurationMs: number | null = null;
 
   const refresh = (): Promise<CacheEntry> => {
     if (inflight) return inflight;
+    const startedAt = Date.now();
+    fetchCount += 1;
     inflight = (async () => {
       const jwks = await fetchJwksOnce(url, fetchImpl(), timeoutMs);
       const next: CacheEntry = {
@@ -137,9 +154,19 @@ export const createCachedRemoteJWKSet = (
       };
       entry = next;
       return next;
-    })().finally(() => {
-      inflight = null;
-    });
+    })()
+      .then(
+        (next) => next,
+        (error: unknown) => {
+          fetchFailureCount += 1;
+          // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: counting a fetch failure must preserve the original rejection for jose
+          throw error;
+        },
+      )
+      .finally(() => {
+        lastFetchDurationMs = Date.now() - startedAt;
+        inflight = null;
+      });
     return inflight;
   };
 
@@ -177,6 +204,9 @@ export const createCachedRemoteJWKSet = (
     value: () => ({
       fetchedAt: entry?.fetchedAt ?? null,
       hasJwks: entry !== null,
+      fetchCount,
+      fetchFailureCount,
+      lastFetchDurationMs,
     }),
   });
   return result;

--- a/apps/cloud/src/auth/workos.ts
+++ b/apps/cloud/src/auth/workos.ts
@@ -227,7 +227,33 @@ const verifySealedSessionLocally = (
     });
     if (!session) return { _tag: "InvalidCookie" };
 
-    const verified = yield* verifyJwtWithRefreshRetry(session.accessToken, jwks);
+    // Snapshot the JWKS cache around the verify so the `local_verify` span
+    // says whether THIS verify was a warm-cache signature check or paid for a
+    // live upstream JWKS fetch. The Aug 2026 latency regression was the cache
+    // silently missing on most verifies, and no span attribute distinguished
+    // the two paths.
+    const jwksBefore = jwks.inspect();
+    // Entry-state annotation goes on BEFORE the verify so a failing verify
+    // (the case worth debugging) still records whether the cache was warm.
+    yield* Effect.annotateCurrentSpan({
+      "jwks.cache_populated_at_start": jwksBefore.hasJwks,
+      ...(jwksBefore.fetchedAt === null
+        ? {}
+        : { "jwks.cache_age_ms": Date.now() - jwksBefore.fetchedAt }),
+    });
+    const verified = yield* verifyJwtWithRefreshRetry(session.accessToken, jwks).pipe(
+      Effect.onExit(() => {
+        const jwksAfter = jwks.inspect();
+        return Effect.annotateCurrentSpan({
+          "jwks.fetched_during_verify": jwksAfter.fetchCount > jwksBefore.fetchCount,
+          "jwks.fetch_count": jwksAfter.fetchCount,
+          "jwks.fetch_failure_count": jwksAfter.fetchFailureCount,
+          ...(jwksAfter.lastFetchDurationMs === null
+            ? {}
+            : { "jwks.last_fetch_ms": jwksAfter.lastFetchDurationMs }),
+        });
+      }),
+    );
     if (!verified) return { _tag: "Refresh" };
 
     const claims = Option.getOrNull(decodeJwtClaims(decodeJwt(session.accessToken)));

--- a/apps/cloud/src/edge/docs.ts
+++ b/apps/cloud/src/edge/docs.ts
@@ -13,9 +13,17 @@
 // so this never shadows an Effect-served route.
 // ---------------------------------------------------------------------------
 
+import { SpanKind, SpanStatusCode, trace } from "@opentelemetry/api";
 import { createMiddleware } from "@tanstack/react-start";
 
 const DOCS_UPSTREAM_HOST = "executor.mintlify.dev";
+
+// The proxy fetch gets its own client span: `/docs` requests otherwise render
+// as a single opaque server span, and during the Aug 2026 regression there
+// was no way to tell upstream (Mintlify/Vercel) latency from worker-side
+// dispatch cost. The noop tracer applies when no provider is installed
+// (local dev without AXIOM_TOKEN), so this is free there.
+const tracer = trace.getTracer("executor-cloud-docs-proxy");
 
 export const isDocsPath = (pathname: string) =>
   pathname === "/docs" || pathname.startsWith("/docs/");
@@ -43,6 +51,38 @@ export const buildDocsUpstream = (request: Request): Request => {
 export const docsProxyMiddleware = createMiddleware({ type: "request" }).server(
   ({ pathname, request, next }) => {
     if (!isDocsPath(pathname)) return next();
-    return fetch(buildDocsUpstream(request));
+    return tracer.startActiveSpan(
+      `http.client ${request.method}`,
+      {
+        kind: SpanKind.CLIENT,
+        attributes: {
+          "server.address": DOCS_UPSTREAM_HOST,
+          "url.path": pathname,
+          "http.request.method": request.method,
+        },
+      },
+      async (span) => {
+        // oxlint-disable-next-line executor/no-try-catch-or-throw -- adapter boundary; observe upstream response/error for span status, then pass both through unchanged
+        try {
+          const response = await fetch(buildDocsUpstream(request));
+          span.setAttribute("http.response.status_code", response.status);
+          if (response.status >= 500) {
+            span.setStatus({ code: SpanStatusCode.ERROR, message: `HTTP ${response.status}` });
+          }
+          return response;
+        } catch (err) {
+          // oxlint-disable-next-line executor/no-instanceof-error, executor/no-unknown-error-message -- adapter boundary: fetch rejects untyped; normalized only for the OTel span record, the original error is rethrown below
+          const cause = err instanceof Error ? err : String(err);
+          span.recordException(cause);
+          // oxlint-disable-next-line executor/no-unknown-error-message -- adapter boundary: same normalization as the recordException line above
+          const message = typeof cause === "string" ? cause : cause.message;
+          span.setStatus({ code: SpanStatusCode.ERROR, message });
+          // oxlint-disable-next-line executor/no-try-catch-or-throw -- adapter boundary; preserve the original rejection for the platform handler
+          throw err;
+        } finally {
+          span.end();
+        }
+      },
+    );
   },
 );

--- a/apps/cloud/src/env-augment.d.ts
+++ b/apps/cloud/src/env-augment.d.ts
@@ -6,6 +6,13 @@ declare global {
   namespace Cloudflare {
     interface Env {
       // Observability
+      // Worker version metadata binding (wrangler.jsonc `version_metadata`).
+      // Optional so test workers and local setups without the binding still
+      // typecheck; spans then carry the "dev" service.version default.
+      CF_VERSION_METADATA?: WorkerVersionMetadata;
+      // Commit that produced the running deploy, passed by CI as
+      // `wrangler deploy --var GIT_COMMIT_SHA:$GITHUB_SHA`. Absent outside CI.
+      GIT_COMMIT_SHA?: string;
       AXIOM_TOKEN?: string;
       AXIOM_DATASET?: string;
       AXIOM_TRACES_URL?: string;

--- a/apps/cloud/src/observability/telemetry.ts
+++ b/apps/cloud/src/observability/telemetry.ts
@@ -54,7 +54,26 @@ import {
 } from "./memory-metrics";
 
 const SERVICE_NAME = "executor-cloud";
-const SERVICE_VERSION = "1.0.0";
+
+// `service.version` is the Cloudflare Worker version id (from the
+// `version_metadata` binding) so any span links back to the exact deploy in a
+// step-change investigation; "dev" is the documented default for hosts without
+// the binding (local dev, older test workers). `executor.commit_sha` rides
+// along when CI passed it (`wrangler deploy --var GIT_COMMIT_SHA:...`).
+const serviceVersion = (): string => env.CF_VERSION_METADATA?.id ?? "dev";
+
+// One id per isolate: distinguishes "many isolates each paying a cold cost"
+// from "one isolate is slow", and makes per-isolate cache behavior (JWKS,
+// module caches) measurable from Axiom. The Aug 2026 latency investigation
+// stalled for lack of exactly this attribute.
+const ISOLATE_INSTANCE_ID = crypto.randomUUID();
+const ISOLATE_STARTED_AT = Date.now();
+
+const resourceAttributes = (): Record<string, string | number> => ({
+  "service.instance.id": ISOLATE_INSTANCE_ID,
+  "executor.isolate_started_at": new Date(ISOLATE_STARTED_AT).toISOString(),
+  ...(env.GIT_COMMIT_SHA === undefined ? {} : { "executor.commit_sha": env.GIT_COMMIT_SHA }),
+});
 
 // Module-scope: one provider per isolate, never shut down. The provider holds
 // the SimpleSpanProcessor + OTLP exporter, so any tracer reference captured by
@@ -66,7 +85,8 @@ const ensureGlobalTracerProvider = (): boolean => {
   provider = new WebTracerProvider({
     resource: resourceFromAttributes({
       [ATTR_SERVICE_NAME]: SERVICE_NAME,
-      [ATTR_SERVICE_VERSION]: SERVICE_VERSION,
+      [ATTR_SERVICE_VERSION]: serviceVersion(),
+      ...resourceAttributes(),
     }),
     spanProcessors: (() => {
       let countingProcessor: CountingSpanProcessor;
@@ -135,7 +155,11 @@ const makeTelemetryLive = (): Layer.Layer<never> =>
         ensureGlobalTracerProvider()
           ? OtelTracer.layerGlobal.pipe(
               Layer.provide(
-                Resource.layer({ serviceName: SERVICE_NAME, serviceVersion: SERVICE_VERSION }),
+                Resource.layer({
+                  serviceName: SERVICE_NAME,
+                  serviceVersion: serviceVersion(),
+                  attributes: resourceAttributes(),
+                }),
               ),
             )
           : Layer.empty,

--- a/apps/cloud/src/server.ts
+++ b/apps/cloud/src/server.ts
@@ -1,5 +1,5 @@
 import { DurableObject } from "cloudflare:workers";
-import { SpanKind, SpanStatusCode, context, trace } from "@opentelemetry/api";
+import { SpanKind, SpanStatusCode, context, trace, type SpanContext } from "@opentelemetry/api";
 import type { ErrorEvent } from "@sentry/cloudflare";
 import {
   ATTR_HTTP_REQUEST_METHOD,
@@ -110,6 +110,15 @@ const fetchHandler = handler.fetch as (
 
 const tracer = trace.getTracer("executor-cloud-worker");
 
+const traceparentValueFor = (spanContext: SpanContext): string =>
+  `00-${spanContext.traceId}-${spanContext.spanId}-${(spanContext.traceFlags & 0xff).toString(16).padStart(2, "0")}`;
+
+const withTraceparent = (request: Request, spanContext: SpanContext): Request => {
+  const headers = new Headers(request.headers);
+  headers.set("traceparent", traceparentValueFor(spanContext));
+  return new Request(request, { headers });
+};
+
 const traceCloudMcpRequest = async (
   request: Request,
   _env: Env,
@@ -138,15 +147,9 @@ const traceCloudMcpRequest = async (
       span.setAttribute(ATTR_URL_FULL, request.url);
       span.setAttribute(ATTR_URL_PATH, url.pathname);
       span.setAttribute(ATTR_URL_SCHEME, url.protocol.replace(/:$/, ""));
-      const spanContext = span.spanContext();
-      const headers = new Headers(request.headers);
-      headers.set(
-        "traceparent",
-        `00-${spanContext.traceId}-${spanContext.spanId}-${(spanContext.traceFlags & 0xff).toString(16).padStart(2, "0")}`,
-      );
       // oxlint-disable-next-line executor/no-try-catch-or-throw -- adapter boundary; observe response/error for span status, keep trace export alive after the Agents bridge resolves or rejects
       try {
-        const response = await handle(new Request(request, { headers }));
+        const response = await handle(withTraceparent(request, span.spanContext()));
         span.setAttribute(ATTR_HTTP_RESPONSE_STATUS_CODE, response.status);
         if (response.status >= 500) {
           span.setStatus({ code: SpanStatusCode.ERROR, message: `HTTP ${response.status}` });
@@ -221,16 +224,47 @@ const cloudflareHandler: ExportedHandler<Env> = {
       return fetchHandler(request, env, ctx);
     }
     // Effect-served paths bring their own http.server span (with traceparent
-    // join) — opening one here too would duplicate it. See the header note.
+    // join) — a second SERVER span here would duplicate it (the header note).
+    // What they do NOT cover is the time between this invocation starting and
+    // the Effect router opening its span (Start dispatch, middleware, lazy
+    // module graph): during the Aug 2026 regression that gap was seconds of
+    // invisible wall time. `worker.dispatch` is an INTERNAL parent that
+    // brackets the whole invocation; Effect's http.server span joins under it
+    // via the injected traceparent, so gap = dispatch minus server span.
     if (isAppOwnedPath(url.pathname)) {
-      // The provider is installed (above) and the flush still must outlive
-      // the request — Effect's BatchSpanProcessor ships on a timer.
-      // oxlint-disable-next-line executor/no-try-catch-or-throw -- adapter boundary; mirror the traced path's finally
-      try {
-        return await fetchHandler(request, env, ctx);
-      } finally {
-        ctx.waitUntil(flushTracerProvider());
-      }
+      return tracer.startActiveSpan(
+        "worker.dispatch",
+        { kind: SpanKind.INTERNAL },
+        parentContext,
+        async (span) => {
+          span.setAttribute(ATTR_HTTP_REQUEST_METHOD, request.method);
+          span.setAttribute(ATTR_URL_PATH, url.pathname);
+          // oxlint-disable-next-line executor/no-try-catch-or-throw -- adapter boundary; observe response/error for span status, keep the flush alive past the response
+          try {
+            const response = await fetchHandler(
+              withTraceparent(request, span.spanContext()),
+              env,
+              ctx,
+            );
+            span.setAttribute(ATTR_HTTP_RESPONSE_STATUS_CODE, response.status);
+            return response;
+          } catch (err) {
+            // oxlint-disable-next-line executor/no-instanceof-error, executor/no-unknown-error-message -- adapter boundary: Cloudflare's fetch callback throws untyped; normalized only for the OTel span record, the original error is rethrown below
+            const cause = err instanceof Error ? err : String(err);
+            span.recordException(cause);
+            // oxlint-disable-next-line executor/no-unknown-error-message -- adapter boundary: same normalization as the recordException line above
+            const message = typeof cause === "string" ? cause : cause.message;
+            span.setStatus({ code: SpanStatusCode.ERROR, message });
+            // oxlint-disable-next-line executor/no-try-catch-or-throw -- adapter boundary; preserve original error to Cloudflare runtime
+            throw err;
+          } finally {
+            span.end();
+            // The flush still must outlive the request — Effect's
+            // BatchSpanProcessor ships on a timer.
+            ctx.waitUntil(flushTracerProvider());
+          }
+        },
+      );
     }
     return tracer.startActiveSpan(
       `http.server ${request.method}`,

--- a/apps/cloud/wrangler.jsonc
+++ b/apps/cloud/wrangler.jsonc
@@ -102,6 +102,13 @@
       "binding": "LOADER",
     },
   ],
+  // Stamps spans (`service.version`) and mem-metrics snapshots with the
+  // running Worker version id, so an Axiom step-change maps to the exact
+  // deploy without Cloudflare API archaeology. memory-metrics.ts already
+  // reads this binding; it was never declared before, so it always fell back.
+  "version_metadata": {
+    "binding": "CF_VERSION_METADATA",
+  },
   // DEPLOYMENT PREREQUISITE: MCP 2026-07-28 requestState is shared between
   // stateless Worker isolates and session DOs. Configure the same 32+ byte
   // secret for both with `wrangler secret put MCP_REQUEST_STATE_KEY`.
@@ -111,6 +118,13 @@
     // inbound serving. Set the Worker var to "false" for emergency rollback;
     // legacy serving remains available.
     "VITE_PUBLIC_SITE_URL": "https://executor.sh",
+    // Keeps the /__sentry-otel-verify probe live in production: Sentry
+    // delivery failed silently for weeks (zero events after ~Jul 30 with an
+    // active DSN), and without this there is no way to test the pipeline
+    // end-to-end short of waiting for a real error. The endpoint only fires
+    // when its exact path is requested and the events are explicitly tagged
+    // synthetic.
+    "SENTRY_OTEL_VERIFY": "true",
     "VITE_PUBLIC_POSTHOG_KEY": "phc_nNLrNMALpRsfrEkZovUkfMxYbcJvHnsJHeoSPavprgLL",
     // Browser OTLP spans → same-origin, forwarded to Axiom by the worker
     // (src/observability/browser-traces.ts). Relative on purpose: the


### PR DESCRIPTION
Closes the observability gaps that made the Aug 16 latency regression take two days to attribute.

- wrangler: declare the version_metadata binding (CF_VERSION_METADATA). memory-metrics.ts already read it; it was never bound, so scriptVersion always fell back to empty.
- telemetry: spans now carry service.version = worker version id, service.instance.id (one uuid per isolate), isolate start time, and the deploy commit sha when CI passes it.
- deploy workflow: passes GIT_COMMIT_SHA to the worker and ingests a deploy-marker event into the executor-cloud Axiom dataset (skips cleanly when AXIOM_INGEST_TOKEN is not configured, never blocks the deploy).
- jwks-cache: lifetime fetch/failure counters and last-fetch duration exposed via inspect().
- workos local_verify: span annotations for cache-warm state, cache age, whether this verify paid for a live JWKS fetch, and the fetch duration. This is the exact signal that was missing while p50 sat at 2.6s.
- server: app-owned paths get a worker.dispatch INTERNAL parent span bracketing the whole invocation, so time between invocation start and Effect's http.server span (Start dispatch, middleware, lazy imports) is measurable instead of invisible. Not a second SERVER span, so the old duplicate-span problem does not return.
- docs proxy: upstream fetch gets a client span (status, upstream host), so Mintlify/Vercel latency separates from worker-side cost.
- vars: SENTRY_OTEL_VERIFY=true keeps the existing /__sentry-otel-verify probe live; Sentry has silently received zero events since ~Jul 30 with an active DSN, and this makes delivery testable end to end.

Verified: oxlint clean, tsgo 0 errors, auth test folder green (73 tests), full cloud build succeeds and dist/server/wrangler.json carries version_metadata.