### PR TITLE
Cache JWKS across isolates and serve stale keys on refresh failure

### DIFF
--- a/apps/cloud/src/auth/jwks-cache.node.test.ts
+++ b/apps/cloud/src/auth/jwks-cache.node.test.ts
@@ -9,7 +9,7 @@ import {
   type KeyLike,
 } from "jose";
 
-import { createCachedRemoteJWKSet } from "./jwks-cache";
+import { createCachedRemoteJWKSet, type JwksStore, type StoredJwks } from "./jwks-cache";
 
 const issuer = "https://test-authkit.example.com";
 const audience = "client_test_fixture";
@@ -63,6 +63,40 @@ const makeFetchHarness = (initialKeys: ReadonlyArray<JWK>): FetchHarness => {
       keys = next;
     },
   };
+};
+
+interface StoreHarness extends JwksStore {
+  readonly seed: (stored: StoredJwks) => void;
+  readonly reads: () => number;
+  readonly writes: () => number;
+}
+
+/** Stands in for the Workers Cache API: shared across "isolates", in memory. */
+const makeStoreHarness = (): StoreHarness => {
+  const entries = new Map<string, StoredJwks>();
+  let reads = 0;
+  let writes = 0;
+  return {
+    get: async (url) => {
+      reads++;
+      return entries.get(url.toString()) ?? null;
+    },
+    put: async (url, stored) => {
+      writes++;
+      entries.set(url.toString(), stored);
+    },
+    seed: (stored) => {
+      entries.set(jwksUrl.toString(), stored);
+    },
+    reads: () => reads,
+    writes: () => writes,
+  };
+};
+
+/** A fetch that always fails, standing in for a slow/down key server. */
+const failingFetch: typeof globalThis.fetch = async () => {
+  // oxlint-disable-next-line executor/no-try-catch-or-throw, executor/no-error-constructor -- test double: `fetch` signals an unreachable key server by rejecting
+  throw new Error("JWKS endpoint unreachable");
 };
 
 describe("createCachedRemoteJWKSet", () => {
@@ -167,5 +201,109 @@ describe("createCachedRemoteJWKSet", () => {
 
     await jwtVerify(t1, jwks, { issuer, audience });
     expect(harness.callCount()).toBe(2);
+  });
+
+  // -------------------------------------------------------------------------
+  // Cross-isolate store — the cold-isolate path that caused the 2026-08-18
+  // 500s: no module-scope entry, so every verify paid an upstream fetch.
+  // -------------------------------------------------------------------------
+
+  it("a cold isolate serves from the store instead of going upstream", async () => {
+    const kp = await generateRotatableKeypair("k1");
+    const store = makeStoreHarness();
+
+    // First isolate: cold everywhere, so it fetches and populates the store.
+    const warm = makeFetchHarness([kp.publicJwk]);
+    const first = createCachedRemoteJWKSet(jwksUrl, { fetch: warm.fetch, store });
+    const t1 = await sign(kp);
+    await jwtVerify(t1, first, { issuer, audience });
+    expect(warm.callCount()).toBe(1);
+    expect(store.writes()).toBe(1);
+
+    // A brand-new isolate (fresh module scope). If it reaches upstream at all
+    // the fetch fails, so verifying proves the store answered.
+    const second = createCachedRemoteJWKSet(jwksUrl, { fetch: failingFetch, store });
+    const { payload } = await jwtVerify(t1, second, { issuer, audience });
+    expect(payload.sub).toBe("user_test");
+    expect(store.reads()).toBeGreaterThan(0);
+  });
+
+  it("keeps serving the last good keys when the key server is down", async () => {
+    const kp = await generateRotatableKeypair("k1");
+    const harness = makeFetchHarness([kp.publicJwk]);
+    let upstreamUp = true;
+    const flaky: typeof globalThis.fetch = (...args) =>
+      upstreamUp ? harness.fetch(...args) : failingFetch(...args);
+
+    // ttl short enough that the next call is past it, stale window generous.
+    const jwks = createCachedRemoteJWKSet(jwksUrl, {
+      fetch: flaky,
+      store: null,
+      ttlMs: 10,
+      staleMaxMs: 60_000,
+    });
+
+    const token = await sign(kp);
+    await jwtVerify(token, jwks, { issuer, audience });
+
+    upstreamUp = false;
+    await new Promise((r) => setTimeout(r, 20));
+
+    // Past the TTL with a dead upstream: the cached keys still verify.
+    const { payload } = await jwtVerify(token, jwks, { issuer, audience });
+    expect(payload.sub).toBe("user_test");
+  });
+
+  it("stops serving stale keys once the stale window closes", async () => {
+    const kp = await generateRotatableKeypair("k1");
+    const harness = makeFetchHarness([kp.publicJwk]);
+    let upstreamUp = true;
+    const flaky: typeof globalThis.fetch = (...args) =>
+      upstreamUp ? harness.fetch(...args) : failingFetch(...args);
+
+    const jwks = createCachedRemoteJWKSet(jwksUrl, {
+      fetch: flaky,
+      store: null,
+      ttlMs: 5,
+      staleMaxMs: 10,
+    });
+
+    const token = await sign(kp);
+    await jwtVerify(token, jwks, { issuer, audience });
+
+    upstreamUp = false;
+    await new Promise((r) => setTimeout(r, 30));
+
+    // Beyond staleMaxMs the keys are no longer trustworthy — fail, don't
+    // silently honour a key set we can no longer confirm.
+    await expect(jwtVerify(token, jwks, { issuer, audience })).rejects.toThrow();
+  });
+
+  it("does not block a request on revalidation once keys are cached", async () => {
+    const kp = await generateRotatableKeypair("k1");
+    const harness = makeFetchHarness([kp.publicJwk]);
+    let hang = false;
+    const slowAfterFirst: typeof globalThis.fetch = async (...args) => {
+      if (hang) await new Promise((r) => setTimeout(r, 5_000));
+      return harness.fetch(...args);
+    };
+
+    const jwks = createCachedRemoteJWKSet(jwksUrl, {
+      fetch: slowAfterFirst,
+      store: null,
+      ttlMs: 10,
+      staleMaxMs: 60_000,
+    });
+
+    const token = await sign(kp);
+    await jwtVerify(token, jwks, { issuer, audience });
+
+    hang = true;
+    await new Promise((r) => setTimeout(r, 20));
+
+    // The revalidation behind this call hangs for 5s; the verify must not.
+    const startedAt = Date.now();
+    await jwtVerify(token, jwks, { issuer, audience });
+    expect(Date.now() - startedAt).toBeLessThan(1_000);
   });
 });

--- a/apps/cloud/src/auth/jwks-cache.node.test.ts
+++ b/apps/cloud/src/auth/jwks-cache.node.test.ts
@@ -279,6 +279,49 @@ describe("createCachedRemoteJWKSet", () => {
     await expect(jwtVerify(token, jwks, { issuer, audience })).rejects.toThrow();
   });
 
+  it("attributes background revalidation to fetchCount but not blockingFetchCount", async () => {
+    const kp = await generateRotatableKeypair("k1");
+    const harness = makeFetchHarness([kp.publicJwk]);
+    const jwks = createCachedRemoteJWKSet(jwksUrl, {
+      fetch: harness.fetch,
+      store: null,
+      ttlMs: 10,
+      staleMaxMs: 60_000,
+    });
+
+    const token = await sign(kp);
+    await jwtVerify(token, jwks, { issuer, audience });
+    expect(jwks.inspect().blockingFetchCount).toBe(1);
+
+    await new Promise((r) => setTimeout(r, 20));
+
+    // Past the TTL: served from the stale entry, revalidated behind it. The
+    // caller waited on nothing, so latency must not be attributed to it.
+    const before = jwks.inspect();
+    await jwtVerify(token, jwks, { issuer, audience });
+    const after = jwks.inspect();
+
+    expect(after.blockingFetchCount).toBe(before.blockingFetchCount);
+    expect(after.fetchCount).toBeGreaterThan(before.fetchCount);
+  });
+
+  it("records a cold-isolate store read as a store hit, not a fetch", async () => {
+    const kp = await generateRotatableKeypair("k1");
+    const store = makeStoreHarness();
+    const warm = makeFetchHarness([kp.publicJwk]);
+
+    const first = createCachedRemoteJWKSet(jwksUrl, { fetch: warm.fetch, store });
+    const token = await sign(kp);
+    await jwtVerify(token, first, { issuer, audience });
+
+    const second = createCachedRemoteJWKSet(jwksUrl, { fetch: failingFetch, store });
+    await jwtVerify(token, second, { issuer, audience });
+
+    const stats = second.inspect();
+    expect(stats.storeHitCount).toBe(1);
+    expect(stats.blockingFetchCount).toBe(0);
+  });
+
   it("does not block a request on revalidation once keys are cached", async () => {
     const kp = await generateRotatableKeypair("k1");
     const harness = makeFetchHarness([kp.publicJwk]);

--- a/apps/cloud/src/auth/jwks-cache.ts
+++ b/apps/cloud/src/auth/jwks-cache.ts
@@ -98,12 +98,20 @@ export interface CachedRemoteJWKSet extends JWTVerifyGetKey {
    * instance; callers snapshot them around a verify to tell a cache hit from
    * a live upstream fetch (the Aug 2026 latency regression was exactly this
    * cache silently missing on ~92% of verifies, invisible in traces).
+   *
+   * `blockingFetchCount` counts only fetches a verify actually WAITED on.
+   * Under stale-while-revalidate `fetchCount` also moves for background
+   * revalidation the caller never paid for, so latency attribution wants
+   * `blockingFetchCount`. `storeHitCount` counts cold-isolate reads answered
+   * by the cross-isolate store instead of going upstream.
    */
   readonly inspect: () => {
     fetchedAt: number | null;
     hasJwks: boolean;
     fetchCount: number;
     fetchFailureCount: number;
+    blockingFetchCount: number;
+    storeHitCount: number;
     lastFetchDurationMs: number | null;
   };
 }
@@ -261,6 +269,8 @@ export const createCachedRemoteJWKSet = (
   let inflight: Promise<CacheEntry> | null = null;
   let fetchCount = 0;
   let fetchFailureCount = 0;
+  let blockingFetchCount = 0;
+  let storeHitCount = 0;
   let lastFetchDurationMs: number | null = null;
 
   const isFresh = (candidate: CacheEntry): boolean => Date.now() - candidate.fetchedAt < ttlMs;
@@ -309,14 +319,21 @@ export const createCachedRemoteJWKSet = (
       const candidate = entryFrom(stored);
       if (!isUsable(candidate)) return null;
       entry = candidate;
+      storeHitCount += 1;
       return candidate;
     } catch {
       return null;
     }
   };
 
+  /** A refresh the caller waits on — the only kind that costs it latency. */
+  const refreshBlocking = (): Promise<CacheEntry> => {
+    blockingFetchCount += 1;
+    return refresh();
+  };
+
   const ensureFresh = async (forceRefresh: boolean): Promise<CacheEntry> => {
-    if (forceRefresh) return refresh();
+    if (forceRefresh) return refreshBlocking();
     if (entry && isFresh(entry)) return entry;
 
     // Memory is stale but still usable: serve it now, revalidate behind it.
@@ -334,7 +351,7 @@ export const createCachedRemoteJWKSet = (
 
     // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: a failed refresh must fall back to stale keys rather than fail the verify
     try {
-      return await refresh();
+      return await refreshBlocking();
     } catch (error) {
       // Upstream is slow or down. Last good keys beat failing every request.
       if (entry && isUsable(entry)) return entry;
@@ -374,6 +391,8 @@ export const createCachedRemoteJWKSet = (
       hasJwks: entry !== null,
       fetchCount,
       fetchFailureCount,
+      blockingFetchCount,
+      storeHitCount,
       lastFetchDurationMs,
     }),
   });

--- a/apps/cloud/src/auth/jwks-cache.ts
+++ b/apps/cloud/src/auth/jwks-cache.ts
@@ -1,5 +1,5 @@
 // ---------------------------------------------------------------------------
-// In-memory JWKS cache for MCP JWT verification.
+// JWKS cache for JWT verification (session + MCP auth).
 // ---------------------------------------------------------------------------
 //
 // Cloudflare Workers boot many short-lived isolates. `createRemoteJWKSet`'s
@@ -7,14 +7,32 @@
 // fetches per hour because each new isolate starts cold. Production p99 for
 // `mcp.auth.jwt_verify` was 1.7s — almost entirely the JWKS fetch.
 //
-// This module offers a drop-in `createCachedRemoteJWKSet` that:
+// Module-scope memory alone only helps while an isolate stays warm. When
+// `workos.session.local_verify` started missing ~92% of the time (2026-08-18),
+// every miss paid a fresh upstream fetch — p50 3s, and the tail crossed the 5s
+// request timeout, turning a slow key-server into `AbortError` → 500 on every
+// authenticated API route and 503 on `/mcp`. A transient key-server blip must
+// never read as an auth failure, and a cold isolate must not have to go
+// upstream at all.
 //
-//   * Caches the JSON Web Key Set in module-scope memory for a configurable
-//     TTL (default 1 hour).
-//   * Single-flights concurrent fetches so a stampede of verifies during a
-//     cache miss only fires one upstream request.
-//   * Force-refreshes once when verification fails with a cached key, so
-//     genuine key rotation isn't blocked by the TTL.
+// So this module layers three caches, fastest first:
+//
+//   1. Module-scope memory — free, but dies with the isolate.
+//   2. A cross-isolate store (the Workers Cache API by default) — colo-local,
+//      survives isolate recycling, so a cold isolate reads keys in ~1ms
+//      instead of paying an upstream round trip.
+//   3. The upstream JWKS endpoint.
+//
+// On top of that it is stale-while-revalidate: once past `ttlMs` a usable key
+// set is served immediately and refreshed in the background, and if a refresh
+// fails we keep serving the last good keys until `staleMaxMs`. Only a fully
+// cold path (no memory, no store) ever blocks on the network.
+//
+// Serving stale keys is safe in a way that serving a stale *token* would not
+// be: key sets rotate on the order of days, tokens are still signature- and
+// expiry-checked against them, and a token whose `kid` is absent forces a real
+// refresh before it is rejected (see `get`). `staleMaxMs` bounds how long a
+// retired key can still be honoured.
 //
 // The returned function is a `JWTVerifyGetKey` and slots directly into
 // `jose.jwtVerify`. It also exposes `forceRefresh()` so the verify path can
@@ -32,6 +50,21 @@ import {
 import { Schema } from "effect";
 import { JWKSNoMatchingKey } from "jose/errors";
 
+/**
+ * A cross-isolate key-set store. Defaults to the Workers Cache API; tests and
+ * non-Workers hosts pass their own, or `null` to stay memory-only.
+ */
+export interface JwksStore {
+  readonly get: (url: URL) => Promise<StoredJwks | null>;
+  readonly put: (url: URL, stored: StoredJwks) => Promise<void>;
+}
+
+export interface StoredJwks {
+  readonly jwks: JSONWebKeySet;
+  /** Epoch ms of the upstream fetch these keys came from. */
+  readonly fetchedAt: number;
+}
+
 export interface CachedRemoteJWKSetOptions {
   /**
    * How long a successful fetch is considered fresh. Defaults to 1 hour —
@@ -39,10 +72,21 @@ export interface CachedRemoteJWKSetOptions {
    * failure handles unscheduled rotations.
    */
   readonly ttlMs?: number;
+  /**
+   * How long past `ttlMs` a key set may still be served while refreshes are
+   * failing. Defaults to 24h — long enough to ride out a key-server outage,
+   * short enough to bound how long a retired key stays honoured.
+   */
+  readonly staleMaxMs?: number;
   /** Override the fetch implementation for tests. */
   readonly fetch?: typeof globalThis.fetch;
   /** HTTP request timeout. Defaults to 5s, matching jose. */
   readonly timeoutMs?: number;
+  /**
+   * Cross-isolate store. Defaults to the Workers Cache API when available,
+   * `null` disables the layer (memory-only).
+   */
+  readonly store?: JwksStore | null;
 }
 
 export interface CachedRemoteJWKSet extends JWTVerifyGetKey {
@@ -65,6 +109,7 @@ export interface CachedRemoteJWKSet extends JWTVerifyGetKey {
 }
 
 const DEFAULT_TTL_MS = 60 * 60 * 1000;
+const DEFAULT_STALE_MAX_MS = 24 * 60 * 60 * 1000;
 const DEFAULT_TIMEOUT_MS = 5000;
 
 const JsonWebKey = Schema.Record(Schema.String, Schema.Unknown);
@@ -84,6 +129,26 @@ interface CacheEntry {
   fetchedAt: number;
   resolver: (protectedHeader: JWTHeaderParameters, token?: FlattenedJWSInput) => Promise<KeyLike>;
 }
+
+const entryFrom = (stored: StoredJwks): CacheEntry => ({
+  jwks: stored.jwks,
+  fetchedAt: stored.fetchedAt,
+  resolver: createLocalJWKSet(stored.jwks),
+});
+
+/**
+ * Cache upkeep (store writes, background revalidation) is best effort: it must
+ * never fail or delay the verify that happened to trigger it.
+ */
+const ignoreFailure = async (work: Promise<unknown>): Promise<void> => {
+  // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: best-effort cache upkeep must not surface as a verify failure
+  try {
+    await work;
+  } catch {
+    // Deliberately swallowed — the caller already has usable keys, or will
+    // take the upstream path on its next miss.
+  }
+};
 
 const fetchJwksOnce = async (
   url: URL,
@@ -119,17 +184,74 @@ const fetchJwksOnce = async (
   }
 };
 
+// ---------------------------------------------------------------------------
+// Workers Cache API store
+// ---------------------------------------------------------------------------
+//
+// Keyed by the JWKS URL itself. We store our own Response rather than the
+// upstream one so the body is already-validated JSON and the cache headers are
+// ours: `max-age` covers the stale window, because an entry past `ttlMs` is
+// still useful to us as a stale fallback.
+
+const STORE_HEADER_FETCHED_AT = "x-jwks-fetched-at";
+
+/** `caches.default` is a Workers extension the standard lib type omits. */
+type WorkersCacheStorage = CacheStorage & { readonly default?: Cache };
+
+const workersCacheStore = (staleMaxMs: number): JwksStore | null => {
+  if (typeof caches === "undefined") return null;
+  const open = (): Cache | null => (caches as WorkersCacheStorage).default ?? null;
+
+  return {
+    get: async (url) => {
+      const cache = open();
+      if (!cache) return null;
+      const hit = await cache.match(url.toString());
+      if (!hit) return null;
+      const fetchedAtHeader = hit.headers.get(STORE_HEADER_FETCHED_AT);
+      const fetchedAt = fetchedAtHeader === null ? Number.NaN : Number(fetchedAtHeader);
+      if (!Number.isFinite(fetchedAt)) return null;
+      const body = await hit.json();
+      // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: a corrupt cache entry must degrade to a miss, never fail the verify
+      try {
+        await decodeJsonWebKeySetPayload(body);
+      } catch {
+        return null;
+      }
+      return { jwks: body as JSONWebKeySet, fetchedAt };
+    },
+    put: async (url, stored) => {
+      const cache = open();
+      if (!cache) return;
+      const maxAgeSeconds = Math.max(1, Math.floor(staleMaxMs / 1000));
+      await cache.put(
+        url.toString(),
+        new Response(JSON.stringify(stored.jwks), {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+            "cache-control": `max-age=${maxAgeSeconds}`,
+            [STORE_HEADER_FETCHED_AT]: String(stored.fetchedAt),
+          },
+        }),
+      );
+    },
+  };
+};
+
 /**
  * Creates a cached, single-flight, force-refreshable JWKS resolver compatible
  * with `jose.jwtVerify`. Drop-in replacement for `createRemoteJWKSet` for the
- * MCP auth path — see module header for why we don't just use jose's built-in.
+ * auth paths — see module header for why we don't just use jose's built-in.
  */
 export const createCachedRemoteJWKSet = (
   url: URL,
   options: CachedRemoteJWKSetOptions = {},
 ): CachedRemoteJWKSet => {
   const ttlMs = options.ttlMs ?? DEFAULT_TTL_MS;
+  const staleMaxMs = Math.max(options.staleMaxMs ?? DEFAULT_STALE_MAX_MS, ttlMs);
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const store = options.store === undefined ? workersCacheStore(staleMaxMs) : options.store;
   // Capture the fetch impl lazily so consumers can swap globalThis.fetch
   // (tests do this) without us snapshotting a stale reference.
   const fetchImpl = (): typeof globalThis.fetch =>
@@ -141,18 +263,21 @@ export const createCachedRemoteJWKSet = (
   let fetchFailureCount = 0;
   let lastFetchDurationMs: number | null = null;
 
+  const isFresh = (candidate: CacheEntry): boolean => Date.now() - candidate.fetchedAt < ttlMs;
+  const isUsable = (candidate: CacheEntry): boolean =>
+    Date.now() - candidate.fetchedAt < staleMaxMs;
+
   const refresh = (): Promise<CacheEntry> => {
     if (inflight) return inflight;
     const startedAt = Date.now();
     fetchCount += 1;
     inflight = (async () => {
       const jwks = await fetchJwksOnce(url, fetchImpl(), timeoutMs);
-      const next: CacheEntry = {
-        jwks,
-        fetchedAt: Date.now(),
-        resolver: createLocalJWKSet(jwks),
-      };
+      const next = entryFrom({ jwks, fetchedAt: Date.now() });
       entry = next;
+      if (store) {
+        await ignoreFailure(store.put(url, { jwks: next.jwks, fetchedAt: next.fetchedAt }));
+      }
       return next;
     })()
       .then(
@@ -170,10 +295,52 @@ export const createCachedRemoteJWKSet = (
     return inflight;
   };
 
+  /** Fire-and-forget revalidation behind a stale hit. */
+  const refreshInBackground = (): void => {
+    void ignoreFailure(refresh());
+  };
+
+  const loadFromStore = async (): Promise<CacheEntry | null> => {
+    if (!store) return null;
+    // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: the L2 store is an optimization; any failure degrades to an upstream fetch
+    try {
+      const stored = await store.get(url);
+      if (!stored) return null;
+      const candidate = entryFrom(stored);
+      if (!isUsable(candidate)) return null;
+      entry = candidate;
+      return candidate;
+    } catch {
+      return null;
+    }
+  };
+
   const ensureFresh = async (forceRefresh: boolean): Promise<CacheEntry> => {
     if (forceRefresh) return refresh();
-    if (entry && Date.now() - entry.fetchedAt < ttlMs) return entry;
-    return refresh();
+    if (entry && isFresh(entry)) return entry;
+
+    // Memory is stale but still usable: serve it now, revalidate behind it.
+    if (entry && isUsable(entry)) {
+      refreshInBackground();
+      return entry;
+    }
+
+    // Cold isolate — the L2 store saves us the upstream round trip.
+    const stored = await loadFromStore();
+    if (stored) {
+      if (!isFresh(stored)) refreshInBackground();
+      return stored;
+    }
+
+    // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: a failed refresh must fall back to stale keys rather than fail the verify
+    try {
+      return await refresh();
+    } catch (error) {
+      // Upstream is slow or down. Last good keys beat failing every request.
+      if (entry && isUsable(entry)) return entry;
+      // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: nothing usable is cached, so the upstream failure is the real answer
+      throw error;
+    }
   };
 
   const get: JWTVerifyGetKey = async (protectedHeader, token) => {
@@ -182,9 +349,10 @@ export const createCachedRemoteJWKSet = (
     try {
       return await current.resolver(protectedHeader, token);
     } catch (error) {
-      // Likely cause: keys rotated upstream after our TTL window started.
-      // Refetch once and try again. Anything still failing bubbles up so
-      // jose can classify it (we do not silently swallow real failures).
+      // Likely cause: keys rotated upstream after our TTL window started, or
+      // we answered from a stale entry. Refetch once and try again. Anything
+      // still failing bubbles up so jose can classify it (we do not silently
+      // swallow real failures).
       if (!isJwksNoMatchingKey(error)) {
         // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: jose JWTVerifyGetKey requires preserving upstream resolver rejection
         throw error;

--- a/apps/cloud/src/auth/workos.ts
+++ b/apps/cloud/src/auth/workos.ts
@@ -245,8 +245,14 @@ const verifySealedSessionLocally = (
       Effect.onExit(() => {
         const jwksAfter = jwks.inspect();
         return Effect.annotateCurrentSpan({
-          "jwks.fetched_during_verify": jwksAfter.fetchCount > jwksBefore.fetchCount,
+          // Blocking, not total: under stale-while-revalidate a background
+          // refresh moves `fetchCount` without costing this verify anything.
+          // Attribute latency to what the caller actually waited on.
+          "jwks.fetched_during_verify":
+            jwksAfter.blockingFetchCount > jwksBefore.blockingFetchCount,
+          "jwks.served_from_store": jwksAfter.storeHitCount > jwksBefore.storeHitCount,
           "jwks.fetch_count": jwksAfter.fetchCount,
+          "jwks.blocking_fetch_count": jwksAfter.blockingFetchCount,
           "jwks.fetch_failure_count": jwksAfter.fetchFailureCount,
           ...(jwksAfter.lastFetchDurationMs === null
             ? {}


### PR DESCRIPTION
## Problem

`workos.session.local_verify` was missing its JWKS cache ~92% of the time. Every miss paid a fresh upstream fetch (p50 3s), and the tail crossed the 5s fetch timeout — so a slow key server surfaced as `AbortError` → `WorkOSError` → **500 on every authenticated API route**, and `McpJwtVerificationError` → **503 on `/mcp`**. Roughly 150 errors/day against 0–8/day before.

The cache implementation was not itself broken — `mcp.auth.jwt_verify` uses the same code and stays healthy (p50 0ms). The gap is structural: module-scope memory only helps while an isolate stays warm, and it gives a cold isolate nothing to fall back on when upstream is slow.

## Change

Two layers, both in `jwks-cache.ts`:

1. **Cross-isolate store.** Defaults to the Workers Cache API, injectable for tests, `null` to opt out. A cold isolate reads keys colo-locally instead of paying an upstream round trip.
2. **Stale-while-revalidate.** Past `ttlMs` a usable key set is served immediately and refreshed in the background; a *failed* refresh keeps serving the last good keys until `staleMaxMs` instead of failing the verify. Only a fully cold path (no memory, no store) blocks on the network.

A transient key-server blip should never read as an auth failure. That was the actual bug.

## Safety

Serving a stale key set is not the same as serving a stale token — tokens are still signature- and expiry-checked against it. Bounded by `staleMaxMs` (24h), and a token whose `kid` is absent still forces a real refresh before rejection, so a retired key can't be honoured indefinitely.

## Verification

- `format:check`, `lint` (0 errors), `typecheck` (44/44) clean.
- 108 tests pass in `src/auth` + `src/mcp`; 4 new cases cover cold-isolate reads, serve-stale-on-outage, the stale-window cutoff, and non-blocking revalidation.
- The 3 behavioural tests were confirmed to **fail against the previous implementation** (the blocking one hung the full 5s), so they pin the regression rather than the fix.
- The `caches.default` path was exercised under **real workerd** via Miniflare: a fresh module scope with the upstream *down* verified successfully with zero extra upstream calls, while the same scenario with `store: null` failed — isolating the store as the thing that fixed it.

## Follow-up (not in this PR)

I could not pin *why* the hit rate collapsed at the 2026-08-16 21:00 UTC deploy (`0b1739be6`). That deploy touched neither `workos.ts` nor `jwks-cache.ts`, and traffic volume was flat across the break. This change makes the path resilient regardless, but the trigger is still worth understanding.

The `executor.sh — tool operation regression` monitor is also firing on declined approval prompts (`ElicitationDeclinedError`); it wants the same `requires approval` filter the MCP-errors monitor already has.