### PR TITLE
Attribute local_verify latency to a phase

### DIFF
--- a/apps/cloud/src/auth/workos.ts
+++ b/apps/cloud/src/auth/workos.ts
@@ -213,18 +213,33 @@ const verifySealedSessionLocally = (
   jwks: CachedRemoteJWKSet,
 ): Effect.Effect<LocalSessionVerification, ServiceAdapterError> =>
   Effect.gen(function* () {
+    // Phase timings, not just child spans. `local_verify` is a leaf in
+    // production traces, so a ~3.3s verify has nothing under it to blame —
+    // and it stayed 3.3s after the JWKS fetch was eliminated entirely
+    // (jwks.fetch_count == 0), so the cost is one of the phases below. Under
+    // workerd `Date.now()` only advances at I/O boundaries, which is exactly
+    // what makes a raw span duration misleading here: recording each phase
+    // explicitly says which await the wall-clock actually crossed.
+    const verifyStartedAt = Date.now();
+
+    const unsealStartedAt = Date.now();
     const unsealed = yield* Effect.tryPromise({
       try: () => unsealWorkOSSession(sessionData, cookiePassword),
       catch: (cause) => new LocalSessionCookieError({ cause }),
     }).pipe(
       Effect.catchTag("LocalSessionCookieError", () => Effect.succeed(null as unknown | null)),
+      Effect.withSpan("workos.session.unseal"),
     );
+    const unsealMs = Date.now() - unsealStartedAt;
+    yield* Effect.annotateCurrentSpan({ "verify.unseal_ms": unsealMs });
     if (!unsealed) return { _tag: "InvalidCookie" };
 
+    const decodeStartedAt = Date.now();
     const session = Option.match(decodeSealedSessionPayload(unsealed), {
       onNone: (): SealedSessionPayload | null => null,
       onSome: (payload) => payload,
     });
+    yield* Effect.annotateCurrentSpan({ "verify.decode_ms": Date.now() - decodeStartedAt });
     if (!session) return { _tag: "InvalidCookie" };
 
     // Snapshot the JWKS cache around the verify so the `local_verify` span
@@ -241,10 +256,15 @@ const verifySealedSessionLocally = (
         ? {}
         : { "jwks.cache_age_ms": Date.now() - jwksBefore.fetchedAt }),
     });
+    const jwtStartedAt = Date.now();
     const verified = yield* verifyJwtWithRefreshRetry(session.accessToken, jwks).pipe(
+      Effect.withSpan("workos.session.jwt_verify"),
       Effect.onExit(() => {
         const jwksAfter = jwks.inspect();
+        const finishedAt = Date.now();
         return Effect.annotateCurrentSpan({
+          "verify.jwt_ms": finishedAt - jwtStartedAt,
+          "verify.total_ms": finishedAt - verifyStartedAt,
           // Blocking, not total: under stale-while-revalidate a background
           // refresh moves `fetchCount` without costing this verify anything.
           // Attribute latency to what the caller actually waited on.


### PR DESCRIPTION
`workos.session.local_verify` sits at p50 ~3.3s on executor-cloud and is a **leaf span** — nothing underneath it to attribute the time to.

Two things are already ruled out:

- **Not the JWKS fetch.** After #1665 every post-deploy verify reports `jwks.fetch_count: 0`, `jwks.served_from_store: true` — zero upstream fetches — and the p50 is unchanged at ~3.3s.
- **Not cold start.** Splitting verifies by isolate reuse, isolates with >10 spans still show p50 **3262ms** (9% fast). Warm and hot look the same.

So the cost is inside `verifySealedSessionLocally`. This adds per-phase timings (`verify.unseal_ms`, `verify.decode_ms`, `verify.jwt_ms`, `verify.total_ms`) and child spans for `unseal` and `jwt_verify`.

Timings are recorded explicitly rather than relying on span durations alone: under workerd `Date.now()` only advances at I/O boundaries, which is precisely what makes the parent span duration hard to read here. The explicit numbers say which await the wall-clock actually crossed.

Diagnostic only — no behaviour change. The comparison worth noting: `mcp.auth.jwt_verify` does the JWT half against the same cache and sits at p50 0ms, so the unseal is the prime suspect.