### PR TITLE
Split the jwt_verify cost into store read vs key import

### DIFF
--- a/apps/cloud/src/auth/jwks-cache.ts
+++ b/apps/cloud/src/auth/jwks-cache.ts
@@ -113,6 +113,10 @@ export interface CachedRemoteJWKSet extends JWTVerifyGetKey {
     blockingFetchCount: number;
     storeHitCount: number;
     lastFetchDurationMs: number | null;
+    /** Wall-clock of the last cross-isolate store read (I/O). */
+    lastStoreReadMs: number | null;
+    /** Wall-clock of the last key resolution — WebCrypto `importKey`. */
+    lastResolveMs: number | null;
   };
 }
 
@@ -272,6 +276,8 @@ export const createCachedRemoteJWKSet = (
   let blockingFetchCount = 0;
   let storeHitCount = 0;
   let lastFetchDurationMs: number | null = null;
+  let lastStoreReadMs: number | null = null;
+  let lastResolveMs: number | null = null;
 
   const isFresh = (candidate: CacheEntry): boolean => Date.now() - candidate.fetchedAt < ttlMs;
   const isUsable = (candidate: CacheEntry): boolean =>
@@ -314,7 +320,9 @@ export const createCachedRemoteJWKSet = (
     if (!store) return null;
     // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: the L2 store is an optimization; any failure degrades to an upstream fetch
     try {
+      const storeReadStartedAt = Date.now();
       const stored = await store.get(url);
+      lastStoreReadMs = Date.now() - storeReadStartedAt;
       if (!stored) return null;
       const candidate = entryFrom(stored);
       if (!isUsable(candidate)) return null;
@@ -364,7 +372,10 @@ export const createCachedRemoteJWKSet = (
     const current = await ensureFresh(false);
     // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: jose JWTVerifyGetKey retry path is defined by thrown resolver failures
     try {
-      return await current.resolver(protectedHeader, token);
+      const resolveStartedAt = Date.now();
+      const key = await current.resolver(protectedHeader, token);
+      lastResolveMs = Date.now() - resolveStartedAt;
+      return key;
     } catch (error) {
       // Likely cause: keys rotated upstream after our TTL window started, or
       // we answered from a stale entry. Refetch once and try again. Anything
@@ -394,6 +405,8 @@ export const createCachedRemoteJWKSet = (
       blockingFetchCount,
       storeHitCount,
       lastFetchDurationMs,
+      lastStoreReadMs,
+      lastResolveMs,
     }),
   });
   return result;

--- a/apps/cloud/src/auth/workos.ts
+++ b/apps/cloud/src/auth/workos.ts
@@ -277,6 +277,15 @@ const verifySealedSessionLocally = (
           ...(jwksAfter.lastFetchDurationMs === null
             ? {}
             : { "jwks.last_fetch_ms": jwksAfter.lastFetchDurationMs }),
+          // Splits the ~3.4s that sits inside jwt_verify with zero upstream
+          // fetches: the cross-isolate store read (I/O) vs WebCrypto key
+          // import vs the signature check itself.
+          ...(jwksAfter.lastStoreReadMs === null
+            ? {}
+            : { "jwks.store_read_ms": jwksAfter.lastStoreReadMs }),
+          ...(jwksAfter.lastResolveMs === null
+            ? {}
+            : { "jwks.key_resolve_ms": jwksAfter.lastResolveMs }),
         });
       }),
     );


### PR DESCRIPTION
Follow-up to #1667, which showed the whole ~3.4s of `local_verify` sits in `jwt_verify` (`unseal_ms` and `decode_ms` are both 0ms) while doing **zero** upstream JWKS fetches.

Two candidates remain inside it. This times both:

- `jwks.store_read_ms` — the cross-isolate store read, which is real I/O and now runs on every verify (`jwks.cache_populated_at_start` is false on 100% of spans, so module memory is always empty).
- `jwks.key_resolve_ms` — WebCrypto `importKey`, which jose does lazily inside the resolver.

Whatever is left after those two is the signature check itself.

Diagnostic only, no behaviour change.