### PR TITLE
Add temporary clock-sync probe to separate pre-work time from real work

### DIFF
--- a/apps/cloud/src/server.ts
+++ b/apps/cloud/src/server.ts
@@ -179,6 +179,32 @@ const mcpAgentHandler = makeCloudMcpAgentHandler({
 
 const cloudflareHandler: ExportedHandler<Env> = {
   fetch: async (request, env, ctx) => {
+    // TEMPORARY DIAGNOSTIC (Aug 2026 latency hunt).
+    //
+    // workerd freezes `Date.now()` and only advances it when I/O completes, so
+    // every `Date.now()` delta taken ACROSS the first I/O of a request silently
+    // includes all wall-clock since the request started — queueing, isolate
+    // start, module evaluation. That is why per-phase timings kept reporting
+    // 0ms for everything up to the first await and then a multi-second number
+    // for whichever await happened to be first: the instrument was measuring
+    // the clock jump, not the operation.
+    //
+    // `scheduler.wait(0)` is an I/O boundary, so awaiting it here forces the
+    // clock forward before any real work. The delta it absorbs IS the
+    // pre-work time (queue + start + module eval); every measurement after it
+    // is honest.
+    const entryPinned = Date.now();
+    await scheduler.wait(0);
+    const preWorkMs = Date.now() - entryPinned;
+    const probeUrl = new URL(request.url);
+    console.log(
+      JSON.stringify({
+        probe: "clock-sync",
+        path: probeUrl.pathname,
+        preWorkMs,
+      }),
+    );
+
     // Public pages must not enter TanStack Start: its first-request dynamic
     // import loads the entire React + Effect server graph and can take seconds
     // on a cold isolate. Classify and service-bind marketing at the Worker


### PR DESCRIPTION
Temporary diagnostic for the Aug 2026 latency hunt. To be reverted once it has answered the question.

**Why the existing numbers can't be trusted.** workerd freezes `Date.now()` and only advances it when I/O completes. Any `Date.now()` delta taken *across* a request's first I/O therefore includes all wall-clock since the request started — queue time, isolate start, module evaluation — not the duration of the operation being measured.

That artifact fully explains the readings so far: `verify.unseal_ms: 0`, `verify.decode_ms: 0`, `jwks.key_resolve_ms: 0`, and then `jwks.store_read_ms: 6135` on a 6135ms span. It looked like a single Cache API read taking 6 seconds. It is at least as likely to be 6 seconds of accumulated pre-work released at the first I/O boundary.

**The probe.** `await scheduler.wait(0)` at handler entry is an I/O boundary, so it forces the clock forward before any real work runs. The delta it absorbs is the pre-work time; every measurement after it is honest.

Reading it: if `preWorkMs` is ~3-5s the latency is before the handler does anything (queueing / start / module eval). If it is ~0 and later phases are slow, the work is genuinely slow and the phase timings can be believed.