### PR TITLE
Probe cache and timer latency directly in the handler

### DIFF
--- a/apps/cloud/src/server.ts
+++ b/apps/cloud/src/server.ts
@@ -197,11 +197,25 @@ const cloudflareHandler: ExportedHandler<Env> = {
     await scheduler.wait(0);
     const preWorkMs = Date.now() - entryPinned;
     const probeUrl = new URL(request.url);
+
+    // With the clock synced above, these two deltas are real durations. They
+    // answer whether the multi-second cost is specific to the Cache API or
+    // hits every outbound subrequest from this Worker.
+    const cacheStartedAt = Date.now();
+    await caches.default.match("https://executor.sh/__probe_never_cached");
+    const cacheProbeMs = Date.now() - cacheStartedAt;
+
+    const timerStartedAt = Date.now();
+    await scheduler.wait(1);
+    const timerProbeMs = Date.now() - timerStartedAt;
+
     console.log(
       JSON.stringify({
         probe: "clock-sync",
         path: probeUrl.pathname,
         preWorkMs,
+        cacheProbeMs,
+        timerProbeMs,
       }),
     );
 


### PR DESCRIPTION
Extends the clock-sync probe. `preWorkMs` came back 0-3ms on every slow request, so there is no queueing or startup penalty — the handler starts immediately and the multi-second cost is real work inside the request.

With the clock synced, downstream deltas are honest. `workos.session.local_verify` now reads `store_read_ms` p50 **2895ms** out of a 2895ms span, with `unseal` and `key_resolve` at 0 — a single `caches.default.match()` taking ~2.9s.

This times two things per request to pin the scope: a Cache API read that can never hit, and a bare timer. If the cache probe is seconds and the timer is ~1ms, it is subrequest I/O specifically; if both are slow, it is the event loop.