### PR TITLE
Probe a real outbound fetch alongside the local probes

### DIFF
--- a/apps/cloud/src/server.ts
+++ b/apps/cloud/src/server.ts
@@ -210,6 +210,20 @@ const cloudflareHandler: ExportedHandler<Env> = {
     await scheduler.wait(1);
     const timerProbeMs = Date.now() - timerStartedAt;
 
+    // The cache and timer probes are LOCAL. Neither leaves the isolate, and
+    // both come back in single-digit ms while the same requests take 4-6s.
+    // This one is a real outbound network subrequest to a small, fast,
+    // unrelated endpoint — the only class of I/O not yet measured, and the
+    // one the docs proxy (0.098s direct, 3-6s through the Worker) implicates.
+    const fetchStartedAt = Date.now();
+    // oxlint-disable-next-line executor/no-try-catch-or-throw -- temporary diagnostic: a probe failure must not affect the request
+    try {
+      await fetch("https://cloudflare.com/cdn-cgi/trace", { method: "GET" });
+    } catch {
+      // ignored — the timing is the signal, not the result
+    }
+    const fetchProbeMs = Date.now() - fetchStartedAt;
+
     console.log(
       JSON.stringify({
         probe: "clock-sync",
@@ -217,6 +231,7 @@ const cloudflareHandler: ExportedHandler<Env> = {
         preWorkMs,
         cacheProbeMs,
         timerProbeMs,
+        fetchProbeMs,
       }),
     );
 


### PR DESCRIPTION
The previous probes came back: `preWorkMs` 0-4ms, `cacheProbeMs` 2-21ms, `timerProbeMs` 1ms — on requests whose wall time was 4000-7800ms.

So there is no startup/queue penalty, and local I/O (Cache API, timers) is fast. Both of those probes stay inside the isolate. The one class not yet measured is a real outbound network subrequest, which is exactly what the docs proxy implicates: `executor.mintlify.dev` answers in 0.098s directly and 3-6s through the Worker.

This times a fetch to a small unrelated endpoint on every request. If `fetchProbeMs` is seconds, outbound subrequests are the cost and the search narrows to why.