### PR TITLE
Split header time from body-read time on the docs upstream

### DIFF
--- a/apps/cloud/src/server.ts
+++ b/apps/cloud/src/server.ts
@@ -224,6 +224,31 @@ const cloudflareHandler: ExportedHandler<Env> = {
     }
     const fetchProbeMs = Date.now() - fetchStartedAt;
 
+    // `fetch()` above resolves when HEADERS arrive — it never reads a body,
+    // which is why it returns in ~1ms while the request it lives in takes
+    // seconds. Both genuinely slow operations read a body: the docs proxy
+    // reads a 179KB page, and the JWKS store does `hit.json()`. Split header
+    // time from body time on the exact URL the docs proxy uses.
+    //
+    // Gated to one cheap path so normal traffic never pays for the probe.
+    let bodyHeadersMs = -1;
+    let bodyReadMs = -1;
+    let bodyBytes = -1;
+    if (probeUrl.pathname === "/robots.txt") {
+      // oxlint-disable-next-line executor/no-try-catch-or-throw -- temporary diagnostic: a probe failure must not affect the request
+      try {
+        const h0 = Date.now();
+        const probeRes = await fetch("https://executor.mintlify.dev/docs/concepts/policies");
+        bodyHeadersMs = Date.now() - h0;
+        const b0 = Date.now();
+        const text = await probeRes.text();
+        bodyReadMs = Date.now() - b0;
+        bodyBytes = text.length;
+      } catch {
+        // ignored — the timing is the signal
+      }
+    }
+
     console.log(
       JSON.stringify({
         probe: "clock-sync",
@@ -232,6 +257,9 @@ const cloudflareHandler: ExportedHandler<Env> = {
         cacheProbeMs,
         timerProbeMs,
         fetchProbeMs,
+        bodyHeadersMs,
+        bodyReadMs,
+        bodyBytes,
       }),
     );
 


### PR DESCRIPTION
Elimination so far, all measured in the same requests that took 3-11s wall: `preWorkMs` 0-4ms, `cacheProbeMs` 2-21ms, `timerProbeMs` 1ms, `fetchProbeMs` median 1ms, cpu 18-323ms.

Everything generic is fast. But two app operations are genuinely slow, and both read a response body:

- `http.client GET` to `executor.mintlify.dev` — p50 **3001ms** from the Worker, while the same URL is 0.063-0.196s from a laptop (`x-vercel-cache: HIT`, 179KB) and a probe fetch to cloudflare.com from inside the same request is 1ms.
- `workos.session.jwt_verify` — p50 **2895ms**, whose only I/O is a Cache API hit plus `hit.json()`, while a Cache API *miss* probe is 4ms.

The earlier `fetchProbeMs` never read a body, which is why it looked fast. This times headers and body separately. Gated to `/robots.txt`.