### PR TITLE
Separate Start cold-graph cost from per-request cost

### DIFF
--- a/apps/cloud/src/server.ts
+++ b/apps/cloud/src/server.ts
@@ -102,11 +102,46 @@ export { McpExecutionOwnerDirectoryDO } from "@executor-js/cloudflare/mcp/execut
 // until the in-flight export resolves.
 // ---------------------------------------------------------------------------
 
-const fetchHandler = handler.fetch as (
+const rawFetchHandler = handler.fetch as (
   request: Request,
   env: Env,
   ctx: ExecutionContext,
 ) => Response | Promise<Response>;
+
+// TEMPORARY DIAGNOSTIC (Aug 2026 latency hunt).
+//
+// The standing explanation is that Start's lazy `loadEntries` import of the
+// 2.56MB server graph costs seconds on the first Start-handled request per
+// isolate. That does not fit the numbers: module evaluation is CPU work, but
+// these requests report 45-72ms of CPU against 4s of wall time.
+//
+// So distinguish the two directly. `wasWarm` is false only for the FIRST
+// Start-handled request in this isolate — the one that pays the module load.
+// If cold requests are slow and warm ones are fast, the graph load is real.
+// If both are slow, the cost is per-request work inside Start/Effect and the
+// module-load story is wrong.
+let startHandledInThisIsolate = false;
+
+const fetchHandler = async (
+  request: Request,
+  env: Env,
+  ctx: ExecutionContext,
+): Promise<Response> => {
+  const wasWarm = startHandledInThisIsolate;
+  startHandledInThisIsolate = true;
+  const startedAt = Date.now();
+  const response = await rawFetchHandler(request, env, ctx);
+  const handlerMs = Date.now() - startedAt;
+  console.log(
+    JSON.stringify({
+      probe: "start-graph",
+      path: new URL(request.url).pathname,
+      wasWarm,
+      handlerMs,
+    }),
+  );
+  return response;
+};
 
 const tracer = trace.getTracer("executor-cloud-worker");
 


### PR DESCRIPTION
The accepted explanation (#1628) is that Start's lazy `loadEntries` import of the 2.56MB server graph costs seconds on the first Start-handled request per isolate, and that MCP traffic spreads the worker across so many isolates that nearly every page request is such a first request. The isolate numbers support the second half: `worker.dispatch` runs **1,666 requests across 1,608 isolates (1.04 req/isolate)**.

But the first half does not fit. Module evaluation is CPU work, and these requests report **45-72ms of CPU against 4s of wall time**. Every non-Start operation has now measured fast — cache 4ms, timer 1ms, outbound fetch 1ms, a 179KB body read 0ms, DB queries 15-108ms, and `preWorkMs` (queue/isolate start) 0-4ms.

This wraps `fetchHandler` to record `wasWarm` (false only for the first Start-handled request in an isolate) and `handlerMs`. Cold slow + warm fast confirms the module-load story; both slow refutes it and moves the search to per-request work inside Start/Effect.

Diagnostic only.