### PR TITLE
Clock-sync both sides of fetchHandler so handlerMs is real

### DIFF
--- a/apps/cloud/src/server.ts
+++ b/apps/cloud/src/server.ts
@@ -129,8 +129,14 @@ const fetchHandler = async (
 ): Promise<Response> => {
   const wasWarm = startHandledInThisIsolate;
   startHandledInThisIsolate = true;
+  // Sync the clock on BOTH sides. Without the trailing `scheduler.wait(0)`,
+  // a handler that performs no I/O leaves `Date.now()` pinned and reports
+  // 0ms for work that actually took seconds — which is exactly what the
+  // first run of this probe showed (handlerMs 0 against 6002ms wall).
+  await scheduler.wait(0);
   const startedAt = Date.now();
   const response = await rawFetchHandler(request, env, ctx);
+  await scheduler.wait(0);
   const handlerMs = Date.now() - startedAt;
   console.log(
     JSON.stringify({


### PR DESCRIPTION
First run of the cold/warm probe returned `handlerMs: 0` on requests with **6002ms wall time** — the same `Date.now()` pinning trap: a handler that performs no I/O leaves the clock frozen, so the delta reads 0 for work that took seconds.

Syncing with `scheduler.wait(0)` on both sides makes `handlerMs` a real duration, which finally splits the invocation cleanly into time inside Start versus time outside it.

It also already established that `wasWarm` is **false on every request** (13 cold, 0 warm), confirming every Start-handled request is the first in its isolate.