### PR TITLE
Time Start module evaluation separately from first-request app init

### DIFF
--- a/apps/cloud/src/server.ts
+++ b/apps/cloud/src/server.ts
@@ -134,6 +134,22 @@ const fetchHandler = async (
   // 0ms for work that actually took seconds — which is exactly what the
   // first run of this probe showed (handlerMs 0 against 6002ms wall).
   await scheduler.wait(0);
+
+  // "First Start request in this isolate" does TWO things: it evaluates the
+  // 2.56MB module graph, and it builds the app's Effect layers (DB, WorkOS)
+  // for the first time. Those have different fixes, so time them apart.
+  // Importing the same virtual ids `loadEntries` uses means its cache finds
+  // the module already evaluated, so `handlerMs` below excludes the load.
+  const moduleStartedAt = Date.now();
+  // oxlint-disable-next-line executor/no-try-catch-or-throw -- temporary diagnostic: a probe failure must not affect the request
+  try {
+    await Promise.all([import("#tanstack-router-entry"), import("#tanstack-start-entry")]);
+  } catch {
+    // ignored — the timing is the signal
+  }
+  await scheduler.wait(0);
+  const moduleMs = Date.now() - moduleStartedAt;
+
   const startedAt = Date.now();
   const response = await rawFetchHandler(request, env, ctx);
   await scheduler.wait(0);
@@ -143,6 +159,7 @@ const fetchHandler = async (
       probe: "start-graph",
       path: new URL(request.url).pathname,
       wasWarm,
+      moduleMs,
       handlerMs,
     }),
   );

--- a/apps/cloud/src/start-virtual-entries.d.ts
+++ b/apps/cloud/src/start-virtual-entries.d.ts
@@ -1,0 +1,9 @@
+// TanStack Start's internal virtual server-entry modules (registered by the
+// Start vite plugin; the same ids `start-server-core`'s `loadEntries`
+// imports). server.ts imports them to time module evaluation separately from
+// first-request app initialization — only the evaluation side effect matters,
+// so the value shape is left untyped. Kept in a standalone declaration file:
+// shorthand ambient modules only register from a non-module file
+// (env-augment.d.ts is a module).
+declare module "#tanstack-router-entry";
+declare module "#tanstack-start-entry";


### PR DESCRIPTION
The cold/warm probe showed warm isolates answering in **9-104ms** and cold ones in **2.5-4.9s**, with `wasWarm` false on essentially every request. But one warm sample took 5247ms and n=4 warm is too small to conclude from.

More importantly, "first Start request in this isolate" bundles two different costs:

1. evaluating the 2.56MB module graph (`loadEntries`)
2. building the app's Effect layers — DB, WorkOS — for the first time

Those want different fixes (warm/split/slim the graph vs. fix layer construction), and nothing so far distinguishes them. Importing the same virtual ids `loadEntries` uses means its cache finds the module already evaluated, so `moduleMs` captures the graph load and `handlerMs` captures everything else.

Diagnostic only.