### PR TITLE
Disable product telemetry in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,18 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+# CI is not a user. Without this, executor's own product telemetry reports to the
+# production PostHog project from every e2e shard: the analytics layer
+# (integration_added, execution_completed, artifact_*) and the
+# integrations-registry fetch, which lands as a `hit` event. Each shard is a
+# fresh container, so it mints a fresh anonymous id and arrives on a fresh
+# runner IP — inflating machine and user counts by roughly an order of
+# magnitude. Both opt-outs are the packages' documented CI/test hooks.
+env:
+  DO_NOT_TRACK: "1"
+  EXECUTOR_DISABLE_ANALYTICS: "1"
+  EXECUTOR_DISABLE_INTEGRATIONS_FETCH: "1"
+
 jobs:
   changes:
     name: Changed paths

--- a/.github/workflows/publish-desktop.yml
+++ b/.github/workflows/publish-desktop.yml
@@ -21,6 +21,18 @@ concurrency:
   group: publish-desktop-${{ github.ref }}
   cancel-in-progress: false
 
+# CI is not a user. Without this, executor's own product telemetry reports to the
+# production PostHog project from every e2e shard: the analytics layer
+# (integration_added, execution_completed, artifact_*) and the
+# integrations-registry fetch, which lands as a `hit` event. Each shard is a
+# fresh container, so it mints a fresh anonymous id and arrives on a fresh
+# runner IP — inflating machine and user counts by roughly an order of
+# magnitude. Both opt-outs are the packages' documented CI/test hooks.
+env:
+  DO_NOT_TRACK: "1"
+  EXECUTOR_DISABLE_ANALYTICS: "1"
+  EXECUTOR_DISABLE_INTEGRATIONS_FETCH: "1"
+
 jobs:
   build:
     permissions:

--- a/.github/workflows/publish-selfhost-docker.yml
+++ b/.github/workflows/publish-selfhost-docker.yml
@@ -16,6 +16,18 @@ concurrency:
   group: publish-selfhost-docker-${{ inputs.tag }}
   cancel-in-progress: false
 
+# CI is not a user. Without this, executor's own product telemetry reports to the
+# production PostHog project from every e2e shard: the analytics layer
+# (integration_added, execution_completed, artifact_*) and the
+# integrations-registry fetch, which lands as a `hit` event. Each shard is a
+# fresh container, so it mints a fresh anonymous id and arrives on a fresh
+# runner IP — inflating machine and user counts by roughly an order of
+# magnitude. Both opt-outs are the packages' documented CI/test hooks.
+env:
+  DO_NOT_TRACK: "1"
+  EXECUTOR_DISABLE_ANALYTICS: "1"
+  EXECUTOR_DISABLE_INTEGRATIONS_FETCH: "1"
+
 jobs:
   metadata:
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,18 @@ concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
 
+# CI is not a user. Without this, executor's own product telemetry reports to the
+# production PostHog project from every e2e shard: the analytics layer
+# (integration_added, execution_completed, artifact_*) and the
+# integrations-registry fetch, which lands as a `hit` event. Each shard is a
+# fresh container, so it mints a fresh anonymous id and arrives on a fresh
+# runner IP — inflating machine and user counts by roughly an order of
+# magnitude. Both opt-outs are the packages' documented CI/test hooks.
+env:
+  DO_NOT_TRACK: "1"
+  EXECUTOR_DISABLE_ANALYTICS: "1"
+  EXECUTOR_DISABLE_INTEGRATIONS_FETCH: "1"
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/packages/core/integrations-registry/src/registry.test.ts
+++ b/packages/core/integrations-registry/src/registry.test.ts
@@ -131,6 +131,10 @@ describe("IntegrationsRegistry", () => {
           Effect.provide(
             integrationsRegistryLayer({
               userAgent: TEST_USER_AGENT,
+              // Pinned: this case asserts the fetch happens, so it must not
+              // inherit an ambient DO_NOT_TRACK / EXECUTOR_DISABLE_INTEGRATIONS_FETCH
+              // (CI sets both). Mirrors the analytics package's test config.
+              disabled: false,
               cacheDir,
               url: "https://integrations.test/api.json",
             }).pipe(Layer.provide(httpLayer), Layer.provide(NodeFileSystem.layer)),
@@ -164,6 +168,10 @@ describe("IntegrationsRegistry", () => {
           Effect.provide(
             integrationsRegistryLayer({
               userAgent: TEST_USER_AGENT,
+              // Pinned: this case asserts the fetch happens, so it must not
+              // inherit an ambient DO_NOT_TRACK / EXECUTOR_DISABLE_INTEGRATIONS_FETCH
+              // (CI sets both). Mirrors the analytics package's test config.
+              disabled: false,
               cacheDir,
               url: "https://integrations.test/api.json",
             }).pipe(Layer.provide(httpLayer), Layer.provide(NodeFileSystem.layer)),


### PR DESCRIPTION
CI reports to the production PostHog project from every e2e shard. Each shard is a fresh container, so it mints a fresh anonymous analytics id (`<dataDir>/analytics-id`) and arrives on a fresh Blacksmith runner IP.

Effect on 2026-08-18, after #1644 took the e2e matrix from 11 to 26 runners:

- `Active machines per day` read 896 for the CLI surface; 503 of those were runner IPs from Blacksmith's `192.240.192.0/18`. Real number was 393.
- CI was ~96% of all `integration_added` events (8,092 of ~8,400) and 892 of the 1,019 reported users.

Both opt-outs already existed and are documented as CI/test hooks; nothing set them. This sets `DO_NOT_TRACK`, `EXECUTOR_DISABLE_ANALYTICS` and `EXECUTOR_DISABLE_INTEGRATIONS_FETCH` at the top level of the four workflows that execute product code (ci, publish-selfhost-docker, publish-desktop, release).

Two registry tests asserted that the fetch happens while omitting `disabled`, so they inherited the new ambient flags and failed. Pinned `disabled: false` in both, matching how the analytics package's test config already does it. Verified green with and without the env set.

No e2e scenario depends on the remote catalog — `update-endpoint.test.ts` explicitly tolerates an unreachable registry.