### PR TITLE
Restore targeted placement to aws:us-east-1

### DIFF
--- a/apps/cloud/wrangler.jsonc
+++ b/apps/cloud/wrangler.jsonc
@@ -94,6 +94,14 @@
       "bucket_name": "executor-cloud-blobs",
     },
   ],
+  // Pins the Worker to the Hyperdrive/Postgres region. Added in #420 to fix
+  // MCP Hyperdrive connection pressure; dropped in #1693 as a placement
+  // experiment, which took `user_store.*` from ~12ms to ~300ms because every
+  // query started crossing regions. Restored to measure that against the
+  // JWKS verify time the experiment also moved.
+  "placement": {
+    "region": "aws:us-east-1",
+  },
   "worker_loaders": [
     {
       "binding": "LOADER",


### PR DESCRIPTION
Reverts the wrangler config change from #1693.

Since that deploy (2026-08-19 15:07 UTC), per-deploy p50 keyed on `executor.commit_sha`:

| span | d89c7331 (before) | f08e84d21 (after) |
|---|---|---|
| `user_store.getOrganization` | 14ms | 297ms |
| `workos.userManagement.listOrganizationMemberships` | 50ms | 110-234ms |
| `mcp.auth.authorize_organization` | 89ms | 400-724ms |
| `workos.session.local_verify` | 2482ms | 0ms |

`user_store.*` is Drizzle to Postgres over the HYPERDRIVE binding, and the placement pin existed since #420 specifically to co-locate the Worker with it, so the DB-side regression has a clear mechanism. The JWKS side moved the other way in the same window but is confounded by #1696 and #1697 landing within hours.

Restoring the pin to measure the two effects independently. If the JWKS stall returns with it, that isolates the trade-off and points at fixing the JWKS cache directly rather than paying for it with placement.