### PR TITLE
Disable product telemetry in every workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,16 @@ concurrency:
   group: deploy-production
   cancel-in-progress: false
 
+# CI is not a user — see the note in ci.yml. Applied to every workflow rather
+# than the ones that look like they run product code: the first pass guessed,
+# missed preview/deploy/pkg-pr-new, and kept leaking. These vars are inert
+# where the product is not executed, so the blanket application is the cheap
+# structural answer.
+env:
+  DO_NOT_TRACK: "1"
+  EXECUTOR_DISABLE_ANALYTICS: "1"
+  EXECUTOR_DISABLE_INTEGRATIONS_FETCH: "1"
+
 jobs:
   migrate:
     name: Migrate database

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -10,6 +10,16 @@ concurrency:
   group: pkg-pr-new-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+# CI is not a user — see the note in ci.yml. Applied to every workflow rather
+# than the ones that look like they run product code: the first pass guessed,
+# missed preview/deploy/pkg-pr-new, and kept leaking. These vars are inert
+# where the product is not executed, so the blanket application is the cheap
+# structural answer.
+env:
+  DO_NOT_TRACK: "1"
+  EXECUTOR_DISABLE_ANALYTICS: "1"
+  EXECUTOR_DISABLE_INTEGRATIONS_FETCH: "1"
+
 jobs:
   # Per-platform matrix: build the executor binary, tar it, upload to R2.
   # The wrapper npm package is built later by the `publish` job which just

--- a/.github/workflows/preview-sweep.yml
+++ b/.github/workflows/preview-sweep.yml
@@ -16,6 +16,16 @@ permissions:
   contents: read
   pull-requests: read
 
+# CI is not a user — see the note in ci.yml. Applied to every workflow rather
+# than the ones that look like they run product code: the first pass guessed,
+# missed preview/deploy/pkg-pr-new, and kept leaking. These vars are inert
+# where the product is not executed, so the blanket application is the cheap
+# structural answer.
+env:
+  DO_NOT_TRACK: "1"
+  EXECUTOR_DISABLE_ANALYTICS: "1"
+  EXECUTOR_DISABLE_INTEGRATIONS_FETCH: "1"
+
 jobs:
   sweep:
     name: Destroy previews for closed PRs

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -23,6 +23,16 @@ concurrency:
   group: preview-${{ github.event.pull_request.number }}
   cancel-in-progress: ${{ github.event.action != 'closed' }}
 
+# CI is not a user — see the note in ci.yml. Applied to every workflow rather
+# than the ones that look like they run product code: the first pass guessed,
+# missed preview/deploy/pkg-pr-new, and kept leaking. These vars are inert
+# where the product is not executed, so the blanket application is the cheap
+# structural answer.
+env:
+  DO_NOT_TRACK: "1"
+  EXECUTOR_DISABLE_ANALYTICS: "1"
+  EXECUTOR_DISABLE_INTEGRATIONS_FETCH: "1"
+
 jobs:
   deploy:
     name: Deploy preview

--- a/.github/workflows/publish-executor-package.yml
+++ b/.github/workflows/publish-executor-package.yml
@@ -21,6 +21,16 @@ concurrency:
   group: publish-executor-package-${{ github.ref }}
   cancel-in-progress: false
 
+# CI is not a user — see the note in ci.yml. Applied to every workflow rather
+# than the ones that look like they run product code: the first pass guessed,
+# missed preview/deploy/pkg-pr-new, and kept leaking. These vars are inert
+# where the product is not executed, so the blanket application is the cheap
+# structural answer.
+env:
+  DO_NOT_TRACK: "1"
+  EXECUTOR_DISABLE_ANALYTICS: "1"
+  EXECUTOR_DISABLE_INTEGRATIONS_FETCH: "1"
+
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Follow-up to #1701, which did not fully stop the leak.

That PR added the opt-out only to the workflows that looked like they ran product code (ci, publish-selfhost-docker, publish-desktop, release). Blacksmith runners kept reporting to production PostHog after it merged — `hit` events from `executor/stable/1.5.42/cli` were still arriving 100 minutes later. The missed workflows are `preview`, `deploy`, `pkg-pr-new` and `publish-executor-package`, which also invoke the CLI.

Rather than guess again, this applies the opt-out at the top level of every workflow. The variables are inert where the product is not executed, so there is no cost to the blanket application and no next workflow can silently reintroduce it.

Verified all 9 workflows now carry all three variables and still parse.

Note one residual source this cannot fix: `pull_request` runs use the workflow file from the PR head branch, so open PRs branched before #1701 keep the old file until they rebase. That decays on its own.