### PR TITLE
MCP: add Bright Data to well-known server presets

### DIFF
--- a/.changeset/brightdata-mcp-preset.md
+++ b/.changeset/brightdata-mcp-preset.md
@@ -1,0 +1,12 @@
+---
+"@executor-js/plugin-mcp": patch
+---
+
+**Bright Data joins the well-known MCP preset catalog**
+
+The MCP plugin's preset catalog now includes Bright Data's hosted MCP server
+(`https://mcp.brightdata.com/mcp`), exposing 69 tools for web search, page
+scraping, structured data extraction, and remote browser automation. The
+connection flow authenticates with a Bright Data API token placed in the
+server URL's `token` query parameter (the `query` API-key placement, already
+supported by the plugin).

--- a/packages/plugins/mcp/src/sdk/presets.ts
+++ b/packages/plugins/mcp/src/sdk/presets.ts
@@ -69,6 +69,15 @@ export const mcpPresets: readonly McpPreset[] = [
     featured: true,
   },
   {
+    id: "brightdata",
+    name: "Bright Data",
+    summary: "Web search, scraping, structured data extraction, and browser automation via MCP.",
+    url: "https://mcp.brightdata.com/mcp",
+    endpoint: "https://mcp.brightdata.com/mcp",
+    icon: "https://integrations.sh/logo/brightdata.com",
+    featured: true,
+  },
+  {
     id: "firecrawl",
     name: "Firecrawl",
     summary: "Crawl and scrape websites into structured data.",

--- a/packages/plugins/mcp/src/sdk/probe-shape-real-servers.live.test.ts
+++ b/packages/plugins/mcp/src/sdk/probe-shape-real-servers.live.test.ts
@@ -74,6 +74,7 @@ const liveServers: ReadonlyArray<{ readonly name: string; readonly url: string }
   // JSON-RPC error envelopes; ref.tools omits WWW-Authenticate on the
   // 401 entirely so wire-shape detection rejects it (the URL-token
   // detect fallback still surfaces it as low-confidence).
+  { name: "brightdata", url: "https://mcp.brightdata.com/mcp" },
   { name: "cubic", url: "https://www.cubic.dev/api/mcp" },
   { name: "reftools", url: "https://api.ref.tools/mcp" },
 


### PR DESCRIPTION
## What

Adds Bright Data's hosted MCP server to the MCP plugin's well-known server
preset catalog, so it shows up in the add-connection flow alongside Context7,
Browserbase, Firecrawl, etc.

```diff
   {
     id: "browserbase",
     name: "Browserbase",
     summary: "Cloud browser sessions for web scraping and automation.",
     url: "https://mcp.browserbase.com/mcp",
     endpoint: "https://mcp.browserbase.com/mcp",
     icon: "https://integrations.sh/logo/browserbase.com",
     featured: true,
   },
+  {
+    id: "brightdata",
+    name: "Bright Data",
+    summary: "Web search, scraping, structured data extraction, and browser automation via MCP.",
+    url: "https://mcp.brightdata.com/mcp",
+    endpoint: "https://mcp.brightdata.com/mcp",
+    icon: "https://integrations.sh/logo/brightdata.com",
+    featured: true,
+  },
```

Also adds the endpoint to the API-key section of
`probe-shape-real-servers.live.test.ts` so live probe runs keep verifying
auth-shape detection for it.

## Why

Bright Data's MCP server (https://github.com/brightdata/brightdata-mcp) is a
hosted, actively maintained web-access server exposing 69 tools: web search
(Google/Bing/Yandex), page scraping with unblocking, structured extraction
(45 `web_data_*` tools for Amazon, LinkedIn, TikTok, etc.), and remote browser
automation (13 `scraping_browser_*` tools). Free tier: 5,000 requests/month.

Auth is an API token placed in the server URL's `token` query parameter —
already supported by the plugin via the `query` API-key placement
(`queryParams` in connection config), so no auth code changes are needed.

## Verification

1. `bun install`.
2. `bun run format` then `bun run format:check`.
3. `bun run lint` and `bun run typecheck`.
4. `bun run test` (turbo, e2e excluded).

All gates pass locally: format/lint/typecheck clean,
`@executor-js/plugin-mcp` 138 tests pass (30 skipped are the live-server
tests, skipped by default).

## Changeset

`.changeset/brightdata-mcp-preset.md` — `@executor-js/plugin-mcp` patch.