### PR TITLE
Presets: add Supabase to MCP and OpenAPI catalogs

### DIFF
--- a/.changeset/supabase-presets.md
+++ b/.changeset/supabase-presets.md
@@ -1,0 +1,14 @@
+---
+"@executor-js/plugin-mcp": patch
+"@executor-js/plugin-openapi": patch
+---
+
+**Supabase joins the well-known integration catalogs**
+
+The MCP plugin's preset catalog now includes Supabase's hosted MCP server
+(`https://mcp.supabase.com/mcp`, OAuth-authenticated) for Postgres queries,
+auth, storage, edge functions, and project management. The OpenAPI plugin's
+catalog additionally includes the Supabase Management API
+(`https://api.supabase.com/api/v1-json`, access-token auth) for projects,
+organizations, databases, and billing. Both endpoints are already exercised by
+the plugin's probe/health-check paths.

--- a/packages/plugins/mcp/src/sdk/presets.ts
+++ b/packages/plugins/mcp/src/sdk/presets.ts
@@ -87,6 +87,15 @@ export const mcpPresets: readonly McpPreset[] = [
     featured: true,
   },
   {
+    id: "supabase",
+    name: "Supabase",
+    summary: "Postgres, auth, storage, edge functions, and project management via MCP.",
+    url: "https://mcp.supabase.com/mcp",
+    endpoint: "https://mcp.supabase.com/mcp",
+    icon: "https://integrations.sh/logo/supabase.com",
+    featured: true,
+  },
+  {
     id: "axiom",
     name: "Axiom",
     summary: "Query, analyze, and monitor your logs and event data.",

--- a/packages/plugins/openapi/src/sdk/presets.ts
+++ b/packages/plugins/openapi/src/sdk/presets.ts
@@ -102,6 +102,14 @@ const openApiOnlyPresets: readonly OpenApiPreset[] = [
     featured: true,
   },
   {
+    id: "supabase",
+    name: "Supabase",
+    summary: "Projects, organizations, databases, auth, and storage management.",
+    url: "https://api.supabase.com/api/v1-json",
+    icon: "https://integrations.sh/logo/supabase.com",
+    featured: true,
+  },
+  {
     id: "openai",
     name: "OpenAI",
     summary: "Models, files, responses, and fine-tuning.",


### PR DESCRIPTION
## What

Adds Supabase to both well-known integration catalogs:

**MCP preset** (`packages/plugins/mcp/src/sdk/presets.ts`) — Supabase's hosted
MCP server:

```diff
   {
     id: "neon",
     name: "Neon",
     summary: "Serverless Postgres — branches, queries, and management.",
     url: "https://mcp.neon.tech/mcp",
     endpoint: "https://mcp.neon.tech/mcp",
     icon: "https://integrations.sh/logo/neon.tech",
     featured: true,
   },
+  {
+    id: "supabase",
+    name: "Supabase",
+    summary: "Postgres, auth, storage, edge functions, and project management via MCP.",
+    url: "https://mcp.supabase.com/mcp",
+    endpoint: "https://mcp.supabase.com/mcp",
+    icon: "https://integrations.sh/logo/supabase.com",
+    featured: true,
+  },
```

**OpenAPI preset** (`packages/plugins/openapi/src/sdk/presets.ts`) — Supabase
Management API:

```diff
   {
     id: "neon",
     name: "Neon",
     summary: "Serverless Postgres: projects, branches, and endpoints.",
     url: "https://neon.tech/api_spec/release/v2.json",
     icon: "https://integrations.sh/logo/neon.tech",
     featured: true,
   },
+  {
+    id: "supabase",
+    name: "Supabase",
+    summary: "Projects, organizations, databases, auth, and storage management.",
+    url: "https://api.supabase.com/api/v1-json",
+    icon: "https://integrations.sh/logo/supabase.com",
+    featured: true,
+  },
```

## Why

Supabase's hosted MCP server (`https://mcp.supabase.com/mcp`) covers Postgres
queries, auth, storage, edge functions, and project management over OAuth. It
is already exercised by the MCP plugin's live probe suite
(`probe-shape-real-servers.live.test.ts`) and its OAuth challenge shape is
explicitly handled in `probe-shape.ts` — only the catalog entry was missing.

The Management API spec (`https://api.supabase.com/api/v1-json`, access-token
auth) adds the REST surface: projects, organizations, databases, auth, storage,
and billing.

Both endpoints verified live: `mcp.supabase.com/mcp` responds (OAuth
challenge, as expected), `api.supabase.com/api/v1-json` serves the spec (200),
and `integrations.sh/logo/supabase.com` resolves.

## Verification

1. `bun install`.
2. `bun run format` then `bun run format:check`.
3. `bun run lint` and `bun run typecheck`.
4. `bun run test` (turbo, e2e excluded).

All gates pass locally: format/lint/typecheck clean,
`@executor-js/plugin-mcp` 138 tests pass (30 skipped are the live-server
tests, skipped by default), `@executor-js/plugin-openapi` 283 tests pass.

## Changeset

`.changeset/supabase-presets.md` — `@executor-js/plugin-mcp` + `@executor-js/plugin-openapi` patch.