### PR TITLE
Presets: add Firebase MCP and Google Firebase/Firestore REST catalogs

### DIFF
--- a/.changeset/firebase-presets.md
+++ b/.changeset/firebase-presets.md
@@ -1,0 +1,14 @@
+---
+"@executor-js/plugin-mcp": patch
+"@executor-js/plugin-openapi": patch
+---
+
+**Firebase joins the well-known integration catalogs**
+
+The MCP plugin's preset catalog now includes the Firebase CLI's MCP server
+(`npx -y firebase-tools@latest mcp`, local stdio) for project management, Auth
+users, Firestore, security rules, Cloud Messaging, and deploys. The OpenAPI
+plugin's Google catalog additionally includes Firebase Management
+(`firebase.googleapis.com/v1beta1`) and Cloud Firestore
+(`firestore.googleapis.com/v1`) as OAuth presets, covering projects, apps,
+hosting, extensions, documents, collections, queries, and indexes.

--- a/packages/plugins/mcp/src/sdk/presets.ts
+++ b/packages/plugins/mcp/src/sdk/presets.ts
@@ -151,4 +151,14 @@ export const mcpPresets: readonly McpPreset[] = [
     command: "npx",
     args: ["-y", "chrome-devtools-mcp@latest"],
   },
+  {
+    id: "firebase",
+    name: "Firebase",
+    summary: "Manage projects, Auth, Firestore, rules, and deploys via the Firebase CLI.",
+    icon: "https://integrations.sh/logo/firebase.google.com",
+    featured: true,
+    transport: "stdio",
+    command: "npx",
+    args: ["-y", "firebase-tools@latest", "mcp"],
+  },
 ];

--- a/packages/plugins/openapi/src/providers/google/__snapshots__/presets.test.ts.snap
+++ b/packages/plugins/openapi/src/providers/google/__snapshots__/presets.test.ts.snap
@@ -90,5 +90,13 @@ exports[`classifies every Google service for bundle OAuth UX 1`] = `
     "id": "google-cloud-resource-manager",
     "oauthAudience": "advanced-user",
   },
+  {
+    "id": "google-firebase",
+    "oauthAudience": "advanced-user",
+  },
+  {
+    "id": "google-firestore",
+    "oauthAudience": "advanced-user",
+  },
 ]
 `;

--- a/packages/plugins/openapi/src/providers/google/presets.test.ts
+++ b/packages/plugins/openapi/src/providers/google/presets.test.ts
@@ -199,6 +199,8 @@ const FROZEN_GOOGLE_SLUGS = [
   "google_apps_script",
   "google_bigquery",
   "google_cloud_resource_manager",
+  "google_firebase",
+  "google_firestore",
 ] as const;
 
 it("keeps Select all limited to Google services that can use normal user OAuth", () => {

--- a/packages/plugins/openapi/src/providers/google/presets.ts
+++ b/packages/plugins/openapi/src/providers/google/presets.ts
@@ -232,6 +232,22 @@ export const googleOpenApiPresets: readonly GoogleOpenApiPreset[] = [
     icon: "https://fonts.gstatic.com/s/i/productlogos/google_cloud/v6/192px.svg",
     oauthAudience: "advanced-user",
   },
+  {
+    id: "google-firebase",
+    name: "Firebase Management",
+    summary: "Firebase projects, apps, hosting, extensions, and configuration.",
+    url: gd("firebase", "v1beta1"),
+    icon: "https://fonts.gstatic.com/s/i/productlogos/firebase/v7/192px.svg",
+    oauthAudience: "advanced-user",
+  },
+  {
+    id: "google-firestore",
+    name: "Cloud Firestore",
+    summary: "Documents, collections, queries, and indexes.",
+    url: gd("firestore", "v1"),
+    icon: "https://fonts.gstatic.com/s/i/productlogos/google_cloud/v6/192px.svg",
+    oauthAudience: "advanced-user",
+  },
 ];
 
 export const googleStandardUserOAuthPresets = googleOpenApiPresets.filter(
@@ -313,6 +329,10 @@ const GOOGLE_HEALTH_CHECKS: Readonly<Record<string, HealthCheckSpec>> = {
   },
   "google-cloud-resource-manager": {
     operation: "cloudresourcemanager.projects.search",
+    args: { pageSize: 1 },
+  },
+  "google-firebase": {
+    operation: "firebase.projects.list",
     args: { pageSize: 1 },
   },
 };

--- a/packages/plugins/openapi/src/providers/google/service-policy.ts
+++ b/packages/plugins/openapi/src/providers/google/service-policy.ts
@@ -105,6 +105,8 @@ export const googleOAuthConsentScopes: Readonly<Record<string, readonly string[]
   ],
   "google-bigquery": [auth("bigquery")],
   "google-cloud-resource-manager": [auth("cloud-platform")],
+  "google-firebase": [auth("firebase")],
+  "google-firestore": [auth("datastore")],
 };
 
 export const googleOAuthConsentScopesForPreset = (presetId: string): readonly string[] =>
@@ -237,6 +239,8 @@ const GOOGLE_DISCOVERY_POLICIES: Readonly<Record<string, GoogleDiscoveryServiceP
   }),
   "bigquery/v2": policy("google-bigquery"),
   "cloudresourcemanager/v3": policy("google-cloud-resource-manager"),
+  "firebase/v1beta1": policy("google-firebase"),
+  "firestore/v1": policy("google-firestore"),
 };
 
 export const googleDiscoveryPolicyFor = (


### PR DESCRIPTION
## What

Adds Firebase to the well-known integration catalogs, three entries across two
plugins:

**MCP stdio preset** (`packages/plugins/mcp/src/sdk/presets.ts`) — the official
Firebase CLI MCP server (GA since Oct 2025):

```diff
   {
     id: "chrome-devtools",
     name: "Chrome DevTools",
     summary: "Debug a live Chrome browser session via local stdio.",
     icon: "https://integrations.sh/logo/chrome.com",
     featured: true,
     transport: "stdio",
     command: "npx",
     args: ["-y", "chrome-devtools-mcp@latest"],
   },
+  {
+    id: "firebase",
+    name: "Firebase",
+    summary: "Manage projects, Auth, Firestore, rules, and deploys via the Firebase CLI.",
+    icon: "https://integrations.sh/logo/firebase.google.com",
+    featured: true,
+    transport: "stdio",
+    command: "npx",
+    args: ["-y", "firebase-tools@latest", "mcp"],
+  },
```

**Google catalog REST presets** (`packages/plugins/openapi/src/providers/google/`)
— Firebase Management + Cloud Firestore via the Google Discovery conversion:

- `presets.ts`: `google-firebase` (`firebase.googleapis.com/v1beta1`, 9 project
  methods: projects, apps, hosting, extensions) and `google-firestore`
  (`firestore.googleapis.com/v1`: documents, collections, queries, indexes),
  both `oauthAudience: "advanced-user"`, plus a `firebase.projects.list`
  health check (Firestore intentionally gets none — no stable cheap read,
  per the existing catalog convention).
- `service-policy.ts`: consent scopes (`firebase`, `datastore`) and policy
  entries for `firebase/v1beta1` + `firestore/v1`.
- `presets.test.ts`: frozen-slug list + snapshot updated for the two new rows.

## Why

Firebase's MCP server covers project management, Auth users, Firestore, rules,
Cloud Messaging, and deploys — but is stdio/local only, so it suits local and
desktop executor hosts. The Google REST presets give remote hosts the same
reach (OAuth): Firebase Management for project/app configuration, Firestore
for document data.

Verified against live sources: both Discovery documents resolve
(`firebase/v1beta1` — scopes `firebase`, `firebase.readonly`,
`cloud-platform`; `firestore/v1` — scopes `datastore`, `cloud-platform`), and
the official docs confirm the GA invocation `npx -y firebase-tools@latest mcp`.

## Verification

1. `bun install`.
2. `bun run format` then `bun run format:check`.
3. `bun run lint` and `bun run typecheck`.
4. `bun run test` (turbo, e2e excluded).

All gates pass locally: format/lint/typecheck clean,
`@executor-js/plugin-openapi` 283 tests pass (incl. google catalog tests),
`@executor-js/plugin-mcp` 138 tests pass (29 skipped are the live-server
tests, skipped by default).

## Changeset

`.changeset/firebase-presets.md` — `@executor-js/plugin-mcp` + `@executor-js/plugin-openapi` patch.